### PR TITLE
baseLine NaN / undefined

### DIFF
--- a/src/cartesian/Area.js
+++ b/src/cartesian/Area.js
@@ -393,6 +393,9 @@ class Area extends Component {
               if (isNumber(baseLine)) {
                 const interpolator = interpolateNumber(prevBaseLine, baseLine);
                 stepBaseLine = interpolator(t);
+              } else if (_.isNil(baseLine) || _.isNaN(baseLine)) {
+                const interpolator = interpolateNumber(prevBaseLine, 0);
+                stepBaseLine = interpolator(t);
               } else {
                 stepBaseLine = baseLine.map((entry, index) => {
                   if (prevBaseLine[index]) {


### PR DESCRIPTION
Fixed a bug when the baseline is NaN, null or undefined it will attempt to map an unmappable entity. Resulting in a full page crash.