### PR TITLE
Fix version name typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "1.0.0-apha.5",
+  "version": "1.0.0-alpha.5",
   "description": "React charts",
   "main": "lib/index",
   "module": "es6/index",


### PR DESCRIPTION
Fix the typo `apha ` -> `alpha` in package.json. 
It might be better to update git tag and npm published version as well.