### PR TITLE
Allow to add more classes in tooltips

### DIFF
--- a/src/component/DefaultTooltipContent.js
+++ b/src/component/DefaultTooltipContent.js
@@ -4,6 +4,7 @@
 import _ from 'lodash';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import pureRender from '../util/PureRender';
 import { isNumOrStr } from '../util/DataUtils';
 
@@ -20,6 +21,8 @@ class DefaultTooltipContent extends Component {
 
   static propTypes = {
     separator: PropTypes.string,
+    wrapperClassName: PropTypes.string,
+    labelClassName: PropTypes.string,
     formatter: PropTypes.func,
     itemStyle: PropTypes.object,
     labelStyle: PropTypes.object,
@@ -80,7 +83,13 @@ class DefaultTooltipContent extends Component {
   }
 
   render() {
-    const { labelStyle, label, labelFormatter } = this.props;
+    const {
+      wrapperClassName,
+      labelClassName,
+      labelStyle,
+      label,
+      labelFormatter,
+    } = this.props;
     const finalStyle = {
       margin: 0,
       padding: 10,
@@ -94,12 +103,14 @@ class DefaultTooltipContent extends Component {
     };
     const hasLabel = isNumOrStr(label);
     let finalLabel = hasLabel ? label : '';
+    const wrapperCN = classNames('recharts-default-tooltip', wrapperClassName);
+    const labelCN = classNames('recharts-tooltip-label', labelClassName);
 
     if (hasLabel && labelFormatter) { finalLabel = labelFormatter(label); }
 
     return (
-      <div className="recharts-default-tooltip" style={finalStyle}>
-        <p className="recharts-tooltip-label" style={finalLabelStyle}>{finalLabel}</p>
+      <div className={wrapperCN} style={finalStyle}>
+        <p className={labelCN} style={finalLabelStyle}>{finalLabel}</p>
         {this.renderContent()}
       </div>
     );


### PR DESCRIPTION
Since #798 was fixed, there was no way to change the tooltip wrapper
style other than defining another class in css for
"recharts-default-tooltip" and mark everything as "important.

The problem with that approach is that we would be changing all the
tooltips, but what if we want to change it for only one chart?

This will allow to define extra classes  for both the wrapper and the
label, allowing us to customize a single chart easily.