### PR TITLE
Add overflow to tooltip styles

### DIFF
--- a/src/component/DefaultTooltipContent.js
+++ b/src/component/DefaultTooltipContent.js
@@ -103,7 +103,7 @@ class DefaultTooltipContent extends Component {
       padding: 10,
       backgroundColor: '#fff',
       border: '1px solid #ccc',
-      whiteSpace: 'nowrap',
+      overflow: 'hidden',
       ...contentStyle,
     };
     const finalLabelStyle = {


### PR DESCRIPTION
Currently tooltips will overflow to the edge of their container if the text content is large, as you can see here:

![before_cropped](https://user-images.githubusercontent.com/6605287/63178709-81d36480-c042-11e9-8a2b-1b1934f5b511.png)

With fix:

![after_crop](https://user-images.githubusercontent.com/6605287/63178715-8861dc00-c042-11e9-9595-dc2042c963fd.png)
