### PR TITLE
Add number of ticks to tick props

### DIFF
--- a/src/cartesian/CartesianAxis.js
+++ b/src/cartesian/CartesianAxis.js
@@ -378,6 +378,7 @@ class CartesianAxis extends Component {
         ...customTickProps,
         ...tickCoord,
         index: i, payload: entry,
+        totalTicks: finalTicks.length,
       };
 
       return (

--- a/src/cartesian/CartesianAxis.js
+++ b/src/cartesian/CartesianAxis.js
@@ -378,7 +378,7 @@ class CartesianAxis extends Component {
         ...customTickProps,
         ...tickCoord,
         index: i, payload: entry,
-        totalTicks: finalTicks.length,
+        visibleTicksCount: finalTicks.length,
       };
 
       return (


### PR DESCRIPTION
This is helpful when trying to render each tick based on the total available width and the number of ticks visible.