### PR TITLE
Create property on tooltip for gpu rendering

### DIFF
--- a/src/component/Tooltip.js
+++ b/src/component/Tooltip.js
@@ -58,7 +58,7 @@ const propTypes = {
   ]),
   itemSorter: PropTypes.func,
   filterNull: PropTypes.bool,
-  gpuRender: PropTypes.bool,
+  useTranslate3d: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -77,7 +77,7 @@ const defaultProps = {
   animationDuration: 400,
   itemSorter: () => -1,
   filterNull: true,
-  gpuRender: false,
+  useTranslate3d: false,
 };
 
 const renderContent = (content, props) => {
@@ -169,7 +169,7 @@ class Tooltip extends Component {
     outerStyle = {
       ...outerStyle,
       ...translateStyle({
-        transform: this.props.gpuRender ? `translate3d(${translateX}px, ${translateY}px, 0)` : `translate(${translateX}px, ${translateY}px)`,
+        transform: this.props.useTranslate3d ? `translate3d(${translateX}px, ${translateY}px, 0)` : `translate(${translateX}px, ${translateY}px)`,
       }),
     };
 

--- a/src/component/Tooltip.js
+++ b/src/component/Tooltip.js
@@ -58,6 +58,7 @@ const propTypes = {
   ]),
   itemSorter: PropTypes.func,
   filterNull: PropTypes.bool,
+  gpuRender: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -76,6 +77,7 @@ const defaultProps = {
   animationDuration: 400,
   itemSorter: () => -1,
   filterNull: true,
+  gpuRender: false,
 };
 
 const renderContent = (content, props) => {
@@ -167,7 +169,7 @@ class Tooltip extends Component {
     outerStyle = {
       ...outerStyle,
       ...translateStyle({
-        transform: `translate(${translateX}px, ${translateY}px)`,
+        transform: this.props.gpuRender ? `translate3d(${translateX}px, ${translateY}px, 0)` : `translate(${translateX}px, ${translateY}px)`,
       }),
     };
 


### PR DESCRIPTION
#1060

replaces translate with translate3d on the tooltip wrapper for smoother animation at the cost of some memory. 

```js
    <BarChart>
          <Tooltip gpuRendering />
          ...
      </BarChart>
```