### PR TITLE
Dot events

### DIFF
--- a/src/cartesian/ReferenceDot.js
+++ b/src/cartesian/ReferenceDot.js
@@ -7,7 +7,8 @@ import pureRender from '../util/PureRender';
 import Layer from '../container/Layer';
 import Dot from '../shape/Dot';
 import Text from '../component/Text';
-import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES, getPresentationAttributes, filterEventAttributes } from '../util/ReactUtils';
+import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES,
+  getPresentationAttributes, filterEventAttributes } from '../util/ReactUtils';
 import { validateCoordinateInRange, isNumOrStr } from '../util/DataUtils';
 
 @pureRender

--- a/src/cartesian/ReferenceDot.js
+++ b/src/cartesian/ReferenceDot.js
@@ -7,7 +7,7 @@ import pureRender from '../util/PureRender';
 import Layer from '../container/Layer';
 import Dot from '../shape/Dot';
 import Text from '../component/Text';
-import { PRESENTATION_ATTRIBUTES, getPresentationAttributes } from '../util/ReactUtils';
+import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES, getPresentationAttributes, filterEventAttributes } from '../util/ReactUtils';
 import { validateCoordinateInRange, isNumOrStr } from '../util/DataUtils';
 
 @pureRender
@@ -17,6 +17,7 @@ class ReferenceDot extends Component {
 
   static propTypes = {
     ...PRESENTATION_ATTRIBUTES,
+    ...EVENT_ATTRIBUTES,
     r: PropTypes.number,
 
     label: PropTypes.oneOfType([
@@ -126,9 +127,15 @@ class ReferenceDot extends Component {
 
     const { shape } = this.props;
 
+    const dotProps = {
+      ...getPresentationAttributes(this.props),
+      ...filterEventAttributes(this.props),
+      ...coordinate,
+    };
+
     return (
       <Layer className="recharts-reference-dot">
-        {this.renderDot(shape, { ...getPresentationAttributes(this.props), ...coordinate })}
+        {this.renderDot(shape, dotProps)}
         {this.renderLabel(coordinate)}
       </Layer>
     );

--- a/src/shape/Dot.js
+++ b/src/shape/Dot.js
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import classNames from 'classnames';
 import pureRender from '../util/PureRender';
-import { getPresentationAttributes } from '../util/ReactUtils';
+import { getPresentationAttributes, filterEventAttributes } from '../util/ReactUtils';
 
 @pureRender
 class Dot extends Component {
@@ -25,6 +25,7 @@ class Dot extends Component {
       return (
         <circle
           {...getPresentationAttributes(this.props)}
+          {...filterEventAttributes(this.props)}
           className={layerClass}
           cx={cx}
           cy={cy}


### PR DESCRIPTION
This adds event handlers to Dots. The specific use-case that prompted this PR was that I wanted to attach an onClick event to a ReferenceDot, but was unable to.