### PR TITLE
tooltip move smoothly, fix suddenly jump

### DIFF
--- a/src/component/Tooltip.js
+++ b/src/component/Tooltip.js
@@ -98,6 +98,7 @@ class Tooltip extends Component {
       pointerEvents: 'none',
       display: active ? 'block' : 'none',
       position: 'absolute',
+      transition: '200ms linear',
     };
     const contentItem = renderContent(content, this.props);
     const box = getTooltipBBox(outerStyle, contentItem);


### PR DESCRIPTION
when tooltip reach viewBox.x + viewBox.y, it will suddenly jump to another coordination, fix to stay at bottom or top feels no surprise to user :)