### PR TITLE
Prevent texts from being selected when dragging the brush

### DIFF
--- a/src/cartesian/Brush.js
+++ b/src/cartesian/Brush.js
@@ -11,6 +11,7 @@ import pureRender from '../util/PureRender';
 import Layer from '../container/Layer';
 import Text from '../component/Text';
 import { isNumber } from '../util/DataUtils';
+import { generatePrefixStyle } from '../util/CssPrefixUtils';
 
 @pureRender
 class Brush extends Component {
@@ -413,6 +414,7 @@ class Brush extends Component {
 
     const layerClass = classNames('recharts-brush', className);
     const isPanoramic = React.Children.count(children) === 1;
+    const style = generatePrefixStyle('userSelect', 'none');
 
     return (
       <Layer
@@ -422,6 +424,7 @@ class Brush extends Component {
         onMouseUp={this.handleDragEnd}
         onTouchEnd={this.handleDragEnd}
         onTouchMove={this.handleTouchMove}
+        style={style}
       >
         {this.renderBackground()}
         {isPanoramic && this.renderPanorama()}


### PR DESCRIPTION
When the brush is being dragged, sometimes the labels of the chart will be selected too, let's fix this undesirable effect.