### PR TITLE
Draw Area stroke above fill

### DIFF
--- a/src/cartesian/Area.js
+++ b/src/cartesian/Area.js
@@ -312,6 +312,13 @@ class Area extends Component {
 
     return (
       <Layer clipPath={needClip ? `url(#clipPath-${this.id})` : null}>
+        <Curve
+          {...this.props}
+          points={points}
+          baseLine={baseLine}
+          stroke="none"
+          className="recharts-area-area"
+        />
         {stroke !== 'none' && (
           <Curve
             {...getPresentationAttributes(this.props)}
@@ -334,13 +341,6 @@ class Area extends Component {
             points={baseLine}
           />
         )}
-        <Curve
-          {...this.props}
-          points={points}
-          baseLine={baseLine}
-          stroke="none"
-          className="recharts-area-area"
-        />
       </Layer>
     );
   }

--- a/test/specs/cartesian/AreaSpec.js
+++ b/test/specs/cartesian/AreaSpec.js
@@ -105,4 +105,28 @@ describe('<Area />', () => {
     expect(wrapper.find('.recharts-area-curve').length).to.equal(0);
     expect(wrapper.find('.recharts-area-dot').length).to.equal(0);
   });
+
+  it('renders the curve with the stroke on top (i.e 2nd) of the curve with ' +
+    'the fill (i.e first)', () => {
+    const wrapper = mount(
+      <Surface width={500} height={500}>
+        <Area
+          points={data}
+          baseLine={200}
+          stroke="teal"
+          fill="teal"
+        />
+      </Surface>
+    );
+
+    expect(wrapper.find('.recharts-curve').length).to.equal(2);
+    expect(wrapper.find('.recharts-curve').first().prop('stroke'))
+      .to.equal('none');
+    expect(wrapper.find('.recharts-curve').first().prop('fill'))
+      .to.equal('teal');
+    expect(wrapper.find('.recharts-curve').last().prop('stroke'))
+      .to.equal('teal');
+    expect(wrapper.find('.recharts-curve').last().prop('fill'))
+      .to.equal('none');
+  });
 });

--- a/test/specs/cartesian/AreaSpec.js
+++ b/test/specs/cartesian/AreaSpec.js
@@ -106,8 +106,7 @@ describe('<Area />', () => {
     expect(wrapper.find('.recharts-area-dot').length).to.equal(0);
   });
 
-  it('renders the curve with the stroke on top (i.e 2nd) of the curve with ' +
-    'the fill (i.e first)', () => {
+  it('renders the curve with the stroke on top (2nd) of the curve with the fill (1st)', () => {
     const wrapper = mount(
       <Surface width={500} height={500}>
         <Area
@@ -120,13 +119,9 @@ describe('<Area />', () => {
     );
 
     expect(wrapper.find('.recharts-curve').length).to.equal(2);
-    expect(wrapper.find('.recharts-curve').first().prop('stroke'))
-      .to.equal('none');
-    expect(wrapper.find('.recharts-curve').first().prop('fill'))
-      .to.equal('teal');
-    expect(wrapper.find('.recharts-curve').last().prop('stroke'))
-      .to.equal('teal');
-    expect(wrapper.find('.recharts-curve').last().prop('fill'))
-      .to.equal('none');
+    expect(wrapper.find('.recharts-curve').first().prop('stroke')).to.equal('none');
+    expect(wrapper.find('.recharts-curve').first().prop('fill')).to.equal('teal');
+    expect(wrapper.find('.recharts-curve').last().prop('stroke')).to.equal('teal');
+    expect(wrapper.find('.recharts-curve').last().prop('fill')).to.equal('none');
   });
 });


### PR DESCRIPTION
Fixes issue #879.
The approach here is to switch the order in which the svg paths are drawn to the screen in order to ensure that the stroke would always cover the fill.