### PR TITLE
allow label function to return a string

### DIFF
--- a/src/polar/Pie.js
+++ b/src/polar/Pie.js
@@ -250,8 +250,13 @@ class Pie extends Component {
   renderLabelItem(option, props, value) {
     if (React.isValidElement(option)) {
       return React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
-      return option(props);
+    }
+    let label = value;
+    if (_.isFunction(option)) {
+      label = option(props);
+      if (React.isValidElement(label)) {
+        return label;
+      }
     }
 
     return (
@@ -260,7 +265,7 @@ class Pie extends Component {
         alignmentBaseline="middle"
         className="recharts-pie-label-text"
       >
-        {value}
+        {label}
       </text>
     );
   }

--- a/test/specs/polar/PieSpec.js
+++ b/test/specs/polar/PieSpec.js
@@ -138,6 +138,29 @@ describe('<Pie />', () => {
     expect(wrapper.find('.customized-label').length).to.equal(data.length);
   });
 
+  it('Render customized label when label is set to be a function that returns the label text', () => {
+    const Label = (props) => {
+      const { name, value } = props;
+      return `${name}: ${value}`;
+    };
+    const wrapper = render(
+      <Surface width={500} height={500}>
+        <Pie
+          isAnimationActive={false}
+          cx={250}
+          cy={250}
+          label={Label}
+          innerRadius={0}
+          outerRadius={200}
+          data={data}
+        />
+      </Surface>
+    );
+
+    expect(wrapper.find('.recharts-pie-label-text').length).to.equal(data.length);
+    expect(wrapper.find('.recharts-pie-label-text').first().text()).to.equal('A: 40');
+  });
+
   it('Render customized label when label is set to be a react element', () => {
     const renderLabel = (props) => {
       const { x, y } = props;


### PR DESCRIPTION
This allows for easier custom label generation, like in
```jsx
<Pie data={chartData} label={(name, value)=>`${name}: ${value}`} />
```
This addresses only the pie chart, but it should be easy to port the change to the other chart types.