### PR TITLE
Fix #267: Add Error Bars to BarChart [enhancement]

### DIFF
--- a/demo/component/BarChart.js
+++ b/demo/component/BarChart.js
@@ -8,10 +8,10 @@ import { changeNumberOfData } from './utils';
 const colors = scaleOrdinal(schemeCategory10).range();
 
 const data = [
-  { name: 'food', uv: 2000, pv: 2013, amt: 4500, time: 1 },
-  { name: 'cosmetic', uv: 3300, pv: 2000, amt: 6500, time: 2 },
-  { name: 'storage', uv: 3200, pv: 1398, amt: 5000, time: 3 },
-  { name: 'digital', uv: 2800, pv: 2800, amt: 4000, time: 4 },
+  { name: 'food', uv: 2000, pv: 2013, amt: 4500, time: 1, uvError: 200, pvError: 110 },
+  { name: 'cosmetic', uv: 3300, pv: 2000, amt: 6500, time: 2, uvError: 240, pvError: 100 },
+  { name: 'storage', uv: 3200, pv: 1398, amt: 5000, time: 3, uvError: 220, pvError: 200 },
+  { name: 'digital', uv: 2800, pv: 2800, amt: 4000, time: 4, uvError: 200, pvError: 130 },
 ];
 
 const data01 = [
@@ -286,6 +286,33 @@ export default React.createClass({
             </Bar>
           </BarChart>
         </div>
+        
+        <p>BarChart with error bars</p>
+        <div className="bar-chart-wrapper" style={{textAlign: 'right'}}>
+          <BarChart width={400} height={400} data={data} onClick={this.handlePvBarClick}>
+            <XAxis dataKey="name" />
+            <YAxis yAxisId="a" />
+            <YAxis yAxisId="b" orientation="right" />
+            <Legend />
+            <Tooltip />
+            <CartesianGrid vertical={false}/>
+            <Bar yAxisId="a" dataKey="uv" onAnimationStart={this.handleBarAnimationStart} onAnimationEnd={this.handleBarAnimationEnd} shouldShowErrorBar={true} >
+              {
+                data.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={colors[index % 20]}/>
+                ))
+              }
+            </Bar>
+            <Bar yAxisId="b" dataKey="pv" shouldShowErrorBar={true}>
+              {
+                data.map((entry, index) => (
+                  <Cell key={`cell-${index}`} fill={colors[index % 20]}/>
+                ))
+              }
+            </Bar>
+          </BarChart>
+        </div>
+
 
 
         <p>Tiny BarChart</p>

--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -191,17 +191,16 @@ class Bar extends Component {
     if (isAnimationActive && !this.state.isAnimationFinished) { return null; }
 
     const { data, errorBarFill, errorBarStrokeWidth } = this.props;
-    const errorKey = this.props.dataKey + 'Error';
+    const errorKey = `${this.props.dataKey}Error`;
     const errorBars = data.map((entry, i) => {
-      let xMid, yMid, xMin, yMin, xMax, yMax, scale = 0;
-      let coordsTop, coordsMid, coordsBot = {};
-      let errorVal = entry[errorKey];
+      let xMid, yMid, xMin, yMin, xMax, yMax, scale, coordsTop, coordsMid, coordsBot;
+      const errorVal = entry[errorKey];
 
       if (errorVal) {
         if (this.props.layout === 'vertical') {
-          scale = entry.width / entry.value; 
+          scale = entry.width / entry.value;
           xMid = entry.x + entry.width;
-          yMid = entry.y + entry.height / 2;  
+          yMid = entry.y + entry.height / 2;
           xMin = xMid - errorVal / 2 * scale;
           yMin = yMid + entry.height / 5;
           xMax = xMid + errorVal / 2 * scale;
@@ -210,7 +209,7 @@ class Bar extends Component {
           coordsMid = { x1: xMin, y1: yMid, x2: xMax, y2: yMid };
           coordsBot = { x1: xMin, y1: yMin, x2: xMin, y2: yMax };
         } else if (this.props.layout === 'horizontal') {
-          scale = entry.height / entry.value; 
+          scale = entry.height / entry.value;
           xMid = entry.x + entry.width / 2;
           yMid = entry.y;
           xMin = xMid - entry.width / 5;
@@ -223,16 +222,15 @@ class Bar extends Component {
         }
 
         return (
-          <Layer className={`recharts-bar-errorBar-${i}`}  key={i}>
+          <Layer className={`recharts-bar-errorBar-${i}`} key={i}>
             <line {...coordsTop} stroke={errorBarFill} strokeWidth={errorBarStrokeWidth} />;
             <line {...coordsMid} stroke={errorBarFill} strokeWidth={errorBarStrokeWidth} />;
             <line {...coordsBot} stroke={errorBarFill} strokeWidth={errorBarStrokeWidth} />;
           </Layer>
         );
-      } else {
-        return null;
       }
 
+      return null;
     });
 
     return <Layer className="recharts-bar-errorBars">{errorBars}</Layer>;


### PR DESCRIPTION
Let me know if I need to add tests or make any changes. I'll add to the api docs once the change is integrated.

Here are example pictures of the current implementation:
Basic bar chart with error bars:
<img width="384" alt="screen shot 2016-12-05 at 11 33 20 am" src="https://cloud.githubusercontent.com/assets/9427089/20899659/26ff0358-bae0-11e6-89d8-20f5dba5edde.png">

Vertical bar chart with error bar color and width options changes:
![screen shot 2016-12-05 at 11 41 17 am](https://cloud.githubusercontent.com/assets/9427089/20899677/3dc172d8-bae0-11e6-8a33-8abbba89d6c4.png)

