### PR TITLE
Fix bug preventing use of functions or custom components for the Bar background prop

### DIFF
--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -327,7 +327,7 @@ class Bar extends Component {
         className: 'recharts-bar-background-rectangle',
       };
 
-      return this.constructor.renderRectangle(background, props);
+      return this.constructor.renderRectangle(this.props.background, props);
     });
   }
 

--- a/test/specs/cartesian/BarSpec.js
+++ b/test/specs/cartesian/BarSpec.js
@@ -52,4 +52,50 @@ describe('<Bar />', () => {
 
     expect(wrapper.find('.recharts-bar-rectangle').length).to.equal(0);
   });
+
+  describe('With background', () => {
+    const composedDataWithBackground = [{
+      x: 10,
+      y: 50,
+      width: 20,
+      height: 20,
+      value: 40,
+      label: 'test',
+      background: { x: 10, y: 50, width: 20, height: 50 },
+    }, {
+      x: 50,
+      y: 50,
+      width: 20,
+      height: 50,
+      value: 100,
+      label: 'test',
+      background: { x: 50, y: 50, width: 20, height: 50 },
+    }];
+
+    it('Will create a background Rectangle with the passed in props', () => {
+      const wrapper = render(
+        <Surface width={500} height={500}>
+          <Bar data={composedDataWithBackground} background={{ fill: '#000' }} />
+        </Surface>
+      );
+
+      expect(wrapper.find('.recharts-bar-background-rectangle').length).to.equal(2);
+    });
+
+    it('Will accept a function for the background prop', () => {
+      const wrapper = render(
+        <Surface width={500} height={500}>
+          <Bar
+            data={composedDataWithBackground}
+            background={({ index }) => {
+              return (index === 0) ? <div className='test-custom-background' /> : null;
+            }}
+          />
+        </Surface>
+      );
+
+      expect(wrapper.find('.recharts-bar-background-rectangle').length).to.equal(0);
+      expect(wrapper.find('.test-custom-background').length).to.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
The `Bar` is supposed to be able to take a function for the `background` prop but it's currently broken. See https://github.com/recharts/recharts/issues/1543