### PR TITLE
Fix label/tick vertical alignment.  Fix #268

### DIFF
--- a/src/cartesian/Brush.js
+++ b/src/cartesian/Brush.js
@@ -344,8 +344,8 @@ class Brush extends Component {
       <Layer className="recharts-brush-texts">
         <Text
           textAnchor="end"
+          verticalAnchor="middle"
           style={style}
-          dy={offset}
           x={Math.min(startX, endX) - offset}
           y={y + height / 2}
         >
@@ -353,8 +353,8 @@ class Brush extends Component {
         </Text>
         <Text
           textAnchor="start"
+          verticalAnchor="middle"
           style={style}
-          dy={offset}
           x={Math.max(startX, endX) + travellerWidth + offset}
           y={y + height / 2}
         >

--- a/src/cartesian/CartesianAxis.js
+++ b/src/cartesian/CartesianAxis.js
@@ -192,24 +192,24 @@ class CartesianAxis extends Component {
     return textAnchor;
   }
 
-  getDy() {
+  getTickVerticalAnchor() {
     const { orientation } = this.props;
-    let dy = 0;
+    let verticalAnchor = 'end';
 
     switch (orientation) {
       case 'left':
       case 'right':
-        dy = 8;
+        verticalAnchor = 'middle';
         break;
       case 'top':
-        dy = -2;
+        verticalAnchor = 'end';
         break;
       default:
-        dy = 15;
+        verticalAnchor = 'start';
         break;
     }
 
-    return dy;
+    return verticalAnchor;
   }
 
   getLabelProps() {
@@ -278,6 +278,7 @@ class CartesianAxis extends Component {
     const { ticks, tickLine, stroke, tick, tickFormatter } = this.props;
     const finalTicks = CartesianAxis.getTicks(this.props);
     const textAnchor = this.getTickTextAnchor();
+    const verticalAnchor = this.getTickVerticalAnchor();
     const axisProps = getPresentationAttributes(this.props);
     const customTickProps = getPresentationAttributes(tick);
     const tickLineProps = {
@@ -286,7 +287,8 @@ class CartesianAxis extends Component {
     const items = finalTicks.map((entry, i) => {
       const lineCoord = this.getTickLineCoord(entry);
       const tickProps = {
-        dy: this.getDy(entry), textAnchor,
+        textAnchor,
+        verticalAnchor,
         ...axisProps,
         stroke: 'none', fill: stroke,
         ...customTickProps,


### PR DESCRIPTION
Fix labels/ticks being cut off after using <Text> component and passing explicit `dy`.  Use `verticalAnchor` prop on <Text> instead.  Fixes #268