### PR TITLE
Avoid same keys on label and line, fix #1302

### DIFF
--- a/src/polar/Pie.js
+++ b/src/polar/Pie.js
@@ -356,6 +356,7 @@ class Pie extends Component {
         ...customLabelLineProps,
         index: i,
         points: [polarToCartesian(entry.cx, entry.cy, entry.outerRadius, midAngle), endPoint],
+        key: 'line'
       };
       let realDataKey = dataKey;
       // TODO: compatible to lower versions


### PR DESCRIPTION
Using the label attribute in Pie components results in duplicate-keys React warnings in the console (and missing components during render). This fix avoid merging the same `key` property.