### PR TITLE
Remove react-transition-group from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
   "homepage": "https://github.com/recharts/recharts",
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0",
-    "react-transition-group": "^2.2.1"
+    "react-dom": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "classnames": "2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4830,10 +4830,6 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
-react-addons-test-utils@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
-
 react-dom@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"


### PR DESCRIPTION
This was already done in #888, but somehow managed to trickle in via #916.
Since the dependency is unused, I believe there is no reason to keep it around, it's just causing confusion, bloating the node_modules and can cause incompatibility issues with `react-transition-group@1.x.x`.