### PR TITLE
use prop-types instead of React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "d3-scale": "1.0.4",
     "d3-shape": "1.0.4",
     "lodash": "~4.17.4",
+    "prop-types": "^15.5.7",
     "react-resize-detector": "0.3.3",
     "react-smooth": "0.1.20",
     "recharts-scale": "0.3.0",

--- a/src/cartesian/Area.js
+++ b/src/cartesian/Area.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Area
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
 import _ from 'lodash';

--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Render a group of bar
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Animate, { translateStyle } from 'react-smooth';
 import _ from 'lodash';

--- a/src/cartesian/Brush.js
+++ b/src/cartesian/Brush.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Brush
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { scalePoint } from 'd3-scale';
 import _ from 'lodash';

--- a/src/cartesian/CartesianAxis.js
+++ b/src/cartesian/CartesianAxis.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Cartesian Axis
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { shallowEqual } from '../util/PureRender';
 import { getStringSize } from '../util/DOMUtils';

--- a/src/cartesian/CartesianGrid.js
+++ b/src/cartesian/CartesianGrid.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Cartesian Grid
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import pureRender from '../util/PureRender';
 import { PRESENTATION_ATTRIBUTES, getPresentationAttributes } from '../util/ReactUtils';

--- a/src/cartesian/ErrorBar.js
+++ b/src/cartesian/ErrorBar.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Render a group of error bar
 */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Layer from '../container/Layer';
 import { getPresentationAttributes } from '../util/ReactUtils';
 

--- a/src/cartesian/Line.js
+++ b/src/cartesian/Line.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Line
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Animate from 'react-smooth';
 import classNames from 'classnames';
 import _ from 'lodash';

--- a/src/cartesian/ReferenceArea.js
+++ b/src/cartesian/ReferenceArea.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Reference Line
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import pureRender from '../util/PureRender';
 import Layer from '../container/Layer';

--- a/src/cartesian/ReferenceDot.js
+++ b/src/cartesian/ReferenceDot.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Reference Line
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import pureRender from '../util/PureRender';
 import Layer from '../container/Layer';

--- a/src/cartesian/ReferenceLine.js
+++ b/src/cartesian/ReferenceLine.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Reference Line
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import pureRender from '../util/PureRender';
 import Layer from '../container/Layer';

--- a/src/cartesian/Scatter.js
+++ b/src/cartesian/Scatter.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Render a group of scatters
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Animate from 'react-smooth';
 import classNames from 'classnames';
 import _ from 'lodash';

--- a/src/cartesian/XAxis.js
+++ b/src/cartesian/XAxis.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview X Axis
  */
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 import pureRender from '../util/PureRender';
 
 @pureRender

--- a/src/cartesian/YAxis.js
+++ b/src/cartesian/YAxis.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Y Axis
  */
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 import pureRender from '../util/PureRender';
 
 @pureRender

--- a/src/cartesian/ZAxis.js
+++ b/src/cartesian/ZAxis.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Z Axis
  */
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 import pureRender from '../util/PureRender';
 
 @pureRender

--- a/src/chart/AreaChart.js
+++ b/src/chart/AreaChart.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Area Chart
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Smooth from 'react-smooth';
 import _ from 'lodash';
 import Layer from '../container/Layer';

--- a/src/chart/BarChart.js
+++ b/src/chart/BarChart.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Bar Chart
  */
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Layer from '../container/Layer';
 import Tooltip from '../component/Tooltip';

--- a/src/chart/ComposedChart.js
+++ b/src/chart/ComposedChart.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Composed Chart
  */
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Layer from '../container/Layer';
 import Tooltip from '../component/Tooltip';

--- a/src/chart/LineChart.js
+++ b/src/chart/LineChart.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Line Chart
  */
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Smooth from 'react-smooth';
 import _ from 'lodash';
 import Layer from '../container/Layer';

--- a/src/chart/PieChart.js
+++ b/src/chart/PieChart.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Pie Chart
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Surface from '../container/Surface';
 import Legend from '../component/Legend';

--- a/src/chart/RadarChart.js
+++ b/src/chart/RadarChart.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Radar Chart
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { scalePoint } from 'd3-scale';
 import { getNiceTickValues } from 'recharts-scale';

--- a/src/chart/RadialBarChart.js
+++ b/src/chart/RadialBarChart.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Radar Bar Chart
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { scaleBand } from 'd3-scale';
 import _ from 'lodash';

--- a/src/chart/Sankey.js
+++ b/src/chart/Sankey.js
@@ -1,7 +1,8 @@
 /**
  * @file TreemapChart
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import _ from 'lodash';
 import Surface from '../container/Surface';

--- a/src/chart/ScatterChart.js
+++ b/src/chart/ScatterChart.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Scatter Chart
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Surface from '../container/Surface';
 import Layer from '../container/Layer';

--- a/src/chart/Treemap.js
+++ b/src/chart/Treemap.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview TreemapChart
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Smooth from 'react-smooth';
 import classNames from 'classnames';
 import _ from 'lodash';

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import _ from 'lodash';
 import Surface from '../container/Surface';

--- a/src/component/DefaultLegendContent.js
+++ b/src/component/DefaultLegendContent.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Default Legend Content
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import pureRender from '../util/PureRender';
 import Surface from '../container/Surface';
 import Symbols from '../shape/Symbols';

--- a/src/component/DefaultTooltipContent.js
+++ b/src/component/DefaultTooltipContent.js
@@ -2,7 +2,8 @@
  * @fileOverview Default Tooltip Content
  */
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import pureRender from '../util/PureRender';
 import { isNumOrStr } from '../util/DataUtils';
 

--- a/src/component/Legend.js
+++ b/src/component/Legend.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Legend
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import pureRender from '../util/PureRender';
 import DefaultLegendContent from './DefaultLegendContent';

--- a/src/component/ResponsiveContainer.js
+++ b/src/component/ResponsiveContainer.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Wrapper component to make charts adapt to the size of parent * DOM
  */
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactResizeDetector from 'react-resize-detector';
 import _ from 'lodash';
 import { isPercent } from '../util/DataUtils';

--- a/src/component/Text.js
+++ b/src/component/Text.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import reduceCSSCalc from 'reduce-css-calc';
 import classNames from 'classnames';
 import _ from 'lodash';

--- a/src/component/Tooltip.js
+++ b/src/component/Tooltip.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Tooltip
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { translateStyle } from 'react-smooth';
 import _ from 'lodash';
 import DefaultTooltipContent from './DefaultTooltipContent';

--- a/src/container/Layer.js
+++ b/src/container/Layer.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Layer
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 const propTypes = {

--- a/src/container/Surface.js
+++ b/src/container/Surface.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Surface
  */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { getPresentationAttributes } from '../util/ReactUtils';
 

--- a/src/polar/Pie.js
+++ b/src/polar/Pie.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Render sectors of a pie
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Animate from 'react-smooth';
 import classNames from 'classnames';
 import _ from 'lodash';

--- a/src/polar/PolarAngleAxis.js
+++ b/src/polar/PolarAngleAxis.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Axis of radial direction
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import pureRender from '../util/PureRender';
 import Layer from '../container/Layer';

--- a/src/polar/PolarGrid.js
+++ b/src/polar/PolarGrid.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Polar Grid
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import pureRender from '../util/PureRender';
 import { polarToCartesian } from '../util/PolarUtils';
 import { PRESENTATION_ATTRIBUTES, getPresentationAttributes } from '../util/ReactUtils';

--- a/src/polar/PolarRadiusAxis.js
+++ b/src/polar/PolarRadiusAxis.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview The axis of polar coordinate system
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import pureRender from '../util/PureRender';
 import Text from '../component/Text';

--- a/src/polar/Radar.js
+++ b/src/polar/Radar.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Radar
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Animate from 'react-smooth';
 import classNames from 'classnames';
 import _ from 'lodash';

--- a/src/polar/RadialBar.js
+++ b/src/polar/RadialBar.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Render a group of radial bar
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
 import _ from 'lodash';

--- a/src/shape/Cross.js
+++ b/src/shape/Cross.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Cross
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import pureRender from '../util/PureRender';
 import { isNumber } from '../util/DataUtils';

--- a/src/shape/Curve.js
+++ b/src/shape/Curve.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Curve
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { line as shapeLine, area as shapeArea, curveBasisClosed, curveBasisOpen,
   curveBasis, curveLinearClosed, curveLinear, curveMonotoneX, curveMonotoneY,
   curveNatural, curveStep, curveStepAfter, curveStepBefore } from 'd3-shape';

--- a/src/shape/Dot.js
+++ b/src/shape/Dot.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Dot
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import pureRender from '../util/PureRender';
 import { getPresentationAttributes, filterEventAttributes } from '../util/ReactUtils';

--- a/src/shape/Polygon.js
+++ b/src/shape/Polygon.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Polygon
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import pureRender from '../util/PureRender';
 import { PRESENTATION_ATTRIBUTES, getPresentationAttributes,

--- a/src/shape/Rectangle.js
+++ b/src/shape/Rectangle.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Rectangle
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
 import pureRender from '../util/PureRender';

--- a/src/shape/Sector.js
+++ b/src/shape/Sector.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Sector
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import pureRender from '../util/PureRender';
 import { PRESENTATION_ATTRIBUTES, getPresentationAttributes,

--- a/src/shape/Symbols.js
+++ b/src/shape/Symbols.js
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Curve
  */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { symbol as shapeSymbol, symbolCircle, symbolCross, symbolDiamond,
  symbolSquare, symbolStar, symbolTriangle, symbolWye } from 'd3-shape';
 import classNames from 'classnames';

--- a/src/util/AnimationDecorator.js
+++ b/src/util/AnimationDecorator.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { getDisplayName } from './ReactUtils';
 
 export default function (WrappedComponent) {

--- a/src/util/ComposedDataDecorator.js
+++ b/src/util/ComposedDataDecorator.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { shallowEqual } from './PureRender';
 import { getDisplayName, findAllByType } from './ReactUtils';

--- a/src/util/ReactUtils.js
+++ b/src/util/ReactUtils.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Children } from 'react';
+import React, { Children } from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { isNumber } from './DataUtils';
 import { shallowEqual } from './PureRender';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,12 @@ var config = {
       commonjs: 'react-addons-transition-group',
       amd: 'react-addons-transition-group',
     },
+    'prop-types': {
+      root: 'PropTypes',
+      commonjs2: 'prop-types',
+      commonjs: 'prop-types',
+      amd: 'prop-types',
+    },
   },
 
   plugins: [


### PR DESCRIPTION
As of React 15.5, `React.PropTypes` is deprecated. https://facebook.github.io/react/blog/