### PR TITLE
Stopped domain calculation reverting to 0 for missing data points

### DIFF
--- a/src/util/CartesianUtils.js
+++ b/src/util/CartesianUtils.js
@@ -201,30 +201,26 @@ export const getDomainOfDataByKey = (data, key, type) => {
 };
 
 const getDomainOfSingle = (data) => (
-  data.reduce((result, entry) => {
-    const sanitizedEntry = entry.map((thisEntry, index) =>
-      (thisEntry !== null ? thisEntry : result[index])
-    );
-
-    return [
-      Math.min(result[0], sanitizedEntry[0], sanitizedEntry[1]),
-      Math.max(result[1], sanitizedEntry[0], sanitizedEntry[1]),
-    ];
-  }, [Infinity, -Infinity])
+  data.reduce((result, entry) => [
+    Math.min.apply(null, entry.concat([result[0]]).filter(_.isNumber)),
+    Math.max.apply(null, entry.concat([result[1]]).filter(_.isNumber)),
+  ], [Infinity, -Infinity])
 );
 
 export const getDomainOfStackGroups = (stackGroups, startIndex, endIndex) => (
-  Object.keys(stackGroups).reduce((result, stackId) => {
-    const group = stackGroups[stackId];
-    const { stackedData } = group;
-    const domain = stackedData.reduce((res, entry) => {
-      const s = getDomainOfSingle(entry.slice(startIndex, endIndex + 1));
+  Object.keys(stackGroups)
+    .reduce((result, stackId) => {
+      const group = stackGroups[stackId];
+      const { stackedData } = group;
+      const domain = stackedData.reduce((res, entry) => {
+        const s = getDomainOfSingle(entry.slice(startIndex, endIndex + 1));
 
-      return [Math.min(res[0], s[0]), Math.max(res[1], s[1])];
-    }, [Infinity, -Infinity]);
+        return [Math.min(res[0], s[0]), Math.max(res[1], s[1])];
+      }, [Infinity, -Infinity]);
 
-    return [Math.min(domain[0], result[0]), Math.max(domain[1], result[1])];
-  }, [Infinity, -Infinity])
+      return [Math.min(domain[0], result[0]), Math.max(domain[1], result[1])];
+    }, [Infinity, -Infinity])
+    .map(result => (result === Infinity || result === -Infinity ? 0 : result))
 );
 
 /**

--- a/src/util/CartesianUtils.js
+++ b/src/util/CartesianUtils.js
@@ -186,7 +186,9 @@ export const calculateDomainOfTicks = (ticks, type) => {
  */
 export const getDomainOfDataByKey = (data, key, type) => {
   if (type === 'number') {
-    const domain = data.map(entry => (_.isNumber(entry[key]) ? entry[key] : 0));
+    const domain = data
+      .map(entry => entry[key])
+      .filter(_.isNumber);
 
     return [Math.min.apply(null, domain), Math.max.apply(null, domain)];
   }
@@ -199,12 +201,16 @@ export const getDomainOfDataByKey = (data, key, type) => {
 };
 
 const getDomainOfSingle = (data) => (
-  data.reduce((result, entry) => (
-    [
-      Math.min(result[0], entry[0], entry[1]),
-      Math.max(result[1], entry[0], entry[1]),
-    ]
-  ), [Infinity, -Infinity])
+  data.reduce((result, entry) => {
+    const sanitizedEntry = entry.map((thisEntry, index) =>
+      (thisEntry !== null ? thisEntry : result[index])
+    );
+
+    return [
+      Math.min(result[0], sanitizedEntry[0], sanitizedEntry[1]),
+      Math.max(result[1], sanitizedEntry[0], sanitizedEntry[1]),
+    ];
+  }, [Infinity, -Infinity])
 );
 
 export const getDomainOfStackGroups = (stackGroups, startIndex, endIndex) => (

--- a/test/specs/util/CartesianUtilsSpec.js
+++ b/test/specs/util/CartesianUtilsSpec.js
@@ -1,6 +1,10 @@
-import { expect } from 'chai';
-import { calculateActiveTickIndex, calculateDomainOfTicks
- } from '../../../src/util/CartesianUtils';
+import {expect} from 'chai';
+import {
+  calculateActiveTickIndex,
+  calculateDomainOfTicks,
+  getDomainOfStackGroups,
+  getDomainOfDataByKey
+} from '../../../src/util/CartesianUtils';
 
 describe('calculateActiveTickIndex', () => {
   const ticks = [
@@ -34,6 +38,71 @@ describe('calculateDomainOfTicks', () => {
     const result = calculateDomainOfTicks(ticks, 'category');
     expect(result).to.deep.equal(ticks);
   });
-
 });
 
+describe('getDomainOfStackGroups', () => {
+  let stackData;
+
+  before(() => {
+    stackData = {
+      a: {
+        stackedData: [[[10, 14], [12, 16]], [[8, 14], [34, 11]]]
+      }
+      ,
+      b: {
+        stackedData: [[[9, 13], [11, 15]], [[12, 14], [25, 22]]]
+      }
+    };
+  });
+
+  it('correctly calculates the highest and lowest values in a stack of many values', () => {
+    expect(getDomainOfStackGroups(stackData, 0, 1)).to.deep.equal([8, 34]);
+  });
+
+  it('deals with a null value without assuming it should be === 0', () => {
+    stackData.a.stackedData[0][0][0] = null;
+
+    expect(getDomainOfStackGroups(stackData, 0, 1)).to.deep.equal([8, 34]);
+  });
+
+  it('domain of all nulls should return [0, 0]', () => {
+    stackData = {
+      a: {stackedData: [[[null, null]]]}
+    };
+
+    expect(getDomainOfStackGroups(stackData, 0, 1)).to.deep.equal([0, 0]);
+  });
+});
+
+describe('getDomainOfDataByKey', () => {
+  describe('with type === "number"', () => {
+    const data = [
+      {
+        "x": 1,
+        "actual": 35.4,
+        "benchmark": 35.4
+      }, {
+        "x": 2,
+        "actual": 40
+      }, {
+        "x": 3,
+        "actual": 40.7
+      }, {
+        "x": 4,
+        "actual": 42.5
+      }, {
+        "x": 5,
+        "benchmark": 31.86
+      }
+    ];
+
+    it('should calculate the correct domain for a simple linear set', () => {
+      expect(getDomainOfDataByKey(data, 'x', 'number')).to.deep.equal([1, 5]);
+    });
+
+    it('should calculate the correct domain even if there is no data for certain items in the set', () => {
+      expect(getDomainOfDataByKey(data, 'actual', 'number')).to.deep.equal([35.4, 42.5]);
+      expect(getDomainOfDataByKey(data, 'benchmark', 'number')).to.deep.equal([31.86, 35.4]);
+    });
+  });
+});


### PR DESCRIPTION
Thanks for creating this library!

I've just started using it and I've had trouble charting two datasets against each other that don't have exactly overlapping data points (e.g. 1/1/2010 has a value for one line, 1/2/2010 has a value for the other line etc) - fortunately I can use `connectNulls` to make the lines make sense, but the axis always starts from 0 even if I override it.

This is because domain calculation makes use of `Math.max|min` and javascript thinks that `null` is `0`. This PR simply excludes null data from domain calculation, reverting to `0` only if there's no other data to go off whatsoever.