### PR TITLE
allows functions to determine fill values on Bar component

### DIFF
--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -81,6 +81,10 @@ class Bar extends Component {
   renderRectangle(option, props) {
     let rectangle;
 
+    if (typeof props.fill === 'function') {
+      props.fill = props.fill(props.value)
+    }
+
     if (React.isValidElement(option)) {
       rectangle = React.cloneElement(option, props);
     } else if (_.isFunction(option)) {

--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -28,6 +28,7 @@ class Bar extends Component {
     name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     dataKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     formatter: PropTypes.func,
+    fillFormatter: PropTypes.func,
 
     shape: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
     label: PropTypes.oneOfType([
@@ -81,10 +82,6 @@ class Bar extends Component {
   renderRectangle(option, props) {
     let rectangle;
 
-    if (typeof props.fill === 'function') {
-      props.fill = props.fill(props.value)
-    }
-
     if (React.isValidElement(option)) {
       rectangle = React.cloneElement(option, props);
     } else if (_.isFunction(option)) {
@@ -99,15 +96,21 @@ class Bar extends Component {
   renderRectangles() {
     const { data, shape, layout, isAnimationActive, animationBegin,
       animationDuration, animationEasing, animationId } = this.props;
+
     const baseProps = getPresentationAttributes(this.props);
     const getStyle = (isBegin) => ({
       transform: `scale${layout === 'vertical' ? 'X' : 'Y'}(${isBegin ? 0 : 1})`,
     });
 
     return data.map((entry, index) => {
+      let fill = this.props.fill
+      if (this.props.fillFormatter) {
+        fill = this.props.fillFormatter(entry.value)
+      }
+
       const { width, height } = entry;
       const props = {
-        ...baseProps, ...entry, index, ...filterEventsOfChild(this.props, entry, index),
+        ...baseProps, ...entry, index, fill, ...filterEventsOfChild(this.props, entry, index),
       };
       let transformOrigin = '';
 

--- a/src/util/ReactUtils.js
+++ b/src/util/ReactUtils.js
@@ -17,7 +17,7 @@ export const PRESENTATION_ATTRIBUTES = {
   display: PropTypes.string,
   dominantBaseline: PropTypes.string,
   enableBackground: PropTypes.string,
-  fill: PropTypes.string,
+  fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   fillOpacity: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   fillRule: PropTypes.oneOf(['nonzero', 'evenodd', 'inherit']),
   filter: PropTypes.string,

--- a/src/util/ReactUtils.js
+++ b/src/util/ReactUtils.js
@@ -17,7 +17,7 @@ export const PRESENTATION_ATTRIBUTES = {
   display: PropTypes.string,
   dominantBaseline: PropTypes.string,
   enableBackground: PropTypes.string,
-  fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  fill: PropTypes.string,
   fillOpacity: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   fillRule: PropTypes.oneOf(['nonzero', 'evenodd', 'inherit']),
   filter: PropTypes.string,

--- a/test/specs/cartesian/BarSpec.js
+++ b/test/specs/cartesian/BarSpec.js
@@ -52,4 +52,17 @@ describe('<Bar />', () => {
 
     expect(wrapper.find('.recharts-bar-rectangle').length).to.equal(0);
   });
+
+  it('Allows a function to determine fill value', () => {
+    const wrapper = render(
+      <Surface width={500} height={500}>
+        <Bar
+          data={data}
+          fill={(value) => value === 100 ? '#d00' : '#333'}
+        />
+      </Surface>
+    );
+
+    expect(wrapper.find('.recharts-bar-rectangle').props().fill).to.equal('#d00');
+  });
 });

--- a/test/specs/cartesian/BarSpec.js
+++ b/test/specs/cartesian/BarSpec.js
@@ -58,7 +58,7 @@ describe('<Bar />', () => {
       <Surface width={500} height={500}>
         <Bar
           data={data}
-          fill={(value) => value === 100 ? '#d00' : '#333'}
+          fillFormatter={(value) => value === 100 ? '#d00' : '#333'}
         />
       </Surface>
     );

--- a/test/specs/cartesian/BarSpec.js
+++ b/test/specs/cartesian/BarSpec.js
@@ -6,7 +6,7 @@ import { mount, render } from 'enzyme';
 describe('<Bar />', () => {
   const data = [
     { x: 10, y: 50, width: 20, height: 50, value: 100, label: 'test' },
-    { x: 50, y: 50, width: 20, height: 50, value: 100, label: 'test' },
+    { x: 50, y: 50, width: 20, height: 50, value: 10, label: 'test' },
     { x: 90, y: 50, width: 20, height: 50, value: 100, label: 'test' },
     { x: 130, y: 50, width: 20, height: 50, value: 100, label: 'test' },
     { x: 170, y: 50, width: 20, height: 50, value: 100, label: 'test' },
@@ -63,6 +63,7 @@ describe('<Bar />', () => {
       </Surface>
     );
 
-    expect(wrapper.find('.recharts-bar-rectangle').props().fill).to.equal('#d00');
+    expect(wrapper.find('.recharts-bar-rectangle')[0].attribs.fill).to.equal('#d00');
+    expect(wrapper.find('.recharts-bar-rectangle')[1].attribs.fill).to.equal('#333');
   });
 });


### PR DESCRIPTION
Was a simple addition I needed for a project I'm using it on. Useful for when you want the bars on a Barchart to be separate colors as determined by their values.

A few thoughts:

- could be better as a separate prop rather than overloading the `fill` prop and allowing 2 different types.
- let me know if the method could be executed in a better place w/n `Bar.js` other than `renderRectangle()`
- when we're ok with the implementation I'd be happy to add this feature to the other components in the `cartesian/` folder.