### PR TITLE
Add lodash as a peer dependency instead of a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -977,6 +977,15 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -987,12 +996,14 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
-      "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.1.0.tgz",
+      "integrity": "sha512-IXio+GWY+Q8XUjHUOgK7wx8fpvr7IFffgyXb1bnJFfX3001KmHt35Zq4tp7MXZyjJPCLPuadesDYNk41LYtVjw==",
       "dev": true,
       "requires": {
-        "array-from": "^2.1.1"
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "^4.4.2"
       }
     },
     "@types/node": {
@@ -7278,9 +7289,9 @@
       }
     },
     "just-extend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
-      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
     },
     "karma": {
@@ -8174,25 +8185,25 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.5.tgz",
-      "integrity": "sha512-OHRVvdxKgwZELf2DTgsJEIA4MOq8XWvpSUzoOXyxJ2mY0mMENWC66+70AShLR2z05B1dzrzWlUQJmJERlOUpZw==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+      "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "3.0.0",
-        "just-extend": "^3.0.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "just-extend": "^4.0.2",
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
       },
       "dependencies": {
         "@sinonjs/formatio": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
-          "integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+          "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
           "dev": true,
           "requires": {
-            "@sinonjs/samsam": "2.1.0"
+            "@sinonjs/samsam": "^2 || ^3"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "homepage": "https://github.com/recharts/recharts",
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react-dom": "^15.0.0 || ^16.0.0",
+    "lodash": "~4.17.5"
   },
   "dependencies": {
     "classnames": "~2.2.5",
@@ -59,7 +60,6 @@
     "d3-interpolate": "~1.3.0",
     "d3-scale": "~2.1.0",
     "d3-shape": "~1.2.0",
-    "lodash": "~4.17.5",
     "prop-types": "~15.6.0",
     "react-resize-detector": "~2.3.0",
     "react-smooth": "~1.0.0",


### PR DESCRIPTION
See issue #919 for more details

Right now lodash is packaged in together with recharts, even if the project using recharts has lodash installed. I imagine most people are shipping two separate versions of lodash to production, even if they are the same version. Having lodash packaged in together with recharts as a `dependency` makes it so it cannot be "deduped" correctly with a build tool such as webpack.

Comparisons:

![screen shot 2019-02-11 at 10 32 01 am](https://user-images.githubusercontent.com/13840573/52574414-3d90ae80-2dea-11e9-800d-90f45ec374d7.png)

![screen shot 2019-02-11 at 10 32 12 am](https://user-images.githubusercontent.com/13840573/52574417-3ec1db80-2dea-11e9-845a-0230cdd6f11b.png)

