### PR TITLE
Add `none` legend type

### DIFF
--- a/demo/component/Legend.js
+++ b/demo/component/Legend.js
@@ -23,15 +23,15 @@ const data3 = [
 ];
 
 export default React.createClass({
-  render () {
+  render() {
     return (
       <div>
         <div style={{ position: 'relative', height: 200 }}>
           <Legend width={500} height={30} payload={data} />
         </div>
 
-        <div style={{ position: 'relative', height: 200 }}>
-          <Legend layout='vertical' width={200} height={100} payload={data2} />
+        <div style={{ position: 'relative', height: 200, left: 100 }}>
+          <Legend layout="vertical" width={200} height={100} payload={data2} />
         </div>
 
         <div style={{ position: 'relative', height: 200 }}>
@@ -39,6 +39,5 @@ export default React.createClass({
         </div>
       </div>
     );
-  }
+  },
 });
-

--- a/demo/component/Legend.js
+++ b/demo/component/Legend.js
@@ -22,6 +22,13 @@ const data3 = [
   { value: 'Sony', type: 'line', color: '#ff7812' },
 ];
 
+const data4 = [
+  { value: 'Apple', color: '#ff7300' },
+  { value: 'Samsung', color: '#bb7300' },
+  { value: 'Huawei', color: '#bb7300' },
+  { value: 'Sony', type: 'none' },
+];
+
 export default React.createClass({
   render() {
     return (
@@ -36,6 +43,10 @@ export default React.createClass({
 
         <div style={{ position: 'relative', height: 200 }}>
           <Legend width={200} height={30} payload={data3} />
+        </div>
+
+        <div style={{ position: 'relative', height: 200 }}>
+          <Legend width={200} height={30} payload={data4} />
         </div>
       </div>
     );

--- a/src/cartesian/Area.js
+++ b/src/cartesian/Area.js
@@ -10,7 +10,7 @@ import Dot from '../shape/Dot';
 import Layer from '../container/Layer';
 import Text from '../component/Text';
 import pureRender from '../util/PureRender';
-import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES,
+import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES, LEGEND_TYPES,
   getPresentationAttributes, isSsr } from '../util/ReactUtils';
 import { isNumber, uniqueId } from '../util/DataUtils';
 
@@ -35,10 +35,7 @@ class Area extends Component {
     yAxis: PropTypes.object,
     xAxis: PropTypes.object,
     stackId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    legendType: PropTypes.oneOf([
-      'line', 'square', 'rect', 'circle', 'cross', 'diamond', 'square', 'star',
-      'triangle', 'wye',
-    ]),
+    legendType: PropTypes.oneOf(LEGEND_TYPES),
     connectNulls: PropTypes.bool,
 
     activeDot: PropTypes.oneOfType([

--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -11,8 +11,8 @@ import Text from '../component/Text';
 import ErrorBar from './ErrorBar';
 import pureRender from '../util/PureRender';
 import { getValueByDataKey, uniqueId } from '../util/DataUtils';
-import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES, getPresentationAttributes,
-  filterEventsOfChild, isSsr, findChildByType } from '../util/ReactUtils';
+import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES, LEGEND_TYPES,
+  getPresentationAttributes, filterEventsOfChild, isSsr, findChildByType } from '../util/ReactUtils';
 
 @pureRender
 class Bar extends Component {
@@ -33,10 +33,7 @@ class Bar extends Component {
     unit: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     name: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     dataKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.func]).isRequired,
-    legendType: PropTypes.oneOf([
-      'line', 'square', 'rect', 'circle', 'cross', 'diamond', 'square', 'star',
-      'triangle', 'wye',
-    ]),
+    legendType: PropTypes.oneOf(LEGEND_TYPES),
     minPointSize: PropTypes.number,
     maxBarSize: PropTypes.number,
 

--- a/src/cartesian/Line.js
+++ b/src/cartesian/Line.js
@@ -12,7 +12,7 @@ import Layer from '../container/Layer';
 import Text from '../component/Text';
 import ErrorBar from './ErrorBar';
 import { getValueByDataKey, uniqueId } from '../util/DataUtils';
-import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES,
+import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES, LEGEND_TYPES,
   getPresentationAttributes, isSsr, findChildByType } from '../util/ReactUtils';
 
 const FACTOR = 1.0000001;
@@ -36,10 +36,7 @@ class Line extends Component {
     xAxisId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     yAxis: PropTypes.object,
     xAxis: PropTypes.object,
-    legendType: PropTypes.oneOf([
-      'line', 'square', 'rect', 'circle', 'cross', 'diamond', 'square', 'star',
-      'triangle', 'wye',
-    ]),
+    legendType: PropTypes.oneOf(LEGEND_TYPES),
     layout: PropTypes.oneOf(['horizontal', 'vertical']),
     connectNulls: PropTypes.bool,
 

--- a/src/cartesian/Scatter.js
+++ b/src/cartesian/Scatter.js
@@ -7,8 +7,8 @@ import classNames from 'classnames';
 import _ from 'lodash';
 import pureRender from '../util/PureRender';
 import Layer from '../container/Layer';
-import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES, getPresentationAttributes,
-  filterEventsOfChild, isSsr, findAllByType } from '../util/ReactUtils';
+import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES, LEGEND_TYPES,
+  getPresentationAttributes, filterEventsOfChild, isSsr, findAllByType } from '../util/ReactUtils';
 import Curve from '../shape/Curve';
 import Symbols from '../shape/Symbols';
 import ErrorBar from './ErrorBar';
@@ -36,10 +36,7 @@ class Scatter extends Component {
       'basis', 'basisClosed', 'basisOpen', 'linear', 'linearClosed', 'natural',
       'monotoneX', 'monotoneY', 'monotone', 'step', 'stepBefore', 'stepAfter',
     ]), PropTypes.func]),
-    legendType: PropTypes.oneOf([
-      'line', 'square', 'rect', 'circle', 'cross', 'diamond', 'star',
-      'triangle', 'wye',
-    ]),
+    legendType: PropTypes.oneOf(LEGEND_TYPES),
     className: PropTypes.string,
 
     activeIndex: PropTypes.number,

--- a/src/component/DefaultLegendContent.js
+++ b/src/component/DefaultLegendContent.js
@@ -101,6 +101,10 @@ class DefaultLegendContent extends Component {
     return payload.map((entry, i) => {
       const finalFormatter = entry.formatter || formatter;
 
+      if (entry.type === 'none') {
+        return null;
+      }
+
       return (
         <li
           className={`recharts-legend-item legend-item-${i}`}

--- a/src/component/DefaultLegendContent.js
+++ b/src/component/DefaultLegendContent.js
@@ -5,7 +5,7 @@ import React, { Component, PropTypes } from 'react';
 import pureRender from '../util/PureRender';
 import Surface from '../container/Surface';
 import Symbols from '../shape/Symbols';
-import { filterEventsOfChild } from '../util/ReactUtils';
+import { filterEventsOfChild, LEGEND_TYPES } from '../util/ReactUtils';
 
 const SIZE = 32;
 
@@ -16,20 +16,14 @@ class DefaultLegendContent extends Component {
   static propTypes = {
     content: PropTypes.element,
     iconSize: PropTypes.number,
-    iconType: PropTypes.oneOf([
-      'line', 'square', 'rect', 'circle', 'cross', 'diamond',
-      'star', 'triangle', 'wye',
-    ]),
+    iconType: PropTypes.oneOf(LEGEND_TYPES),
     layout: PropTypes.oneOf(['horizontal', 'vertical']),
     align: PropTypes.oneOf(['center', 'left', 'right']),
     verticalAlign: PropTypes.oneOf(['top', 'bottom', 'middle']),
     payload: PropTypes.arrayOf(PropTypes.shape({
       value: PropTypes.any,
       id: PropTypes.any,
-      type: PropTypes.oneOf([
-        'line', 'square', 'rect', 'circle', 'cross', 'diamond', 'square',
-        'star', 'triangle', 'wye',
-      ]),
+      type: PropTypes.oneOf(LEGEND_TYPES),
     })),
     formatter: PropTypes.func,
     onMouseEnter: PropTypes.func,

--- a/src/component/DefaultLegendContent.js
+++ b/src/component/DefaultLegendContent.js
@@ -8,6 +8,7 @@ import Symbols from '../shape/Symbols';
 import { filterEventsOfChild, LEGEND_TYPES } from '../util/ReactUtils';
 
 const SIZE = 32;
+const ICON_TYPES = LEGEND_TYPES.filter(type => type !== 'none');
 
 @pureRender
 class DefaultLegendContent extends Component {
@@ -16,7 +17,7 @@ class DefaultLegendContent extends Component {
   static propTypes = {
     content: PropTypes.element,
     iconSize: PropTypes.number,
-    iconType: PropTypes.oneOf(LEGEND_TYPES),
+    iconType: PropTypes.oneOf(ICON_TYPES),
     layout: PropTypes.oneOf(['horizontal', 'vertical']),
     align: PropTypes.oneOf(['center', 'left', 'right']),
     verticalAlign: PropTypes.oneOf(['top', 'bottom', 'middle']),

--- a/src/component/Legend.js
+++ b/src/component/Legend.js
@@ -6,6 +6,8 @@ import _ from 'lodash';
 import pureRender from '../util/PureRender';
 import DefaultLegendContent from './DefaultLegendContent';
 import { isNumber } from '../util/DataUtils';
+import { LEGEND_TYPES } from '../util/ReactUtils';
+
 
 const renderContent = (content, props) => {
   if (React.isValidElement(content)) {
@@ -31,10 +33,7 @@ class Legend extends Component {
     width: PropTypes.number,
     height: PropTypes.number,
     iconSize: PropTypes.number,
-    iconType: PropTypes.oneOf([
-      'line', 'square', 'rect', 'circle', 'cross', 'diamond',
-      'star', 'triangle', 'wye',
-    ]),
+    iconType: PropTypes.oneOf(LEGEND_TYPES),
     layout: PropTypes.oneOf(['horizontal', 'vertical']),
     align: PropTypes.oneOf(['center', 'left', 'right']),
     verticalAlign: PropTypes.oneOf(['top', 'bottom', 'middle']),
@@ -47,10 +46,7 @@ class Legend extends Component {
     payload: PropTypes.arrayOf(PropTypes.shape({
       value: PropTypes.any,
       id: PropTypes.any,
-      type: PropTypes.oneOf([
-        'line', 'square', 'rect', 'circle', 'cross', 'diamond',
-        'star', 'triangle', 'wye',
-      ]),
+      type: PropTypes.oneOf(LEGEND_TYPES),
     })),
     formatter: PropTypes.func,
     onMouseEnter: PropTypes.func,

--- a/src/component/Legend.js
+++ b/src/component/Legend.js
@@ -20,6 +20,7 @@ const renderContent = (content, props) => {
 };
 
 const EPS = 1;
+const ICON_TYPES = LEGEND_TYPES.filter(type => type !== 'none');
 
 @pureRender
 class Legend extends Component {
@@ -33,7 +34,7 @@ class Legend extends Component {
     width: PropTypes.number,
     height: PropTypes.number,
     iconSize: PropTypes.number,
-    iconType: PropTypes.oneOf(LEGEND_TYPES),
+    iconType: PropTypes.oneOf(ICON_TYPES),
     layout: PropTypes.oneOf(['horizontal', 'vertical']),
     align: PropTypes.oneOf(['center', 'left', 'right']),
     verticalAlign: PropTypes.oneOf(['top', 'bottom', 'middle']),

--- a/src/polar/Pie.js
+++ b/src/polar/Pie.js
@@ -10,8 +10,8 @@ import Layer from '../container/Layer';
 import Sector from '../shape/Sector';
 import Curve from '../shape/Curve';
 import Text from '../component/Text';
-import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES, getPresentationAttributes,
-  filterEventsOfChild, isSsr } from '../util/ReactUtils';
+import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES, LEGEND_TYPES,
+  getPresentationAttributes, filterEventsOfChild, isSsr } from '../util/ReactUtils';
 import { polarToCartesian } from '../util/PolarUtils';
 import AnimationDecorator from '../util/AnimationDecorator';
 import { isNumber, getValueByDataKey, uniqueId } from '../util/DataUtils';
@@ -40,10 +40,7 @@ class Pie extends Component {
     data: PropTypes.arrayOf(PropTypes.object),
     composedData: PropTypes.arrayOf(PropTypes.object),
     minAngle: PropTypes.number,
-    legendType: PropTypes.oneOf([
-      'line', 'square', 'rect', 'circle', 'cross', 'diamond', 'square', 'star',
-      'triangle', 'wye',
-    ]),
+    legendType: PropTypes.oneOf(LEGEND_TYPES),
     maxRadius: PropTypes.number,
 
     labelLine: PropTypes.oneOfType([

--- a/src/polar/Radar.js
+++ b/src/polar/Radar.js
@@ -6,7 +6,8 @@ import Animate from 'react-smooth';
 import classNames from 'classnames';
 import _ from 'lodash';
 import pureRender from '../util/PureRender';
-import { PRESENTATION_ATTRIBUTES, getPresentationAttributes, isSsr } from '../util/ReactUtils';
+import { PRESENTATION_ATTRIBUTES, LEGEND_TYPES,
+  getPresentationAttributes, isSsr } from '../util/ReactUtils';
 import Polygon from '../shape/Polygon';
 import Dot from '../shape/Dot';
 import Layer from '../container/Layer';
@@ -39,10 +40,7 @@ class Radar extends Component {
     label: PropTypes.oneOfType([
       PropTypes.element, PropTypes.func, PropTypes.object, PropTypes.bool,
     ]),
-    legendType: PropTypes.oneOf([
-      'line', 'square', 'rect', 'circle', 'cross', 'diamond', 'square',
-      'star', 'triangle', 'wye',
-    ]),
+    legendType: PropTypes.oneOf(LEGEND_TYPES),
 
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,

--- a/src/polar/RadialBar.js
+++ b/src/polar/RadialBar.js
@@ -8,8 +8,8 @@ import _ from 'lodash';
 import Sector from '../shape/Sector';
 import Layer from '../container/Layer';
 import { getStringSize } from '../util/DOMUtils';
-import { PRESENTATION_ATTRIBUTES, getPresentationAttributes,
-  filterEventsOfChild, isSsr } from '../util/ReactUtils';
+import { PRESENTATION_ATTRIBUTES, LEGEND_TYPES,
+  getPresentationAttributes, filterEventsOfChild, isSsr } from '../util/ReactUtils';
 import pureRender from '../util/PureRender';
 import { polarToCartesian } from '../util/PolarUtils';
 import { uniqueId } from '../util/DataUtils';
@@ -44,10 +44,7 @@ class RadialBar extends Component {
       outerRadius: PropTypes.number,
       value: PropTypes.value,
     })),
-    legendType: PropTypes.oneOf([
-      'line', 'square', 'rect', 'circle', 'cross', 'diamond', 'square',
-      'star', 'triangle', 'wye',
-    ]),
+    legendType: PropTypes.oneOf(LEGEND_TYPES),
     label: PropTypes.oneOfType([
       PropTypes.bool, PropTypes.func, PropTypes.element, PropTypes.object,
     ]),

--- a/src/util/ReactUtils.js
+++ b/src/util/ReactUtils.js
@@ -111,7 +111,7 @@ export const EVENT_ATTRIBUTES = {
 
 export const LEGEND_TYPES = [
   'line', 'square', 'rect', 'circle', 'cross', 'diamond',
-  'star', 'triangle', 'wye',
+  'star', 'triangle', 'wye', 'none',
 ];
 
 /**

--- a/src/util/ReactUtils.js
+++ b/src/util/ReactUtils.js
@@ -108,6 +108,12 @@ export const EVENT_ATTRIBUTES = {
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
 };
+
+export const LEGEND_TYPES = [
+  'line', 'square', 'rect', 'circle', 'cross', 'diamond',
+  'star', 'triangle', 'wye',
+];
+
 /**
  * Get the display name of a component
  * @param  {Object} Comp Specified Component

--- a/test/specs/component/LegendSpec.js
+++ b/test/specs/component/LegendSpec.js
@@ -31,4 +31,19 @@ describe('<Legend />', () => {
     expect(wrapper.find('.recharts-default-legend').length).to.equal(0);
     expect(wrapper.find('.customized-legend').length).to.equal(1);
   });
+
+  it('Does not render items with a type of `none`', () => {
+    const dataWithNone = [
+      { value: 'Apple', color: '#ff7300' },
+      { value: 'Samsung', color: '#bb7300' },
+      { value: 'Huawei', color: '#887300' },
+      { value: 'Sony', type: 'none' },
+    ];
+    const wrapper = render(
+      <Legend width={500} height={30} payload={dataWithNone} />
+    );
+
+    expect(wrapper.find('.recharts-default-legend').length).to.equal(1);
+    expect(wrapper.find('.recharts-default-legend .recharts-legend-item').length).to.equal(3);
+  });
 });


### PR DESCRIPTION
Fixes #368 

This does two main things:

- Consolidates the legend type PropType array into one place, in `ReactUtils`, to ensure they stay consistent.
- Adds a `"none"` item to valid legend types, which if used will cause the legend item to not be included.  This is useful in some cases for example when you are plotting comparison data between two periods, but you don't want to have two legend items.

I've also added a spec and demo as well.