### PR TITLE
Adds forceCornerRadius prop to RadialBar

### DIFF
--- a/src/polar/RadialBar.js
+++ b/src/polar/RadialBar.js
@@ -35,6 +35,7 @@ class RadialBar extends Component {
     dataKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.func]).isRequired,
 
     cornerRadius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    forceCornerRadius: PropTypes.bool,
     minPointSize: PropTypes.number,
     maxBarSize: PropTypes.number,
     data: PropTypes.arrayOf(PropTypes.shape({
@@ -218,6 +219,7 @@ class RadialBar extends Component {
         ...filterEventsOfChild(this.props, entry, i),
         key: `sector-${i}`,
         className: 'recharts-radial-bar-sector',
+        forceCornerRadius: others.forceCornerRadius,
       };
 
       return this.constructor.renderSectorShape(i === activeIndex ? activeShape : shape, props);

--- a/src/shape/Sector.js
+++ b/src/shape/Sector.js
@@ -60,8 +60,8 @@ const getSectorPath = ({ cx, cy, innerRadius, outerRadius, startAngle, endAngle 
   return path;
 };
 
-const getSectorWithCorner = ({ cx, cy, innerRadius, outerRadius, cornerRadius, startAngle,
-  endAngle }) => {
+const getSectorWithCorner = ({ cx, cy, innerRadius, outerRadius, cornerRadius, forceCornerRadius,
+  startAngle, endAngle }) => {
   const sign = mathSign(endAngle - startAngle);
   const { circleTangency: soct, lineTangency: solt, theta: sot } =
     getTangentCircle({
@@ -74,6 +74,12 @@ const getSectorWithCorner = ({ cx, cy, innerRadius, outerRadius, cornerRadius, s
   const outerArcAngle = Math.abs(startAngle - endAngle) - sot - eot;
 
   if (outerArcAngle < 0) {
+    if (forceCornerRadius) {
+      return `M ${solt.x},${solt.y}
+        a${cornerRadius},${cornerRadius},0,0,1,${cornerRadius * 2},0
+        a${cornerRadius},${cornerRadius},0,0,1,${-cornerRadius * 2},0
+      `;
+    }
     return getSectorPath({
       cx, cy, innerRadius, outerRadius, startAngle, endAngle,
     });
@@ -140,7 +146,7 @@ class Sector extends Component {
   };
 
   render() {
-    const { cx, cy, innerRadius, outerRadius, cornerRadius, startAngle, endAngle,
+    const { cx, cy, innerRadius, outerRadius, cornerRadius, forceCornerRadius, startAngle, endAngle,
       className } = this.props;
 
     if (outerRadius < innerRadius || startAngle === endAngle) { return null; }
@@ -154,6 +160,7 @@ class Sector extends Component {
       path = getSectorWithCorner({
         cx, cy, innerRadius, outerRadius,
         cornerRadius: Math.min(cr, deltaRadius / 2),
+        forceCornerRadius,
         startAngle, endAngle,
       });
     } else {


### PR DESCRIPTION
This adds the `forceCornerRadius` prop, which allows you to have a bar with rounded corners (a circle actually) when a small value in the `RadialBar` results in a bar shorter than the specified `cornerRadius`, in which case a normal bar with straight edges is drawn.

Hope it's useful!