### PR TITLE
Move style spread to after default styles to allow overriding

### DIFF
--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -1498,7 +1498,7 @@ const generateCategoricalChart = ({
       return (
         <div
           className={classNames('recharts-wrapper', className)}
-          style={{ ...style, position: 'relative', cursor: 'default', width, height }}
+          style={{ position: 'relative', cursor: 'default', width, height, ...style }}
           {...events}
           ref={(node) => { this.container = node; }}
         >


### PR DESCRIPTION
Fixes #1340

Moved `...style` spread to the end of the inline style of the `recharts-wrapper` to allow default style overriding.