### PR TITLE
Add angle property to PRESENTATION_ATTRIBUTES

### DIFF
--- a/src/util/ReactUtils.js
+++ b/src/util/ReactUtils.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 
 export const PRESENTATION_ATTRIBUTES = {
   alignmentBaseline: PropTypes.string,
+  angle: PropTypes.number,
   baselineShift: PropTypes.string,
   clip: PropTypes.string,
   clipPath: PropTypes.string,
@@ -284,4 +285,3 @@ export const filterSvgElements = (children) => {
 
   return svgElements;
 };
-


### PR DESCRIPTION
Adding the angle property to the PRESENTATION_ATTRIBUTES array in util/ReactUtils.js allows ticks in the cartesian axes to be positioned at any angle. It was not listed as a presentation attribute before, but I believe it should be, as there is no other way to rotate each tick's text while using tickFormatter, i. e., without creating a custom React class as it's done in the [CustomizedLabelLineChart](http://recharts.org/examples#CustomizedLabelLineChart) in the docs.