### PR TITLE
:bug: #955 Fix minAngle and maxAngle for the polar RadialBar

### DIFF
--- a/demo/component/RadialBarChart.js
+++ b/demo/component/RadialBarChart.js
@@ -61,7 +61,7 @@ export default class Demo extends Component {
             barSize={10}
             data={data}
           >
-            <RadialBar minPointSize={15} background dataKey="uv" >
+            <RadialBar minAngle={15} background dataKey="uv" >
               {
                 data.map((entry, index) => (
                   <Cell key={`cell-${index}`} fill={colors[index]}/>
@@ -105,7 +105,7 @@ export default class Demo extends Component {
               innerRadius="20%"
               outerRadius="90%"
             >
-              <RadialBar minPointSize={15} label={label} background dataKey="uv" />
+              <RadialBar minAngle={15} label={label} background dataKey="uv" />
               <Legend iconSize={10} width={120} height={140} layout="vertical" verticalAlign="middle" wrapperStyle={style} />
             </RadialBarChart>
           </ResponsiveContainer>
@@ -122,14 +122,14 @@ export default class Demo extends Component {
               outerRadius="90%"
             >
               <PolarAngleAxis type="number" range={[0, 300]} />
-              <RadialBar stackId="stack" minPointSize={15} background dataKey="uv">
+              <RadialBar stackId="stack" minAngle={15} background dataKey="uv">
                 {
                   data.map((entry, index) => (
                     <Cell key={`cell-${index}`} fill="#8884d8" />
                   ))
                 }
               </RadialBar>
-              <RadialBar stackId="stack" minPointSize={15} dataKey="uv" animationBegin={1500}>
+              <RadialBar stackId="stack" minAngle={15} dataKey="uv" animationBegin={1500}>
                 {
                   data.map((entry, index) => (
                     <Cell key={`cell-${index}`} fill="#83a6ed" />

--- a/src/polar/RadialBar.js
+++ b/src/polar/RadialBar.js
@@ -35,8 +35,8 @@ class RadialBar extends Component {
     dataKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.func]).isRequired,
 
     cornerRadius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    minPointSize: PropTypes.number,
-    maxBarSize: PropTypes.number,
+    minAngle: PropTypes.number,
+    maxAngle: PropTypes.number,
     data: PropTypes.arrayOf(PropTypes.shape({
       cx: PropTypes.number,
       cy: PropTypes.number,
@@ -68,7 +68,8 @@ class RadialBar extends Component {
   static defaultProps = {
     angleAxisId: 0,
     radiusAxisId: 0,
-    minPointSize: 0,
+    maxAngle: 135,
+    minAngle: 0,
     hide: false,
     legendType: 'rect',
     data: [],
@@ -85,7 +86,7 @@ class RadialBar extends Component {
 
     const { cx, cy } = angleAxis;
     const { layout } = props;
-    const { children, minPointSize } = item.props;
+    const { children, minAngle, maxAngle } = item.props;
     const numericAxis = layout === 'radial' ? angleAxis : radiusAxis;
     const stackedDomain = stackedData ? numericAxis.scale.domain() : null;
     const baseValue = getBaseValueOfBar({ props, numericAxis });
@@ -114,12 +115,17 @@ class RadialBar extends Component {
         outerRadius = innerRadius + pos.size;
         const deltaAngle = endAngle - startAngle;
 
-        if (Math.abs(minPointSize) > 0 && Math.abs(deltaAngle) < Math.abs(minPointSize)) {
-          const delta = mathSign(deltaAngle || minPointSize) *
-            (Math.abs(minPointSize) - Math.abs(deltaAngle));
+        if (Math.abs(minAngle) > 0 && Math.abs(deltaAngle) < Math.abs(minAngle)) {
+          const delta = mathSign(deltaAngle || minAngle) *
+            (Math.abs(minAngle) - Math.abs(deltaAngle));
 
           endAngle += delta;
         }
+
+        if (Math.abs(maxAngle) > 0 && Math.abs(deltaAngle) > Math.abs(maxAngle)) {
+          endAngle = maxAngle;
+        }
+
         backgroundSector = {
           background: {
             cx, cy, innerRadius, outerRadius, startAngle: props.startAngle,
@@ -140,9 +146,9 @@ class RadialBar extends Component {
         endAngle = startAngle + pos.size;
         const deltaRadius = outerRadius - innerRadius;
 
-        if (Math.abs(minPointSize) > 0 && Math.abs(deltaRadius) < Math.abs(minPointSize)) {
-          const delta = mathSign(deltaRadius || minPointSize) *
-            (Math.abs(minPointSize) - Math.abs(deltaRadius));
+        if (Math.abs(minAngle) > 0 && Math.abs(deltaRadius) < Math.abs(minAngle)) {
+          const delta = mathSign(deltaRadius || minAngle) *
+            (Math.abs(minAngle) - Math.abs(deltaRadius));
           outerRadius += delta;
         }
       }


### PR DESCRIPTION
This pull request fixes only the prop `minAngle` `maxAngle` of `Polar/RadialBar`, 

I have two questions

1. Isn't it better if this prop being set in `RadialBarChart` since it affects all the cells of the radial bar inside the RadialBarchart? Unless there is a requirement to set two `RadialBar`s within one RadialBarChart.
1. should we use the prop name `minPointSize` `maxBarSize` instead of `minAngle` `maxAngle`, I think the latter is more proper with the given word `Angle`

_Example code and screenshot :_

```es6
const data = [
  { uv: 100, fill: '#8884d8' },
  { uv: 0, fill: '#83a6ed' },
  { uv: 0, fill: '#8dd1e1' },
  { uv: 0, fill: '#82ca9d' },
  { uv: 0, fill: '#a4de6c' },
  { uv: 0, fill: '#d0ed57' },
  { uv: 0, fill: '#ffc658' },
];

<RadialBarChart
    width={500}
    height={300}
    cx={150}
    cy={150}
    data={data}
    innerRadius={20}
    outerRadius={140}
    startAngle={0}
    endAngle={180}>

    <RadialBar minAngle={22.5} maxAngle={90} background dataKey="uv" >
    {
        data.map((entry, index) => (
            <Cell key={`cell-${index}`} fill={colors[index]}/>
        ));
    }
    </RadialBar>

</RadialBarChart>
```

![screen shot 2017-11-15 at 12 49 31](https://user-images.githubusercontent.com/18140315/32834665-a7d1589a-ca03-11e7-980f-05c562a66018.png)
