### PR TITLE
Support for "strokeDasharray" in <Legend/>

### DIFF
--- a/src/component/DefaultLegendContent.js
+++ b/src/component/DefaultLegendContent.js
@@ -56,18 +56,32 @@ class DefaultLegendContent extends Component {
     const color = data.inactive ? inactiveColor : data.color;
 
     if (data.type === 'line') {
-      return (
-        <path
-          strokeWidth={4}
-          fill="none"
-          stroke={color}
-          d={`M0,${halfSize}h${thirdSize}
-            A${sixthSize},${sixthSize},0,1,1,${2 * thirdSize},${halfSize}
-            H${SIZE}M${2 * thirdSize},${halfSize}
-            A${sixthSize},${sixthSize},0,1,1,${thirdSize},${halfSize}`}
-          className="recharts-legend-icon"
-        />
-      );
+      if (data.payload.strokeDasharray === undefined) {
+        return (
+          <path
+            strokeWidth={4}
+            fill="none"
+            stroke={color}
+            d={`M0,${halfSize}h${thirdSize}
+              A${sixthSize},${sixthSize},0,1,1,${2 * thirdSize},${halfSize}
+              H${SIZE}M${2 * thirdSize},${halfSize}
+              A${sixthSize},${sixthSize},0,1,1,${thirdSize},${halfSize}`}
+            className="recharts-legend-icon"
+          />
+        );
+      } else {
+          return <line
+            strokeWidth={4}
+            fill="none"
+            stroke={color}
+            strokeDasharray={data.payload.strokeDasharray}
+            x1={0}
+            y1={halfSize}
+            x2={SIZE}
+            y2={halfSize}
+            className={'recharts-legend-icon'}
+          />
+      }
     } else if (data.type === 'rect') {
       return (
         <path

--- a/src/component/DefaultLegendContent.js
+++ b/src/component/DefaultLegendContent.js
@@ -55,20 +55,18 @@ class DefaultLegendContent extends Component {
     const thirdSize = SIZE / 3;
     const color = data.inactive ? inactiveColor : data.color;
 
-    if (data.type === 'line') {
+    if (data.type === 'plainline') {
       if (data.payload.strokeDasharray === undefined) {
-        return (
-          <path
+          return <line
             strokeWidth={4}
             fill="none"
             stroke={color}
-            d={`M0,${halfSize}h${thirdSize}
-              A${sixthSize},${sixthSize},0,1,1,${2 * thirdSize},${halfSize}
-              H${SIZE}M${2 * thirdSize},${halfSize}
-              A${sixthSize},${sixthSize},0,1,1,${thirdSize},${halfSize}`}
-            className="recharts-legend-icon"
+            x1={0}
+            y1={halfSize}
+            x2={SIZE}
+            y2={halfSize}
+            className={'recharts-legend-icon'}
           />
-        );
       } else {
           return <line
             strokeWidth={4}
@@ -82,6 +80,19 @@ class DefaultLegendContent extends Component {
             className={'recharts-legend-icon'}
           />
       }
+    } else if (data.type === 'line') {
+      return (
+        <path
+          strokeWidth={4}
+          fill="none"
+          stroke={color}
+          d={`M0,${halfSize}h${thirdSize}
+            A${sixthSize},${sixthSize},0,1,1,${2 * thirdSize},${halfSize}
+            H${SIZE}M${2 * thirdSize},${halfSize}
+            A${sixthSize},${sixthSize},0,1,1,${thirdSize},${halfSize}`}
+          className="recharts-legend-icon"
+        />
+      );
     } else if (data.type === 'rect') {
       return (
         <path

--- a/src/component/DefaultLegendContent.js
+++ b/src/component/DefaultLegendContent.js
@@ -56,30 +56,17 @@ class DefaultLegendContent extends Component {
     const color = data.inactive ? inactiveColor : data.color;
 
     if (data.type === 'plainline') {
-      if (data.payload.strokeDasharray === undefined) {
-          return <line
-            strokeWidth={4}
-            fill="none"
-            stroke={color}
-            x1={0}
-            y1={halfSize}
-            x2={SIZE}
-            y2={halfSize}
-            className={'recharts-legend-icon'}
-          />
-      } else {
-          return <line
-            strokeWidth={4}
-            fill="none"
-            stroke={color}
-            strokeDasharray={data.payload.strokeDasharray}
-            x1={0}
-            y1={halfSize}
-            x2={SIZE}
-            y2={halfSize}
-            className={'recharts-legend-icon'}
-          />
-      }
+        return <line
+          strokeWidth={4}
+          fill="none"
+          stroke={color}
+          strokeDasharray={data.payload.strokeDasharray}
+          x1={0}
+          y1={halfSize}
+          x2={SIZE}
+          y2={halfSize}
+          className={'recharts-legend-icon'}
+        />
     } else if (data.type === 'line') {
       return (
         <path

--- a/src/util/ReactUtils.js
+++ b/src/util/ReactUtils.js
@@ -135,8 +135,8 @@ export const SCALE_TYPES = [
 ];
 
 export const LEGEND_TYPES = [
-  'line', 'square', 'rect', 'circle', 'cross', 'diamond',
-  'star', 'triangle', 'wye', 'none',
+  'plainline', 'line', 'square', 'rect', 'circle', 'cross',
+  'diamond', 'star', 'triangle', 'wye', 'none',
 ];
 
 /**

--- a/test/specs/component/LegendSpec.js
+++ b/test/specs/component/LegendSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, render } from 'enzyme';
 import { expect } from 'chai';
-import { Surface, Legend } from 'recharts';
+import { Surface, Legend, LineChart, Line } from 'recharts';
 
 describe('<Legend />', () => {
   const data = [
@@ -46,4 +46,59 @@ describe('<Legend />', () => {
     expect(wrapper.find('.recharts-default-legend').length).to.equal(1);
     expect(wrapper.find('.recharts-default-legend .recharts-legend-item').length).to.equal(3);
   });
+
+  it('Renders `strokeDasharray` (if present) in Legend when iconType is set to `line`', () => {
+
+    const data = [
+      {name: 'Page A', uv: 4000, pv: 2400, amt: 2400},
+      {name: 'Page B', uv: 3000, pv: 1398, amt: 2210},
+      {name: 'Page C', uv: 2000, pv: 9800, amt: 2290},
+      {name: 'Page D', uv: 2780, pv: 3908, amt: 2000},
+      {name: 'Page E', uv: 1890, pv: 4800, amt: 2181},
+      {name: 'Page F', uv: 2390, pv: 3800, amt: 2500},
+      {name: 'Page G', uv: 3490, pv: 4300, amt: 2100}
+    ];
+
+    const wrapper = render(
+      <LineChart width={600} height={300} data={data} margin={{top: 5, right: 30, left: 20, bottom: 5}}>
+        <Legend />
+        <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{r: 8}} strokeDasharray="5 5" />
+        <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+      </LineChart>
+    );
+
+    expect(wrapper.find('.recharts-default-legend').length).to.equal(1);
+    expect(wrapper.find('.recharts-default-legend .recharts-legend-item').length).to.equal(2);
+    expect(wrapper.find('.recharts-default-legend .recharts-legend-item path').length).to.equal(1);
+    expect(wrapper.find('.recharts-default-legend .recharts-legend-item line').length).to.equal(1);
+
+  });
+
+  it('Does not render `strokeDasharray` (if not present) in Legend when iconType is set to `line`', () => {
+
+    const data = [
+      {name: 'Page A', uv: 4000, pv: 2400, amt: 2400},
+      {name: 'Page B', uv: 3000, pv: 1398, amt: 2210},
+      {name: 'Page C', uv: 2000, pv: 9800, amt: 2290},
+      {name: 'Page D', uv: 2780, pv: 3908, amt: 2000},
+      {name: 'Page E', uv: 1890, pv: 4800, amt: 2181},
+      {name: 'Page F', uv: 2390, pv: 3800, amt: 2500},
+      {name: 'Page G', uv: 3490, pv: 4300, amt: 2100}
+    ];
+
+    const wrapper = render(
+      <LineChart width={600} height={300} data={data} margin={{top: 5, right: 30, left: 20, bottom: 5}}>
+        <Legend />
+        <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{r: 8}} />
+        <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+      </LineChart>
+    );
+
+    expect(wrapper.find('.recharts-default-legend').length).to.equal(1);
+    expect(wrapper.find('.recharts-default-legend .recharts-legend-item').length).to.equal(2);
+    expect(wrapper.find('.recharts-default-legend .recharts-legend-item path').length).to.equal(2);
+    expect(wrapper.find('.recharts-default-legend .recharts-legend-item line').length).to.equal(0);
+
+  });
+
 });

--- a/test/specs/component/LegendSpec.js
+++ b/test/specs/component/LegendSpec.js
@@ -22,7 +22,7 @@ describe('<Legend />', () => {
 
   it('Render customized legend when content is set to be a react element', () => {
     const CustomizedLegend = () =>
-      <div className="customized-legend">test</div>
+      <div className='customized-legend'>test</div>
     ;
     const wrapper = render(
       <Legend width={500} height={30} payload={data} content={<CustomizedLegend />} />
@@ -47,7 +47,7 @@ describe('<Legend />', () => {
     expect(wrapper.find('.recharts-default-legend .recharts-legend-item').length).to.equal(3);
   });
 
-  it('Renders `strokeDasharray` (if present) in Legend when iconType is set to `line`', () => {
+  it('Renders `strokeDasharray` (if present) in Legend when iconType is set to `plainline`', () => {
 
     const data = [
       {name: 'Page A', uv: 4000, pv: 2400, amt: 2400},
@@ -61,9 +61,9 @@ describe('<Legend />', () => {
 
     const wrapper = render(
       <LineChart width={600} height={300} data={data} margin={{top: 5, right: 30, left: 20, bottom: 5}}>
-        <Legend />
-        <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{r: 8}} strokeDasharray="5 5" />
-        <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+        <Legend iconType='plainline' />
+        <Line type='monotone' dataKey='pv' stroke='#8884d8' activeDot={{r: 8}} strokeDasharray='5 5' />
+        <Line type='monotone' dataKey='uv' stroke='#82ca9d' />
       </LineChart>
     );
 
@@ -74,7 +74,7 @@ describe('<Legend />', () => {
 
   });
 
-  it('Does not render `strokeDasharray` (if not present) in Legend when iconType is set to `line`', () => {
+  it('Does not render `strokeDasharray` (if not present) in Legend when iconType is set to `plainline`', () => {
 
     const data = [
       {name: 'Page A', uv: 4000, pv: 2400, amt: 2400},
@@ -88,9 +88,9 @@ describe('<Legend />', () => {
 
     const wrapper = render(
       <LineChart width={600} height={300} data={data} margin={{top: 5, right: 30, left: 20, bottom: 5}}>
-        <Legend />
-        <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{r: 8}} />
-        <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+        <Legend iconType='plainline' />
+        <Line type='monotone' dataKey='pv' stroke='#8884d8' activeDot={{r: 8}} />
+        <Line type='monotone' dataKey='uv' stroke='#82ca9d' />
       </LineChart>
     );
 

--- a/test/specs/component/LegendSpec.js
+++ b/test/specs/component/LegendSpec.js
@@ -69,12 +69,12 @@ describe('<Legend />', () => {
 
     expect(wrapper.find('.recharts-default-legend').length).to.equal(1);
     expect(wrapper.find('.recharts-default-legend .recharts-legend-item').length).to.equal(2);
-    expect(wrapper.find('.recharts-default-legend .recharts-legend-item path').length).to.equal(1);
-    expect(wrapper.find('.recharts-default-legend .recharts-legend-item line').length).to.equal(1);
+    expect(wrapper.find('.recharts-default-legend .recharts-legend-item path').length).to.equal(0);
+    expect(wrapper.find('.recharts-default-legend .recharts-legend-item line').length).to.equal(2);
 
   });
 
-  it('Does not render `strokeDasharray` (if not present) in Legend when iconType is set to `plainline`', () => {
+  it('Does not render `strokeDasharray` (if not present) in Legend when iconType is set to something else than `plainline`', () => {
 
     const data = [
       {name: 'Page A', uv: 4000, pv: 2400, amt: 2400},
@@ -88,8 +88,8 @@ describe('<Legend />', () => {
 
     const wrapper = render(
       <LineChart width={600} height={300} data={data} margin={{top: 5, right: 30, left: 20, bottom: 5}}>
-        <Legend iconType='plainline' />
-        <Line type='monotone' dataKey='pv' stroke='#8884d8' activeDot={{r: 8}} />
+        <Legend iconType='line' />
+        <Line type='monotone' dataKey='pv' stroke='#8884d8' activeDot={{r: 8}} strokeDasharray='5 5' />
         <Line type='monotone' dataKey='uv' stroke='#82ca9d' />
       </LineChart>
     );


### PR DESCRIPTION
This PR implements #970

## iconType="plainline"

When legend `iconType` is set to `plainline` and one of the lines uses `strokeDasharray`:

```ts
<LineChart width={600} height={300} data={data}>
    <Legend iconType='plainline' />
    <Line type="monotone" dataKey="pv" stroke="#8884d8" strokeDasharray="5 5"/>
    <Line type="monotone" dataKey="uv" stroke="#8884d8"/>
</LineChart>
```

The `strokeDasharray` is displayed in the legend:

![screenshot from 2017-10-31 14-27-42](https://user-images.githubusercontent.com/10656223/32229117-01a20454-be48-11e7-8d9b-66b1a18e623d.png)

The legend is displayed using the default size:

![screenshot from 2017-10-31 14-27-42 copy](https://user-images.githubusercontent.com/10656223/32229161-17c23100-be48-11e7-9243-af4ab95bfb84.png)

## IconSize

It is also possible to scale the size:

```ts
<Legend iconType="plainline" iconSize={30} />
```

![screenshot from 2017-10-31 14-24-07](https://user-images.githubusercontent.com/10656223/32228920-7edc2446-be47-11e7-9afc-0d75fea19bff.png)


The legend is displayed as follows:

![screenshot from 2017-10-31 14-24-07 copy](https://user-images.githubusercontent.com/10656223/32228947-8d00029a-be47-11e7-94fe-2840a6f72b61.png)




