### PR TITLE
feat: default nameKey to name property

### DIFF
--- a/src/polar/Pie.js
+++ b/src/polar/Pie.js
@@ -101,6 +101,7 @@ class Pie extends Component {
     animationBegin: 400,
     animationDuration: 1500,
     animationEasing: 'ease',
+    nameKey: 'name',
   };
 
   static parseDeltaAngle = ({ startAngle, endAngle }) => {


### PR DESCRIPTION
The idea originally shared by @ZephD in #758 didn't get a response:

> @xile611
> Why is nameKey and dataKey not defaulted to "name" and "value" respectively?

This was a big time waste for me today too, to find the `nameKey` prop and realize that it defaults to nothing. This Pull Request defaults `nameKey` to `"name"` property in the data set. If `name` is not present in the data set, the behavior is the same as before the PR: name will become an index of the entry in the pie chart data.