### PR TITLE
Fix tooltips that disappear while mouse still over a scatter point

### DIFF
--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -1176,6 +1176,7 @@ const generateCategoricalChart = ({
       const key = element.key || '_recharts-cursor';
       const cursorProps = {
         stroke: '#ccc',
+        pointerEvents: 'none',
         ...offset,
         ...restProps,
         ...getPresentationAttributes(element.props.cursor),


### PR DESCRIPTION
Thanks for this great library! I'm excited to use it and to contribute.

Reported here: https://github.com/recharts/recharts.org/issues/45

Reproducible in this jsfiddle:

https://jsfiddle.net/alidingling/uLysj0u2/

This happens because the cursor draws on top of the scatter. Once it appears, it starts snagging mouse events which belong to the scatter. The behavior becomes even more pronounced as the scatter dots get smaller.

It probably does not make sense for the cursor ever to receive pointer events.