### PR TITLE
Fix Line Animation with given Magic Number

### DIFF
--- a/src/cartesian/Line.js
+++ b/src/cartesian/Line.js
@@ -301,7 +301,8 @@ class Line extends Component {
 
   renderCurveWithAnimation(needClip) {
     const { points, strokeDasharray, isAnimationActive, animationBegin,
-      animationDuration, animationEasing, animationId, ...other } = this.props;
+      animationDuration, animationEasing, animationId, width, height, ...other
+    } = this.props;
     const { prevPoints, totalLength } = this.state;
 
     return (
@@ -328,7 +329,10 @@ class Line extends Component {
                   return { ...entry, x: interpolatorX(t), y: interpolatorY(t) };
                 }
 
-                return entry;
+                // magic number of faking previous x and y location
+                const interpolatorX = interpolateNumber(width * 2, entry.x);
+                const interpolatorY = interpolateNumber(height / 2, entry.y);
+                return { ...entry, x: interpolatorX(t), y: interpolatorY(t) };
               });
               return this.renderCurveStatically(stepData, needClip);
             }


### PR DESCRIPTION
Resolves https://github.com/recharts/recharts/issues/1015,

**The magic number** gives a better smooth animation rather than the buggy animation (See the issue 1015). 

This is just the concept of fixing the line animation, it can be even more smooth if you take XAxis domain, YAxis domain into the calculation for the magic number.

GIF

![recharts-line-animation-fixed](https://user-images.githubusercontent.com/18140315/33029616-5aa98e74-ce19-11e7-816a-f52201d33d41.gif)

Code

```html
<LineChart
    width={800} height={300} data={data}
    margin={{ top: 40, right: 40, bottom: 20, left: 20 }}
    >
    <CartesianGrid />
    <XAxis dataKey="index" domain={[left,right]} type="number" allowDataOverflow={true}/>
    <YAxis domain={['auto', 'auto']} />
    <Tooltip />
    <Line type="natural" dataKey="uv" stroke="#ff7300" dot={true} animationDuration={1000} animationEasing='ease-in-out'/>
</LineChart>

<script>
// data_from => data_to
const data_from = [
  { index : 0, uv: 600 },
  { index : 2, uv: 280 },
  { index : 4, uv: 278 },
  { index : 6, uv: 189 },
  { index : 8, uv: 700 },
];
const data_to = [
  { index : 0, uv: 600 },
  { index : 1, uv: 500 },
  { index : 2, uv: 280 },
  { index : 3, uv: 279 },
  { index : 4, uv: 278 },
  { index : 5, uv: 200 },
  { index : 6, uv: 189 },
  { index : 7, uv: 400 },
  { index : 8, uv: 700 },
  { index : 9, uv: 200 },
  { index : 10, uv: 200 },
  { index : 11, uv: 200 },
  { index : 12, uv: 200 },
  { index : 13, uv: 200 },
  { index : 14, uv: 200 },
];
</script>
```