### PR TITLE
Add optional scaleToFit to prevent label cutoff.

### DIFF
--- a/demo/component/PieChart.js
+++ b/demo/component/PieChart.js
@@ -182,6 +182,7 @@ export default React.createClass({
           <ResponsiveContainer>
             <PieChart onMouseEnter={this.onPieEnter}>
               <Pie
+                scaleToFit
                 data={data01}
                 innerRadius="25%"
                 outerRadius="40%"

--- a/src/chart/PieChart.js
+++ b/src/chart/PieChart.js
@@ -179,6 +179,8 @@ class PieChart extends Component {
         key: `recharts-pie-${i}`,
         cx,
         cy,
+        height,
+        width,
         maxRadius: child.props.maxRadius || Math.sqrt(width * width + height * height) / 2,
         innerRadius: getPercentValue(innerRadius, maxRadius, 0),
         outerRadius: getPercentValue(outerRadius, maxRadius, maxRadius * 0.8),

--- a/src/polar/Pie.js
+++ b/src/polar/Pie.js
@@ -2,6 +2,7 @@
  * @fileOverview Render sectors of a pie
  */
 import React, { Component, PropTypes } from 'react';
+import ReactDOM from 'react-dom';
 import pureRender from '../util/PureRender';
 import classNames from 'classnames';
 import Layer from '../container/Layer';
@@ -23,8 +24,11 @@ class Pie extends Component {
   static propTypes = {
     ...PRESENTATION_ATTRIBUTES,
     className: PropTypes.string,
+    scaleToFit: PropTypes.bool,
     cx: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     cy: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    height: PropTypes.number,
+    width: PropTypes.number,
     startAngle: PropTypes.number,
     endAngle: PropTypes.number,
     paddingAngle: PropTypes.number,
@@ -95,18 +99,22 @@ class Pie extends Component {
     animationBegin: 400,
     animationDuration: 1500,
     animationEasing: 'ease',
+    scaleToFit: false,
   };
 
   constructor(props, ctx) {
     super(props, ctx);
 
     this.state = {
+      scale: 1,
       isAnimationFinished: false,
     };
 
     if (!this.id) {
       this.id = `clipPath${Date.now()}`;
     }
+
+    this.checkSize = this.checkSize.bind(this);
   }
 
   getDeltaAngle() {
@@ -175,6 +183,25 @@ class Pie extends Component {
     }
 
     return 'middle';
+  }
+
+  checkSize() {
+    if (this.props.scaleToFit) {
+      const { width, height } = this.props;
+      const bbox = ReactDOM.findDOMNode(this).getBBox();
+      let factor;
+      if (bbox.x + bbox.width > width) {
+        factor = (bbox.x + bbox.width / width) / 100;
+        const wide = { scale: factor };
+        this.setState(wide);
+      }
+      if (bbox.y + bbox.height > height) {
+        const heightFactor = (bbox.x + bbox.height / height) / 100;
+        factor = Math.min(factor, heightFactor);
+        const tall = { scale: factor };
+        this.setState(tall);
+      }
+    }
   }
 
   isActiveIndex(i) {
@@ -347,14 +374,17 @@ class Pie extends Component {
 
     const sectors = this.getSectors(pieData);
     const layerClass = classNames('recharts-pie', className);
+    const scale = this.state.scale;
 
     return (
-      <Layer className={layerClass}>
-        {this.renderClipPath()}
-        <g clipPath={`url(#${this.id})`}>
-          {this.renderSectors(sectors)}
+      <Layer className={layerClass} ref={() => this.checkSize()}>
+        <g className="recharts-pie-scale" transform={`scale(${scale})`}>
+          {this.renderClipPath()}
+          <g clipPath={`url(#${this.id})`}>
+            {this.renderSectors(sectors)}
+          </g>
+          {label && this.renderLabels(sectors)}
         </g>
-        {label && this.renderLabels(sectors)}
       </Layer>
     );
   }


### PR DESCRIPTION
* This adds a new scaleToFit property to Pie which ensures
  that the labels are completely visible. It accomplishes this
  by measuring the actual chart and scaling down if the labels
  do not completely fit in the bounding box on first render.
  While this will shrink the size of the text in the chart
  for many users this will be preferable to clipping.