### PR TITLE
Pie chart label

### DIFF
--- a/src/component/DefaultTooltipContent.js
+++ b/src/component/DefaultTooltipContent.js
@@ -15,6 +15,7 @@ class DefaultTooltipContent extends Component {
     wrapperStyle: PropTypes.object,
     itemStyle: PropTypes.object,
     labelStyle: PropTypes.object,
+    labelFormatter: PropTypes.func,
     label: PropTypes.any,
     payload: PropTypes.arrayOf(PropTypes.shape({
       name: PropTypes.any,
@@ -61,7 +62,7 @@ class DefaultTooltipContent extends Component {
   }
 
   render() {
-    const { labelStyle, label, wrapperStyle } = this.props;
+    const { labelStyle, label, labelFormatter, wrapperStyle } = this.props;
     const finalStyle = {
       margin: 0,
       padding: 10,
@@ -74,10 +75,11 @@ class DefaultTooltipContent extends Component {
       margin: 0,
       ...labelStyle,
     };
-
+    let finalLabel = label;
+    if (label && labelFormatter) finalLabel = labelFormatter(label);
     return (
       <div className="recharts-default-tooltip" style={finalStyle}>
-        <p className="recharts-tooltip-label" style={finalLabelStyle}>{label || ''}</p>
+        <p className="recharts-tooltip-label" style={finalLabelStyle}>{  finalLabel || ''}</p>
         {this.renderContent()}
       </div>
     );

--- a/src/polar/Pie.js
+++ b/src/polar/Pie.js
@@ -127,6 +127,7 @@ class Pie extends Component {
         );
 
         prev = {
+          percent,
           ...entry,
           cx,
           cy,
@@ -267,10 +268,14 @@ class Pie extends Component {
         points: [polarToCartesian(entry.cx, entry.cy, entry.outerRadius, midAngle), endPoint],
       };
 
-      return isLabelElement ? React.cloneElement(label, { labelProps, key: `label-${i}` }) : (
+      return (
         <g key={`label-${i}`}>
           <Curve {...lineProps} type="linear" className="recharts-pie-label-line"/>
-          <text {...labelProps} className="recharts-pie-label-text">{entry[valueKey]}</text>
+          {
+            isLabelElement 
+              ? React.cloneElement(label, { key: `label-${i}`, ...labelProps })
+              : <text {...labelProps} className="recharts-pie-label-text">{entry[valueKey]}</text>
+          }
         </g>
       );
     });


### PR DESCRIPTION
When using custom label element, It wasn't getting rendered next to the slice.

- added label formatter for tooltip. (Ex: date formatting)
- pass the pie slice percentage as part of props for custom pie label element
