### PR TITLE
[WIP] Enable Tooltip's `translate` style

### DIFF
--- a/src/component/Tooltip.js
+++ b/src/component/Tooltip.js
@@ -188,18 +188,18 @@ class Tooltip extends Component {
     }
 
     outerStyle = {
-      ...outerStyle,
       ...translateStyle({
         transform: this.props.useTranslate3d ? `translate3d(${translateX}px, ${translateY}px, 0)` : `translate(${translateX}px, ${translateY}px)`,
       }),
+      ...outerStyle,
     };
 
     if (isAnimationActive && active) {
       outerStyle = {
-        ...outerStyle,
         ...translateStyle({
           transition: `transform ${animationDuration}ms ${animationEasing}`,
         }),
+        ...outerStyle,
       };
     }
 


### PR DESCRIPTION
We can pass `wrapperStyle` props to `Tooltip` but can't change `translate` style. Sometimes I want to set it manually when, for example, I want Tooltip to show along `XAxis` .
I just changed style property's order, so it overridden only when we set it.