### PR TITLE
Added animateNewValues property to Line

### DIFF
--- a/src/cartesian/Line.js
+++ b/src/cartesian/Line.js
@@ -62,6 +62,7 @@ class Line extends Component {
     onAnimationEnd: PropTypes.func,
 
     isAnimationActive: PropTypes.bool,
+    animateNewValues: PropTypes.bool,
     animationBegin: PropTypes.number,
     animationDuration: PropTypes.number,
     animationEasing: PropTypes.oneOf([
@@ -87,6 +88,7 @@ class Line extends Component {
     fill: '#fff',
     points: [],
     isAnimationActive: !isSsr(),
+    animateNewValues: true,
     animationBegin: 0,
     animationDuration: 1500,
     animationEasing: 'ease',
@@ -336,9 +338,13 @@ class Line extends Component {
                 }
 
                 // magic number of faking previous x and y location
-                const interpolatorX = interpolateNumber(width * 2, entry.x);
-                const interpolatorY = interpolateNumber(height / 2, entry.y);
-                return { ...entry, x: interpolatorX(t), y: interpolatorY(t) };
+                if (animateNewValues) {
+                  const interpolatorX = interpolateNumber(width * 2, entry.x);
+                  const interpolatorY = interpolateNumber(height / 2, entry.y);
+                  return { ...entry, x: interpolatorX(t), y: interpolatorY(t) };
+                } else {
+                  return { ...entry, x: entry.x, y: entry.y };
+                }
               });
               return this.renderCurveStatically(stepData, needClip, clipPathId);
             }

--- a/src/cartesian/Line.js
+++ b/src/cartesian/Line.js
@@ -311,6 +311,7 @@ class Line extends Component {
     const { points, strokeDasharray, isAnimationActive, animationBegin,
       animationDuration, animationEasing, animationId, width, height
     } = this.props;
+    const that = this;
     const { prevPoints, totalLength } = this.state;
 
     return (
@@ -338,13 +339,12 @@ class Line extends Component {
                 }
 
                 // magic number of faking previous x and y location
-                if (animateNewValues) {
+                if (that.animateNewValues) {
                   const interpolatorX = interpolateNumber(width * 2, entry.x);
                   const interpolatorY = interpolateNumber(height / 2, entry.y);
                   return { ...entry, x: interpolatorX(t), y: interpolatorY(t) };
-                } else {
-                  return { ...entry, x: entry.x, y: entry.y };
                 }
+                return { ...entry, x: entry.x, y: entry.y };
               });
               return this.renderCurveStatically(stepData, needClip, clipPathId);
             }


### PR DESCRIPTION
I need the ability to add items dynamically to a line chart in a smooth way. Currently a "magic number" is calculated when items are added, which creates a large animation, but it's too much of a show. 
I've added attribute animateNewValues to Line. It's default is true, and then the Line behaves as usual. When it's false, new points are not animated.