### PR TITLE
#1195 Replace axis scale value `utcTime` with `utc`

### DIFF
--- a/src/cartesian/YAxis.js
+++ b/src/cartesian/YAxis.js
@@ -50,7 +50,7 @@ class YAxis extends Component {
     allowDataOverflow: PropTypes.bool,
     scale: PropTypes.oneOfType([
       PropTypes.oneOf(['auto', 'linear', 'pow', 'sqrt', 'log', 'identity', 'time',
-        'band', 'point', 'ordinal', 'quantile', 'quantize', 'utcTime', 'sequential',
+        'band', 'point', 'ordinal', 'quantile', 'quantize', 'utc', 'sequential',
         'threshold']),
       PropTypes.func,
     ]),

--- a/src/cartesian/ZAxis.js
+++ b/src/cartesian/ZAxis.js
@@ -24,7 +24,7 @@ class ZAxis extends Component {
     range: PropTypes.arrayOf(PropTypes.number),
     scale: PropTypes.oneOfType([
       PropTypes.oneOf(['auto', 'linear', 'pow', 'sqrt', 'log', 'identity', 'time',
-        'band', 'point', 'ordinal', 'quantile', 'quantize', 'utcTime', 'sequential',
+        'band', 'point', 'ordinal', 'quantile', 'quantize', 'utc', 'sequential',
         'threshold']),
       PropTypes.func,
     ]),

--- a/src/polar/PolarRadiusAxis.js
+++ b/src/polar/PolarRadiusAxis.js
@@ -46,7 +46,7 @@ class PolarRadiusAxis extends Component {
     ])),
     scale: PropTypes.oneOfType([
       PropTypes.oneOf(['auto', 'linear', 'pow', 'sqrt', 'log', 'identity', 'time',
-        'band', 'point', 'ordinal', 'quantile', 'quantize', 'utcTime', 'sequential',
+        'band', 'point', 'ordinal', 'quantile', 'quantize', 'utc', 'sequential',
         'threshold']),
       PropTypes.func,
     ]),

--- a/src/util/ReactUtils.js
+++ b/src/util/ReactUtils.js
@@ -133,7 +133,7 @@ const REACT_BROWSER_EVENT_MAP = {
 
 export const SCALE_TYPES = [
   'auto', 'linear', 'pow', 'sqrt', 'log', 'identity', 'time', 'band', 'point',
-  'ordinal', 'quantile', 'quantize', 'utcTime', 'sequential', 'threshold',
+  'ordinal', 'quantile', 'quantize', 'utc', 'sequential', 'threshold',
 ];
 
 export const LEGEND_TYPES = [


### PR DESCRIPTION
The d3-scale dependency renamed this export here: https://github.com/d3/d3-scale/commit/2cc073c99a682f290bb7f689c21baeefa625177b