### PR TITLE
Fix unknown props warning on Legend

### DIFF
--- a/src/component/Legend.js
+++ b/src/component/Legend.js
@@ -12,7 +12,7 @@ import { LEGEND_TYPES } from '../util/ReactUtils';
 
 const renderContent = (content, props) => {
   if (React.isValidElement(content)) {
-    return React.cloneElement(content, props);
+    return content;
   } else if (_.isFunction(content)) {
     return content(props);
   }


### PR DESCRIPTION
Fixes https://github.com/recharts/recharts/issues/324
When the `content` prop is a React element, eg. ```<Legend content={<SomeComponent />} />```, users should not be expecting the props to be passed to `SomeComponent` as that intention is not clear from the declaration.

To pass in the props, it should be declared as 
```<Legend content={props => <SomeComponent {...props} />} />``` 
or simply
```<Legend content={SomeComponent} />```.