### PR TITLE
Updated package.json to mark effectful modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "lib/index",
   "module": "es6/index",
   "jsnext:main": "es6/index",
-  "sideEffects": false,
+  "sideEffects": [
+    "./*/index.js",
+    "./*/polyfill.js"
+  ],
   "files": [
     "*.md",
     "demo",


### PR DESCRIPTION
Fixes #1594

This commit marks `index.js` and `polyfill.js` as potentially causing side effects. This prevents Webpack from discarding polyfills that are needed for correct operation of the library.