### PR TITLE
refactor clipPathId of Area

### DIFF
--- a/src/cartesian/Area.js
+++ b/src/cartesian/Area.js
@@ -233,7 +233,7 @@ class Area extends Component {
     }
   };
 
-  renderDots() {
+  renderDots(needClip, clipPathId) {
     const { isAnimationActive } = this.props;
     const { isAnimationFinished } = this.state;
 
@@ -261,8 +261,10 @@ class Area extends Component {
 
       return this.constructor.renderDotItem(dot, dotProps);
     });
-
-    return <Layer className="recharts-area-dots">{dots}</Layer>;
+    const dotsProps = {
+      clipPath: needClip ? `url(#clipPath-${clipPathId})` : null,
+    };
+    return <Layer className="recharts-area-dots" {...dotsProps}>{dots}</Layer>;
   }
 
   renderHorizontalRect(alpha) {
@@ -329,11 +331,11 @@ class Area extends Component {
     return this.renderHorizontalRect(alpha);
   }
 
-  renderAreaStatically(points, baseLine, needClip) {
+  renderAreaStatically(points, baseLine, needClip, clipPathId) {
     const { layout, type, stroke, connectNulls, isRange } = this.props;
 
     return (
-      <Layer clipPath={needClip ? `url(#clipPath-${this.id})` : null}>
+      <Layer clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
         <Curve
           {...this.props}
           points={points}
@@ -367,11 +369,11 @@ class Area extends Component {
     );
   }
 
-  renderAreaWithAnimation(needClip) {
+  renderAreaWithAnimation(needClip, clipPathId) {
     const { points, baseLine, isAnimationActive, animationBegin,
-      animationDuration, animationEasing, animationId, id } = this.props;
+      animationDuration, animationEasing, animationId } = this.props;
     const { prevPoints, prevBaseLine } = this.state;
-    const clipPathId = _.isNil(id) ? this.id : id;
+    // const clipPathId = _.isNil(id) ? this.id : id;
 
     return (
       <Animate
@@ -422,7 +424,7 @@ class Area extends Component {
                 });
               }
 
-              return this.renderAreaStatically(stepPoints, stepBaseLine, needClip);
+              return this.renderAreaStatically(stepPoints, stepBaseLine, needClip, clipPathId);
             }
 
             return (
@@ -433,7 +435,7 @@ class Area extends Component {
                   </clipPath>
                 </defs>
                 <Layer clipPath={`url(#animationClipPath-${clipPathId})`}>
-                  {this.renderAreaStatically(points, baseLine, needClip)}
+                  {this.renderAreaStatically(points, baseLine, needClip, clipPathId)}
                 </Layer>
               </Layer>
             );
@@ -443,17 +445,17 @@ class Area extends Component {
     );
   }
 
-  renderArea(needClip) {
+  renderArea(needClip, clipPathId) {
     const { points, baseLine, isAnimationActive } = this.props;
     const { prevPoints, prevBaseLine, totalLength } = this.state;
 
     if (isAnimationActive && points && points.length &&
       ((!prevPoints && totalLength > 0) || !_.isEqual(prevPoints, points) ||
         !_.isEqual(prevBaseLine, baseLine))) {
-      return this.renderAreaWithAnimation(needClip);
+      return this.renderAreaWithAnimation(needClip, clipPathId);
     }
 
-    return this.renderAreaStatically(points, baseLine, needClip);
+    return this.renderAreaStatically(points, baseLine, needClip, clipPathId);
   }
 
   render() {
@@ -477,8 +479,8 @@ class Area extends Component {
             </clipPath>
           </defs>
         ) : null}
-        {!hasSinglePoint ? this.renderArea(needClip) : null}
-        {(dot || hasSinglePoint) && this.renderDots()}
+        {!hasSinglePoint ? this.renderArea(needClip, clipPathId) : null}
+        {(dot || hasSinglePoint) && this.renderDots(needClip, clipPathId)}
         {(!isAnimationActive || isAnimationFinished) &&
           LabelList.renderCallByParent(this.props, points)}
       </Layer>


### PR DESCRIPTION
This mimics the behavior of [this PR](https://github.com/recharts/recharts/commit/c1423726fb7b7e5c22e076d9bf556c8644b4a5a3#diff-ab5884655462c4807891c3e26ca065ef) but for Area charts.

It correctly cuts off dots on the Y-Axis for that chart type. Screenshots below show the changes.

<img width="805" alt="screen shot 2018-11-19 at 4 33 18 pm" src="https://user-images.githubusercontent.com/1429113/48736352-03fc3d00-ec19-11e8-97a5-ddef3eb4fe54.png">
<img width="801" alt="screen shot 2018-11-19 at 4 33 43 pm" src="https://user-images.githubusercontent.com/1429113/48736353-03fc3d00-ec19-11e8-9439-8e5afe6c3574.png">
