### PR TITLE
Add itemSorter to tooltips

### DIFF
--- a/src/component/DefaultTooltipContent.js
+++ b/src/component/DefaultTooltipContent.js
@@ -23,6 +23,7 @@ class DefaultTooltipContent extends Component {
       value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
       unit: PropTypes.any,
     })),
+    itemSorter: PropTypes.func,
   };
 
   static defaultProps = {
@@ -32,12 +33,13 @@ class DefaultTooltipContent extends Component {
   };
 
   renderContent() {
-    const { payload, separator, formatter, itemStyle } = this.props;
+    const { payload, separator, formatter, itemStyle, itemSorter } = this.props;
 
     if (payload && payload.length) {
       const listStyle = { padding: 0, margin: 0 };
 
       const items = payload.filter(entry => (_.isNumber(entry.value) || _.isString(entry.value)))
+      .sort(itemSorter)
       .map((entry, i) => {
         const finalItemStyle = {
           display: 'block',

--- a/src/component/Tooltip.js
+++ b/src/component/Tooltip.js
@@ -50,6 +50,7 @@ const propTypes = {
     'ease-in-out',
     'linear',
   ]),
+  itemSorter: PropTypes.func,
 };
 
 const defaultProps = {
@@ -66,6 +67,7 @@ const defaultProps = {
   isAnimationActive: true,
   animationEasing: 'ease',
   animationDuration: 400,
+  itemSorter: (item1, item2) => -1,
 };
 
 const getTooltipBBox = (wrapperStyle, contentItem) => {


### PR DESCRIPTION
https://github.com/recharts/recharts/issues/150

could be used like this to sort by name
`<Tooltip itemSorter={(item1, item2) => item1.name.localeCompare(item2.name)} />`

Or sort opposite of natural order
`<Tooltip itemSorter={(item1, item2) => 1} />`
