### PR TITLE
Replace reduce to _.flatmap

### DIFF
--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -31,15 +31,7 @@ export const getValueByDataKey = (obj, dataKey, defaultValue) => {
  * @return {Array} Domain of data
  */
 export const getDomainOfDataByKey = (data, key, type, filterNil) => {
-  const flattenData = data.reduce((result, entry) => {
-    const value = getValueByDataKey(entry, key);
-
-    if (_.isArray(value)) {
-      return [...result, ...value];
-    }
-
-    return [...result, value];
-  }, []);
+  const flattenData = _.flatMap(data, entry => getValueByDataKey(entry, key));
 
   if (type === 'number') {
     const domain = flattenData.filter(isNumber);


### PR DESCRIPTION
I found the bottleneck.
My large data drawing is 6x faster (4.2s → 0.7s) with this change.

Other reduce's flatmap was not rewritten because I unconfirmed.

#1146