### PR TITLE
[BUG-1529] fix inconsistent chart height due to faulty domain update

### DIFF
--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -756,7 +756,7 @@ export const calculateDomainOfTicks = (ticks, type) => {
  * @return {Object}      null
  */
 export const getTicksOfScale = (scale, opts) => {
-  const { realScaleType, type, tickCount, originalDomain, allowDecimals, hide:axisHidden } = opts;
+  const { realScaleType, type, tickCount, originalDomain, allowDecimals, hide : axisHidden } = opts;
   const scaleType = realScaleType || opts.scale;
 
   if (scaleType !== 'auto' && scaleType !== 'linear') {

--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -756,7 +756,7 @@ export const calculateDomainOfTicks = (ticks, type) => {
  * @return {Object}      null
  */
 export const getTicksOfScale = (scale, opts) => {
-  const { realScaleType, type, tickCount, originalDomain, allowDecimals, hide : axisHidden } = opts;
+  const { realScaleType, type, tickCount, originalDomain, allowDecimals, hide: axisHidden } = opts;
   const scaleType = realScaleType || opts.scale;
 
   if (scaleType !== 'auto' && scaleType !== 'linear') {

--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -756,7 +756,7 @@ export const calculateDomainOfTicks = (ticks, type) => {
  * @return {Object}      null
  */
 export const getTicksOfScale = (scale, opts) => {
-  const { realScaleType, type, tickCount, originalDomain, allowDecimals } = opts;
+  const { realScaleType, type, tickCount, originalDomain, allowDecimals, hide:axisHidden } = opts;
   const scaleType = realScaleType || opts.scale;
 
   if (scaleType !== 'auto' && scaleType !== 'linear') {
@@ -769,7 +769,11 @@ export const getTicksOfScale = (scale, opts) => {
     const domain = scale.domain();
     const tickValues = getNiceTickValues(domain, tickCount, allowDecimals);
 
-    scale.domain(calculateDomainOfTicks(tickValues, type));
+    // Don't update the domain based on the ticks if we're not showing the YAxis component
+    // This means keeping the chart height consistent with the 'height' provided by the client
+    if (!axisHidden) {
+      scale.domain(calculateDomainOfTicks(tickValues, type));
+    }
 
     return { niceTicks: tickValues };
   } if (tickCount && type === 'number') {


### PR DESCRIPTION
Fixing unwanted behavior, demos included in the issue.
https://github.com/recharts/recharts/issues/1529

The problem,
If we update the domain even when we don't show an axis (YAxis), then the 'y' offset for the max value of the data is different for each set of data.
(since the max tick value may differ from the max value of the data supplied)

This means that if an app displays several simple charts (tiny*chart) in a row with different sets of data, the charts will have different heights, resulting in inconsistent UX.

