### PR TITLE
Improve label rendering for vertical Bar Charts

### DIFF
--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -145,23 +145,35 @@ class Bar extends Component {
   renderLabels() {
     const { isAnimationActive } = this.props;
     if (isAnimationActive && !this.state.isAnimationFinished) { return null; }
-
-    const { data, label } = this.props;
+    const { data, label, layout } = this.props;
     const barProps = getPresentationAttributes(this.props);
     const customLabelProps = getPresentationAttributes(label);
+    const textAnchor = layout === 'vertical' ? 'start' : 'middle';
     const labels = data.map((entry, i) => {
+      let x;
+      let y;
+      if (layout === 'vertical') {
+        x = 5 + entry.x + entry.width;
+        y = 5 + entry.y + entry.height / 2;
+      } else {
+        x = entry.x + entry.width / 2;
+      }
       const labelProps = {
-        textAnchor: 'middle',
+        textAnchor,
         ...barProps,
         ...entry,
         ...customLabelProps,
-        x: entry.x + entry.width / 2,
+        x: x || 0,
+        y: y || 0,
         index: i,
         key: `label-${i}`,
         payload: entry,
       };
-
-      return this.renderLabelItem(label, labelProps, entry.value);
+      let labelValue = entry.value;
+      if (label === true && entry.value && labelProps.label) {
+        labelValue = labelProps.label;
+      }
+      return this.renderLabelItem(label, labelProps, labelValue);
     });
 
     return <Layer className="recharts-bar-labels">{labels}</Layer>;


### PR DESCRIPTION
When rendering a default or "horizontal" bar chart, the labels are rendered at the tip of each bar.

However, when rendering a "vertical" bar chart, the labels are rendered at the top center of each bar.

This Pull Requests adjusts the label rendering so that the labels remain at the "tip" of each bar.

![screen shot 2016-04-06 at 3 45 14 pm](https://cloud.githubusercontent.com/assets/55945/14335247/abf6f912-fc0e-11e5-8afc-f8fbcc2ca765.png)

This Pull Request includes two additional improvements:

* In the event that the `x` or `y` coordinate math results in a `NaN` (which can happen regardless of `layout` orientation, the values default to `0` which prevents an SVG XML error when setting `x=NaN`

* If the `label` prop is a Boolean (as in `<Bar dataKey="value" label />`, then the actual label value will be derived from the entry's `label` property instead of the raw `value` property.

  This allows, as in the above example, for the label to appear as a formatted "$19M" String (as defined in the data) as opposed to the charted value of `19000000` while retaining the shorthand `label=true` API behavior.

  Example data:

    ```js
    data = [
      {
        "label": "$19M",
        "value": 19000000
      }
    ]
    ```