### PR TITLE
Domain support for categorical axes

### DIFF
--- a/demo/component/LineChart.js
+++ b/demo/component/LineChart.js
@@ -175,15 +175,15 @@ export default React.createClass({
           </LineChart>
         </div>
 
-        {/*<p>LineChart with category range</p>
+        <p>LineChart with category range</p>
         <div className="line-chart-wrapper">
           <LineChart width={400} height={400} data={data}>
-            <XAxis type="category" dataKey="name" domain={[0, 7]} />
+            <XAxis type="category" dataKey="name" domain={[-2, 7]} />
             <YAxis type="number" />
             <Tooltip />
             <Line dataKey="uv" type="monotone" stroke="#387908" strokeWidth={2} />
           </LineChart>
-        </div>*/}
+        </div>
 
         <p>LineChart of discrete values</p>
         <div className='line-chart-wrapper'>

--- a/demo/component/LineChart.js
+++ b/demo/component/LineChart.js
@@ -175,6 +175,16 @@ export default React.createClass({
           </LineChart>
         </div>
 
+        {/*<p>LineChart with category range</p>
+        <div className="line-chart-wrapper">
+          <LineChart width={400} height={400} data={data}>
+            <XAxis type="category" dataKey="name" domain={[0, 7]} />
+            <YAxis type="number" />
+            <Tooltip />
+            <Line dataKey="uv" type="monotone" stroke="#387908" strokeWidth={2} />
+          </LineChart>
+        </div>*/}
+
         <p>LineChart of discrete values</p>
         <div className='line-chart-wrapper'>
           <LineChart width={400} height={400} data={data01} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>

--- a/src/chart/AreaChart.js
+++ b/src/chart/AreaChart.js
@@ -31,6 +31,7 @@ class AreaChart extends Component {
     data: PropTypes.array,
     isTooltipActive: PropTypes.bool,
     activeTooltipIndex: PropTypes.number,
+    activePointIndex: PropTypes.number,
     xAxisMap: PropTypes.object,
     yAxisMap: PropTypes.object,
     offset: PropTypes.object,
@@ -180,7 +181,7 @@ class AreaChart extends Component {
    * @return {ReactComponent} The instances of Area
    */
   renderItems(items, xAxisMap, yAxisMap, offset, stackGroups) {
-    const { children, layout, isTooltipActive, activeTooltipIndex } = this.props;
+    const { children, layout, isTooltipActive, activePointIndex } = this.props;
     const tooltipItem = findChildByType(children, Tooltip);
     const hasDot = tooltipItem && isTooltipActive;
     const dotItems = [];
@@ -195,7 +196,7 @@ class AreaChart extends Component {
       const composeData = this.getComposedData(
         xAxisMap[xAxisId], yAxisMap[yAxisId], dataKey, stackedData
       );
-      const activePoint = composeData.points && composeData.points[activeTooltipIndex];
+      const activePoint = composeData.points && composeData.points[activePointIndex];
 
       if (hasDot && activeDot && activePoint) {
         const dotProps = {

--- a/src/chart/AreaChart.js
+++ b/src/chart/AreaChart.js
@@ -8,7 +8,7 @@ import Dot from '../shape/Dot';
 import Curve from '../shape/Curve';
 import { getPresentationAttributes, findChildByType,
   findAllByType, validateWidthHeight } from '../util/ReactUtils';
-import { getTicksOfAxis, getStackedDataOfItem,
+import { getCoordinateOfTicks, getTicksOfAxis, getStackedDataOfItem,
   getMainColorOfGraphicItem } from '../util/CartesianUtils';
 import generateCategoricalChart from './generateCategoricalChart';
 import Area from '../cartesian/Area';
@@ -67,7 +67,7 @@ class AreaChart extends Component {
 
       if (layout === 'horizontal') {
         return {
-          x: xTicks[index].coordinate + bandSize / 2,
+          x: getCoordinateOfTicks(xTicks, index, bandSize),
           y: _.isNumber(value[1]) ? yAxis.scale(value[1]) : null,
           value,
         };
@@ -75,7 +75,7 @@ class AreaChart extends Component {
 
       return {
         x: _.isNumber(value[1]) ? xAxis.scale(value[1]) : null,
-        y: yTicks[index].coordinate + bandSize / 2,
+        y: getCoordinateOfTicks(yTicks, index, bandSize),
         value,
       };
     });

--- a/src/chart/AreaChart.js
+++ b/src/chart/AreaChart.js
@@ -13,7 +13,8 @@ import { getCoordinateOfTicks, getTicksOfAxis, getStackedDataOfItem,
 import generateCategoricalChart from './generateCategoricalChart';
 import Area from '../cartesian/Area';
 import pureRender from '../util/PureRender';
-import { getBandSizeOfScale, getAnyElementOfObject } from '../util/DataUtils';
+import { getBandSizeOfScale, getCategoryOffsetOfDomain,
+  getAnyElementOfObject } from '../util/DataUtils';
 import _ from 'lodash';
 import Smooth from 'react-smooth';
 import AnimationDecorator from '../util/AnimationDecorator';
@@ -58,7 +59,9 @@ class AreaChart extends Component {
     const data = this.props.data.slice(dataStartIndex, dataEndIndex + 1);
     const xTicks = getTicksOfAxis(xAxis);
     const yTicks = getTicksOfAxis(yAxis);
-    const bandSize = getBandSizeOfScale(layout === 'horizontal' ? xAxis.scale : yAxis.scale);
+    const categoricalAxis = layout === 'horizontal' ? xAxis : yAxis;
+    const bandSize = getBandSizeOfScale(categoricalAxis.scale);
+    const categoryOffset = getCategoryOffsetOfDomain(categoricalAxis.domain);
     const hasStack = stackedData && stackedData.length;
     const baseValue = this.getBaseValue(xAxis, yAxis);
 
@@ -67,7 +70,7 @@ class AreaChart extends Component {
 
       if (layout === 'horizontal') {
         return {
-          x: getCoordinateOfTicks(xTicks, index, bandSize),
+          x: getCoordinateOfTicks(xTicks, index + categoryOffset, bandSize),
           y: _.isNumber(value[1]) ? yAxis.scale(value[1]) : null,
           value,
         };
@@ -75,7 +78,7 @@ class AreaChart extends Component {
 
       return {
         x: _.isNumber(value[1]) ? xAxis.scale(value[1]) : null,
-        y: getCoordinateOfTicks(yTicks, index, bandSize),
+        y: getCoordinateOfTicks(yTicks, index + categoryOffset, bandSize),
         value,
       };
     });

--- a/src/chart/BarChart.js
+++ b/src/chart/BarChart.js
@@ -29,6 +29,7 @@ class BarChart extends Component {
     data: PropTypes.array,
     isTooltipActive: PropTypes.bool,
     activeTooltipIndex: PropTypes.number,
+    activePointIndex: PropTypes.number,
     xAxisMap: PropTypes.object,
     yAxisMap: PropTypes.object,
     offset: PropTypes.object,

--- a/src/chart/BarChart.js
+++ b/src/chart/BarChart.js
@@ -5,14 +5,15 @@ import React, { PropTypes, Component } from 'react';
 import Layer from '../container/Layer';
 import Tooltip from '../component/Tooltip';
 import Rectangle from '../shape/Rectangle';
-import { getPercentValue, getBandSizeOfScale, getAnyElementOfObject } from '../util/DataUtils';
+import { getPercentValue, getBandSizeOfScale, getCategoryOffsetOfDomain,
+  getAnyElementOfObject } from '../util/DataUtils';
 import { getPresentationAttributes, findChildByType, findAllByType,
   validateWidthHeight, filterEventAttributes } from '../util/ReactUtils';
 import generateCategoricalChart from './generateCategoricalChart';
 import Cell from '../component/Cell';
 import Bar from '../cartesian/Bar';
 import pureRender from '../util/PureRender';
-import { getTicksOfAxis, getStackedDataOfItem } from '../util/CartesianUtils';
+import { getCoordinateOfTicks, getTicksOfAxis, getStackedDataOfItem } from '../util/CartesianUtils';
 import AnimationDecorator from '../util/AnimationDecorator';
 
 @AnimationDecorator
@@ -67,9 +68,11 @@ class BarChart extends Component {
     const data = this.props.data.slice(dataStartIndex, dataEndIndex + 1);
     const xTicks = getTicksOfAxis(xAxis);
     const yTicks = getTicksOfAxis(yAxis);
+    const categoricalAxis = layout === 'horizontal' ? xAxis : yAxis;
     const baseValue = this.getBaseValue(xAxis, yAxis);
     const hasStack = stackedData && stackedData.length;
     const cells = findAllByType(children, Cell);
+    const categoryOffset = getCategoryOffsetOfDomain(categoricalAxis.domain);
 
     return data.map((entry, index) => {
       const value = stackedData ? stackedData[dataStartIndex + index] : [baseValue, entry[dataKey]];
@@ -79,7 +82,7 @@ class BarChart extends Component {
       let height;
 
       if (layout === 'horizontal') {
-        x = xTicks[index].coordinate + pos.offset;
+        x = getCoordinateOfTicks(xTicks, index + categoryOffset, pos.offset * 2);
         y = yAxis.scale(xAxis.orientation === 'top' ? value[0] : value[1]);
         width = pos.size;
         height = xAxis.orientation === 'top' ?
@@ -93,7 +96,7 @@ class BarChart extends Component {
         }
       } else {
         x = xAxis.scale(yAxis.orientation === 'left' ? value[0] : value[1]);
-        y = yTicks[index].coordinate + pos.offset;
+        y = getCoordinateOfTicks(yTicks, index + categoryOffset, pos.offset * 2);
         width = yAxis.orientation === 'left' ?
                 xAxis.scale(value[1]) - xAxis.scale(value[0]) :
                 xAxis.scale(value[0]) - xAxis.scale(value[1]);

--- a/src/chart/LineChart.js
+++ b/src/chart/LineChart.js
@@ -31,6 +31,7 @@ class LineChart extends Component {
     data: PropTypes.array,
     isTooltipActive: PropTypes.bool,
     activeTooltipIndex: PropTypes.number,
+    activePointIndex: PropTypes.number,
     xAxisMap: PropTypes.object,
     yAxisMap: PropTypes.object,
     offset: PropTypes.object,
@@ -140,7 +141,7 @@ class LineChart extends Component {
    * @return {ReactComponent}  All the instances of Line
    */
   renderItems(items, xAxisMap, yAxisMap, offset) {
-    const { children, layout, isTooltipActive, activeTooltipIndex, animationId } = this.props;
+    const { children, layout, isTooltipActive, activePointIndex, animationId } = this.props;
     const tooltipItem = findChildByType(children, Tooltip);
     const hasDot = tooltipItem && isTooltipActive;
     const dotItems = [];
@@ -148,7 +149,7 @@ class LineChart extends Component {
     const lineItems = items.map((child, i) => {
       const { xAxisId, yAxisId, dataKey, stroke, activeDot } = child.props;
       const points = this.getComposedData(xAxisMap[xAxisId], yAxisMap[yAxisId], dataKey);
-      const activePoint = points[activeTooltipIndex];
+      const activePoint = points[activePointIndex];
 
       if (hasDot && activeDot && activePoint) {
         const dotProps = {

--- a/src/chart/LineChart.js
+++ b/src/chart/LineChart.js
@@ -11,7 +11,7 @@ import Line from '../cartesian/Line';
 import { getPresentationAttributes, findChildByType,
   findAllByType, validateWidthHeight } from '../util/ReactUtils';
 import pureRender from '../util/PureRender';
-import { getTicksOfAxis } from '../util/CartesianUtils';
+import { getCoordinateOfTicks, getTicksOfAxis } from '../util/CartesianUtils';
 import { getBandSizeOfScale, getAnyElementOfObject } from '../util/DataUtils';
 import _ from 'lodash';
 import Smooth from 'react-smooth';
@@ -62,7 +62,7 @@ class LineChart extends Component {
 
       if (layout === 'horizontal') {
         return {
-          x: xTicks[index].coordinate + bandSize / 2,
+          x: getCoordinateOfTicks(xTicks, index, bandSize),
           y: _.isNumber(value) ? yAxis.scale(value) : null,
           value,
         };
@@ -70,7 +70,7 @@ class LineChart extends Component {
 
       return {
         x: _.isNumber(value) ? xAxis.scale(value) : null,
-        y: yTicks[index].coordinate + bandSize / 2,
+        y: getCoordinateOfTicks(yTicks, index, bandSize),
         value,
       };
     });

--- a/src/chart/LineChart.js
+++ b/src/chart/LineChart.js
@@ -12,7 +12,8 @@ import { getPresentationAttributes, findChildByType,
   findAllByType, validateWidthHeight } from '../util/ReactUtils';
 import pureRender from '../util/PureRender';
 import { getCoordinateOfTicks, getTicksOfAxis } from '../util/CartesianUtils';
-import { getBandSizeOfScale, getAnyElementOfObject } from '../util/DataUtils';
+import { getBandSizeOfScale, getCategoryOffsetOfDomain,
+  getAnyElementOfObject } from '../util/DataUtils';
 import _ from 'lodash';
 import Smooth from 'react-smooth';
 import AnimationDecorator from '../util/AnimationDecorator';
@@ -53,7 +54,9 @@ class LineChart extends Component {
   getComposedData(xAxis, yAxis, dataKey) {
     const { layout, dataStartIndex, dataEndIndex, isComposed } = this.props;
     const data = this.props.data.slice(dataStartIndex, dataEndIndex + 1);
-    const bandSize = getBandSizeOfScale(layout === 'horizontal' ? xAxis.scale : yAxis.scale);
+    const categoricalAxis = layout === 'horizontal' ? xAxis : yAxis;
+    const bandSize = getBandSizeOfScale(categoricalAxis.scale);
+    const categoryOffset = getCategoryOffsetOfDomain(categoricalAxis.domain);
     const xTicks = getTicksOfAxis(xAxis);
     const yTicks = getTicksOfAxis(yAxis);
 
@@ -62,7 +65,7 @@ class LineChart extends Component {
 
       if (layout === 'horizontal') {
         return {
-          x: getCoordinateOfTicks(xTicks, index, bandSize),
+          x: getCoordinateOfTicks(xTicks, index + categoryOffset, bandSize),
           y: _.isNumber(value) ? yAxis.scale(value) : null,
           value,
         };
@@ -70,7 +73,7 @@ class LineChart extends Component {
 
       return {
         x: _.isNumber(value) ? xAxis.scale(value) : null,
-        y: getCoordinateOfTicks(yTicks, index, bandSize),
+        y: getCoordinateOfTicks(yTicks, index + categoryOffset, bandSize),
         value,
       };
     });

--- a/src/chart/RadarChart.js
+++ b/src/chart/RadarChart.js
@@ -134,7 +134,7 @@ class RadarChart extends Component {
 
       return [Math.min(prev[0], currentMin), Math.max(prev[1], currentMax)];
     }, [Infinity, -Infinity]);
-    const finalDomain = parseSpecifiedDomain(domain, extent, allowDataOverflow);
+    const finalDomain = parseSpecifiedDomain(domain, extent, allowDataOverflow, false);
 
     if (domain && (domain[0] === 'auto' || domain[1] === 'auto')) {
       return getNiceTickValues(finalDomain, tickCount);

--- a/src/chart/ScatterChart.js
+++ b/src/chart/ScatterChart.js
@@ -124,7 +124,8 @@ class ScatterChart extends Component {
       const domain = parseSpecifiedDomain(
         axis.props.domain,
         this.getDomain(items, axis.props.dataKey, axis.props[`${axisType}Id`], axisType),
-        axis.props.allowDataOverflow
+        axis.props.allowDataOverflow,
+        false
       );
 
       return {

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -345,12 +345,14 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
       const pos = layout === 'horizontal' ? e.chartX : e.chartY;
       const axis = getAnyElementOfObject(axisMap);
       const ticks = getTicksOfAxis(axis, false, true);
+      const categoryOffset = getCategoryOffsetOfDomain(axis.domain);
       const activeIndex = calculateActiveTickIndex(pos, ticks);
 
       if (activeIndex >= 0) {
         return {
           ...e,
           activeTooltipIndex: activeIndex,
+          activePointIndex: activeIndex - categoryOffset,
         };
       }
 
@@ -363,13 +365,11 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
      * @return {Array}       The content of tooltip
      */
     getTooltipContent(items, axis) {
-      const { activeTooltipIndex, dataStartIndex, dataEndIndex } = this.state;
+      const { activeTooltipIndex, activePointIndex, dataStartIndex, dataEndIndex } = this.state;
       const data = this.props.data.slice(dataStartIndex, dataEndIndex + 1);
-      const categoryOffset = getCategoryOffsetOfDomain(axis.domain);
-      const dataIndex = activeTooltipIndex - categoryOffset;
 
-      if (dataIndex < 0 || !items || !items.length
-        || dataIndex >= data.length) {
+      if (activePointIndex < 0 || !items || !items.length
+        || activePointIndex >= data.length) {
         return null;
       }
 
@@ -381,8 +381,8 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
           dataKey, unit, formatter,
           name: name || dataKey,
           color: getMainColorOfGraphicItem(child),
-          value: data[dataIndex][dataKey],
-          payload: data[dataIndex],
+          value: data[activePointIndex][dataKey],
+          payload: data[activePointIndex],
         };
       });
     }
@@ -398,6 +398,7 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
         dataStartIndex: 0,
         dataEndIndex: (props.data && (props.data.length - 1)) || 0,
         activeTooltipIndex: -1,
+        activePointIndex: -1,
         isTooltipActive: false,
       };
     }

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -22,7 +22,8 @@ import YAxis from '../cartesian/YAxis';
 import Brush from '../cartesian/Brush';
 import pureRender from '../util/PureRender';
 import { getOffset, calculateChartCoordinate } from '../util/DOMUtils';
-import { parseSpecifiedDomain, getAnyElementOfObject, hasDuplicate } from '../util/DataUtils';
+import { parseSpecifiedDomain, getCategoryOffsetOfDomain,
+  getAnyElementOfObject, hasDuplicate } from '../util/DataUtils';
 import { calculateDomainOfTicks, calculateActiveTickIndex,
   detectReferenceElementsDomain, getMainColorOfGraphicItem, getDomainOfStackGroups,
   getDomainOfDataByKey, getLegendProps, getDomainOfItemsWithSameAxis, getCoordinatesOfGrid,
@@ -357,14 +358,17 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
     /**
      * Get the content to be displayed in the tooltip
      * @param  {Array} items The instances of item
+     * @param  {Object} axis Instance of the categorical axis.
      * @return {Array}       The content of tooltip
      */
-    getTooltipContent(items) {
+    getTooltipContent(items, axis) {
       const { activeTooltipIndex, dataStartIndex, dataEndIndex } = this.state;
       const data = this.props.data.slice(dataStartIndex, dataEndIndex + 1);
+      const categoryOffset = getCategoryOffsetOfDomain(axis.domain);
+      const dataIndex = activeTooltipIndex - categoryOffset;
 
-      if (activeTooltipIndex < 0 || !items || !items.length
-        || activeTooltipIndex >= data.length) {
+      if (dataIndex < 0 || !items || !items.length
+        || dataIndex >= data.length) {
         return null;
       }
 
@@ -376,8 +380,8 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
           dataKey, unit, formatter,
           name: name || dataKey,
           color: getMainColorOfGraphicItem(child),
-          value: data[activeTooltipIndex][dataKey],
-          payload: data[activeTooltipIndex],
+          value: data[dataIndex][dataKey],
+          payload: data[dataIndex],
         };
       });
     }
@@ -678,7 +682,7 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
         viewBox,
         active: isTooltipActive,
         label: ticks[activeTooltipIndex] && ticks[activeTooltipIndex].value,
-        payload: isTooltipActive ? this.getTooltipContent(items) : [],
+        payload: isTooltipActive ? this.getTooltipContent(items, axis) : [],
         coordinate: ticks[activeTooltipIndex] ? {
           x: layout === 'horizontal' ? ticks[activeTooltipIndex].coordinate : validateChartX,
           y: layout === 'horizontal' ? validateChartY : ticks[activeTooltipIndex].coordinate,

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -148,7 +148,7 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
             domain = getDomainOfStackGroups(
               stackGroups[axisId].stackGroups, dataStartIndex, dataEndIndex
             );
-          } else if (isCategorial) {
+          } else if (type === 'category') {
             domain = _.range(0, len);
           } else {
             domain = getDomainOfItemsWithSameAxis(
@@ -158,10 +158,9 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
           if (type === 'number') {
             // To detect wether there is any reference lines whose props alwaysShow is true
             domain = detectReferenceElementsDomain(children, domain, axisId, axisType);
-
-            if (child.props.domain) {
-              domain = parseSpecifiedDomain(child.props.domain, domain, allowDataOverflow);
-            }
+          }
+          if (child.props.domain) {
+            domain = parseSpecifiedDomain(child.props.domain, domain, allowDataOverflow);
           }
 
           return {

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -27,7 +27,7 @@ import { parseSpecifiedDomain, getCategoryOffsetOfDomain,
 import { calculateDomainOfTicks, calculateActiveTickIndex,
   detectReferenceElementsDomain, getMainColorOfGraphicItem, getDomainOfStackGroups,
   getDomainOfDataByKey, getLegendProps, getDomainOfItemsWithSameAxis, getCoordinatesOfGrid,
-  getStackGroupsByAxisId, getTicksOfAxis, isCategorialAxis, getTicksOfScale,
+  getStackGroupsByAxisId, getTicksOfAxis, isCategoricalAxis, getTicksOfScale,
 } from '../util/CartesianUtils';
 import { eventCenter, SYNC_EVENT } from '../util/Events';
 
@@ -126,7 +126,7 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
       const { dataEndIndex, dataStartIndex } = this.state;
       const displayedData = data.slice(dataStartIndex, dataEndIndex + 1);
       const len = displayedData.length;
-      const isCategorial = isCategorialAxis(layout, axisType);
+      const isCategorical = isCategoricalAxis(layout, axisType);
 
       // Eliminate duplicated axes
       const axisMap = axes.reduce((result, child) => {
@@ -149,7 +149,7 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
             domain = getDomainOfStackGroups(
               stackGroups[axisId].stackGroups, dataStartIndex, dataEndIndex
             );
-          } else if (isCategorial) {
+          } else if (isCategorical) {
             domain = _.range(0, len);
           } else {
             domain = getDomainOfItemsWithSameAxis(
@@ -161,7 +161,9 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
             domain = detectReferenceElementsDomain(children, domain, axisId, axisType);
           }
           if (child.props.domain) {
-            domain = parseSpecifiedDomain(child.props.domain, domain, allowDataOverflow);
+            domain = parseSpecifiedDomain(
+                child.props.domain, domain, allowDataOverflow, isCategorical
+            );
           }
 
           return {
@@ -196,7 +198,7 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
       const { dataEndIndex, dataStartIndex } = this.state;
       const displayedData = data.slice(dataStartIndex, dataEndIndex + 1);
       const len = displayedData.length;
-      const isCategorial = isCategorialAxis(layout, axisType);
+      const isCategorical = isCategoricalAxis(layout, axisType);
       let index = -1;
 
       // The default type of x-axis is category axis,
@@ -210,7 +212,7 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
           index++;
           let domain;
 
-          if (isCategorial) {
+          if (isCategorical) {
             domain = _.range(0, len);
           } else if (stackGroups && stackGroups[axisId] && stackGroups[axisId].hasStack) {
             domain = getDomainOfStackGroups(
@@ -223,7 +225,8 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
                 displayedData,
                 items.filter(entry => entry.props[axisIdKey] === axisId), 'number'
               ),
-              Axis.defaultProps.allowDataOverflow
+              Axis.defaultProps.allowDataOverflow,
+              isCategorical
             );
             domain = detectReferenceElementsDomain(children, domain, axisId, axisType);
           }

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -122,10 +122,11 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
      * @return {Object}      Configuration
      */
     getAxisMapByAxes(axes, items, axisType, axisIdKey, stackGroups) {
-      const { children, data } = this.props;
+      const { layout, children, data } = this.props;
       const { dataEndIndex, dataStartIndex } = this.state;
       const displayedData = data.slice(dataStartIndex, dataEndIndex + 1);
       const len = displayedData.length;
+      const isCategorial = isCategorialAxis(layout, axisType);
 
       // Eliminate duplicated axes
       const axisMap = axes.reduce((result, child) => {
@@ -148,7 +149,7 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
             domain = getDomainOfStackGroups(
               stackGroups[axisId].stackGroups, dataStartIndex, dataEndIndex
             );
-          } else if (type === 'category') {
+          } else if (isCategorial) {
             domain = _.range(0, len);
           } else {
             domain = getDomainOfItemsWithSameAxis(

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -121,11 +121,10 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
      * @return {Object}      Configuration
      */
     getAxisMapByAxes(axes, items, axisType, axisIdKey, stackGroups) {
-      const { layout, children, data } = this.props;
+      const { children, data } = this.props;
       const { dataEndIndex, dataStartIndex } = this.state;
       const displayedData = data.slice(dataStartIndex, dataEndIndex + 1);
       const len = displayedData.length;
-      const isCategorial = isCategorialAxis(layout, axisType);
 
       // Eliminate duplicated axes
       const axisMap = axes.reduce((result, child) => {

--- a/src/util/CartesianUtils.js
+++ b/src/util/CartesianUtils.js
@@ -322,6 +322,18 @@ export const getTicksOfAxis = (axis, isGrid, isAll) => {
   ));
 };
 
+/**
+ * Returns the coordinate of a tick at a given index or null if not found.
+ * @param {Array} ticks A list of ticks. Can be obtained using `getTicksOfAxis`.
+ * @param {Number} index Index of the tick to obtain the coordinate from.
+ * @param {Number} bandSize Size of the space reserved for one data point.
+ * @return {Number|null} Either tick coordinate or null if tick wasn't found.
+ */
+export const getCoordinateOfTicks = (ticks, index, bandSize) => {
+  const tick = ticks[index];
+  return tick.coordinate + bandSize / 2;
+};
+
 export const calculateActiveTickIndex = (coordinate, ticks) => {
   let index = -1;
   const len = ticks.length;
@@ -415,4 +427,3 @@ export const getTicksOfScale = (scale, opts) => {
 
   return null;
 };
-

--- a/src/util/CartesianUtils.js
+++ b/src/util/CartesianUtils.js
@@ -255,7 +255,7 @@ export const getDomainOfItemsWithSameAxis = (data, items, type) => {
   }, []);
 };
 
-export const isCategorialAxis = (layout, axisType) => (
+export const isCategoricalAxis = (layout, axisType) => (
   (layout === 'horizontal' && axisType === 'xAxis') ||
   (layout === 'vertical' && axisType === 'yAxis')
 );

--- a/src/util/CartesianUtils.js
+++ b/src/util/CartesianUtils.js
@@ -331,7 +331,7 @@ export const getTicksOfAxis = (axis, isGrid, isAll) => {
  */
 export const getCoordinateOfTicks = (ticks, index, bandSize) => {
   const tick = ticks[index];
-  return tick.coordinate + bandSize / 2;
+  return tick ? tick.coordinate + bandSize / 2 : null;
 };
 
 export const calculateActiveTickIndex = (coordinate, ticks) => {

--- a/src/util/DataUtils.js
+++ b/src/util/DataUtils.js
@@ -46,11 +46,11 @@ export const parseSpecifiedDomain = (specifiedDomain, dataDomain, allowDataOverf
   let domain;
   let domainMin;
   let domainMax;
-  const specifiedDomainMin = specifiedDomain[0];
-  const dataDomainMin = dataDomain[0];
-  const specifiedDomainMax = _.last(specifiedDomain);
-  const dataDomainMax = _.last(dataDomain);
   const isCategorical = dataDomain.length !== 2;
+  const specifiedDomainMin = specifiedDomain[0];
+  const dataDomainMin = isCategorical ? 0 : dataDomain[0];
+  const specifiedDomainMax = specifiedDomain[1];
+  const dataDomainMax = isCategorical ? dataDomain.length - 1 : dataDomain[1];
 
   if (_.isNumber(specifiedDomainMin)) {
     domainMin = allowDataOverflow ?
@@ -75,7 +75,14 @@ export const parseSpecifiedDomain = (specifiedDomain, dataDomain, allowDataOverf
   }
 
   if (isCategorical) {
-    domain = _.range(domainMin, domainMax + 1);
+    domain = [
+      ...(domainMin < dataDomainMin ? _.range(domainMin, dataDomainMin) : []),
+      ...(allowDataOverflow ? dataDomain.slice(
+        Math.max(domainMin, dataDomainMin),
+        Math.min(domainMax, dataDomainMax) + 1
+      ) : dataDomain),
+      ...(dataDomainMax < domainMax ? _.range(dataDomainMax + 1, domainMax + 1) : []),
+    ];
   } else {
     domain = [domainMin, domainMax];
   }

--- a/src/util/DataUtils.js
+++ b/src/util/DataUtils.js
@@ -115,6 +115,16 @@ export const getBandSizeOfScale = (scale) => {
   return 0;
 };
 
+/**
+ * Returns the index offset for categories. Applicable for domains
+ * extending before the first category.
+ * @param {Array} domain Domain of the categorical axis.
+ * @return {Number} index offset of the data.
+ */
+export const getCategoryOffsetOfDomain = (domain) => {
+  const first = domain[0];
+  return _.isNumber(first) ? Math.max(-domain[0], 0) : 0;
+};
 
 export const getAnyElementOfObject = (obj) => {
   if (!obj) { return null; }

--- a/src/util/DataUtils.js
+++ b/src/util/DataUtils.js
@@ -43,29 +43,41 @@ export const parseSpecifiedDomain = (specifiedDomain, dataDomain, allowDataOverf
   if (!_.isArray(specifiedDomain)) {
     return dataDomain;
   }
+  let domain;
+  let domainMin;
+  let domainMax;
+  const specifiedDomainMin = specifiedDomain[0];
+  const dataDomainMin = dataDomain[0];
+  const specifiedDomainMax = _.last(specifiedDomain);
+  const dataDomainMax = _.last(dataDomain);
+  const isCategorical = dataDomain.length !== 2;
 
-  const domain = [];
+  if (_.isNumber(specifiedDomainMin)) {
+    domainMin = allowDataOverflow ?
+      specifiedDomainMin : Math.min(specifiedDomainMin, dataDomainMin);
+  } else if (MIN_VALUE_REG.test(specifiedDomainMin)) {
+    const value = +MIN_VALUE_REG.exec(specifiedDomainMin)[1];
 
-  if (_.isNumber(specifiedDomain[0])) {
-    domain[0] = allowDataOverflow ?
-      specifiedDomain[0] : Math.min(specifiedDomain[0], dataDomain[0]);
-  } else if (MIN_VALUE_REG.test(specifiedDomain[0])) {
-    const value = +MIN_VALUE_REG.exec(specifiedDomain[0])[1];
-
-    domain[0] = dataDomain[0] - value;
+    domainMin = dataDomainMin - value;
   } else {
-    domain[0] = dataDomain[0];
+    domainMin = dataDomainMin;
   }
 
-  if (_.isNumber(specifiedDomain[1])) {
-    domain[1] = allowDataOverflow ?
-      specifiedDomain[1] : Math.max(specifiedDomain[1], dataDomain[1]);
-  } else if (MAX_VALUE_REG.test(specifiedDomain[1])) {
-    const value = +MAX_VALUE_REG.exec(specifiedDomain[1])[1];
+  if (_.isNumber(specifiedDomainMax)) {
+    domainMax = allowDataOverflow ?
+      specifiedDomainMax : Math.max(specifiedDomainMax, dataDomainMax);
+  } else if (MAX_VALUE_REG.test(specifiedDomainMax)) {
+    const value = +MAX_VALUE_REG.exec(specifiedDomainMax)[1];
 
-    domain[1] = dataDomain[1] + value;
+    domainMax = dataDomainMax + value;
   } else {
-    domain[1] = dataDomain[1];
+    domainMax = dataDomainMax;
+  }
+
+  if (isCategorical) {
+    domain = _.range(domainMin, domainMax + 1);
+  } else {
+    domain = [domainMin, domainMax];
   }
 
   return domain;

--- a/src/util/DataUtils.js
+++ b/src/util/DataUtils.js
@@ -123,7 +123,7 @@ export const getBandSizeOfScale = (scale) => {
  */
 export const getCategoryOffsetOfDomain = (domain) => {
   const first = domain[0];
-  return _.isNumber(first) ? Math.max(-domain[0], 0) : 0;
+  return _.isNumber(first) ? Math.max(-first, 0) : 0;
 };
 
 export const getAnyElementOfObject = (obj) => {

--- a/src/util/DataUtils.js
+++ b/src/util/DataUtils.js
@@ -39,14 +39,15 @@ export const getPercentValue = (percent, totalValue, defaultValue = 0, validate 
 const MIN_VALUE_REG = /^dataMin[\s]*-[\s]*([\d]+)$/;
 const MAX_VALUE_REG = /^dataMax[\s]*\+[\s]*([\d]+)$/;
 
-export const parseSpecifiedDomain = (specifiedDomain, dataDomain, allowDataOverflow) => {
+export const parseSpecifiedDomain = (
+    specifiedDomain, dataDomain, allowDataOverflow, isCategorical
+) => {
   if (!_.isArray(specifiedDomain)) {
     return dataDomain;
   }
   let domain;
   let domainMin;
   let domainMax;
-  const isCategorical = dataDomain.length !== 2;
   const specifiedDomainMin = specifiedDomain[0];
   const dataDomainMin = isCategorical ? 0 : dataDomain[0];
   const specifiedDomainMax = specifiedDomain[1];

--- a/test/specs/chart/AreaChartSpec.js
+++ b/test/specs/chart/AreaChartSpec.js
@@ -47,6 +47,7 @@ describe('<AreaChart />', () => {
     wrapper.setState({
       isTooltipActive: true,
       activeTooltipIndex: 4,
+      activePointIndex: 4,
       activeTooltipLabel: 4,
       activeTooltipCoord: {
         x: 95,

--- a/test/specs/chart/LineChartSpec.js
+++ b/test/specs/chart/LineChartSpec.js
@@ -48,6 +48,7 @@ describe('<LineChart />', () => {
     wrapper.setState({
       isTooltipActive: true,
       activeTooltipIndex: 4,
+      activePointIndex: 4,
       activeTooltipLabel: 4,
       activeTooltipCoord: {
         x: 95,

--- a/test/specs/util/CartesianUtilsSpec.js
+++ b/test/specs/util/CartesianUtilsSpec.js
@@ -3,7 +3,8 @@ import {
   calculateActiveTickIndex,
   calculateDomainOfTicks,
   getDomainOfStackGroups,
-  getDomainOfDataByKey
+  getDomainOfDataByKey,
+  getCoordinateOfTicks
 } from '../../../src/util/CartesianUtils';
 
 describe('calculateActiveTickIndex', () => {
@@ -104,5 +105,22 @@ describe('getDomainOfDataByKey', () => {
       expect(getDomainOfDataByKey(data, 'actual', 'number')).to.deep.equal([35.4, 42.5]);
       expect(getDomainOfDataByKey(data, 'benchmark', 'number')).to.deep.equal([31.86, 35.4]);
     });
+  });
+});
+
+describe('getCoordinateOfTicks', () => {
+  const ticks = [
+    { coordinate: 1, value: 5 },
+    { coordinate: 17, value: 42 },
+  ];
+
+  it('should calculate the correct coordinate if the index is in range', () => {
+    expect(getCoordinateOfTicks(ticks, 0, 20)).to.equal(11);
+    expect(getCoordinateOfTicks(ticks, 1, 20)).to.equal(27);
+  });
+
+  it('should return null if the index is out of range', () => {
+    expect(getCoordinateOfTicks(ticks, -1, 20)).to.equal(null);
+    expect(getCoordinateOfTicks(ticks, 2, 20)).to.equal(null);
   });
 });

--- a/test/specs/util/DataUtilsSpec.js
+++ b/test/specs/util/DataUtilsSpec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { getPercentValue, validateCoordinateInRange,
   getBandSizeOfScale, getAnyElementOfObject,
-  parseSpecifiedDomain } from '../../../src/util/DataUtils';
+  parseSpecifiedDomain, getCategoryOffsetOfDomain } from '../../../src/util/DataUtils';
 
 describe('getPercentValue', () => {
   it('DataUtils.getPercentValue("25%", 1) should return 0.25 ', () => {
@@ -109,5 +109,22 @@ describe('parseSpecifiedDomain', () => {
   it('DataUtils.parseSpecifiedDomain([-1, 3], ["foo", "bar", "baz"]) should return [-1, "foo", "bar", "baz", 3]', () => {
     const result = parseSpecifiedDomain([-1, 3], ['foo', 'bar', 'baz']);
     expect(result).to.deep.equal([-1, 'foo', 'bar', 'baz', 3]);
+  });
+});
+
+describe('getCategoryOffsetOfDomain', () => {
+  it('DataUtils.getCategoryOffsetOfDomain([0, 1, 2, 3]) should return 0', () => {
+    const result = getCategoryOffsetOfDomain([0, 1, 2, 3]);
+    expect(result).to.equal(0);
+  });
+
+  it('DataUtils.getCategoryOffsetOfDomain([-2, -1, 0, 1, 2, 3]) should return 2', () => {
+    const result = getCategoryOffsetOfDomain([-2, -1, 0, 1, 2, 3]);
+    expect(result).to.equal(2);
+  });
+
+  it('DataUtils.getCategoryOffsetOfDomain([-2, -1, "foo", "bar"]) should return 2', () => {
+    const result = getCategoryOffsetOfDomain([-2, -1, 'foo', 'bar']);
+    expect(result).to.equal(2);
   });
 });

--- a/test/specs/util/DataUtilsSpec.js
+++ b/test/specs/util/DataUtilsSpec.js
@@ -50,13 +50,39 @@ describe('parseSpecifiedDomain', () => {
     expect(parseSpecifiedDomain(1, domain)).to.equal(domain);
   });
 
-  it('DataUtils.parseSpecifiedDomain(["auto", "auto"], domain) should return null ', () => {
+  it('DataUtils.parseSpecifiedDomain(["auto", "auto"], domain) should return domain ', () => {
     const result = parseSpecifiedDomain(['auto', 'auto'], domain);
     expect(result).to.deep.equal(domain);
   });
 
-  it('DataUtils.parseSpecifiedDomain([-1, 120], domain) should return null ', () => {
+  it('DataUtils.parseSpecifiedDomain([-1, 120], domain) should return [-1, 120] ', () => {
     const result = parseSpecifiedDomain([-1, 120], domain);
     expect(result).to.deep.equal([-1, 120]);
+  });
+
+  const categoricalDomain = [0, 1, 2, 3, 4];
+  it('DataUtils.parseSpecifiedDomain(1, categoricalDomain) should return categoricalDomain', () => {
+    const result = parseSpecifiedDomain(1, categoricalDomain);
+    expect(result).to.deep.equal(categoricalDomain);
+  });
+
+  it('DataUtils.parseSpecifiedDomain(["auto", "auto"], categoricalDomain) should return categoricalDomain', () => {
+    const result = parseSpecifiedDomain(['auto', 'auto'], categoricalDomain);
+    expect(result).to.deep.equal(categoricalDomain);
+  });
+
+  it('DataUtils.parseSpecifiedDomain([-1, 2], categoricalDomain) should return [-1, 0, 1, 2, 3, 4]', () => {
+    const result = parseSpecifiedDomain([-1, 2], categoricalDomain);
+    expect(result).to.deep.equal([-1, 0, 1, 2, 3, 4]);
+  });
+
+  it('DataUtils.parseSpecifiedDomain([-1, 2], categoricalDomain, true) should return [-1, 0, 1, 2]', () => {
+    const result = parseSpecifiedDomain([-1, 2], categoricalDomain, true);
+    expect(result).to.deep.equal([-1, 0, 1, 2]);
+  });
+
+  it('DataUtils.parseSpecifiedDomain(["auto", "auto"], [1]) should return [1]', () => {
+    const result = parseSpecifiedDomain(['auto', 'auto'], [1]);
+    expect(result).to.deep.equal([1]);
   });
 });

--- a/test/specs/util/DataUtilsSpec.js
+++ b/test/specs/util/DataUtilsSpec.js
@@ -85,4 +85,29 @@ describe('parseSpecifiedDomain', () => {
     const result = parseSpecifiedDomain(['auto', 'auto'], [1]);
     expect(result).to.deep.equal([1]);
   });
+
+  it('DataUtils.parseSpecifiedDomain([0, 1], ["foo", "bar", "baz"]) should return ["foo", "bar", "baz"]', () => {
+    const result = parseSpecifiedDomain([0, 1], ['foo', 'bar', 'baz']);
+    expect(result).to.deep.equal(['foo', 'bar', 'baz']);
+  });
+
+  it('DataUtils.parseSpecifiedDomain([0, 1], ["foo", "bar", "baz"], true) should return ["foo", "bar"]', () => {
+    const result = parseSpecifiedDomain([0, 1], ['foo', 'bar', 'baz'], true);
+    expect(result).to.deep.equal(['foo', 'bar']);
+  });
+
+  it('DataUtils.parseSpecifiedDomain([1, 2], ["foo", "bar", "baz"]) should return ["foo", "bar", "baz"]', () => {
+    const result = parseSpecifiedDomain([1, 2], ['foo', 'bar', 'baz']);
+    expect(result).to.deep.equal(['foo', 'bar', 'baz']);
+  });
+
+  it('DataUtils.parseSpecifiedDomain([1, 2], ["foo", "bar", "baz"], true) should return ["bar", "baz"]', () => {
+    const result = parseSpecifiedDomain([1, 2], ['foo', 'bar', 'baz'], true);
+    expect(result).to.deep.equal(['bar', 'baz']);
+  });
+
+  it('DataUtils.parseSpecifiedDomain([-1, 3], ["foo", "bar", "baz"]) should return [-1, "foo", "bar", "baz", 3]', () => {
+    const result = parseSpecifiedDomain([-1, 3], ['foo', 'bar', 'baz']);
+    expect(result).to.deep.equal([-1, 'foo', 'bar', 'baz', 3]);
+  });
 });

--- a/test/specs/util/DataUtilsSpec.js
+++ b/test/specs/util/DataUtilsSpec.js
@@ -61,53 +61,53 @@ describe('parseSpecifiedDomain', () => {
   });
 
   const categoricalDomain = [0, 1, 2, 3, 4];
-  it('DataUtils.parseSpecifiedDomain(1, categoricalDomain) should return categoricalDomain', () => {
-    const result = parseSpecifiedDomain(1, categoricalDomain);
+  it('DataUtils.parseSpecifiedDomain(1, categoricalDomain, false, true) should return categoricalDomain', () => {
+    const result = parseSpecifiedDomain(1, categoricalDomain, false, true);
     expect(result).to.deep.equal(categoricalDomain);
   });
 
-  it('DataUtils.parseSpecifiedDomain(["auto", "auto"], categoricalDomain) should return categoricalDomain', () => {
-    const result = parseSpecifiedDomain(['auto', 'auto'], categoricalDomain);
+  it('DataUtils.parseSpecifiedDomain(["auto", "auto"], categoricalDomain, false, true) should return categoricalDomain', () => {
+    const result = parseSpecifiedDomain(['auto', 'auto'], categoricalDomain, false, true);
     expect(result).to.deep.equal(categoricalDomain);
   });
 
-  it('DataUtils.parseSpecifiedDomain([-1, 2], categoricalDomain) should return [-1, 0, 1, 2, 3, 4]', () => {
-    const result = parseSpecifiedDomain([-1, 2], categoricalDomain);
+  it('DataUtils.parseSpecifiedDomain([-1, 2], categoricalDomain, false, true) should return [-1, 0, 1, 2, 3, 4]', () => {
+    const result = parseSpecifiedDomain([-1, 2], categoricalDomain, false, true);
     expect(result).to.deep.equal([-1, 0, 1, 2, 3, 4]);
   });
 
-  it('DataUtils.parseSpecifiedDomain([-1, 2], categoricalDomain, true) should return [-1, 0, 1, 2]', () => {
-    const result = parseSpecifiedDomain([-1, 2], categoricalDomain, true);
+  it('DataUtils.parseSpecifiedDomain([-1, 2], categoricalDomain, true, true) should return [-1, 0, 1, 2]', () => {
+    const result = parseSpecifiedDomain([-1, 2], categoricalDomain, true, true);
     expect(result).to.deep.equal([-1, 0, 1, 2]);
   });
 
-  it('DataUtils.parseSpecifiedDomain(["auto", "auto"], [1]) should return [1]', () => {
-    const result = parseSpecifiedDomain(['auto', 'auto'], [1]);
+  it('DataUtils.parseSpecifiedDomain(["auto", "auto"], [1], false, true) should return [1]', () => {
+    const result = parseSpecifiedDomain(['auto', 'auto'], [1], false, true);
     expect(result).to.deep.equal([1]);
   });
 
-  it('DataUtils.parseSpecifiedDomain([0, 1], ["foo", "bar", "baz"]) should return ["foo", "bar", "baz"]', () => {
-    const result = parseSpecifiedDomain([0, 1], ['foo', 'bar', 'baz']);
+  it('DataUtils.parseSpecifiedDomain([0, 1], ["foo", "bar", "baz"], false, true) should return ["foo", "bar", "baz"]', () => {
+    const result = parseSpecifiedDomain([0, 1], ['foo', 'bar', 'baz'], false, true);
     expect(result).to.deep.equal(['foo', 'bar', 'baz']);
   });
 
-  it('DataUtils.parseSpecifiedDomain([0, 1], ["foo", "bar", "baz"], true) should return ["foo", "bar"]', () => {
-    const result = parseSpecifiedDomain([0, 1], ['foo', 'bar', 'baz'], true);
+  it('DataUtils.parseSpecifiedDomain([0, 1], ["foo", "bar", "baz"], true, true) should return ["foo", "bar"]', () => {
+    const result = parseSpecifiedDomain([0, 1], ['foo', 'bar', 'baz'], true, true);
     expect(result).to.deep.equal(['foo', 'bar']);
   });
 
-  it('DataUtils.parseSpecifiedDomain([1, 2], ["foo", "bar", "baz"]) should return ["foo", "bar", "baz"]', () => {
-    const result = parseSpecifiedDomain([1, 2], ['foo', 'bar', 'baz']);
+  it('DataUtils.parseSpecifiedDomain([1, 2], ["foo", "bar", "baz"], false, true) should return ["foo", "bar", "baz"]', () => {
+    const result = parseSpecifiedDomain([1, 2], ['foo', 'bar', 'baz'], false, true);
     expect(result).to.deep.equal(['foo', 'bar', 'baz']);
   });
 
-  it('DataUtils.parseSpecifiedDomain([1, 2], ["foo", "bar", "baz"], true) should return ["bar", "baz"]', () => {
-    const result = parseSpecifiedDomain([1, 2], ['foo', 'bar', 'baz'], true);
+  it('DataUtils.parseSpecifiedDomain([1, 2], ["foo", "bar", "baz"], true, true) should return ["bar", "baz"]', () => {
+    const result = parseSpecifiedDomain([1, 2], ['foo', 'bar', 'baz'], true, true);
     expect(result).to.deep.equal(['bar', 'baz']);
   });
 
-  it('DataUtils.parseSpecifiedDomain([-1, 3], ["foo", "bar", "baz"]) should return [-1, "foo", "bar", "baz", 3]', () => {
-    const result = parseSpecifiedDomain([-1, 3], ['foo', 'bar', 'baz']);
+  it('DataUtils.parseSpecifiedDomain([-1, 3], ["foo", "bar", "baz"], false, true) should return [-1, "foo", "bar", "baz", 3]', () => {
+    const result = parseSpecifiedDomain([-1, 3], ['foo', 'bar', 'baz'], false, true);
     expect(result).to.deep.equal([-1, 'foo', 'bar', 'baz', 3]);
   });
 });


### PR DESCRIPTION
Please refer to my concerns here: https://github.com/recharts/recharts/issues/183#issuecomment-248284741

Long story short, currently if you were to create e.g. a `LineChart` with 2 different lines and 2 different x-axes, there's no way to make those lines overlap. Think, Google Analytics chart for comparing visits in 2 different periods of time:
![GA](http://www.kaushik.net/avinash/wp-content/uploads/2007/05/google_analytics_v2_context_from_time.jpg)

With this functionality, you can specify domain for a categorical axis, allowing you to chop off the time period, you are not interested in. Your data could look something like this:
```javascript
const data = [
  {timestamp: '2015-01-01', oldValue: 5, newValue: null},
  {timestamp: '2015-06-01', oldValue: 4, newValue: null},
  {timestamp: '2016-01-01', oldValue: null, newValue: 3},
  {timestamp: '2016-06-01', oldValue: null, newValue: 7}
];
```

And your axis configuration could be:
```javascript
<XAxis dataKey='oldValue' xAxisId='oldValues' domain={[0, 1]} allowDataOverflow />
<XAxis dataKey='newValue' xAxisId='newValues' domain={[2, 3]} allowDataOverflow />
```

Domain configuration is very similar to that of numerical axis, however instead of operating on values, you operate on indices (indices specified are always inclusive - this is different to how `_.range` works, but similar to how you specify domain for the numerical axis), e.g.:
```javascript
const categories = [0, 1, 2];
const domain = [1, 2]; // > visibleCategories === [1, 2];

const categories = [0, 1, 2];
const domain = [-1, 'auto']; // > visibleCategories === [-1, 0, 1, 2];

const categories = ['foo', 'bar', 'baz'];
const domain = ['auto', 3]; // > visibleCategories === ['foo', 'bar', 'baz', 3];
```

~~I probably need to add `BarChart` support as well.~~ done