### PR TITLE
Fix #351: Relax propTypes.ticks in CartesianAxis

### DIFF
--- a/src/cartesian/CartesianAxis.js
+++ b/src/cartesian/CartesianAxis.js
@@ -39,13 +39,7 @@ class CartesianAxis extends Component {
     tickLine: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
 
     minLabelGap: PropTypes.number,
-    ticks: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.shape({
-        value: PropTypes.any,
-        coordinate: PropTypes.value,
-      })),
-      PropTypes.arrayOf(PropTypes.number),
-    ]),
+    ticks: PropTypes.array,
     tickSize: PropTypes.number,
     stroke: PropTypes.string,
     tickFormatter: PropTypes.func,

--- a/test/specs/cartesian/CartesianAxisSpec.js
+++ b/test/specs/cartesian/CartesianAxisSpec.js
@@ -176,6 +176,28 @@ describe('<CartesianAxis />', () => {
     expect(wrapper.find('.customized-tick').length).to.equal(ticks.length);
   });
 
+  it('Render customized ticks when ticks is an array of strings and interval is 0', () => {
+    const CustomizedTick = ({x, y}) => {
+      return <text x={x} y={y} className="customized-tick">test</text>;
+    };
+    const wrapper = render(
+      <Surface width={500} height={500}>
+        <CartesianAxis
+          orientation="bottom"
+          y={100}
+          width={400}
+          height={50}
+          viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
+          ticks={['tick 1', 'tick 2', 'tick 3']}
+          tick={<CustomizedTick/>}
+          interval={0}
+        />
+      </Surface>
+    );
+
+    expect(wrapper.find('.customized-tick').length).to.equal(3);
+  });
+
   it('Render customized ticks when tick is set to be a function', () => {
     const renderCustomizedTick = ({x, y}) => {
       return <text x={x} y={y} className="customized-tick">test</text>;


### PR DESCRIPTION
When interval=0, it's allowed to be an array whose elements are any type.