### PR TITLE
Allow viewing a single bar in a bar chart

### DIFF
--- a/src/util/DataUtils.js
+++ b/src/util/DataUtils.js
@@ -118,18 +118,22 @@ export const getBandSizeOfAxis = (axis, ticks) => {
     return axis.scale.bandwidth();
   }
 
-  if (axis && ticks && ticks.length >= 2) {
-    const orderedTicks = _.sortBy(ticks, o => o.coordinate);
-    let bandSize = Infinity;
+  if (axis && ticks) {
+    if (ticks.length === 1) {
+      return axis.width;
+    } else if (ticks.length >= 2) {
+      const orderedTicks = _.sortBy(ticks, o => o.coordinate);
+      let bandSize = Infinity;
 
-    for (let i = 1, len = orderedTicks.length; i < len; i++) {
-      const cur = orderedTicks[i];
-      const prev = orderedTicks[i - 1];
+      for (let i = 1, len = orderedTicks.length; i < len; i++) {
+        const cur = orderedTicks[i];
+        const prev = orderedTicks[i - 1];
 
-      bandSize = Math.min((cur.coordinate || 0) - (prev.coordinate || 0), bandSize);
+        bandSize = Math.min((cur.coordinate || 0) - (prev.coordinate || 0), bandSize);
+      }
+
+      return bandSize === Infinity ? 0 : bandSize;
     }
-
-    return bandSize === Infinity ? 0 : bandSize;
   }
 
   return 0;

--- a/test/specs/util/DataUtilsSpec.js
+++ b/test/specs/util/DataUtilsSpec.js
@@ -45,6 +45,12 @@ describe('getBandSizeOfAxis', () => {
     const ticks = [{ coordinate: 13 }, { coordinate: 15 }, { coordinate: 20 }];
     expect(getBandSizeOfAxis(axis, ticks)).to.equal(2);
   });
+
+  it('DataUtils.getBandSizeOfAxis() should return axis.width when ticks.length === 1 ', () => {
+    const axis = { width: 600 };
+    const ticks = [{ coordinate: 20 }];
+    expect(getBandSizeOfAxis(axis, ticks)).to.equal(600);
+  });
 });
 
 describe('getAnyElementOfObject', () => {


### PR DESCRIPTION
Currently it's not possible for me to view a single bar in my barchart, since the loop that decides the bandSize can't handle when the ticks array has only one element. BandSize is returned as 0, and that means the bar has 0 width.

My fix for this was to take the axis width if there is only 1 tick in the array. I'm not certain if this is the best way to fix this, but I didn't see any other issues about trying to view a single bar in a bar chart, so I assumed this was an edge case.