### PR TITLE
Don't break text contents on non-breaking spaces

### DIFF
--- a/src/component/Text.js
+++ b/src/component/Text.js
@@ -7,9 +7,11 @@ import { isNumber, isNumOrStr } from '../util/DataUtils';
 import { PRESENTATION_ATTRIBUTES, getPresentationAttributes, isSsr } from '../util/ReactUtils';
 import { getStringSize } from '../util/DOMUtils';
 
+const BREAKING_SPACES = /[ \f\n\r\t\v\u2028\u2029]+/;
+
 const calculateWordWidths = (props) => {
   try {
-    const words = !_.isNil(props.children) ? props.children.toString().split(/\s+/) : [];
+    const words = !_.isNil(props.children) ? props.children.toString().split(BREAKING_SPACES) : [];
     const wordsWithComputedWidth = words.map(word => (
       { word, width: getStringSize(word, props.style).width }
     ));
@@ -90,7 +92,7 @@ class Text extends Component {
   }
 
   updateWordsWithoutCalculate(props) {
-    const words = !_.isNil(props.children) ? props.children.toString().split(/\s+/) : [];
+    const words = !_.isNil(props.children) ? props.children.toString().split(BREAKING_SPACES) : [];
     this.setState({ wordsByLines: [{ words }] });
   }
 

--- a/test/specs/component/TextSpec.js
+++ b/test/specs/component/TextSpec.js
@@ -68,4 +68,13 @@ describe('<Text />', () => {
 
     expect(wrapperNan.text()).to.not.contain('anything');
   });
+
+  it("Only split contents on breaking spaces", () => {
+    const testString = "These spaces\tshould\nbreak,\rbut\xA0these\xA0should\xA0not.";
+    const wrapper = shallow(
+      <Text width="auto">{testString}</Text>
+    );
+
+    expect(wrapper.instance().state.wordsByLines.length).to.equal(5);
+  })
 });


### PR DESCRIPTION
At present, `<Text>` contents will be broken into `<tspan>` elements on all whitespace characters, including the `\xA0` non-breaking space.  This is inconvenient as it doesn't allow the user to guarantee that a piece of text will not be split, regardless of the calculated dimensions of its container (for example, a tick label).

This PR makes the `split` regex more fine-grained to match:
* space
* tab (`\t`)
* newline (`\n`)
* carriage-return (`\r`)
* vertical tab (`\v`)
* line separator (`\u2028`)
* paragraph separator (`\u2029'`)

but **not** non-breaking space (`\u00A0`), so that the user can force text to stay on the same line if required.