### PR TITLE
fix_confuse_startX_in_brush

### DIFF
--- a/src/cartesian/Brush.js
+++ b/src/cartesian/Brush.js
@@ -307,10 +307,10 @@ class Brush extends Component {
     });
   }
 
-  renderTraveller(startX, id) {
+  renderTraveller(travellerX, id) {
     const { y, travellerWidth, height, stroke } = this.props;
     const lineY = Math.floor(y + height / 2) - 1;
-    const x = Math.max(startX, this.props.x);
+    const x = Math.max(travellerX, this.props.x);
 
     return (
       <Layer


### PR DESCRIPTION

The first parameter of renderTraveller function is renamed to "travellerX" that is better "startX".

As is usage like as follows
..
{this.renderTraveller(startX, 'startX')}                                                                        
{this.renderTraveller(endX, 'endX')}                                                                            
..