### PR TITLE
Add prop to restart animation after dataset change

### DIFF
--- a/src/cartesian/Area.js
+++ b/src/cartesian/Area.js
@@ -68,6 +68,7 @@ class Area extends Component {
     onAnimationEnd: PropTypes.func,
     animationId: PropTypes.number,
     isAnimationActive: PropTypes.bool,
+    restartAnimationOnChange: PropTypes.bool,
     animationBegin: PropTypes.number,
     animationDuration: PropTypes.number,
     animationEasing: PropTypes.oneOf(['ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear']),
@@ -90,6 +91,7 @@ class Area extends Component {
     hide: false,
 
     isAnimationActive: !isSsr(),
+    restartAnimationOnChange: false,
     animationBegin: 0,
     animationDuration: 1500,
     animationEasing: 'ease',
@@ -198,9 +200,9 @@ class Area extends Component {
   state = { isAnimationFinished: true };
 
   componentWillReceiveProps(nextProps) {
-    const { animationId, points, baseLine } = this.props;
+    const { restartAnimationOnChange, animationId, points, baseLine } = this.props;
 
-    if (nextProps.animationId !== animationId) {
+    if (!restartAnimationOnChange && nextProps.animationId !== animationId) {
       this.cachePrevData(points, baseLine);
     }
   }

--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -56,6 +56,7 @@ class Bar extends Component {
 
     animationId: PropTypes.number,
     isAnimationActive: PropTypes.bool,
+    restartAnimationOnChange: PropTypes.bool,
     animationBegin: PropTypes.number,
     animationDuration: PropTypes.number,
     animationEasing: PropTypes.oneOf(['ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear']),
@@ -72,6 +73,7 @@ class Bar extends Component {
     data: [],
     layout: 'vertical',
     isAnimationActive: !isSsr(),
+    restartAnimationOnChange: false,
     animationBegin: 0,
     animationDuration: 400,
     animationEasing: 'ease',
@@ -172,9 +174,9 @@ class Bar extends Component {
   state = { isAnimationFinished: false };
 
   componentWillReceiveProps(nextProps) {
-    const { animationId, data } = this.props;
+    const { restartAnimationOnChange, animationId, data } = this.props;
 
-    if (nextProps.animationId !== animationId) {
+    if (!restartAnimationOnChange && nextProps.animationId !== animationId) {
       this.cachePrevData(data);
     }
   }

--- a/src/cartesian/Line.js
+++ b/src/cartesian/Line.js
@@ -62,6 +62,8 @@ class Line extends Component {
     onAnimationEnd: PropTypes.func,
 
     isAnimationActive: PropTypes.bool,
+    restartAnimationOnChange: PropTypes.bool,
+
     animateNewValues: PropTypes.bool,
     animationBegin: PropTypes.number,
     animationDuration: PropTypes.number,
@@ -148,9 +150,9 @@ class Line extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { animationId, points } = this.props;
+    const { restartAnimationOnChange, animationId, points } = this.props;
 
-    if (nextProps.animationId !== animationId) {
+    if (!restartAnimationOnChange && nextProps.animationId !== animationId) {
       this.cachePrevData(points);
     }
   }

--- a/src/cartesian/Scatter.js
+++ b/src/cartesian/Scatter.js
@@ -66,6 +66,8 @@ class Scatter extends Component {
     hide: PropTypes.bool,
 
     isAnimationActive: PropTypes.bool,
+    restartAnimationOnChange: PropTypes.bool,
+
     animationId: PropTypes.number,
     animationBegin: PropTypes.number,
     animationDuration: PropTypes.number,
@@ -156,9 +158,9 @@ class Scatter extends Component {
   state = { isAnimationFinished: false };
 
   componentWillReceiveProps(nextProps) {
-    const { animationId, points } = this.props;
+    const { restartAnimationOnChange, animationId, points } = this.props;
 
-    if (nextProps.animationId !== animationId) {
+    if (!restartAnimationOnChange && nextProps.animationId !== animationId) {
       this.cachePrevPoints(points);
     }
   }

--- a/src/polar/Pie.js
+++ b/src/polar/Pie.js
@@ -65,6 +65,8 @@ class Pie extends Component {
     activeIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.arrayOf(PropTypes.number)]),
 
     isAnimationActive: PropTypes.bool,
+    restartAnimationOnChange: PropTypes.bool,
+
     animationBegin: PropTypes.number,
     animationDuration: PropTypes.number,
     animationEasing: PropTypes.oneOf([
@@ -99,6 +101,7 @@ class Pie extends Component {
     hide: false,
     minAngle: 0,
     isAnimationActive: !isSsr(),
+    restartAnimationOnChange: false,
     animationBegin: 400,
     animationDuration: 1500,
     animationEasing: 'ease',
@@ -230,9 +233,9 @@ class Pie extends Component {
   state = { isAnimationFinished: false };
 
   componentWillReceiveProps(nextProps) {
-    const { animationId, sectors } = this.props;
+    const { restartAnimationOnChange, animationId, sectors } = this.props;
 
-    if (nextProps.isAnimationActive !== this.props.isAnimationActive) {
+    if (restartAnimationOnChange || nextProps.isAnimationActive !== this.props.isAnimationActive) {
       this.cachePrevData([]);
     } else if (nextProps.animationId !== animationId) {
       this.cachePrevData(sectors);

--- a/src/polar/Radar.js
+++ b/src/polar/Radar.js
@@ -57,6 +57,7 @@ class Radar extends Component {
     onMouseLeave: PropTypes.func,
     onClick: PropTypes.func,
     isAnimationActive: PropTypes.bool,
+    restartAnimationOnChange: PropTypes.bool,
     animationId: PropTypes.number,
     animationBegin: PropTypes.number,
     animationDuration: PropTypes.number,
@@ -96,9 +97,9 @@ class Radar extends Component {
   state = { isAnimationFinished: false };
 
   componentWillReceiveProps(nextProps) {
-    const { animationId, points } = this.props;
+    const { restartAnimationOnChange, animationId, points } = this.props;
 
-    if (nextProps.animationId !== animationId) {
+    if (!restartAnimationOnChange && nextProps.animationId !== animationId) {
       this.cachePrevData(points);
     }
   }


### PR DESCRIPTION
As sometimes the animation of data change might be a buggy, this MR adds a prop `restartAnimationOnChange`, which will enforce an animation restart after every change of data, instead of animating intermediate values.