### PR TITLE
fix: replace lodash isFinite with Number.isFinite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "1.3.6",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -1255,7 +1255,7 @@ const generateCategoricalChart = ({
       const { xAxisMap, yAxisMap, offset } = this.state;
       const { width, height } = this.props;
       const xAxis = getAnyElementOfObject(xAxisMap);
-      const yAxisWithFiniteDomain = _.find(yAxisMap, axis => _.every(axis.domain, window.isFinite));
+      const yAxisWithFiniteDomain = _.find(yAxisMap, axis => _.every(axis.domain, Number.isFinite));
       const yAxis = yAxisWithFiniteDomain || getAnyElementOfObject(yAxisMap);
       const props = element.props || {};
 

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -1255,7 +1255,7 @@ const generateCategoricalChart = ({
       const { xAxisMap, yAxisMap, offset } = this.state;
       const { width, height } = this.props;
       const xAxis = getAnyElementOfObject(xAxisMap);
-      const yAxisWithFiniteDomain = _.find(yAxisMap, axis => _.every(axis.domain, _.isFinite));
+      const yAxisWithFiniteDomain = _.find(yAxisMap, axis => _.every(axis.domain, window.isFinite));
       const yAxis = yAxisWithFiniteDomain || getAnyElementOfObject(yAxisMap);
       const props = element.props || {};
 

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,4 +1,5 @@
 import 'core-js/es6/math';
+import 'core-js/es6/number';
 /* eslint no-proto: 0 */
 const testObject = {};
 


### PR DESCRIPTION
lodash's `isFinite` is [based on `Number.isFinite`](https://lodash.com/docs/4.17.11#isFinite) and it [fails on IE](https://mdn.io/Number/isFinite). (#1549)

So we added `core-js`'s Number polyfill and used `Number.usFinite` directly. 
fixes #1549