### PR TITLE
Add ability to define own verticalCoordinatesGenerator and horizontalCoordinatesGenerator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React charts",
   "main": "lib/index",
   "module": "es6/index",

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -1262,8 +1262,10 @@ const generateCategoricalChart = ({
         offset,
         chartWidth: width,
         chartHeight: height,
-        verticalCoordinatesGenerator: this.verticalCoordinatesGenerator,
-        horizontalCoordinatesGenerator: this.horizontalCoordinatesGenerator,
+        verticalCoordinatesGenerator:
+          props.verticalCoordinatesGenerator || this.verticalCoordinatesGenerator,
+        horizontalCoordinatesGenerator:
+          props.horizontalCoordinatesGenerator || this.horizontalCoordinatesGenerator,
       });
     };
 


### PR DESCRIPTION
`verticalCoordinatesGenerator` and `horizontalCoordinatesGenerator` props of the `CartesianGrid` component get overwritten even if the user supplies his own definitions. 