### PR TITLE
Adds cornerIsExternal prop to center rounded corner at radial bar edge

### DIFF
--- a/src/chart/Treemap.js
+++ b/src/chart/Treemap.js
@@ -244,13 +244,13 @@ class Treemap extends Component {
   };
 
   state = this.constructor.createDefaultState();
-  
+
   componentDidMount() {
     const { type, width, height, data, dataKey, aspectRatio } = this.props;
     const {
       formatRoot, currentRoot, nestIndex
     } = this.computeRoot({ type, width, height, data, dataKey, aspectRatio });
-  
+
     this.setState({
       formatRoot,
       currentRoot,
@@ -281,8 +281,8 @@ class Treemap extends Component {
 
   componentWillReceiveProps(nextProps) {
     const { type, width, height, data, dataKey, aspectRatio } = nextProps;
-   
-    if (data !== this.props.data || type !== this.props.type || width !== this.props.width || 
+
+    if (data !== this.props.data || type !== this.props.type || width !== this.props.width ||
       height !== this.props.height || dataKey !== this.props.dataKey || aspectRatio !== this.props.aspectRatio) {
       const nextRoot = this.computeRoot({ type, width, height, data, dataKey, aspectRatio });
       this.setState({

--- a/src/polar/RadialBar.js
+++ b/src/polar/RadialBar.js
@@ -36,6 +36,7 @@ class RadialBar extends Component {
 
     cornerRadius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     forceCornerRadius: PropTypes.bool,
+    cornerIsExternal: PropTypes.bool,
     minPointSize: PropTypes.number,
     maxBarSize: PropTypes.number,
     data: PropTypes.arrayOf(PropTypes.shape({
@@ -77,6 +78,8 @@ class RadialBar extends Component {
     animationBegin: 0,
     animationDuration: 1500,
     animationEasing: 'ease',
+    forceCornerRadius: false,
+    cornerIsExternal: false,
   };
 
   static getComposedData = ({ item, props, radiusAxis, radiusAxisTicks, angleAxis, angleAxisTicks,
@@ -220,6 +223,7 @@ class RadialBar extends Component {
         key: `sector-${i}`,
         className: 'recharts-radial-bar-sector',
         forceCornerRadius: others.forceCornerRadius,
+        cornerIsExternal: others.cornerIsExternal,
       };
 
       return this.constructor.renderSectorShape(i === activeIndex ? activeShape : shape, props);


### PR DESCRIPTION
This adds the `cornerIsExternal` boolean to `RadialBar` props. When used with the `cornerRadius` prop this will make the rounded corner to lie outside the `RadialBar`—by default, the rounded corner will be calculated and drawn inside the length of the `RadialBar`.

Here's a comparison when drawing a `RadialBarChart` with a `RadialBar` filling 50%, starting at 90º. In the current behavior, it looks shorter due to the rounded corner being inside the bar; with `cornerIsExternal` the rounded corner lies outside and looks more balanced.

<img width="328" alt="Screen Shot 2019-05-16 at 20 51 50" src="https://user-images.githubusercontent.com/2023360/57895984-7d699680-781c-11e9-9fd3-15c621ad0e3c.png">


This behavior is optional and can be activated passing the `cornerIsExternal` prop to `RadialBar`.