### PR TITLE
feat: adds support for reveresal of stacked group render order, fix #873

### DIFF
--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -76,7 +76,7 @@ const generateCategoricalChart = ({
       onMouseMove: PropTypes.func,
       onMouseDown: PropTypes.func,
       onMouseUp: PropTypes.func,
-      reverseGroupOrder: PropTypes.bool,
+      reverseStackOrder: PropTypes.bool,
       ...propTypes,
     };
 
@@ -86,7 +86,7 @@ const generateCategoricalChart = ({
       barCategoryGap: '10%',
       barGap: 4,
       margin: { top: 5, right: 5, bottom: 5, left: 5 },
-      reverseGroupOrder: false,
+      reverseStackOrder: false,
       ...defaultProps,
     };
 
@@ -735,11 +735,11 @@ const generateCategoricalChart = ({
     updateStateOfAxisMapsOffsetAndStackGroups({ props, dataStartIndex, dataEndIndex, updateId }) {
       if (!validateWidthHeight({ props })) { return null; }
 
-      const { children, layout, stackOffset, data, reverseGroupOrder } = props;
+      const { children, layout, stackOffset, data, reverseStackOrder } = props;
       const { numericAxisName, cateAxisName } = this.getAxisNameByLayout(layout);
       const graphicalItems = findAllByType(children, GraphicalChild);
       const stackGroups = getStackGroupsByAxisId(
-        data, graphicalItems, `${numericAxisName}Id`, `${cateAxisName}Id`, stackOffset, reverseGroupOrder
+        data, graphicalItems, `${numericAxisName}Id`, `${cateAxisName}Id`, stackOffset, reverseStackOrder
       );
       const axisObj = axisComponents.reduce((result, entry) => {
         const name = `${entry.axisType}Map`;

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -76,6 +76,7 @@ const generateCategoricalChart = ({
       onMouseMove: PropTypes.func,
       onMouseDown: PropTypes.func,
       onMouseUp: PropTypes.func,
+      reverseGroupOrder: PropTypes.bool,
       ...propTypes,
     };
 
@@ -85,6 +86,7 @@ const generateCategoricalChart = ({
       barCategoryGap: '10%',
       barGap: 4,
       margin: { top: 5, right: 5, bottom: 5, left: 5 },
+      reverseGroupOrder: false,
       ...defaultProps,
     };
 
@@ -733,11 +735,11 @@ const generateCategoricalChart = ({
     updateStateOfAxisMapsOffsetAndStackGroups({ props, dataStartIndex, dataEndIndex, updateId }) {
       if (!validateWidthHeight({ props })) { return null; }
 
-      const { children, layout, stackOffset, data } = props;
+      const { children, layout, stackOffset, data, reverseGroupOrder } = props;
       const { numericAxisName, cateAxisName } = this.getAxisNameByLayout(layout);
       const graphicalItems = findAllByType(children, GraphicalChild);
       const stackGroups = getStackGroupsByAxisId(
-        data, graphicalItems, `${numericAxisName}Id`, `${cateAxisName}Id`, stackOffset
+        data, graphicalItems, `${numericAxisName}Id`, `${cateAxisName}Id`, stackOffset, reverseGroupOrder
       );
       const axisObj = axisComponents.reduce((result, entry) => {
         const name = `${entry.axisType}Map`;

--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -636,12 +636,12 @@ export const getStackedData = (data, stackItems, offsetType) => {
 };
 
 export const getStackGroupsByAxisId = (
-  data, _items, numericAxisId, cateAxisId, offsetType, reverseGroupOrder
+  data, _items, numericAxisId, cateAxisId, offsetType, reverseStackOrder
 ) => {
   if (!data) { return null; }
 
   // reversing items to affect render order (for layering)
-  const items = reverseGroupOrder ? _items.reverse() : _items;
+  const items = reverseStackOrder ? _items.reverse() : _items;
 
   const stackGroups = items.reduce((result, item) => {
     const { stackId, hide } = item.props;

--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -635,8 +635,13 @@ export const getStackedData = (data, stackItems, offsetType) => {
   return stack(data);
 };
 
-export const getStackGroupsByAxisId = (data, items, numericAxisId, cateAxisId, offsetType) => {
+export const getStackGroupsByAxisId = (
+  data, _items, numericAxisId, cateAxisId, offsetType, reverseGroupOrder
+) => {
   if (!data) { return null; }
+
+  // reversing items to affect render order (for layering)
+  const items = reverseGroupOrder ? _items.reverse() : _items;
 
   const stackGroups = items.reduce((result, item) => {
     const { stackId, hide } = item.props;
@@ -931,4 +936,3 @@ export const getBandSizeOfAxis = (axis, ticks) => {
 
   return 0;
 };
-


### PR DESCRIPTION
## Related
* https://github.com/recharts/recharts/issues/873
* https://github.com/recharts/recharts.org/pull/37
* http://jsfiddle.net/jayseeg/oc5jtdrz/1/

## Feature
Given a bar chart with multiple bars
When I overlap the bars with a negative bar gap to achieve a layered effect
Then I want to be able to tell the chart which order to render the SVG elements in (calling for reverse rendering should render right to left without changing coordinates so that left most elements can layer on top of elements to the right)

## Details
Adds `reverseGroupOrder` boolean prop to `generateCategoricalChart` with default of false. Setting to true reverses group rendering from left to right to right to left.

## Notes
No tests on `getStackGroupsByAxisId` currently, so I didn't add any.