### PR TITLE
replace lodash _.get with simple Array.prototype.find

### DIFF
--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -435,9 +435,7 @@ const generateCategoricalChart = ({
 
     getActiveCoordinate(tooltipTicks, activeIndex, rangeObj) {
       const { layout } = this.props;
-      const entry = _.get(tooltipTicks.filter(tick => (
-        tick && (tick.index === activeIndex)
-      )), '[0]');
+      const entry = tooltipTicks.find(tick => tick && (tick.index === activeIndex));
 
       if (entry) {
         if (layout === 'horizontal') {


### PR DESCRIPTION
In out Project we used Webpack Plugin `LodashModuleReplacementPlugin` which strippes out path feature of lodash. `_.get` uses path feature. Which caused strange bugs like #1039

This is much simple form for `_.get(arr, '[0]')` which uses ES5 `Array.prototype.find` feature