### PR TITLE
Avoid calculating ticks if tick is set to false

### DIFF
--- a/src/cartesian/CartesianAxis.js
+++ b/src/cartesian/CartesianAxis.js
@@ -76,9 +76,9 @@ class CartesianAxis extends Component {
   };
 
   static getTicks(props) {
-    const { ticks, viewBox, minTickGap, orientation, interval, tickFormatter } = props;
+    const { tick, ticks, viewBox, minTickGap, orientation, interval, tickFormatter } = props;
 
-    if (!ticks || !ticks.length) { return []; }
+    if (!ticks || !ticks.length || !tick) { return []; }
 
     if (isNumber(interval) || isSsr()) {
       return CartesianAxis.getNumberIntervalTicks(ticks, isNumber(interval) ? interval : 0);

--- a/test/specs/cartesian/CartesianAxisSpec.js
+++ b/test/specs/cartesian/CartesianAxisSpec.js
@@ -258,4 +258,21 @@ describe('<CartesianAxis />', () => {
     expect(wrapper.find('.customized-tick').length).to.equal(ticks.length);
   });
 
+  it('Renders no ticks when tick is set to false', () => {
+    const wrapper = render(
+      <Surface width={500} height={500}>
+        <CartesianAxis
+          orientation="bottom"
+          y={100}
+          width={400}
+          height={50}
+          viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
+          tick={false}
+        />
+      </Surface>
+    );
+
+    expect(wrapper.find('.recharts-cartesian-axis-tick').length).to.equal(0);
+  });
+
 });


### PR DESCRIPTION
Calculating the tick width adds to the rendering time and should not be done if no ticks are needed.
<img width="597" alt="screen shot 2017-05-22 at 12 46 06 pm" src="https://cloud.githubusercontent.com/assets/2819448/26299541/bedf07a2-3f0d-11e7-9e16-6d61d3b13a3e.png">

This PR avoids the `getTicks` calculation if `tick` is set to false