### PR TITLE
Improve performance when checking tick text width

### DIFF
--- a/src/util/DOMUtils.js
+++ b/src/util/DOMUtils.js
@@ -61,14 +61,19 @@ export const getStringSize = (text, style = {}) => {
 
   try {
     let measurementSpan = document.getElementById(MEASUREMENT_SPAN_ID);
+    const textNode = document.createTextNode('');
     if (!measurementSpan) {
       measurementSpan = document.createElement('span');
       measurementSpan.setAttribute('id', MEASUREMENT_SPAN_ID);
+      measurementSpan.setAttribute('style', getStyleString(SPAN_STYLE));
+      measurementSpan.appendChild(textNode);
       document.body.appendChild(measurementSpan);
     }
 
-    measurementSpan.setAttribute('style', getStyleString({ ...SPAN_STYLE, ...style }));
-    measurementSpan.textContent = str;
+    if (styleString !== '') {
+      measurementSpan.setAttribute('style', getStyleString({ ...SPAN_STYLE, ...style }));
+    }
+    textNode.nodeValue = str;
 
     const rect = measurementSpan.getBoundingClientRect();
     const result = { width: rect.width, height: rect.height };


### PR DESCRIPTION
While debugging the chart performance, I noticed that ~1sec is spent calculating the tick width before the charts are rendered. 
<img width="814" alt="screen shot 2017-05-22 at 3 06 53 pm" src="https://cloud.githubusercontent.com/assets/2819448/26300142/db0c79ee-3f0f-11e7-824d-3b2e0ddcc832.png">

Digger a little deeper, you'll see that ~700 ms is spent setting the CSS style and text content of the tick text.
<img width="705" alt="screen shot 2017-05-22 at 3 23 12 pm" src="https://cloud.githubusercontent.com/assets/2819448/26300210/06c5d418-3f10-11e7-94ce-1e6f6dc0ec55.png">

According to this [SO](http://stackoverflow.com/questions/17199958/why-does-setting-textcontent-cause-layout-thrashing), textcontent causes layout thrashing.
By creating a text node and updating its text and setting the custom css style only if a user provides one, this is reduced to ~4ms.
<img width="707" alt="screen shot 2017-05-22 at 4 07 11 pm" src="https://cloud.githubusercontent.com/assets/2819448/26300272/3540aade-3f10-11e7-89dd-97ef27091e78.png">
<img width="570" alt="screen shot 2017-05-22 at 5 02 28 pm" src="https://cloud.githubusercontent.com/assets/2819448/26300467/bdd81d32-3f10-11e7-9e6f-807fdec2b10c.png">


