### PR TITLE
Fixing typo in RadialBarChart.js example.

### DIFF
--- a/demo/component/RadialBarChart.js
+++ b/demo/component/RadialBarChart.js
@@ -14,7 +14,7 @@ const data = [
   { name: '35-39', uv: 59, amt: 8.22, pv: 2800, fill: '#82ca9d' },
   { name: '40-49', uv: 48, amt: 8.63, pv: 1908, fill: '#a4de6c' },
   { name: '50+', uv: 62, amt: 2.63, pv: -2800, fill: '#d0ed57' },
-  { name: 'unknow', uv: 38, amt: 6.67, pv: 4800, fill: '#ffc658' },
+  { name: 'unknown', uv: 38, amt: 6.67, pv: 4800, fill: '#ffc658' },
 ];
 
 const initialState = { data };


### PR DESCRIPTION
I noticed a typo in the [radial bar chart example on the website](recharts.org/en-US/api/RadialBarChart). The last entry in the legend was labeled as "unknow". I corrected this to be "unknown".