### PR TITLE
Allow reference areas which extend past the canvas bounds

### DIFF
--- a/src/cartesian/ReferenceArea.js
+++ b/src/cartesian/ReferenceArea.js
@@ -8,10 +8,13 @@ import classNames from 'classnames';
 import pureRender from '../util/PureRender';
 import Layer from '../container/Layer';
 import Label from '../component/Label';
-import { PRESENTATION_ATTRIBUTES } from '../util/ReactUtils';
-import { isNumOrStr } from '../util/DataUtils';
 import { LabeledScaleHelper, rectWithPoints } from '../util/CartesianUtils';
+import { ifOverflowMatches } from '../util/ChartUtils';
+import { isNumOrStr } from '../util/DataUtils';
+import { warn } from '../util/LogUtils';
+import { PRESENTATION_ATTRIBUTES } from '../util/ReactUtils';
 import Rectangle from '../shape/Rectangle';
+
 
 @pureRender
 class ReferenceArea extends Component {
@@ -32,6 +35,7 @@ class ReferenceArea extends Component {
 
     isFront: PropTypes.bool,
     alwaysShow: PropTypes.bool,
+    ifOverflow: PropTypes.oneOf(['clip', 'discard', 'keep', 'extendDomain']),
     x1: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     x2: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     y1: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -45,7 +49,7 @@ class ReferenceArea extends Component {
 
   static defaultProps = {
     isFront: false,
-    alwaysShow: false,
+    ifOverflow: 'discard',
     xAxisId: 0,
     yAxisId: 0,
     r: 10,
@@ -71,11 +75,12 @@ class ReferenceArea extends Component {
       y: hasY2 ? scale.y.apply(yValue2) : scale.y.rangeMax,
     };
 
-    if (scale.isInRange(p1) && scale.isInRange(p2)) {
-      return rectWithPoints(p1, p2);
+    if (ifOverflowMatches(this.props, 'discard') &&
+      (!scale.isInRange(p1) || !scale.isInRange(p2))) {
+      return null;
     }
 
-    return null;
+    return rectWithPoints(p1, p2);
   }
 
   renderRect(option, props) {
@@ -98,7 +103,10 @@ class ReferenceArea extends Component {
   }
 
   render() {
-    const { x1, x2, y1, y2, className } = this.props;
+    const { x1, x2, y1, y2, className, alwaysShow, clipPathId } = this.props;
+
+    warn(alwaysShow !== undefined,
+      'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
 
     const hasX1 = isNumOrStr(x1);
     const hasX2 = isNumOrStr(x2);
@@ -113,9 +121,13 @@ class ReferenceArea extends Component {
 
     const { shape } = this.props;
 
+    const clipPath = ifOverflowMatches(this.props, 'clip') ?
+      `url(#${clipPathId})` :
+      undefined;
+
     return (
       <Layer className={classNames('recharts-reference-area', className)}>
-        {this.renderRect(shape, { ...this.props, ...rect })}
+        {this.renderRect(shape, { clipPath, ...this.props, ...rect })}
         {Label.renderCallByParent(this.props, rect)}
       </Layer>
     );

--- a/src/cartesian/ReferenceArea.js
+++ b/src/cartesian/ReferenceArea.js
@@ -35,7 +35,7 @@ class ReferenceArea extends Component {
 
     isFront: PropTypes.bool,
     alwaysShow: PropTypes.bool,
-    ifOverflow: PropTypes.oneOf(['clip', 'discard', 'keep', 'extendDomain']),
+    ifOverflow: PropTypes.oneOf(['hidden', 'visible', 'discard', 'extendDomain']),
     x1: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     x2: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     y1: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -121,7 +121,7 @@ class ReferenceArea extends Component {
 
     const { shape } = this.props;
 
-    const clipPath = ifOverflowMatches(this.props, 'clip') ?
+    const clipPath = ifOverflowMatches(this.props, 'hidden') ?
       `url(#${clipPathId})` :
       undefined;
 

--- a/src/cartesian/ReferenceDot.js
+++ b/src/cartesian/ReferenceDot.js
@@ -12,7 +12,9 @@ import { PRESENTATION_ATTRIBUTES, EVENT_ATTRIBUTES,
   getPresentationAttributes, filterEventAttributes } from '../util/ReactUtils';
 import Label from '../component/Label';
 import { isNumOrStr } from '../util/DataUtils';
+import { ifOverflowMatches } from '../util/ChartUtils';
 import { LabeledScaleHelper } from '../util/CartesianUtils';
+import { warn } from '../util/LogUtils';
 
 @pureRender
 class ReferenceDot extends Component {
@@ -29,6 +31,7 @@ class ReferenceDot extends Component {
 
     isFront: PropTypes.bool,
     alwaysShow: PropTypes.bool,
+    ifOverflow: PropTypes.oneOf(['clip', 'discard', 'keep', 'extendDomain']),
     x: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     y: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
@@ -36,11 +39,13 @@ class ReferenceDot extends Component {
     yAxisId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     xAxisId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     shape: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
+
+    clipPathId: PropTypes.string,
   };
 
   static defaultProps = {
     isFront: false,
-    alwaysShow: false,
+    ifOverflow: 'discard',
     xAxisId: 0,
     yAxisId: 0,
     r: 10,
@@ -56,7 +61,12 @@ class ReferenceDot extends Component {
 
     const result = scales.apply({ x, y }, { bandAware: true });
 
-    return scales.isInRange(result) ? result : null;
+    if (ifOverflowMatches(this.props, 'discard') &&
+      !scales.isInRange(result)) {
+      return null;
+    }
+
+    return result;
   }
 
   renderDot(option, props) {
@@ -81,9 +91,12 @@ class ReferenceDot extends Component {
   }
 
   render() {
-    const { x, y, r } = this.props;
+    const { x, y, r, alwaysShow, clipPathId } = this.props;
     const isX = isNumOrStr(x);
     const isY = isNumOrStr(y);
+
+    warn(alwaysShow !== undefined,
+      'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
 
     if (!isX || !isY) { return null; }
 
@@ -95,7 +108,12 @@ class ReferenceDot extends Component {
 
     const { shape, className } = this.props;
 
+    const clipPath = ifOverflowMatches(this.props, 'clip') ?
+      `url(#${clipPathId})` :
+      undefined;
+
     const dotProps = {
+      clipPath,
       ...getPresentationAttributes(this.props),
       ...filterEventAttributes(this.props),
       cx,

--- a/src/cartesian/ReferenceDot.js
+++ b/src/cartesian/ReferenceDot.js
@@ -31,7 +31,7 @@ class ReferenceDot extends Component {
 
     isFront: PropTypes.bool,
     alwaysShow: PropTypes.bool,
-    ifOverflow: PropTypes.oneOf(['clip', 'discard', 'keep', 'extendDomain']),
+    ifOverflow: PropTypes.oneOf(['hidden', 'visible', 'discard', 'extendDomain']),
     x: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     y: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
@@ -108,7 +108,7 @@ class ReferenceDot extends Component {
 
     const { shape, className } = this.props;
 
-    const clipPath = ifOverflowMatches(this.props, 'clip') ?
+    const clipPath = ifOverflowMatches(this.props, 'hidden') ?
       `url(#${clipPathId})` :
       undefined;
 

--- a/src/cartesian/ReferenceLine.js
+++ b/src/cartesian/ReferenceLine.js
@@ -10,8 +10,10 @@ import Layer from '../container/Layer';
 import { PRESENTATION_ATTRIBUTES, getPresentationAttributes,
   filterEventAttributes } from '../util/ReactUtils';
 import Label from '../component/Label';
+import { ifOverflowMatches } from '../util/ChartUtils';
 import { isNumOrStr } from '../util/DataUtils';
 import { LabeledScaleHelper, rectWithCoords } from '../util/CartesianUtils';
+import { warn } from '../util/LogUtils';
 
 const renderLine = (option, props) => {
   let line;
@@ -51,6 +53,7 @@ class ReferenceLine extends Component {
 
     isFront: PropTypes.bool,
     alwaysShow: PropTypes.bool,
+    ifOverflow: PropTypes.oneOf(['clip', 'discard', 'keep', 'extendDomain']),
     x: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     y: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
@@ -63,7 +66,7 @@ class ReferenceLine extends Component {
 
   static defaultProps = {
     isFront: false,
-    alwaysShow: false,
+    ifOverflow: 'discard',
     xAxisId: 0,
     yAxisId: 0,
     fill: 'none',
@@ -79,23 +82,31 @@ class ReferenceLine extends Component {
     if (isFixedY) {
       const { y: yCoord, yAxis: { orientation } } = this.props;
       const coord = scales.y.apply(yCoord);
-      if (scales.y.isInRange(coord)) {
-        const points = [
-          { x: x + width, y: coord },
-          { x, y: coord },
-        ];
-        return orientation === 'left' ? points.reverse() : points;
+
+      if (ifOverflowMatches(this.props, 'discard') &&
+        !scales.y.isInRange(coord)) {
+        return null;
       }
+
+      const points = [
+        { x: x + width, y: coord },
+        { x, y: coord },
+      ];
+      return orientation === 'left' ? points.reverse() : points;
     } else if (isFixedX) {
       const { x: xCoord, xAxis: { orientation } } = this.props;
       const coord = scales.x.apply(xCoord);
-      if (scales.x.isInRange(coord)) {
-        const points = [
-          { x: coord, y: y + height },
-          { x: coord, y },
-        ];
-        return orientation === 'top' ? points.reverse() : points;
+
+      if (ifOverflowMatches(this.props, 'discard') &&
+        !scales.x.isInRange(coord)) {
+        return null;
       }
+
+      const points = [
+        { x: coord, y: y + height },
+        { x: coord, y },
+      ];
+      return orientation === 'top' ? points.reverse() : points;
     }
 
     return null;
@@ -109,7 +120,12 @@ class ReferenceLine extends Component {
       yAxis,
       shape,
       className,
+      alwaysShow,
+      clipPathId,
     } = this.props;
+
+    warn(alwaysShow !== undefined,
+      'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
 
     const scales = LabeledScaleHelper.create({ x: xAxis.scale, y: yAxis.scale });
 
@@ -121,7 +137,12 @@ class ReferenceLine extends Component {
 
     const [{ x: x1, y: y1 }, { x: x2, y: y2 }] = endPoints;
 
+    const clipPath = ifOverflowMatches(this.props, 'clip') ?
+      `url(#${clipPathId})` :
+      undefined;
+
     const props = {
+      clipPath,
       ...getPresentationAttributes(this.props),
       ...filterEventAttributes(this.props),
       x1,

--- a/src/cartesian/ReferenceLine.js
+++ b/src/cartesian/ReferenceLine.js
@@ -53,7 +53,7 @@ class ReferenceLine extends Component {
 
     isFront: PropTypes.bool,
     alwaysShow: PropTypes.bool,
-    ifOverflow: PropTypes.oneOf(['clip', 'discard', 'keep', 'extendDomain']),
+    ifOverflow: PropTypes.oneOf(['hidden', 'visible', 'discard', 'extendDomain']),
     x: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     y: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 
@@ -137,7 +137,7 @@ class ReferenceLine extends Component {
 
     const [{ x: x1, y: y1 }, { x: x2, y: y2 }] = endPoints;
 
-    const clipPath = ifOverflowMatches(this.props, 'clip') ?
+    const clipPath = ifOverflowMatches(this.props, 'hidden') ?
       `url(#${clipPathId})` :
       undefined;
 

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -158,6 +158,7 @@ const generateCategoricalChart = ({
         ...this.updateStateOfAxisMapsOffsetAndStackGroups({ props, ...defaultState, updateId }) };
 
       this.uniqueChartId = _.isNil(props.id) ? uniqueId('recharts') : props.id;
+      this.clipPathId = `${this.uniqueChartId}-clip`;
 
       if (props.throttleDelay) {
         this.triggeredAfterMouseMove = _.throttle(this.triggeredAfterMouseMove,
@@ -1349,6 +1350,7 @@ const generateCategoricalChart = ({
 
     renderReferenceElement = (element, displayName, index) => {
       if (!element) { return null; }
+      const { clipPathId } = this;
       const { xAxisMap, yAxisMap, offset } = this.state;
       const { xAxisId, yAxisId } = element.props;
 
@@ -1362,6 +1364,7 @@ const generateCategoricalChart = ({
           width: offset.width,
           height: offset.height,
         },
+        clipPathId,
       });
     };
 
@@ -1459,6 +1462,18 @@ const generateCategoricalChart = ({
       return [graphicalItem, null];
     };
 
+    renderClipPath() {
+      const { clipPathId } = this;
+      const { offset: { left, top, height, width } } = this.state;
+
+      return (
+        <clipPath id={clipPathId}>
+          <rect x={left} y={top} height={height} width={width} />
+        </clipPath>
+      );
+    }
+
+
     render() {
       if (!validateWidthHeight(this)) { return null; }
 
@@ -1489,6 +1504,7 @@ const generateCategoricalChart = ({
       if (compact) {
         return (
           <Surface {...attrs} width={width} height={height}>
+            {this.renderClipPath()}
             {
               renderByOrder(children, map)
             }
@@ -1505,6 +1521,7 @@ const generateCategoricalChart = ({
           ref={(node) => { this.container = node; }}
         >
           <Surface {...attrs} width={width} height={height}>
+            {this.renderClipPath()}
             {
               renderByOrder(children, map)
             }

--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -825,6 +825,17 @@ export const getBaseValueOfBar = ({ numericAxis }) => {
   return domain[0];
 };
 
+export const ifOverflowMatches = (props, value) => {
+  const { alwaysShow } = props;
+  let { ifOverflow } = props;
+
+  if (alwaysShow) {
+    ifOverflow = 'extendDomain';
+  }
+
+  return ifOverflow === value;
+};
+
 export const detectReferenceElementsDomain = (
   children, domain, axisId, axisType, specifiedTicks
 ) => {
@@ -838,7 +849,8 @@ export const detectReferenceElementsDomain = (
 
   if (elements.length) {
     finalDomain = elements.reduce((result, el) => {
-      if (el.props[idKey] === axisId && el.props.alwaysShow &&
+      if (el.props[idKey] === axisId &&
+        ifOverflowMatches(el.props, 'extendDomain') &&
         isNumber(el.props[valueKey])) {
         const value = el.props[valueKey];
 
@@ -853,7 +865,8 @@ export const detectReferenceElementsDomain = (
     const key2 = `${valueKey}2`;
 
     finalDomain = areas.reduce((result, el) => {
-      if (el.props[idKey] === axisId && el.props.alwaysShow &&
+      if (el.props[idKey] === axisId &&
+        ifOverflowMatches(el.props, 'extendDomain') &&
         (isNumber(el.props[key1]) && isNumber(el.props[key2]))) {
         const value1 = el.props[key1];
         const value2 = el.props[key2];

--- a/test/specs/cartesian/ReferenceLineSpec.js
+++ b/test/specs/cartesian/ReferenceLineSpec.js
@@ -113,7 +113,7 @@ describe('<ReferenceLine />', () => {
         <XAxis dataKey="name" />
         <YAxis tickCount={7} />
         <Bar dataKey="uv" />
-        <ReferenceLine y={20} stroke="#666" label={renderLabel} ifOverflow="keep" labelPosition="start" />
+        <ReferenceLine y={20} stroke="#666" label={renderLabel} ifOverflow="visible" labelPosition="start" />
       </BarChart>
     );
     expect(wrapper.find('.recharts-reference-line-line').length).to.equal(1);
@@ -143,7 +143,7 @@ describe('<ReferenceLine />', () => {
         <XAxis dataKey="name" />
         <YAxis tickCount={7} />
         <Bar dataKey="uv" />
-        <ReferenceLine y={20} stroke="#666" ifOverflow="keep" label={<Label text="Custom Text" />} />
+        <ReferenceLine y={20} stroke="#666" ifOverflow="visible" label={<Label text="Custom Text" />} />
       </BarChart>
     );
     expect(wrapper.find('.recharts-reference-line text').text()).to.equal('Custom Text');

--- a/test/specs/cartesian/ReferenceLineSpec.js
+++ b/test/specs/cartesian/ReferenceLineSpec.js
@@ -72,7 +72,20 @@ describe('<ReferenceLine />', () => {
     expect(wrapper.find('.recharts-label').length).to.equal(0);
   });
 
-  it('Render line and label when alwaysShow is true in ReferenceLine', () => {
+  it('Render line and label when ifOverflow is extendDomain in ReferenceLine', () => {
+    const wrapper = render(
+      <BarChart width={1100} height={250} barGap={2} barSize={6} data={data} margin={{ top: 20, right: 60, bottom: 0, left: 20 }}>
+        <XAxis dataKey="name" />
+        <YAxis tickCount={7} />
+        <Bar dataKey="uv" />
+        <ReferenceLine x="201102" label="test" stroke="#666" />
+        <ReferenceLine y={20} stroke="#666" label="20" ifOverflow="extendDomain" labelPosition="start" />
+      </BarChart>
+    );
+    expect(wrapper.find('.recharts-reference-line-line').length).to.equal(2);
+    expect(wrapper.find('.recharts-label').length).to.equal(2);
+  });
+  it('Render line and label when (deprecated) alwaysShow is true in ReferenceLine', () => {
     const wrapper = render(
       <BarChart width={1100} height={250} barGap={2} barSize={6} data={data} margin={{ top: 20, right: 60, bottom: 0, left: 20 }}>
         <XAxis dataKey="name" />
@@ -100,7 +113,7 @@ describe('<ReferenceLine />', () => {
         <XAxis dataKey="name" />
         <YAxis tickCount={7} />
         <Bar dataKey="uv" />
-        <ReferenceLine y={20} stroke="#666" label={renderLabel} alwaysShow labelPosition="start" />
+        <ReferenceLine y={20} stroke="#666" label={renderLabel} ifOverflow="keep" labelPosition="start" />
       </BarChart>
     );
     expect(wrapper.find('.recharts-reference-line-line').length).to.equal(1);
@@ -116,7 +129,7 @@ describe('<ReferenceLine />', () => {
         <XAxis dataKey="name" />
         <YAxis tickCount={7} />
         <Bar dataKey="uv" />
-        <ReferenceLine y={20} stroke="#666" label={{ a: 1 }} alwaysShow labelPosition="start" />
+        <ReferenceLine y={20} stroke="#666" label={{ a: 1 }} labelPosition="start" />
       </BarChart>
     );
 
@@ -130,7 +143,7 @@ describe('<ReferenceLine />', () => {
         <XAxis dataKey="name" />
         <YAxis tickCount={7} />
         <Bar dataKey="uv" />
-        <ReferenceLine y={20} stroke="#666" label={<Label text="Custom Text" />} alwaysShow />
+        <ReferenceLine y={20} stroke="#666" ifOverflow="keep" label={<Label text="Custom Text" />} />
       </BarChart>
     );
     expect(wrapper.find('.recharts-reference-line text').text()).to.equal('Custom Text');


### PR DESCRIPTION
I’m working on a chart with several reference areas, some of which extend past the canvas bounds. Though I want to draw the part of the reference area that lies on the canvas, it doesn’t make sense to draw the part that spills out.

It's possible to grow the canvas to accommodate the reference area by specifying `alwaysShow`. Though after thinking about this for a while, it seems that _both_ these things should be possible: to show reference items which are partly off the canvas, and to extend the chart domain to accommodate reference items. This deprecates the `alwaysShow` prop, and adds an `ifOverflow` prop which supports four values:

- `ifOverflow="discard"` (default) – If the reference item falls partly outside the canvas, don't display it. This is the old default.
- `ifOverflow="extendDomain"` – If the reference item falls partly outside the canvas, extend the domain so it fits. This is the old `alwaysShow` behavior.
- `ifOverflow="clip"` – If the reference item falls partly outside the canvas, clip it to the canvas.
- `ifOverflow="keep"` – If the reference item falls partly outside the canvas, draw it anyway.