### PR TITLE
Remove redundant "this"

### DIFF
--- a/src/util/CartesianUtils.js
+++ b/src/util/CartesianUtils.js
@@ -407,7 +407,7 @@ export const getLegendProps = (children, graphicItems, width) => {
         value: name || dataKey,
         payload: child.props,
       };
-    }, this);
+    });
 
   return {
     ...legendItem.props,


### PR DESCRIPTION
When compiled using Rollup, the "this" argument to map() throws a warning about being undefined.

Remove reference to this as it's redundant.