### PR TITLE
Fixed 'Cannot read property 'map' of undefined'

### DIFF
--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -110,7 +110,7 @@ export const getLegendProps = ({
   } else if (legendContent === 'children') {
     legendData = (formatedGraphicalItems || []).reduce((result, { item, props }, i) => {
       const { nameKey } = item.props;
-      const data = props.sectors || props.data;
+      const data = props.sectors || props.data || [];
 
       return result.concat(data.map(entry => (
         {


### PR DESCRIPTION
Fixed 'Cannot read property 'map' of undefined' bug.

Bug occurs when using PieChart and Legend.

![image](https://cloud.githubusercontent.com/assets/12469814/26472782/4a6aaac0-41b0-11e7-934d-2f2cece864f3.png)
