### PR TITLE
Fix `iteratee is not a function` error

### DIFF
--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -1067,7 +1067,7 @@ const generateCategoricalChart = ({
 
       return {
         tooltipTicks,
-        orderedTooltipTicks: _.sortBy(tooltipTicks, o => o.coordinate),
+        orderedTooltipTicks: _.sortBy(tooltipTicks, [o => o.coordinate]),
         tooltipAxis: axis,
         tooltipAxisBandSize: getBandSizeOfAxis(axis),
       };


### PR DESCRIPTION
I got an error `iteratee is not a function` when trying the sample snippet on Recharts homepage.

```jsx
      <LineChart width={500} height={300} data={data}>
        <XAxis dataKey="name" />
        <YAxis />
        <CartesianGrid stroke="#eee" strokeDasharray="5 5" />
        <Line type="monotone" dataKey="uv" stroke="#8884d8" />
        <Line type="monotone" dataKey="pv" stroke="#82ca9d" />
      </LineChart>
```

![screenshot from 2017-05-29 13-57-47](https://cloud.githubusercontent.com/assets/172503/26547545/2ff705d8-4478-11e7-97b3-4088226c104b.png)

I did check [Lodash's docs](https://lodash.com/docs/4.17.4#sortBy) but apparently passing a single function didn't work in this case, but an array of iteratees did.