### PR TITLE
Save chart's state after properties have been updated

### DIFF
--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -81,7 +81,13 @@ const generateCategoricalChart = (ChartComponent, GraphicalChild) => {
 
     componentWillReceiveProps(nextProps) {
       if (nextProps.data !== this.props.data) {
-        this.setState(this.createDefaultState(nextProps));
+        this.setState({
+          ...this.createDefaultState(this.props),
+          chartX: this.state.chartX,
+          chartY: this.state.chartY,
+          activeTooltipIndex: this.state.activeTooltipIndex,
+          isTooltipActive: this.state.isTooltipActive
+        });
       }
       // add syncId
       if (_.isNil(this.props.syncId) && !_.isNil(nextProps.syncId)) {


### PR DESCRIPTION
According to this [issue](https://github.com/recharts/recharts/issues/287) it is not possible to save tooltip's position after update.