### PR TITLE
Ability to customize hover effect on ComposedStack

### DIFF
--- a/demo/component/ComposedChart.js
+++ b/demo/component/ComposedChart.js
@@ -63,6 +63,21 @@ export default React.createClass({
             <Line dataKey="uv" stroke="#ff7300" />
           </ComposedChart>
         </div>
+        
+        <p>A simple ComposedChart of Line, Bar with custom Hover fill and stroke</p>
+        <div className="composed-chart-wrapper">
+          <ComposedChart width={800} height={400} data={data}
+            margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+            cursorFill="#fff111" cursorStroke="green">
+            <XAxis dataKey="name"/>
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <CartesianGrid stroke="#f5f5f5" />
+            <Bar dataKey="pv" barSize={20} fill="#413ea0" />
+            <Line type="monotone" dataKey="pv" stroke="#ff7300" />
+          </ComposedChart>
+        </div>
       </div>
     );
   }

--- a/src/chart/ComposedChart.js
+++ b/src/chart/ComposedChart.js
@@ -29,6 +29,8 @@ class ComposedChart extends Component {
 
   static propTypes = {
     layout: PropTypes.oneOf(['horizontal', 'vertical']),
+    cursorFill: PropTypes.string,
+    cursorStroke: PropTypes.string,
     dataStartIndex: PropTypes.number,
     dataEndIndex: PropTypes.number,
     isTooltipActive: PropTypes.bool,
@@ -44,8 +46,15 @@ class ComposedChart extends Component {
     ]),
   };
 
+  static defaultProps = {
+    cursorFill: '#f1f1f1',
+    cursorStroke: '',
+  }
+
   renderCursor(xAxisMap, yAxisMap, offset) {
-    const { children, isTooltipActive, layout, activeTooltipIndex } = this.props;
+    const { children, isTooltipActive, layout, activeTooltipIndex
+            , cursorFill, cursorStroke } = this.props;
+
     const tooltipItem = findChildByType(children, Tooltip);
     if (!tooltipItem || !tooltipItem.props.cursor || !isTooltipActive ||
       activeTooltipIndex < 0) { return null; }
@@ -59,7 +68,8 @@ class ComposedChart extends Component {
     const bandSize = getBandSizeOfScale(axis.scale);
     const start = ticks[activeTooltipIndex].coordinate;
     const cursorProps = {
-      fill: '#f1f1f1',
+      fill: cursorFill,
+      stroke: cursorStroke,
       ...getPresentationAttributes(tooltipItem.props.cursor),
       x: layout === 'horizontal' ? start : offset.left + 0.5,
       y: layout === 'horizontal' ? offset.top + 0.5 : start,


### PR DESCRIPTION
When hovering over a bar on ComposedStack (or actually on all bars), the rectangle/cursor background effect should be customizable.

a unified and more global approach of doing this is highly appreciated, due to time constraints, I couldn't develop a global utility, I just fixed it on ComposedStack, any other volunteer?