### PR TITLE
Use more liberal approach to dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5365,7 +5365,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5386,12 +5387,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5406,17 +5409,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5533,7 +5539,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5545,6 +5552,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5559,6 +5567,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5566,12 +5575,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5590,6 +5601,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5670,7 +5682,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5682,6 +5695,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5767,7 +5781,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5803,6 +5818,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5822,6 +5838,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5865,12 +5882,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,17 +54,17 @@
     "react-dom": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "classnames": "~2.2.5",
-    "core-js": "~2.5.1",
-    "d3-interpolate": "~1.3.0",
-    "d3-scale": "~2.1.0",
-    "d3-shape": "~1.2.0",
-    "lodash": "~4.17.5",
-    "prop-types": "~15.6.0",
-    "react-resize-detector": "~2.3.0",
-    "react-smooth": "~1.0.0",
+    "classnames": "^2.2.5",
+    "core-js": "^2.5.1",
+    "d3-interpolate": "^1.3.0",
+    "d3-scale": "^2.1.0",
+    "d3-shape": "^1.2.0",
+    "lodash": "^4.17.5",
+    "prop-types": "^15.6.0",
+    "react-resize-detector": "^2.3.0",
+    "react-smooth": "^1.0.0",
     "recharts-scale": "^0.4.2",
-    "reduce-css-calc": "~1.3.0"
+    "reduce-css-calc": "^1.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",


### PR DESCRIPTION
This allows e.g. prop-types 15.7.0 to be used without issues. Without this change:
* many users will have libraries duplicated in their code because no versions are matching both e.g. ^15.7.0 and ~15.6.0 at the same time, or
* users will be forced not to update the libraries which happen to be also recharts dependencies.