### PR TITLE
Fix tree-shaking for Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index",
   "module": "es6/index",
   "jsnext:main": "es6/index",
+  "sideEffects": false,
   "files": [
     "*.md",
     "demo",


### PR DESCRIPTION
Tree-shaking is currently not working on recharts.

Code
```javascript
import { AreaChart } from 'recharts'
```

Before:
![2018-10-05-181115_4920x1920_scrot](https://user-images.githubusercontent.com/5734722/46549508-313f9680-c8ca-11e8-85a8-793d0d01b46d.png)
= 275.18 KB

After:
![2018-10-05-181108_4920x1920_scrot](https://user-images.githubusercontent.com/5734722/46549512-356bb400-c8ca-11e8-80ec-2b7ee89878e0.png)
= 164.57 KB

The flag `sideEffects` needs to be set to `false` for Webpack to tree shake the lib:
https://webpack.js.org/guides/tree-shaking/

This will fix it when bundling in production mode.