### PR TITLE
Use height for aspect

### DIFF
--- a/src/component/ResponsiveContainer.js
+++ b/src/component/ResponsiveContainer.js
@@ -100,12 +100,19 @@ class ResponsiveContainer extends Component {
       'The aspect(%s) must be greater than zero.',
       aspect);
 
-    const calculatedWidth = isPercent(width) ? containerWidth : width;
+    let calculatedWidth = isPercent(width) ? containerWidth : width;
     let calculatedHeight = isPercent(height) ? containerHeight : height;
 
     if (aspect && aspect > 0) {
       // Preserve the desired aspect ratio
-      calculatedHeight = calculatedWidth / aspect;
+      if (calculatedWidth) {
+        // Will default to using width for aspect ratio
+        calculatedHeight = calculatedWidth / aspect;
+      } else if (calculatedHeight) {
+        // But we should also take height into consideration
+        calculatedWidth = calculatedHeight * aspect;
+      }
+
       // if maxHeight is set, overwrite if calculatedHeight is greater than maxHeight
       if (maxHeight && (calculatedHeight > maxHeight)) {
         calculatedHeight = maxHeight;

--- a/test/specs/component/ResponsiveContainerSpec.js
+++ b/test/specs/component/ResponsiveContainerSpec.js
@@ -57,8 +57,8 @@ describe('<ResponsiveContainer />', () => {
       </ResponsiveContainer>
     );
 
-    expect(wrapper.find('.inside')).to.have.attr('width').equal('0');
-    expect(wrapper.find('.inside')).to.have.attr('height').equal('0');
+    expect(wrapper.find('.inside')).to.have.attr('width').equal('600');
+    expect(wrapper.find('.inside')).to.have.attr('height').equal('300');
   });
 
   // Note that we force height and width here which will trigger a warning.


### PR DESCRIPTION
New to open source so bear with me.
I wanted to use ResponsiveChart with aspect in relation to height and not width. Currently aspect only works with width, but I feel it should also work with height as well. 
Updated test spec as well to accommodate new feature.