### PR TITLE
Add explicit prop to activate tooltip

### DIFF
--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -96,7 +96,7 @@ const generateCategoricalChart = ({
      * @return {Object} Whole new state
      */
     static createDefaultState = (props) => {
-      const { children } = props;
+      const { children, isTooltipActive } = props;
       const brushItem = findChildByType(children, Brush);
       const startIndex = (brushItem && brushItem.props && brushItem.props.startIndex) || 0;
       const endIndex = (brushItem && brushItem.props && brushItem.props.endIndex)
@@ -107,7 +107,7 @@ const generateCategoricalChart = ({
         dataStartIndex: startIndex,
         dataEndIndex: endIndex,
         activeTooltipIndex: -1,
-        isTooltipActive: false,
+        isTooltipActive: isTooltipActive || false,
       };
     };
 


### PR DESCRIPTION
Addresses an issue when we have to re-render the chart as keeping the tooltip displayed.
We allow the developer to explicitly set the tooltip activation status with a `isTooltipActive` prop. It will be used to set the default value of the homonym state property