### PR TITLE
Bugfix - allow consumers to override DefaultTooltipContent's styles

### DIFF
--- a/demo/component/LineChart.js
+++ b/demo/component/LineChart.js
@@ -547,7 +547,7 @@ export default class Demo extends Component {
           </LineChart>
         </div>
 
-        <p>LineChart with panoramic brush</p>
+        <p>LineChart with panoramic brush and custom tooltip styles</p>
         <div className="line-chart-wrapper">
           <LineChart
             width={600} height={400} data={data03}
@@ -556,7 +556,14 @@ export default class Demo extends Component {
             <CartesianGrid vertical={false} />
             <XAxis dataKey="date" label="Date" />
             <YAxis domain={['auto', 'auto']} label="Stock Price" />
-            <Tooltip />
+            <Tooltip
+              wrapperStyle={{
+                borderColor: 'white',
+                boxShadow: '2px 2px 3px 0px rgb(204, 204, 204)',
+              }}
+              contentStyle={{ backgroundColor: 'rgba(255, 255, 255, 0.8)' }}
+              labelStyle={{ fontWeight: 'bold', color: '#666666' }}
+            />
             <Line dataKey="price" stroke="#ff7300" dot={false} />
             <Brush dataKey="date" startIndex={data03.length - 40}>
               <AreaChart>

--- a/src/component/DefaultTooltipContent.js
+++ b/src/component/DefaultTooltipContent.js
@@ -24,6 +24,7 @@ class DefaultTooltipContent extends Component {
     wrapperClassName: PropTypes.string,
     labelClassName: PropTypes.string,
     formatter: PropTypes.func,
+    contentStyle: PropTypes.object,
     itemStyle: PropTypes.object,
     labelStyle: PropTypes.object,
     labelFormatter: PropTypes.func,
@@ -38,6 +39,7 @@ class DefaultTooltipContent extends Component {
 
   static defaultProps = {
     separator: ' : ',
+    contentStyle: {},
     itemStyle: {},
     labelStyle: {},
   };
@@ -85,6 +87,7 @@ class DefaultTooltipContent extends Component {
   render() {
     const {
       wrapperClassName,
+      contentStyle,
       labelClassName,
       labelStyle,
       label,
@@ -96,6 +99,7 @@ class DefaultTooltipContent extends Component {
       backgroundColor: '#fff',
       border: '1px solid #ccc',
       whiteSpace: 'nowrap',
+      ...contentStyle,
     };
     const finalLabelStyle = {
       margin: 0,

--- a/src/component/Tooltip.js
+++ b/src/component/Tooltip.js
@@ -32,6 +32,7 @@ const propTypes = {
   itemStyle: PropTypes.object,
   labelStyle: PropTypes.object,
   wrapperStyle: PropTypes.object,
+  contentStyle: PropTypes.object,
   cursor: PropTypes.oneOfType([PropTypes.bool, PropTypes.element, PropTypes.object]),
 
   coordinate: PropTypes.shape({
@@ -72,6 +73,7 @@ const defaultProps = {
   cursorStyle: {},
   separator: ' : ',
   wrapperStyle: {},
+  contentStyle: {},
   itemStyle: {},
   labelStyle: {},
   cursor: true,


### PR DESCRIPTION
The `wrapperStyle` prop was [recently removed](https://github.com/recharts/recharts/pull/1322) from `DefaultTooltipContent`. This makes sense, but it makes it impossible to override `DefaultTooltipContent`'s styles. This change adds a `contentStyle` prop to the `Tooltip` and `DefaultTooltipContent` components, allowing consumers to override `DefaultTooltipContent`'s styles.

I also updated the LineChart demo to include a Tooltip with custom styles.

Fixes https://github.com/recharts/recharts/issues/1377