### PR TITLE
fix: ensure Line has data before calling SVGPathElement.getTotalLength() for IE

### DIFF
--- a/src/cartesian/Line.js
+++ b/src/cartesian/Line.js
@@ -154,6 +154,13 @@ class Line extends Component {
   }
 
   getTotalLength() {
+    const hasData = this.props.points.reduce((acc, point) => {
+      const val = point.value;
+      return acc && (val !== null && val !== undefined);
+    }, true);
+
+    if (!hasData) { return 0; }
+
     const curveDom = this.mainCurve;
     const totalLength = (curveDom && curveDom.getTotalLength && curveDom.getTotalLength()) || 0;
 


### PR DESCRIPTION
In the Line component if all point values are null or undefined, the SVGPathElement. getTotalLength() function is causing the following error in IE:

> Unexpected call to method or property access

[Fiddle showing the error(Open in IE).](http://jsfiddle.net/j64rfyju/)