### PR TITLE
Allow ReferenceArea to cover available space

### DIFF
--- a/src/cartesian/ReferenceArea.js
+++ b/src/cartesian/ReferenceArea.js
@@ -55,7 +55,7 @@ class ReferenceArea extends Component {
     strokeWidth: 1,
   };
 
-  getRect(hasX, hasY) {
+  getRect(hasX1, hasX2, hasY1, hasY2, hasX, hasY) {
     const { x1: xValue1, x2: xValue2, y1: yValue1, y2: yValue2, xAxis,
       yAxis } = this.props;
     const xScale = xAxis.scale;
@@ -66,24 +66,27 @@ class ReferenceArea extends Component {
     const yRange = yScale.range();
     let x1, x2, y1, y2;
 
-    if (hasX && isNumOrStr(xValue1)) {
+    if (hasX1) {
       x1 = xScale(xValue1) + xOffset;
-    } else if (hasY) {
+    } else {
       x1 = xRange[0];
     }
-    if (hasX && isNumOrStr(xValue2)) {
+
+    if (hasX2) {
       x2 = xScale(xValue2) + xOffset;
-    } else if (hasY) {
+    } else {
       x2 = xRange[1];
     }
-    if (hasY && isNumOrStr(yValue1)) {
+
+    if (hasY1) {
       y1 = yScale(yValue1) + yOffset;
-    } else if (hasX) {
+    } else {
       y1 = yRange[0];
     }
-    if (hasY && isNumOrStr(yValue2)) {
+
+    if (hasY2) {
       y2 = yScale(yValue2) + yOffset;
-    } else if (hasX) {
+    } else {
       y2 = yRange[1];
     }
 
@@ -121,12 +124,17 @@ class ReferenceArea extends Component {
 
   render() {
     const { x1, x2, y1, y2, className } = this.props;
-    const hasX = isNumOrStr(x1) && isNumOrStr(x2);
-    const hasY = isNumOrStr(y1) && isNumOrStr(y2);
 
-    if (!hasX && !hasY) { return null; }
+    const hasX1 = isNumOrStr(x1);
+    const hasX2 = isNumOrStr(x2);
+    const hasY1 = isNumOrStr(y1);
+    const hasY2 = isNumOrStr(y2);
+    const hasX = hasX1 && hasX2;
+    const hasY = hasY1 && hasY2;
 
-    const rect = this.getRect(hasX, hasY);
+    if (!hasX1 && !hasX2 && !hasY1 && !hasY2) { return null; }
+
+    const rect = this.getRect(hasX1, hasX2, hasY1, hasY2, hasX, hasY);
 
     if (!rect) { return null; }
 

--- a/src/cartesian/ReferenceArea.js
+++ b/src/cartesian/ReferenceArea.js
@@ -55,7 +55,7 @@ class ReferenceArea extends Component {
     strokeWidth: 1,
   };
 
-  getRect(hasX1, hasX2, hasY1, hasY2, hasX, hasY) {
+  getRect(hasX1, hasX2, hasY1, hasY2) {
     const { x1: xValue1, x2: xValue2, y1: yValue1, y2: yValue2, xAxis,
       yAxis } = this.props;
     const xScale = xAxis.scale;
@@ -134,7 +134,7 @@ class ReferenceArea extends Component {
 
     if (!hasX1 && !hasX2 && !hasY1 && !hasY2) { return null; }
 
-    const rect = this.getRect(hasX1, hasX2, hasY1, hasY2, hasX, hasY);
+    const rect = this.getRect(hasX1, hasX2, hasY1, hasY2);
 
     if (!rect) { return null; }
 

--- a/test/specs/cartesian/ReferenceAreaSpec.js
+++ b/test/specs/cartesian/ReferenceAreaSpec.js
@@ -32,7 +32,20 @@ describe('<ReferenceArea />', () => {
     expect(wrapper.find('.recharts-label').length).to.equal(2);
   });
 
-  it('Don\'t render any rect in ReferenceArea when no x or y is set', () => {
+  it('Don\'t render any rect in ReferenceArea when no x1, x2, y1 or y2 is set', () => {
+    const wrapper = render(
+      <BarChart width={1100} height={250} barGap={2} barSize={6} data={data} margin={{ top: 20, right: 60, bottom: 0, left: 20 }}>
+        <XAxis dataKey="name" orientation="top" />
+        <YAxis tickCount={7} orientation="right" />
+        <Bar dataKey="uv" />
+        <ReferenceArea stroke="#666" label="0" />
+      </BarChart>
+    );
+    expect(wrapper.find('.recharts-reference-area-rect').length).to.equal(0);
+    expect(wrapper.find('.recharts-label').length).to.equal(0);
+  });
+
+  it('Render a rect in ReferenceArea when x1, x2, y1 or y2 is set', () => {
     const wrapper = render(
       <BarChart width={1100} height={250} barGap={2} barSize={6} data={data} margin={{ top: 20, right: 60, bottom: 0, left: 20 }}>
         <XAxis dataKey="name" orientation="top" />
@@ -41,8 +54,8 @@ describe('<ReferenceArea />', () => {
         <ReferenceArea x1="201106" stroke="#666" label="0" />
       </BarChart>
     );
-    expect(wrapper.find('.recharts-reference-area-rect').length).to.equal(0);
-    expect(wrapper.find('.recharts-label').length).to.equal(0);
+    expect(wrapper.find('.recharts-reference-area-rect').length).to.equal(1);
+    expect(wrapper.find('.recharts-label').length).to.equal(1);
   });
 
   it("Don't render any line or label when reference area is outside domain in ReferenceArea", () => {


### PR DESCRIPTION
I needed the `ReferenceArea` element to be able to cover all the available space given a point. For example, cover the entire X axis given one of the Y positions.

Before it was required to specify at least the two components of a pair:

- `x1` and `y2`
- `x1` and `y2`

Now it is possible to declare only one of the components of the area:

- `x1`
- `x2`
- `y1`
- `y2`

For example the following:

![screenshot from 2017-10-03 17-19-46](https://user-images.githubusercontent.com/10656223/31136239-8981e80c-a85f-11e7-981d-0f868665aafe.png)

Can be achieved using:

```ts
<ReferenceArea
    stroke="red"
    fill="red"
    y2={threshold}
    strokeOpacity={0.2}
    fillOpacity={0.1}
/>
```

```ts
<ReferenceArea
    stroke="red"
    fill="red"
    y1={threshold}
    strokeOpacity={0.2}
    fillOpacity={0.1}
/>
```

This feature is useful if you want to highlight when a value goes above or below a threshold.

I'm not sure but I think the issue https://github.com/recharts/recharts/issues/847 is related.
