### PR TITLE
fix webpack config, 

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,11 +48,11 @@ var config = {
       commonjs: 'react-dom-server',
       amd:'react-dom-server'
     },
-    'react-addons-css-transition-group': {
-      root: ['React','addons','CSSTransitionGroup'],
-      commonjs2: 'react-addons-css-transition-group',
-      commonjs: 'react-addons-css-transition-group',
-      amd: 'react-addons-css-transition-group'
+    'react-addons-transition-group': {
+      root: ['React','addons','TransitionGroup'],
+      commonjs2: 'react-addons-transition-group',
+      commonjs: 'react-addons-transition-group',
+      amd: 'react-addons-transition-group'
     }
   },
 


### PR DESCRIPTION
react-addons-css-transition-group is not used but react-smooth uses react-addons-transition-group (fixes #283)