### PR TITLE
Pass tickFormatter to renderer in ScatterChart

### DIFF
--- a/src/chart/ScatterChart.js
+++ b/src/chart/ScatterChart.js
@@ -404,6 +404,7 @@ class ScatterChart extends Component {
             orientation={axis.orientation}
             viewBox={{ x: 0, y: 0, width, height }}
             ticks={getTicksOfAxis(axis)}
+            tickFormatter={axis.tickFormatter}
           />
         </Layer>
       );


### PR DESCRIPTION
Currently, `tickFormatter`s from x- or y-axis are not passed to the underlying `CartesianAxis`.
This PR allows axis ticks in a scatter chart to have custom formatting.