### PR TITLE
fix Scatter Chart:lineType 'fitting' does not work

### DIFF
--- a/src/cartesian/Scatter.js
+++ b/src/cartesian/Scatter.js
@@ -16,7 +16,7 @@ import Curve from '../shape/Curve';
 import Symbols from '../shape/Symbols';
 import ErrorBar from './ErrorBar';
 import Cell from '../component/Cell';
-import { uniqueId, interpolateNumber } from '../util/DataUtils';
+import { uniqueId, interpolateNumber, getlinearRegression } from '../util/DataUtils';
 import { getValueByDataKey, getCateCoordinateOfLine } from '../util/ChartUtils';
 
 @pureRender
@@ -322,6 +322,10 @@ class Scatter extends Component {
 
     if (lineType === 'joint') {
       linePoints = points.map(entry => ({ x: entry.cx, y: entry.cy }));
+    } else if (lineType === 'fitting') {
+      const { xmin, xmax, a, b} = getlinearRegression(points);
+      const linearExp = x => a * x + b 
+      linePoints = [{ x: xmin, y : linearExp(xmin) }, { x: xmax, y: linearExp(xmax) }];
     }
     const lineProps = {
       ...scatterProps,

--- a/src/util/DataUtils.js
+++ b/src/util/DataUtils.js
@@ -100,3 +100,32 @@ export const findEntryInArray = (ary, specifiedKey, specifiedValue) => {
 
   return ary.find(entry => (entry && _.get(entry, specifiedKey) === specifiedValue));
 };
+
+export const getlinearRegression = (data) => {
+  let xsum = 0, ysum = 0;
+  for (let i = 0; i < data.length; i++) {
+    xsum += data[i].cx;
+    ysum += data[i].cy;
+  }
+  var xmean = xsum / data.length;
+  var ymean = ysum / data.length;
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < data.length; i++) {
+    let x = data[i].cx;
+    let y = data[i].cy;
+    num += (x - xmean) * (y - ymean);
+    den += (x - xmean) * (x - xmean);
+  }
+  const a = num / den,
+    b = ymean - a * xmean,
+    xmin = Math.min.apply(0, data.map(elem => elem.cx)),
+    xmax = Math.max.apply(0, data.map(elem => elem.cx));
+
+  return {
+    xmin,
+    xmax,
+    a,
+    b
+  };
+};


### PR DESCRIPTION
#868 Fits a straight line using least squares method

![image](https://user-images.githubusercontent.com/21354661/35088461-d6ad68be-fc6e-11e7-944f-f45fec542a5a.png)
