### PR TITLE
Fix Bar Animation with the given Magic Number

### DIFF
--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -226,7 +226,8 @@ class Bar extends Component {
 
   renderRectanglesWithAnimation() {
     const { data, layout, isAnimationActive, animationBegin,
-      animationDuration, animationEasing, animationId } = this.props;
+      animationDuration, animationEasing, animationId, width,
+    } = this.props;
     const { prevData } = this.state;
 
     return (
@@ -262,10 +263,16 @@ class Bar extends Component {
               }
 
               if (layout === 'horizontal') {
-                const interpolator = interpolateNumber(0, entry.height);
-                const h = interpolator(t);
+                const interpolatorX = interpolateNumber(width * 2, entry.x);
+                const interpolatorHeight = interpolateNumber(0, entry.height);
+                const h = interpolatorHeight(t);
 
-                return { ...entry, y: entry.y + entry.height - h, height: h };
+                return {
+                  ...entry,
+                  x: interpolatorX(t),
+                  y: entry.y + entry.height - h,
+                  height: h,
+                };
               }
 
               const interpolator = interpolateNumber(0, entry.width);

--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -263,6 +263,7 @@ class Bar extends Component {
               }
 
               if (layout === 'horizontal') {
+                // magic number of faking previous x location
                 const interpolatorX = interpolateNumber(width * 2, entry.x);
                 const interpolatorHeight = interpolateNumber(0, entry.height);
                 const h = interpolatorHeight(t);


### PR DESCRIPTION
Before the Magic Number `width * 2`
![recharts-bar-animation-w o-magic](https://user-images.githubusercontent.com/18140315/33071593-6bbe47ec-cebc-11e7-8e65-b373f872d7fc.gif)

After the Magic Number
![recahrts-bar-animation-magic](https://user-images.githubusercontent.com/18140315/33071599-6f73639a-cebc-11e7-9751-2d27a58a3ab9.gif)

similar to https://github.com/recharts/recharts/pull/1025