### PR TITLE
Update Bar and Line to allow them to recognise multiple ErrorBars

### DIFF
--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -301,9 +301,9 @@ class Bar extends Component {
     if (this.props.isAnimationActive && !this.state.isAnimationFinished) { return null; }
 
     const { data, xAxis, yAxis, layout, children } = this.props;
-    const errorBarItem = findChildByType(children, ErrorBar);
+    const errorBarItems = findAllByType(children, ErrorBar);
 
-    if (!errorBarItem) { return null; }
+    if (!errorBarItems) { return null; }
 
     const offset = (layout === 'vertical') ? data[0].height / 2 : data[0].width / 2;
 
@@ -316,13 +316,16 @@ class Bar extends Component {
       };
     }
 
-    return React.cloneElement(errorBarItem, {
-      data,
-      xAxis,
-      yAxis,
-      layout,
-      offset,
-      dataPointFormatter,
+    return errorBarItems.map((item, i) => {
+      return React.cloneElement(item, {
+        key: i,
+        data,
+        xAxis,
+        yAxis,
+        layout,
+        offset,
+        dataPointFormatter,
+      });
     });
   }
 

--- a/src/cartesian/Line.js
+++ b/src/cartesian/Line.js
@@ -14,7 +14,7 @@ import LabelList from '../component/LabelList';
 import ErrorBar from './ErrorBar';
 import { uniqueId, interpolateNumber } from '../util/DataUtils';
 import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES, LEGEND_TYPES, filterEventAttributes,
-  getPresentationAttributes, isSsr, findChildByType } from '../util/ReactUtils';
+  getPresentationAttributes, isSsr, findAllByType } from '../util/ReactUtils';
 import { getCateCoordinateOfLine, getValueByDataKey } from '../util/ChartUtils';
 
 const FACTOR = 1.0000001;
@@ -218,9 +218,9 @@ class Line extends Component {
     if (this.props.isAnimationActive && !this.state.isAnimationFinished) { return null; }
 
     const { points, xAxis, yAxis, layout, children } = this.props;
-    const errorBarItem = findChildByType(children, ErrorBar);
+    const errorBarItems = findAllByType(children, ErrorBar);
 
-    if (!errorBarItem) { return null; }
+    if (!errorBarItems) { return null; }
 
     function dataPointFormatter(dataPoint, dataKey) {
       return {
@@ -231,12 +231,15 @@ class Line extends Component {
       };
     }
 
-    return React.cloneElement(errorBarItem, {
-      data: points,
-      xAxis,
-      yAxis,
-      layout,
-      dataPointFormatter,
+    return errorBarItems.map((item, i) => {
+      return React.cloneElement(item, {
+        key: i,
+        data: points,
+        xAxis,
+        yAxis,
+        layout,
+        dataPointFormatter,
+      });
     });
   }
 

--- a/test/specs/cartesian/ErrorBarSpec.js
+++ b/test/specs/cartesian/ErrorBarSpec.js
@@ -27,12 +27,29 @@ describe('<ErrorBar />', () => {
     expect(wrapper.find('.recharts-errorBar').length).to.equal(4);
   });
 
+  it('Renders Multiple Error Bars in Bar', () => {
+    const wrapper = render(
+      <BarChart data={barData} width={500} height={500} layout="vertical">
+        <Bar
+          isAnimationActive={false}
+          label={{ label: 'test' }}
+          dataKey="uv"
+        >
+          <ErrorBar dataKey="uvError" />
+          <ErrorBar dataKey="pvError" />
+        </Bar>
+      </BarChart>,
+    );
+
+    expect(wrapper.find('.recharts-errorBar').length).to.equal(8);
+  });
+
   const lineData = [
-    { name: 'Page A', uv: 1000, pv: 2400, amt: 2400, uvError: [75, 20] },
-    { name: 'Page B', uv: 300, pv: 4567, amt: 2400, uvError: [90, 40] },
-    { name: 'Page C', uv: 280, pv: 1398, amt: 2400, uvError: 40 },
-    { name: 'Page D', uv: 200, pv: 9800, amt: 2400, uvError: 20 },
-    { name: 'Page I', uv: 189, pv: 4800, amt: 2400, uvError: 28 },
+    { name: 'Page A', uv: 1000, pv: 2400, amt: 2400, uvError: [75, 20], pvError: [90, 40] },
+    { name: 'Page B', uv: 300, pv: 4567, amt: 2400, uvError: [90, 40], pvError: [75, 20] },
+    { name: 'Page C', uv: 280, pv: 1398, amt: 2400, uvError: 40, pvError: 20 },
+    { name: 'Page D', uv: 200, pv: 9800, amt: 2400, uvError: 20, pvError: 28 },
+    { name: 'Page I', uv: 189, pv: 4800, amt: 2400, uvError: 28, pvError: 40 },
   ];
 
   it('Renders Error Bars in Line', () => {
@@ -49,5 +66,22 @@ describe('<ErrorBar />', () => {
     );
 
     expect(wrapper.find('.recharts-errorBar').length).to.equal(5);
+  });
+
+  it('Renders Multiple Error Bars in Line', () => {
+    const wrapper = render(
+      <LineChart data={lineData} width={500} height={500}>
+        <Line
+          isAnimationActive={false}
+          label={{ label: 'test' }}
+          dataKey="uv"
+        >
+          <ErrorBar dataKey="uvError" />
+          <ErrorBar dataKey="pvError" />
+        </Line>
+      </LineChart>,
+    );
+
+    expect(wrapper.find('.recharts-errorBar').length).to.equal(10);
   });
 });


### PR DESCRIPTION
The Scatter points currently allow multiple ErrorBars but Bar and Line only recognise the first ErrorBar when multiple are added.