### PR TITLE
fix: disable babel transform es2015 modules to commonjs for es6 build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,11 +7,10 @@
     "transform-function-bind",
     "lodash"
   ],
-  presets: ["es2015", "react"],
+  presets: [["es2015", { "modules": false }], "react"],
   env: {
     test: {
-      plugins: ["istanbul"]
+      plugins: ["transform-es2015-modules-commonjs", "istanbul"]
     }
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   ],
   "scripts": {
     "build": "npm run build-cjs && npm run build-es6 && rimraf umd && npm run build-umd && npm run build-min",
-    "build-cjs": "rimraf lib && babel ./src -d lib",
-    "build-es6": "rimraf es6 && babel ./src -d es6 --blacklist=es6.modules",
+    "build-cjs": "rimraf lib && babel ./src -d lib --plugins=transform-es2015-modules-commonjs",
+    "build-es6": "rimraf es6 && babel ./src -d es6",
     "build-umd": "NODE_ENV=development webpack src/index.js umd/Recharts.js",
     "build-min": "NODE_ENV=production webpack src/index.js umd/Recharts.min.js",
     "demo": "webpack-dev-server --progress --port 3000 --content-base demo --inline --config demo/webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.20.2",
   "description": "React charts",
   "main": "lib/index",
+  "module": "es6/index",
   "jsnext:main": "es6/index",
   "files": [
     "*.md",


### PR DESCRIPTION
Babel since 6 version doesn't support _blacklist_ option anymore. So last versions actually doesn't have build with es6 modules.