### PR TITLE
Add blendStroke prop to Pie component

### DIFF
--- a/src/polar/Pie.js
+++ b/src/polar/Pie.js
@@ -43,6 +43,7 @@ class Pie extends Component {
     nameKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.func]),
     valueKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.func]),
     data: PropTypes.arrayOf(PropTypes.object),
+    blendStroke: PropTypes.bool,
     minAngle: PropTypes.number,
     legendType: PropTypes.oneOf(LEGEND_TYPES),
     maxRadius: PropTypes.number,
@@ -102,6 +103,8 @@ class Pie extends Component {
     animationDuration: 1500,
     animationEasing: 'ease',
     nameKey: 'name',
+    // Match each sector's stroke color to it's fill color
+    blendStroke: false
   };
 
   static parseDeltaAngle = ({ startAngle, endAngle }) => {
@@ -378,17 +381,25 @@ class Pie extends Component {
   }
 
   renderSectorsStatically(sectors) {
-    const { activeShape } = this.props;
+    const { activeShape, blendStroke } = this.props;
 
-    return sectors.map((entry, i) => (
-      <Layer
-        className="recharts-pie-sector"
-        {...filterEventsOfChild(this.props, entry, i)}
-        key={`sector-${i}`}
-      >
-        {this.constructor.renderSectorItem(this.isActiveIndex(i) ? activeShape : null, entry)}
-      </Layer>
-    ));
+    return sectors.map((entry, i) => {
+      const sectorOptions = this.isActiveIndex(i) ? activeShape : null;
+      const sectorProps = {
+        ...entry,
+        stroke: blendStroke ? entry.fill : entry.stroke
+      };
+
+      return (
+        <Layer
+          className="recharts-pie-sector"
+          {...filterEventsOfChild(this.props, entry, i)}
+          key={`sector-${i}`}
+        >
+          {this.constructor.renderSectorItem(sectorOptions, sectorProps)}
+        </Layer>
+      );
+    });
   }
 
   renderSectorsWithAnimation() {


### PR DESCRIPTION
Some people were complaining about the white bars between pie sectors over in issue #1255 

While it's possible to hide the bars by setting the ```stroke``` attribute manually on each entry of your pie data, this feels like a common enough use case to warrant it's own prop.

I've simply overridden each sector's stroke attribute with it's fill attribute if the ```blendStroke``` attribute is set.