### PR TITLE
LabelList: Position the 'top' label outside the element for negative heights

### DIFF
--- a/src/component/Label.js
+++ b/src/component/Label.js
@@ -151,7 +151,7 @@ const getAttrsOfCartesianLabel = (props) => {
       x: x + width / 2,
       y: y - sign * offset,
       textAnchor: 'middle',
-      verticalAnchor: 'end',
+      verticalAnchor: sign > 0 ? 'end' : 'start',
     };
   }
 


### PR DESCRIPTION
I ran into an issue when using `LabelList` for `Bar` elements with mixed positive / negative values - `position: 'top'` positions labels unexpectedly for negative values.

For example, with the following source:

```
<ComposedChart data={data} >
  <XAxis dataKey='timestamp' />
  <YAxis />
  <CartesianGrid />
  <Bar dataKey='delta'>
    <LabelList dataKey='delta' position='top' />
  </Bar>
</ComposedChart>
```

Outcome currently is this:

![screen shot 2018-06-18 at 16 50 31](https://user-images.githubusercontent.com/222126/41540758-80e0ed08-7319-11e8-80f0-154aa311bb78.png)

With my change, it now renders (subjectively) better:

![screen shot 2018-06-18 at 16 49 27](https://user-images.githubusercontent.com/222126/41540797-9590dff6-7319-11e8-85bd-52178eaa1b38.png)

However, I'm not sure about the semantics of `'top'`, or usage in different places.