### PR TITLE
ScatterChart axis are missing labels

### DIFF
--- a/src/chart/ScatterChart.js
+++ b/src/chart/ScatterChart.js
@@ -378,14 +378,9 @@ class ScatterChart extends Component {
       return (
         <Layer key={layerKey} className={layerKey}>
           <CartesianAxis
-            x={axis.x}
-            y={axis.y}
-            width={axis.width}
-            height={axis.height}
-            orientation={axis.orientation}
+            {...axis}
             viewBox={{ x: 0, y: 0, width, height }}
-            ticks={getTicksOfAxis(axis)}
-            tickFormatter={axis.tickFormatter}
+            ticks={getTicksOfAxis(axis, true)}
           />
         </Layer>
       );


### PR DESCRIPTION
**I noticed that the `label` property does not work when creating `ScatterChart`s, but yet works correctly when creating `LineChart`s.**

This seems to be [because `ScatterChart#renderAxis` does not share the same rendering logic to `LineChart`](https://github.com/recharts/recharts/blob/f9b5ed039f75da9135297c3fe7288a46647e996c/src/chart/ScatterChart.js#L371-L392). The latter seems to [share some logic between other similar charts and uses `generateCategoricalChart#renderAxes` to render its axes](https://github.com/recharts/recharts/blob/38b1f73942959f9221387cc5d50f5eea4b4eecaa/src/chart/generateCategoricalChart.js#L582-L587).

The simplest solution seemed to be to make sure that the logic within `ScatterChart#renderAxis` aligned with the logic within `generateCategoricalChart#renderAxes`.

Is there anything wrong with what I've done?

*NOTE: It makes sense to share a lot of the rendering logic, however I cannot refactor towards this since I do not understand your codebase well enough.*