### PR TITLE
Fix sankey diagram not re-rendering when updating data prop

### DIFF
--- a/src/chart/Sankey.js
+++ b/src/chart/Sankey.js
@@ -375,7 +375,7 @@ class Sankey extends Component {
       nextProps.height !== height || !shallowEqual(nextProps.margin, margin) ||
       nextProps.iterations !== iterations || nextProps.nodeWidth !== nodeWidth ||
       nextProps.nodePadding !== nodePadding || nextProps.nameKey !== nameKey) {
-      this.setState(this.createDefaultState(this.props));
+      this.setState(this.createDefaultState(nextProps));
     }
   }
   /**

--- a/test/specs/chart/SankeySpec.js
+++ b/test/specs/chart/SankeySpec.js
@@ -138,4 +138,26 @@ describe('<Sankey />', () => {
   it('renders 68 links in simple SankeyChart', () => {
     expect(wrapper.find('.recharts-sankey-link').length).to.equal(68);
   });
+
+  it('re-renders links and nodes when data changes', () => {
+    const wrapper = mount(<Sankey width={1000} height={500} data={data} />);
+    expect(wrapper.render().find('.recharts-sankey-node').length).to.equal(48);
+    expect(wrapper.render().find('.recharts-sankey-link').length).to.equal(68);
+
+    const newData = {
+      ...data,
+      nodes: [
+        ...data.nodes,
+        { name: "New Node" }
+      ],
+      links: [
+        ...data.links,
+        { source: 2, target: data.nodes.length, value: 100.0 }
+      ]
+    };
+    wrapper.setProps({ data: newData });
+
+    expect(wrapper.render().find('.recharts-sankey-node').length).to.equal(49);
+    expect(wrapper.render().find('.recharts-sankey-link').length).to.equal(69);
+  })
 });


### PR DESCRIPTION
When `Sankey` component `data` prop changed, the chart did not update
right away, instead it was deferred until next props update.

This was because `componentWillReceiveProps` function used `this.props` instead of `nextProps` to calculate the next state.

Demo:
http://jsfiddle.net/s2tz0ey7/1/

Affected version:
1.0.0-beta.5, possibly earlier versions

PS. Thank you for maintaining recharts, I've been using it for months and find it very useful 😄  ❤️  