### PR TITLE
fix: fix bug of stacks in barchart are misplaced #177

### DIFF
--- a/src/util/CartesianUtils.js
+++ b/src/util/CartesianUtils.js
@@ -23,7 +23,7 @@ const offsetSign = (series, order) => {
       if (value >= 0) {
         series[i][j][0] = positive;
         series[i][j][1] = positive + value;
-        positive += series[i][j][1];
+        positive = series[i][j][1];
       } else {
         series[i][j][0] = negative;
         series[i][j][1] = negative + value;


### PR DESCRIPTION
This PR fixes #177 .

`series[i][j][1]` is summation of previous values, so there's no need to add it to `positive`.
