### PR TITLE
Fix incorrect sort logic in stripe rendering

### DIFF
--- a/src/cartesian/CartesianGrid.js
+++ b/src/cartesian/CartesianGrid.js
@@ -143,7 +143,7 @@ class CartesianGrid extends Component {
     if (!verticalFill || !verticalFill.length) { return null; }
 
     const { fillOpacity, x, y, width, height } = this.props;
-    const verticalPointsUpdated = verticalPoints.slice().sort((a, b) => ((a - b) > 0));
+    const verticalPointsUpdated = verticalPoints.slice().sort((a, b) => a - b);
 
     if (x !== verticalPointsUpdated[0]) {
       verticalPointsUpdated.unshift(0);
@@ -182,7 +182,7 @@ class CartesianGrid extends Component {
     if (!horizontalFill || !horizontalFill.length) { return null; }
 
     const { fillOpacity, x, y, width, height } = this.props;
-    const horizontalPointsUpdated = horizontalPoints.slice().sort((a, b) => ((a - b) > 0));
+    const horizontalPointsUpdated = horizontalPoints.slice().sort((a, b) => a - b);
     if (y !== horizontalPointsUpdated[0]) {
       horizontalPointsUpdated.unshift(0);
     }


### PR DESCRIPTION
The implementation of the comparison function in `Array.sort([compareFunc])` is supposed to return a positive, negative, or 0 value not a boolean value as is currently implemented.