### PR TITLE
Use original data value in Scatter/dataPointFormatter

### DIFF
--- a/src/cartesian/Scatter.js
+++ b/src/cartesian/Scatter.js
@@ -288,7 +288,7 @@ class Scatter extends Component {
       return {
         x: dataPoint.cx,
         y: dataPoint.cy,
-        value: dataPoint.y,
+        value: dataPoint.node.y,
         errorVal: getValueByDataKey(dataPoint, dataKey),
       };
     }
@@ -297,7 +297,7 @@ class Scatter extends Component {
       return {
         x: dataPoint.cx,
         y: dataPoint.cy,
-        value: dataPoint.x,
+        value: dataPoint.node.x,
         errorVal: getValueByDataKey(dataPoint, dataKey),
       };
     }


### PR DESCRIPTION
ErrorBar in Scatter shows at unexpected location, as illustrated in http://recharts.org/en-US/api/ErrorBar and in issue #1453