### PR TITLE
Brush drag fix

### DIFF
--- a/src/cartesian/Brush.js
+++ b/src/cartesian/Brush.js
@@ -448,8 +448,6 @@ class Brush extends Component {
         className={layerClass}
         onMouseMove={this.handleDrag}
         onMouseLeave={this.handleLeaveWrapper}
-        onMouseUp={this.handleDragEnd}
-        onTouchEnd={this.handleDragEnd}
         onTouchMove={this.handleTouchMove}
         style={style}
       >

--- a/src/cartesian/Brush.js
+++ b/src/cartesian/Brush.js
@@ -198,6 +198,8 @@ class Brush extends Component {
       isSlideMoving: true,
       slideMoveStartX: event.pageX,
     });
+    document.addEventListener('mouseup', this.handleDragEnd);
+    document.addEventListener('touchend', this.handleDragEnd);
   };
 
   handleSlideDrag(e) {
@@ -300,6 +302,8 @@ class Brush extends Component {
       startX: this.scale(startIndex),
       endX: this.scale(endIndex),
     };
+    document.removeEventListener('mouseup', this.handleDragEnd);
+    document.removeEventListener('touchend', this.handleDragEnd);
   }
 
   renderBackground() {

--- a/src/cartesian/Brush.js
+++ b/src/cartesian/Brush.js
@@ -102,6 +102,8 @@ class Brush extends Component {
       clearTimeout(this.leaveTimer);
       this.leaveTimer = null;
     }
+    document.removeEventListener('mouseup', this.handleDragEnd);
+    document.removeEventListener('touchend', this.handleDragEnd);
   }
 
   static getIndexInRange(range, x) {
@@ -166,6 +168,8 @@ class Brush extends Component {
       isTravellerMoving: false,
       isSlideMoving: false,
     });
+    document.removeEventListener('mouseup', this.handleDragEnd);
+    document.removeEventListener('touchend', this.handleDragEnd);
   };
 
   handleLeaveWrapper = () => {
@@ -235,6 +239,8 @@ class Brush extends Component {
       movingTravellerId: id,
       brushMoveStartX: event.pageX,
     });
+    document.addEventListener('mouseup', this.handleDragEnd);
+    document.addEventListener('touchend', this.handleDragEnd);
   }
 
   handleTravellerMove(e) {

--- a/src/cartesian/Brush.js
+++ b/src/cartesian/Brush.js
@@ -102,6 +102,8 @@ class Brush extends Component {
       clearTimeout(this.leaveTimer);
       this.leaveTimer = null;
     }
+    document.removeEventListener('mousemove', this.handleDrag);
+    document.removeEventListener('touchmove', this.handleTouchMove);
     document.removeEventListener('mouseup', this.handleDragEnd);
     document.removeEventListener('touchend', this.handleDragEnd);
   }
@@ -168,6 +170,8 @@ class Brush extends Component {
       isTravellerMoving: false,
       isSlideMoving: false,
     });
+    document.removeEventListener('mousemove', this.handleDrag);
+    document.removeEventListener('touchmove', this.handleTouchMove);
     document.removeEventListener('mouseup', this.handleDragEnd);
     document.removeEventListener('touchend', this.handleDragEnd);
   };
@@ -198,6 +202,8 @@ class Brush extends Component {
       isSlideMoving: true,
       slideMoveStartX: event.pageX,
     });
+    document.addEventListener('mousemove', this.handleDrag);
+    document.addEventListener('touchmove', this.handleTouchMove);
     document.addEventListener('mouseup', this.handleDragEnd);
     document.addEventListener('touchend', this.handleDragEnd);
   };
@@ -241,6 +247,8 @@ class Brush extends Component {
       movingTravellerId: id,
       brushMoveStartX: event.pageX,
     });
+    document.addEventListener('mousemove', this.handleDrag);
+    document.addEventListener('touchmove', this.handleTouchMove);
     document.addEventListener('mouseup', this.handleDragEnd);
     document.addEventListener('touchend', this.handleDragEnd);
   }
@@ -295,6 +303,12 @@ class Brush extends Component {
       .domain(_.range(0, len))
       .range([x, x + width - travellerWidth]);
     this.scaleValues = this.scale.domain().map(entry => this.scale(entry));
+
+    document.removeEventListener('mousemove', this.handleDrag);
+    document.removeEventListener('touchmove', this.handleTouchMove);
+    document.removeEventListener('mouseup', this.handleDragEnd);
+    document.removeEventListener('touchend', this.handleDragEnd);
+
     return {
       isTextActive: false,
       isSlideMoving: false,
@@ -302,8 +316,6 @@ class Brush extends Component {
       startX: this.scale(startIndex),
       endX: this.scale(endIndex),
     };
-    document.removeEventListener('mouseup', this.handleDragEnd);
-    document.removeEventListener('touchend', this.handleDragEnd);
   }
 
   renderBackground() {
@@ -450,9 +462,7 @@ class Brush extends Component {
     return (
       <Layer
         className={layerClass}
-        onMouseMove={this.handleDrag}
         onMouseLeave={this.handleLeaveWrapper}
-        onTouchMove={this.handleTouchMove}
         style={style}
       >
         {this.renderBackground()}


### PR DESCRIPTION
When while dragging a brush the mouse is moved outside of the brush the brush will stick to the mouse, even when the mouse button was released while outside. This PR adds a document wide mouseup listener fixing this issue. 
When moving the mouse outside the brush area while dragging the brush, the dragging would pause. This PR also enables dragging the brush while outside the brush area.

This could be seen as a successor to #1717.