### PR TITLE
Show tooltip on drag movement on touch devices

### DIFF
--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -969,8 +969,8 @@ const generateCategoricalChart = ({
     handleMouseMove = (e) => {
       if (e && _.isFunction(e.persist)) {
         e.persist();
-        this.triggeredAfterMouseMove(e);
       }
+      this.triggeredAfterMouseMove(e);
     }
     /**
      * The handler if mouse leaving chart


### PR DESCRIPTION
It's probably a bugfix. The issue and the solution came from #509 

I only moved the trigger function to outside of the if clause. This way the function will be called on touch move event on touch devices.