### PR TITLE
Factor out some scale- and rect-related functions

### DIFF
--- a/src/cartesian/ReferenceArea.js
+++ b/src/cartesian/ReferenceArea.js
@@ -10,7 +10,7 @@ import Layer from '../container/Layer';
 import Label from '../component/Label';
 import { PRESENTATION_ATTRIBUTES } from '../util/ReactUtils';
 import { isNumOrStr } from '../util/DataUtils';
-import { validateCoordinateInRange } from '../util/ChartUtils';
+import { LabeledScaleHelper, rectWithPoints } from '../util/CartesianUtils';
 import Rectangle from '../shape/Rectangle';
 
 @pureRender
@@ -58,46 +58,21 @@ class ReferenceArea extends Component {
   getRect(hasX1, hasX2, hasY1, hasY2) {
     const { x1: xValue1, x2: xValue2, y1: yValue1, y2: yValue2, xAxis,
       yAxis } = this.props;
-    const xScale = xAxis.scale;
-    const yScale = yAxis.scale;
-    const xOffset = xScale.bandwidth ? xScale.bandwidth() / 2 : 0;
-    const yOffset = yScale.bandwidth ? yScale.bandwidth() / 2 : 0;
-    const xRange = xScale.range();
-    const yRange = yScale.range();
-    let x1, x2, y1, y2;
 
-    if (hasX1) {
-      x1 = xScale(xValue1) + xOffset;
-    } else {
-      x1 = xRange[0];
-    }
+    const scale = LabeledScaleHelper.create({ x: xAxis.scale, y: yAxis.scale });
 
-    if (hasX2) {
-      x2 = xScale(xValue2) + xOffset;
-    } else {
-      x2 = xRange[1];
-    }
+    const p1 = {
+      x: hasX1 ? scale.x.apply(xValue1) : scale.x.rangeMin,
+      y: hasY1 ? scale.y.apply(yValue1) : scale.y.rangeMin,
+    };
 
-    if (hasY1) {
-      y1 = yScale(yValue1) + yOffset;
-    } else {
-      y1 = yRange[0];
-    }
+    const p2 = {
+      x: hasX2 ? scale.x.apply(xValue2) : scale.x.rangeMax,
+      y: hasY2 ? scale.y.apply(yValue2) : scale.y.rangeMax,
+    };
 
-    if (hasY2) {
-      y2 = yScale(yValue2) + yOffset;
-    } else {
-      y2 = yRange[1];
-    }
-
-    if (validateCoordinateInRange(x1, xScale) && validateCoordinateInRange(x2, xScale) &&
-      validateCoordinateInRange(y1, yScale) && validateCoordinateInRange(y2, yScale)) {
-      return {
-        x: Math.min(x1, x2),
-        y: Math.min(y1, y2),
-        width: Math.abs(x2 - x1),
-        height: Math.abs(y2 - y1),
-      };
+    if (scale.isInRange(p1) && scale.isInRange(p2)) {
+      return rectWithPoints(p1, p2);
     }
 
     return null;

--- a/src/cartesian/ReferenceDot.js
+++ b/src/cartesian/ReferenceDot.js
@@ -12,7 +12,7 @@ import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES,
   getPresentationAttributes, filterEventAttributes } from '../util/ReactUtils';
 import Label from '../component/Label';
 import { isNumOrStr } from '../util/DataUtils';
-import { validateCoordinateInRange } from '../util/ChartUtils';
+import { LabeledScaleHelper } from '../util/CartesianUtils';
 
 @pureRender
 class ReferenceDot extends Component {
@@ -52,19 +52,11 @@ class ReferenceDot extends Component {
 
   getCoordinate() {
     const { x, y, xAxis, yAxis } = this.props;
-    const xScale = xAxis.scale;
-    const yScale = yAxis.scale;
-    const result = {
-      cx: xScale(x) + (xScale.bandwidth ? xScale.bandwidth() / 2 : 0),
-      cy: yScale(y) + (yScale.bandwidth ? yScale.bandwidth() / 2 : 0),
-    };
+    const scales = LabeledScaleHelper.create({ x: xAxis.scale, y: yAxis.scale });
 
-    if (validateCoordinateInRange(result.cx, xScale) &&
-      validateCoordinateInRange(result.cy, yScale)) {
-      return result;
-    }
+    const result = scales.apply({ x, y }, { bandAware: true });
 
-    return null;
+    return scales.isInRange(result) ? result : null;
   }
 
   renderDot(option, props) {
@@ -99,20 +91,23 @@ class ReferenceDot extends Component {
 
     if (!coordinate) { return null; }
 
+    const { x: cx, y: cy } = coordinate;
+
     const { shape, className } = this.props;
 
     const dotProps = {
       ...getPresentationAttributes(this.props),
       ...filterEventAttributes(this.props),
-      ...coordinate,
+      cx,
+      cy,
     };
 
     return (
       <Layer className={classNames('recharts-reference-dot', className)}>
         {this.renderDot(shape, dotProps)}
         {Label.renderCallByParent(this.props, {
-          x: coordinate.cx - r,
-          y: coordinate.cy - r,
+          x: cx - r,
+          y: cy - r,
           width: 2 * r,
           height: 2 * r,
         })}

--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -961,19 +961,6 @@ export const parseSpecifiedDomain = (specifiedDomain, dataDomain, allowDataOverf
   return domain;
 };
 
-export const validateCoordinateInRange = (coordinate, scale) => {
-  if (!scale) { return false; }
-
-  const range = scale.range();
-  const first = range[0];
-  const last = range[range.length - 1];
-  const isValidate = first <= last ?
-    (coordinate >= first && coordinate <= last) :
-    (coordinate >= last && coordinate <= first);
-
-  return isValidate;
-};
-
 /**
  * Calculate the size between two category
  * @param  {Object} axis  The options of axis

--- a/test/specs/util/CartesianUtilsSpec.js
+++ b/test/specs/util/CartesianUtilsSpec.js
@@ -1,2 +1,70 @@
 import { expect } from 'chai';
 import { scaleLinear, scaleBand } from 'd3-scale';
+import { ScaleHelper, LabeledScaleHelper } from '../../../src/util/CartesianUtils';
+
+
+describe('ScaleHelper', () => {
+  it('apply() should return the expected value', () => {
+    const scale = new ScaleHelper(scaleLinear());
+    expect(scale.apply(2)).to.equal(2);
+  });
+
+  it('apply() should return the expected value when bandAware = true', () => {
+    const scale = new ScaleHelper(scaleLinear());
+    expect(scale.apply(2, { bandAware: true })).to.equal(2);
+  });
+
+  it('apply() should return the expected value for band scale', () => {
+    const scale = new ScaleHelper(scaleBand().domain([0, 1, 2, 3]).range([0, 100]));
+    expect(scale.apply(2)).to.equal(50);
+  });
+
+  it('apply() should return the expected value for band scale when bandAware = true', () => {
+    const scale = new ScaleHelper(scaleBand().domain([0, 1, 2, 3]).range([0, 100]));
+    expect(scale.apply(2, { bandAware: true })).to.equal(50 + 25 / 2.);
+  });
+
+  it('apply() should return undefined for undefined', () => {
+    const scale = new ScaleHelper(scaleLinear());
+    expect(scale.apply(undefined)).to.equal(undefined);
+  });
+
+  it('apply() should return undefined for undefined', () => {
+    const scale = new ScaleHelper(scaleLinear());
+    expect(scale.apply(undefined)).to.equal(undefined);
+  });
+
+  it('isInRange() should return true for a value in range', () => {
+    const scale = new ScaleHelper(scaleLinear().domain([-200, 200]).range([0, 50]));
+    expect(scale.isInRange(35)).to.equal(true);
+  });
+
+  it('isInRange() should return false for a value out of range', () => {
+    const scale = new ScaleHelper(scaleLinear().domain([-200, 200]).range([0, 50]));
+    expect(scale.isInRange(-10)).to.equal(false);
+  });
+});
+
+describe('LabeledScaleHelper', () => {
+  it('apply() should return the expected values', () => {
+    const scales = new LabeledScaleHelper({
+      x: scaleBand().domain([0, 1, 2, 3]).range([0, 100]),
+      y: scaleLinear().domain([-200, 200]).range([0, 50]),
+    });
+    expect(scales.apply({ x: 2 }, { bandAware: true })).to.deep.equal({ x: 50 + 25 / 2. });
+    expect(scales.apply({ y: 100 }, { bandAware: true })).to.deep.equal({ y: 37.5 });
+  });
+
+  it('isInRange() should return the expected values', () => {
+    const scales = new LabeledScaleHelper({
+      x: scaleBand().domain([0, 1, 2, 3]).range([0, 100]),
+      y: scaleLinear().domain([-200, 200]).range([0, 50]),
+    });
+    expect(scales.isInRange({ x: 50 })).to.equal(true);
+    expect(scales.isInRange({ x: 50, y: 35 })).to.equal(true);
+    expect(scales.isInRange({ y: 35 })).to.equal(true);
+    expect(scales.isInRange({ y: 100 })).to.equal(false);
+    expect(scales.isInRange({ x: 50, y: 100 })).to.equal(false);
+    expect(scales.isInRange({})).to.equal(true);
+  });
+});

--- a/test/specs/util/ChartUtilsSpec.js
+++ b/test/specs/util/ChartUtilsSpec.js
@@ -3,15 +3,10 @@ import { scaleLinear, scaleBand } from 'd3-scale';
 import {
   calculateActiveTickIndex, getDomainOfStackGroups,
   getDomainOfDataByKey, appendOffsetOfLegend,
-  validateCoordinateInRange, getBandSizeOfAxis, calculateDomainOfTicks,
+  getBandSizeOfAxis, calculateDomainOfTicks,
   parseSpecifiedDomain,  parseScale, getTicksOfScale, getValueByDataKey,
   offsetSign, MIN_VALUE_REG, MAX_VALUE_REG } from '../../../src/util/ChartUtils';
 
-describe('validateCoordinateInRange', () => {
-  it('DataUtils.validateCoordinateInRange(1) should return false ', () => {
-    expect(validateCoordinateInRange(1)).to.equal(false);
-  });
-});
 
 describe('getBandSizeOfAxis', () => {
   it('DataUtils.getBandSizeOfAxis() should return 0 ', () => {

--- a/test/specs/util/DataUtilsSpec.js
+++ b/test/specs/util/DataUtilsSpec.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import { scaleLinear, scaleBand } from 'd3-scale';
-import { getPercentValue, validateCoordinateInRange,
-  getBandSizeOfAxis, getAnyElementOfObject, calculateDomainOfTicks,
-  parseSpecifiedDomain, hasDuplicate, parseScale, getTicksOfScale,
-  getValueByDataKey, mathSign, offsetSign } from '../../../src/util/DataUtils';
+import { getPercentValue, getBandSizeOfAxis, getAnyElementOfObject,
+  calculateDomainOfTicks, parseSpecifiedDomain, hasDuplicate, parseScale,
+  getTicksOfScale, getValueByDataKey, mathSign, offsetSign
+} from '../../../src/util/DataUtils';
 
 describe('getPercentValue', () => {
   it('DataUtils.getPercentValue("25%", 1) should return 0.25 ', () => {


### PR DESCRIPTION
Goal: Make it easy to allow fixed endpoints in ReferenceLine

Create a `ScaleHelper` to provide two useful helper functions on top of what d3-scale provides, and a `LabeledScaleHelper` which makes it convenient to work with multiple scales at once. Includes unit tests of those helpers.

Refactor the reference areas to use the new helpers.