### PR TITLE
Fixing range Area chart with connectNulls bug

### DIFF
--- a/src/cartesian/Area.js
+++ b/src/cartesian/Area.js
@@ -160,10 +160,18 @@ class Area extends Component {
 
     let baseLine;
     if (hasStack || isRange) {
-      baseLine = points.map(entry => ({
-        x: layout === 'horizontal' ? entry.x : xAxis.scale(entry && entry.value[0]),
-        y: layout === 'horizontal' ? yAxis.scale(entry && entry.value[0]) : entry.y,
-      }));
+      baseLine = points.map((entry) => {
+        if (layout === 'horizontal') {
+          return {
+            x: entry.x ? entry.x : null,
+            y: entry.y ? yAxis.scale(entry && entry.value[0]) : null,
+          };
+        }
+        return {
+          x: entry.x ? xAxis.scale(entry && entry.value[0]) : null,
+          y: entry.y ? entry.y : null
+        };
+      });
     } else if (layout === 'horizontal') {
       baseLine = yAxis.scale(baseValue);
     } else {

--- a/src/shape/Curve.js
+++ b/src/shape/Curve.js
@@ -72,8 +72,9 @@ class Curve extends Component {
     let lineFunction;
 
     if (_.isArray(baseLine)) {
+      const formatBaseLine = connectNulls ? baseLine.filter(base => defined(base)) : baseLine;
       const areaPoints = formatPoints.map((entry, index) => (
-        { ...entry, base: baseLine[index] }
+        { ...entry, base: formatBaseLine[index] }
       ));
       if (layout === 'vertical') {
         lineFunction = shapeArea().y(getY).x1(getX).x0(d => d.base.x);


### PR DESCRIPTION
Fixed bug where using `connectNulls` on range Area chart with null values causes the bottom bound to be displayed improperly.

The `baseLine` y values would always scale even if it's null. Null values were also not being filtered from the `baseLine`, therefore causing it to be out of sync with the points.

See example:
https://jsfiddle.net/nwyp1t53/