### PR TITLE
add: find yAxisWithNiceTicks and choose it over getAnyElementOfObject

### DIFF
--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -1255,7 +1255,8 @@ const generateCategoricalChart = ({
       const { xAxisMap, yAxisMap, offset } = this.state;
       const { width, height } = this.props;
       const xAxis = getAnyElementOfObject(xAxisMap);
-      const yAxis = getAnyElementOfObject(yAxisMap);
+      const yAxisWithNiceTicks = Object.values(yAxisMap).find(axis => !_.isEmpty(axis.niceTicks));
+      const yAxis = yAxisWithNiceTicks || getAnyElementOfObject(yAxisMap);
       const props = element.props || {};
 
       return cloneElement(element, {


### PR DESCRIPTION
When rendering the grid the method is grabbing the first YAxis component
The new feature is that it will prefer a YAxis with ticks and will fallback to the first one if none of them got "niceTicks"

![oct-09-2018 18-18-15](https://user-images.githubusercontent.com/13174025/46683489-a07df900-cbf0-11e8-8310-d5778b645dcb.gif)
