### PR TITLE
Fix react-smooth related React warnings.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9682,9 +9682,9 @@
       }
     },
     "react-smooth": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-1.0.2.tgz",
-      "integrity": "sha512-pIGzL1g9VGAsRsdZQokIK0vrCkcdKtnOnS1gyB2rrowdLy69lNSWoIjCTWAfgbiYvria8tm5hEZqj+jwXMkV4A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-1.0.5.tgz",
+      "integrity": "sha512-eW057HT0lFgCKh8ilr0y2JaH2YbNcuEdFpxyg7Gf/qDKk9hqGMyXryZJ8iMGJEuKH0+wxS0ccSsBBB3W8yCn8w==",
       "requires": {
         "lodash": "~4.17.4",
         "prop-types": "^15.6.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lodash": "^4.17.5",
     "prop-types": "^15.6.0",
     "react-resize-detector": "^2.3.0",
-    "react-smooth": "^1.0.0",
+    "react-smooth": "^1.0.5",
     "recharts-scale": "^0.4.2",
     "reduce-css-calc": "^1.3.0"
   },


### PR DESCRIPTION
Fixes #1857.

Most of the deprecated React lifecycle method warnings are handled in #1839 and #1896.