### PR TITLE
In case of area and radar use fill for fallback color

### DIFF
--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -129,6 +129,7 @@ export const getMainColorOfGraphicItem = (item) => {
   switch (displayName) {
     case 'Line':
       result = stroke;
+      break;
     case 'Area':
     case 'Radar':
       result = stroke && stroke !== 'none' ? stroke : fill;

--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -123,16 +123,18 @@ export const calculateActiveTickIndex = (coordinate, ticks, unsortedTicks, axis)
  */
 export const getMainColorOfGraphicItem = (item) => {
   const { type: { displayName } } = item;
+  const { stroke, fill } = item.props;
   let result;
 
   switch (displayName) {
     case 'Line':
+      result = stroke;
     case 'Area':
     case 'Radar':
-      result = item.props.stroke;
+      result = stroke && stroke !== 'none' ? stroke : fill;
       break;
     default:
-      result = item.props.fill;
+      result = fill;
       break;
   }
 


### PR DESCRIPTION
Currently the legend icons for line, area or radar charts depends purely on the `stroke` color. I think when using area or radar charts it makes sense that it can fallback to the fill color. 

Please let me know if I need to add tests. 

Fixes: #1174