### PR TITLE
fix: re-rendered element bug when adding new elements

### DIFF
--- a/demo/component/LineChart.js
+++ b/demo/component/LineChart.js
@@ -419,6 +419,7 @@ export default React.createClass({
         </div>
 
         <p>LineChart with two y-axes</p>
+        <button onClick={() => this.setState({newLine: !this.state.newLine})}>Add another line</button>
         <div className='line-chart-wrapper' style={{ padding: 40 }}>
           <LineChart
             width={400}
@@ -430,8 +431,9 @@ export default React.createClass({
             <XAxis dataKey='name' interval="preserveStartEnd" />
             <Tooltip/>
             <CartesianGrid stroke='#f5f5f5'/>
-            <Line type='monotone' dataKey='uv' stroke='#ff7300' yAxisId={0} activeDot={{fill: '#ff7300', stroke: 'none'}}/>
-            <Line type='monotone' dataKey='pv' stroke='#387908' yAxisId={1} activeDot={{fill: '#387908', stroke: 'none', r: 6}}/>
+            <Line type='monotone' key={'0'} dataKey='uv' stroke='#ff7300' yAxisId={0} activeDot={{fill: '#ff7300', stroke: 'none'}}/>
+            {this.state.newLine && <Line type='monotone' key={'1'} dataKey='amt' stroke='#132908' yAxisId={1} activeDot={{fill: '#132908', stroke: 'none', r: 6}}/>}
+            <Line type='monotone' key={'2'} dataKey='pv' stroke='#387908' yAxisId={1} activeDot={{fill: '#387908', stroke: 'none', r: 6}}/>
           </LineChart>
         </div>
 

--- a/src/chart/AreaChart.js
+++ b/src/chart/AreaChart.js
@@ -258,7 +258,7 @@ export class AreaChart extends Component {
       }
 
       const area = React.cloneElement(child, {
-        key: `area-${i}`,
+        key: child.key || `area-${i}`,
         ...currentComposedData,
         ...offset,
         animationId,

--- a/src/chart/BarChart.js
+++ b/src/chart/BarChart.js
@@ -210,7 +210,7 @@ class BarChart extends Component {
 
     return items.map((child, i) =>
       React.cloneElement(child, {
-        key: `bar-${i}`,
+        key: child.key || `bar-${i}`,
         layout,
         animationId,
         ...offset,

--- a/src/chart/LineChart.js
+++ b/src/chart/LineChart.js
@@ -169,7 +169,7 @@ export class LineChart extends Component {
       }
 
       return React.cloneElement(child, {
-        key: `line-${i}`,
+        key: child.key || `line-${i}`,
         ...offset,
         layout,
         points,

--- a/src/chart/PieChart.js
+++ b/src/chart/PieChart.js
@@ -170,7 +170,7 @@ export class PieChart extends Component {
       const maxRadius = getMaxRadius(width, height, margin);
 
       return React.cloneElement(child, {
-        key: `recharts-pie-${i}`,
+        key: child.key || `recharts-pie-${i}`,
         cx,
         cy,
         maxRadius: child.props.maxRadius || Math.sqrt(width * width + height * height) / 2,

--- a/src/chart/RadarChart.js
+++ b/src/chart/RadarChart.js
@@ -262,7 +262,7 @@ class RadarChart extends Component {
         ...getPresentationAttributes(el),
         animationId: this.props.animationId,
         points: this.getComposedData(el, scale, cx, cy),
-        key: `radar-${index}`,
+        key: el.key || `radar-${index}`,
         onMouseEnter: combineEventHandlers(
           this.handleMouseEnter, onMouseEnter, el.props.onMouseEnter),
         onMouseLeave: combineEventHandlers(

--- a/src/chart/RadialBarChart.js
+++ b/src/chart/RadialBarChart.js
@@ -286,7 +286,7 @@ class RadialBarChart extends Component {
 
       return React.cloneElement(child, {
         ...center,
-        key: `radial-bar-${i}`,
+        key: child.key || `radial-bar-${i}`,
         onMouseEnter: combineEventHandlers(this.handleMouseEnter, onMouseEnter, childOnMouseEnter),
         onMouseLeave: combineEventHandlers(this.handleMouseLeave, onMouseLeave, childOnMouseLeave),
         onClick: combineEventHandlers(null, onClick, childOnClick),

--- a/src/chart/ScatterChart.js
+++ b/src/chart/ScatterChart.js
@@ -458,7 +458,7 @@ class ScatterChart extends Component {
       finalStrokeWidth = activeGroupId === `scatter-${i}` ? finalStrokeWidth + 2 : finalStrokeWidth;
 
       return React.cloneElement(child, {
-        key: `scatter-${i}`,
+        key: child.key || `scatter-${i}`,
         groupId: `scatter-${i}`,
         strokeWidth: finalStrokeWidth,
         onMouseLeave: this.handleScatterMouseLeave,


### PR DESCRIPTION
Fixes: #581 

[index as a key is an anti-pattern](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318)

If you add new children to a chart it will compute the key based on the index of that element.

A problem comes up when you add a new child to the beginning of the children array.  This will bump the other indexes forward and cause a re-render if the key has changed.

The fix I propose is to use children keys if present so a user can specify their own.

Perhaps a more robust solution would be to use something like `child.props.dataKey` as the default.
`key: child.key || child.props.dataKey`