### PR TITLE
Shape prop can be used without any other prop in reference area

### DIFF
--- a/src/cartesian/ReferenceArea.js
+++ b/src/cartesian/ReferenceArea.js
@@ -113,13 +113,14 @@ class ReferenceArea extends Component {
     const hasY1 = isNumOrStr(y1);
     const hasY2 = isNumOrStr(y2);
 
-    if (!hasX1 && !hasX2 && !hasY1 && !hasY2) { return null; }
+    const { shape } = this.props;
+
+    if (!hasX1 && !hasX2 && !hasY1 && !hasY2 && !shape) { return null; }
 
     const rect = this.getRect(hasX1, hasX2, hasY1, hasY2);
 
-    if (!rect) { return null; }
+    if (!rect && !shape) { return null; }
 
-    const { shape } = this.props;
 
     const clipPath = ifOverflowMatches(this.props, 'hidden') ?
       `url(#${clipPathId})` :


### PR DESCRIPTION
`shape` prop is not mentioned in the reference area but it can be used to create custom `svg` shapes but because of the `if` condition you have to pass atleast `one` more prop.

### NEED HELP

Resolves #1880 
Should also affect 
#https://github.com/recharts/recharts.org/issues/34

JSfiddle to reproduce the issue. Removing the `y1` prop will result in `null` from `ReferenceArea`.
https://jsfiddle.net/k0jv2xah/6/