### PR TITLE
use loop to find [min,max] to avoid RangeError

### DIFF
--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -35,8 +35,18 @@ export const getDomainOfDataByKey = (data, key, type, filterNil) => {
 
   if (type === 'number') {
     const domain = flattenData.filter(entry => isNumber(entry) || parseFloat(entry, 10));
-
-    return [Math.min.apply(null, domain), Math.max.apply(null, domain)];
+    let len = domain.length;
+    let min = Number.MAX_VALUE;
+    let max = -Number.MAX_VALUE:
+    while(len--){
+      if(min > domain[len]){
+        min = domain[len];
+      }
+      if(max < domain[len]){
+        max = domain[len];
+      }      
+    }
+    return [min,max];
   }
 
   const validateData = filterNil ?

--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -38,11 +38,11 @@ export const getDomainOfDataByKey = (data, key, type, filterNil) => {
     let len = domain.length;
     let min = Number.MAX_VALUE;
     let max = -Number.MAX_VALUE;
-    while(len--){
+    while (len--) {
       if(min > domain[len]){
         min = domain[len];
       }
-      if(max < domain[len]){
+      if (max < domain[len]) {
         max = domain[len];
       }      
     }

--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -39,14 +39,14 @@ export const getDomainOfDataByKey = (data, key, type, filterNil) => {
     let min = Number.MAX_VALUE;
     let max = -Number.MAX_VALUE;
     while (len--) {
-      if(min > domain[len]){
+      if (min > domain[len]) {
         min = domain[len];
       }
       if (max < domain[len]) {
         max = domain[len];
-      }      
+      }
     }
-    return [min,max];
+    return [min, max];
   }
 
   const validateData = filterNil ?

--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -37,7 +37,7 @@ export const getDomainOfDataByKey = (data, key, type, filterNil) => {
     const domain = flattenData.filter(entry => isNumber(entry) || parseFloat(entry, 10));
     let len = domain.length;
     let min = Number.MAX_VALUE;
-    let max = -Number.MAX_VALUE:
+    let max = -Number.MAX_VALUE;
     while(len--){
       if(min > domain[len]){
         min = domain[len];


### PR DESCRIPTION
Math.min.apply and Math.max.apply are recursive and will throw a RangeError: Maximum call stack size exceeded when the input array is too long. Looping over the elements and collecting the min and max in a single loop prevents the RangeError.