### PR TITLE
Mixed components

### DIFF
--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -263,7 +263,9 @@ const generateCategoricalChart = ({
       stackGroups, dataStartIndex, dataEndIndex }) {
       const { layout, children, stackOffset } = props;
       const displayedData = this.constructor.getDisplayedData(props, {
-        graphicalItems, dataStartIndex, dataEndIndex,
+        graphicalItems: graphicalItems.filter(item => item.props[axisIdKey] === axisId),
+        dataStartIndex,
+        dataEndIndex,
       });
       const len = displayedData.length;
       const isCategorial = isCategorialAxis(layout, axisType);

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -120,17 +120,7 @@ const generateCategoricalChart = ({
     };
 
     static getDisplayedData = (props, { graphicalItems, dataStartIndex, dataEndIndex }, item) => {
-      const { data } = props;
-
-      if (data && data.length && isNumber(dataStartIndex) && isNumber(dataEndIndex)) {
-        return data.slice(dataStartIndex, dataEndIndex + 1);
-      }
-
-      if (item && item.props) {
-        return item.props.data || [];
-      }
-
-      return graphicalItems.reduce((result, child) => {
+      const itemsData = (graphicalItems || []).reduce((result, child) => {
         const itemData = child.props.data;
 
         if (itemData && itemData.length) {
@@ -139,6 +129,21 @@ const generateCategoricalChart = ({
 
         return result;
       }, []);
+      if (itemsData && itemsData.length > 0) {
+        return itemsData;
+      }
+
+      if (item && item.props && item.props.data && item.props.data.length > 0) {
+        return item.props.data;
+      }
+
+      const { data } = props;
+
+        if (data && data.length && isNumber(dataStartIndex) && isNumber(dataEndIndex)) {
+        return data.slice(dataStartIndex, dataEndIndex + 1);
+      }
+
+      return [];
     };
 
     constructor(props) {

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -262,18 +262,18 @@ const generateCategoricalChart = ({
     getAxisMapByAxes(props, { axes, graphicalItems, axisType, axisIdKey,
       stackGroups, dataStartIndex, dataEndIndex }) {
       const { layout, children, stackOffset } = props;
-      const displayedData = this.constructor.getDisplayedData(props, {
-        graphicalItems: graphicalItems.filter(item => item.props[axisIdKey] === axisId),
-        dataStartIndex,
-        dataEndIndex,
-      });
-      const len = displayedData.length;
       const isCategorial = isCategorialAxis(layout, axisType);
 
       // Eliminate duplicated axes
       const axisMap = axes.reduce((result, child) => {
         const { type, dataKey, allowDataOverflow, scale } = child.props;
         const axisId = child.props[axisIdKey];
+        const displayedData = this.constructor.getDisplayedData(props, {
+          graphicalItems: graphicalItems.filter(item => item.props[axisIdKey] === axisId),
+          dataStartIndex,
+          dataEndIndex,
+        });
+        const len = displayedData.length;
 
         if (!result[axisId]) {
           let domain, duplicateDomain, categoricalDomain;


### PR DESCRIPTION
Updates on how data is selected and axis _points_ are calculated.

#### Changed the order in which `getDisplayedData` looks for the data.

The data used to calculated the Axis _points_ are returned in this order:

1. Data from the graphical items;
2. Data from the item properties;
3. data from the chart props.

This allows us to use a general data set for a complement like `Line` while using a specific data set for another component like Scatter.

The example below has the chart's data property defined as the general data used for the `Line` components while the `Scatter` has its own data property.

Without this code changes the `Scatter` would never render since it would use the data from the chart.

The `linesData` and `scatterData` are completely different and they don't use the same `points` on any axis. They are just displayed together.

```jsx
// linesData = [ { label: string, a: number, b: number }, ... ];
// scatterData = [ { x: number, y: number }, ... ];

<ComposedChart width={600} height={400} data={linesData}>
  <CartesianGrid />

  <XAxis xAxisId="a1" dataKey="x" type="number" />
  <YAxis yAxisId="a2" dataKey="y" type="number" />

  <XAxis xAxisId="a3" dataKey="label" type="category" orientation="top" />
  <YAxis yAxisId="a4" type="number" orientation="right" />

  <Scatter xAxisId="a1" yAxisId="a2" data={scatterData} fill="#ff0000" line />

  <Line xAxisId="a3" yAxisId="a4" dataKey="a" type="monotone" stroke="#00ff00" />
  <Line xAxisId="a3" yAxisId="a4" dataKey="b" type="monotone" stroke="#ff00ff" />
</ComposedChart>
```

#### Changed how an axis _points_ are calculated.

Updated the `getAxisMapByAxes` send to `getDisplayedData` `graphicalItems` which are connected with the given axis.

This prevents the axis from considering data it is not supposed to display.

The example code is the same used in the previous item.

Without this change:

<img width="523" alt="screen shot 2017-06-06 at 16 13 14" src="https://user-images.githubusercontent.com/91159/26847344-1f8266aa-4ad3-11e7-998a-4287e1183ec4.png">

With this change:

<img width="521" alt="screen shot 2017-06-06 at 16 13 25" src="https://user-images.githubusercontent.com/91159/26847356-276030be-4ad3-11e7-8a7f-8422a2149292.png">