### PR TITLE
Remove wrapperStyle on <DefaultTooltipContent>

### DIFF
--- a/src/component/DefaultTooltipContent.js
+++ b/src/component/DefaultTooltipContent.js
@@ -21,7 +21,6 @@ class DefaultTooltipContent extends Component {
   static propTypes = {
     separator: PropTypes.string,
     formatter: PropTypes.func,
-    wrapperStyle: PropTypes.object,
     itemStyle: PropTypes.object,
     labelStyle: PropTypes.object,
     labelFormatter: PropTypes.func,
@@ -81,14 +80,13 @@ class DefaultTooltipContent extends Component {
   }
 
   render() {
-    const { labelStyle, label, labelFormatter, wrapperStyle } = this.props;
+    const { labelStyle, label, labelFormatter } = this.props;
     const finalStyle = {
       margin: 0,
       padding: 10,
       backgroundColor: '#fff',
       border: '1px solid #ccc',
       whiteSpace: 'nowrap',
-      ...wrapperStyle,
     };
     const finalLabelStyle = {
       margin: 0,


### PR DESCRIPTION
Does not apply `wrapperStyle` on `<DefaultTooltipContent>` component, since this prop already applied on [tooltip wrapper](https://github.com/recharts/recharts/blob/master/src/component/Tooltip.js#L144).

**Affected version**: 1.0.0-beta.10
**Related issue**: #798 
**Issue playground**: https://jsfiddle.net/n0nhzk1s/
**Screenshot**:
![screen shot 2018-05-30 at 10 07 01 am](https://user-images.githubusercontent.com/5558360/40695047-fb02fe82-63f1-11e8-9acd-f5f988c53092.png)


