### PR TITLE
Fix tooltip location in case x has margin

### DIFF
--- a/src/component/Tooltip.js
+++ b/src/component/Tooltip.js
@@ -111,7 +111,7 @@ class Tooltip extends Component {
     outerStyle.top = Math.max(
       coordinate.y + box.height + offset > (viewBox.y + viewBox.height) ?
       coordinate.y - box.height - offset :
-      coordinate.y + offset, viewBox.x);
+      coordinate.y + offset, viewBox.y);
 
     return (
       <div className="recharts-tooltip-wrapper" style={outerStyle}>


### PR DESCRIPTION
Top was calculated from viewBox.x instead of y,
when I had a chart with margin right the tooltip was going down out of the box even if it could fit there.
anyways it looks like a typo :smile: 