### PR TITLE
Make the timeOut timer for the brush configurable through props

### DIFF
--- a/src/cartesian/Brush.js
+++ b/src/cartesian/Brush.js
@@ -46,6 +46,7 @@ class Brush extends Component {
 
     onChange: PropTypes.func,
     updateId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    leaveTimeOut: PropTypes.number,
   };
 
   static defaultProps = {
@@ -55,6 +56,7 @@ class Brush extends Component {
     fill: '#fff',
     stroke: '#666',
     padding: { top: 1, right: 1, bottom: 1, left: 1 },
+    leaveTimeOut: 1000,
   };
 
   constructor(props) {
@@ -168,7 +170,7 @@ class Brush extends Component {
 
   handleLeaveWrapper = () => {
     if (this.state.isTravellerMoving || this.state.isSlideMoving) {
-      this.leaveTimer = setTimeout(this.handleDragEnd, 1000);
+      this.leaveTimer = setTimeout(this.handleDragEnd, this.props.leaveTimeOut);
     }
   };
 


### PR DESCRIPTION
To start off thanks for the library, I'm using it in a project and while using the brush found the 1sec timeout on leaving the wrapper somewhat annoying. 

Forked it so the timeOut is customisable.

In case it is useful for anyone else feel free to merge it. 

Setting the delay is done through the properties:
```jsx
<Brush leaveTimeOut={100} />
```

Which should make it feel a bit more natural.