### PR TITLE
Disable caching if pie sector state is the same

### DIFF
--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -181,9 +181,12 @@ class Bar extends Component {
 
   id = uniqueId('recharts-bar-');
 
-  cachePrevData = (data) => {
-    this.setState({ prevData: data });
-  };
+  cachePrevData(data) {
+    if (data !== this.state.prevData) {
+      this.setState({ prevData: data });
+    }
+    return null;
+  }
 
   handleAnimationEnd = () => {
     this.setState({ isAnimationFinished: true });

--- a/src/polar/Pie.js
+++ b/src/polar/Pie.js
@@ -251,9 +251,12 @@ class Pie extends Component {
 
   id = uniqueId('recharts-pie-');
 
-  cachePrevData = (sectors) => {
-    this.setState({ prevSectors: sectors });
-  };
+  cachePrevData(sectors) {
+    if (sectors !== this.state.prevSectors) {
+      this.setState({ prevSectors: sectors });
+    }
+    return null;
+  }
 
   isActiveIndex(i) {
     const { activeIndex } = this.props;


### PR DESCRIPTION
Add condition if new sectors match prev sectors don't cache. This should resolve the issue seen with this issue: https://github.com/recharts/recharts/issues/1083

*Edit:* Updated to include Bar chart update as well.