### PR TITLE
Prevent forced axisId for composed bar charts with multiple yAxes

### DIFF
--- a/src/chart/BarChart.js
+++ b/src/chart/BarChart.js
@@ -253,7 +253,7 @@ class BarChart extends Component {
 
     return items.map((child, i) => {
       const { xAxisId, yAxisId } = child.props;
-      const axisId = layout === 'horizontal' ? xAxisId : yAxisId;
+      const axisId = layout === 'horizontal' && yAxisId === 0 ? xAxisId : yAxisId;
       const bandSize = getBandSizeOfScale(
                         layout === 'horizontal' ?
                         xAxisMap[xAxisId].scale :


### PR DESCRIPTION
<img width="782" alt="screen shot 2016-06-23 at 21 58 05" src="https://cloud.githubusercontent.com/assets/2077683/16302318/ca86bd10-398d-11e6-8bd2-8e66d448b75a.png">
