### PR TITLE
improve transition into larger datasets

### DIFF
--- a/src/cartesian/Area.js
+++ b/src/cartesian/Area.js
@@ -388,10 +388,12 @@ class Area extends Component {
         {
           ({ t }) => {
             if (prevPoints) {
+              const prevPointsDiffFactor = prevPoints.length / points.length;
               // update animtaion
               const stepPoints = points.map((entry, index) => {
-                if (prevPoints[index]) {
-                  const prev = prevPoints[index];
+                const prevPointIndex = Math.floor(index * prevPointsDiffFactor);
+                if (prevPoints[prevPointIndex]) {
+                  const prev = prevPoints[prevPointIndex];
                   const interpolatorX = interpolateNumber(prev.x, entry.x);
                   const interpolatorY = interpolateNumber(prev.y, entry.y);
 
@@ -410,8 +412,9 @@ class Area extends Component {
                 stepBaseLine = interpolator(t);
               } else {
                 stepBaseLine = baseLine.map((entry, index) => {
-                  if (prevBaseLine[index]) {
-                    const prev = prevBaseLine[index];
+                  const prevPointIndex = Math.floor(index * prevPointsDiffFactor);
+                  if (prevBaseLine[prevPointIndex]) {
+                    const prev = prevBaseLine[prevPointIndex];
                     const interpolatorX = interpolateNumber(prev.x, entry.x);
                     const interpolatorY = interpolateNumber(prev.y, entry.y);
 

--- a/src/cartesian/Line.js
+++ b/src/cartesian/Line.js
@@ -328,9 +328,11 @@ class Line extends Component {
         {
           ({ t }) => {
             if (prevPoints) {
+              const prevPointsDiffFactor = prevPoints.length / points.length;
               const stepData = points.map((entry, index) => {
-                if (prevPoints[index]) {
-                  const prev = prevPoints[index];
+                const prevPointIndex = Math.floor(index * prevPointsDiffFactor);
+                if (prevPoints[prevPointIndex]) {
+                  const prev = prevPoints[prevPointIndex];
                   const interpolatorX = interpolateNumber(prev.x, entry.x);
                   const interpolatorY = interpolateNumber(prev.y, entry.y);
 

--- a/src/polar/Radar.js
+++ b/src/polar/Radar.js
@@ -216,8 +216,9 @@ class Radar extends Component {
       >
         {
           ({ t }) => {
+            const prevPointsDiffFactor = prevPoints && prevPoints.length / points.length;
             const stepData = points.map((entry, index) => {
-              const prev = prevPoints && prevPoints[index];
+              const prev = prevPoints && prevPoints[Math.floor(index * prevPointsDiffFactor)];
 
               if (prev) {
                 const interpolatorX = interpolateNumber(prev.x, entry.x);


### PR DESCRIPTION
for area-, line- and radar chart

when appending more data, the new data points are not transitioned, and the old
data points transitions from e.g. the edge of end of the chart to the middle of
the chart.

this fixes so the old dataset transitions more smoothly into the whole new dataset.

**before**
![before](https://user-images.githubusercontent.com/5215345/48667253-2b94bd80-ead2-11e8-8976-e0bed2cc2fff.gif)

**after**
![after](https://user-images.githubusercontent.com/5215345/48667252-2b94bd80-ead2-11e8-814b-79091478c8e2.gif)