### PR TITLE
fixed pie charts rendering

### DIFF
--- a/src/shape/Sector.js
+++ b/src/shape/Sector.js
@@ -10,7 +10,7 @@ import { polarToCartesian } from '../util/PolarUtils';
 
 const getDeltaAngle = (startAngle, endAngle) => {
   const sign = Math.sign(endAngle - startAngle);
-  const deltaAngle = Math.min(Math.abs(endAngle - startAngle), 359.9999);
+  const deltaAngle = Math.min(Math.abs(endAngle - startAngle), 359.999);
 
   return sign * deltaAngle;
 };


### PR DESCRIPTION
Hi!
I have a problem with exporting recharts graphs as svg.
In our project we need to make pdf reports and we use wkhtmltopdf.
What I want to do is to get svg representation that recharts generates (actually client browser generates, not nodejs), paste that markup into html report file and give this file to wkhtmltopdf.

Everything works fine for firefox, chrome, but for IE (11) I have got empty pie charts.

After some research I've found that the problem in this line

`  const deltaAngle = Math.min(Math.abs(endAngle - startAngle), 359.9999);`

It seems like IE makes float calculations (rounding) in different way, and the path attributes for pie and pie's clippath for the same pie chart are different.
In other words, if I copy-paste markup from IE to chrome I will get empty pie chart.

So the solution is to decrease `359.9999` to `359.999`.