### PR TITLE
Typo fix: "bursh" to "brush" in Brush component

### DIFF
--- a/src/cartesian/Brush.js
+++ b/src/cartesian/Brush.js
@@ -378,7 +378,7 @@ class Brush extends Component {
 
     if (!data || !data.length) { return null; }
 
-    const layerClass = classNames('recharts-bursh', className);
+    const layerClass = classNames('recharts-brush', className);
 
     return (
       <Layer


### PR DESCRIPTION
Just a small typo I caught for the brush component