### PR TITLE
Don't check for animation finishing when it is disabled

### DIFF
--- a/src/cartesian/Scatter.js
+++ b/src/cartesian/Scatter.js
@@ -260,7 +260,8 @@ class Scatter extends Component {
   }
 
   renderErrorBar() {
-    if (!this.state.isAnimationFinished) { return null; }
+    const { isAnimationActive } = this.props;
+    if (isAnimationActive && !this.state.isAnimationFinished) { return null; }
 
     const { points, xAxis, yAxis, children } = this.props;
     const errorBarItems = findAllByType(children, ErrorBar);


### PR DESCRIPTION
If animation is disabled on the scatter plot then the error bars are never drawn.
This is because this.state.isAnimationFinished defaults to false, so error bar rendering
is never executed.

Also another issue is that when animation is enabled,  the error bars may never actually render if the point animation takes a long time but the error bar rendering functions executes before animation finishes.

Ideally,  error bar rendering should be kicked of by point animation rendering finish. I wasn't sure how to do this.