### PR TITLE
Fix BarChart's hover rectangle covering up data

### DIFF
--- a/src/util/ReactUtils.js
+++ b/src/util/ReactUtils.js
@@ -486,7 +486,7 @@ export const renderByOrder = (children, renderMap) => {
     }
   });
 
-  return elements;
+  return elements.reverse();
 };
 
 export const getReactEventByType = (e) => {


### PR DESCRIPTION
Might close https://github.com/recharts/recharts/issues/1039 (it seems the issue may have taken different forms over the past year)

I am sure this is *not* the best solution, but it does work and is remarkably simple. If you know of a better way to fix this bug, I'll happily update the PR. 😄 

One thing we could do instead of `.reverse()` at the end, is using `Array.unshift` instead of `Array.push` and also unfurling the `results` array after reversing them first.

Before:
<img width="204" alt="Screen Shot 2019-07-18 at 11 05 10 PM" src="https://user-images.githubusercontent.com/1009441/61508672-8e678d00-a9b0-11e9-82f7-af3f592734b6.png">

After:
<img width="196" alt="Screen Shot 2019-07-18 at 11 02 48 PM" src="https://user-images.githubusercontent.com/1009441/61508677-96bfc800-a9b0-11e9-9bb0-d3e04f7893c0.png">
