### PR TITLE
Used UNSAFE_componentWillReceiveProps.

### DIFF
--- a/src/cartesian/Area.js
+++ b/src/cartesian/Area.js
@@ -197,10 +197,11 @@ class Area extends PureComponent {
 
   state = { isAnimationFinished: true };
 
-  componentDidUpdate(prevProps) {
-    const { animationId, points, baseLine } = prevProps;
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { animationId, points, baseLine } = this.props;
 
-    if (this.props.animationId !== animationId) {
+    if (nextProps.animationId !== animationId) {
       this.cachePrevData(points, baseLine);
     }
   }

--- a/src/cartesian/Bar.js
+++ b/src/cartesian/Bar.js
@@ -171,10 +171,11 @@ class Bar extends PureComponent {
 
   state = { isAnimationFinished: false };
 
-  componentDidUpdate(prevProps) {
-    const { animationId, data } = prevProps;
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { animationId, data } = this.props;
 
-    if (this.props.animationId !== animationId) {
+    if (nextProps.animationId !== animationId) {
       this.cachePrevData(data);
     }
   }

--- a/src/cartesian/Brush.js
+++ b/src/cartesian/Brush.js
@@ -70,28 +70,27 @@ class Brush extends PureComponent {
     this.state = props.data && props.data.length ? this.updateScale(props) : {};
   }
 
-  componentDidUpdate(prevProps) {
-    const { data, width, x, travellerWidth, updateId } = prevProps;
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { data, width, x, travellerWidth, updateId } = this.props;
 
     if (
-      (this.props.data !== data || this.props.updateId !== updateId) &&
-      this.props.data &&
-      this.props.data.length
+      (nextProps.data !== data || nextProps.updateId !== updateId) &&
+      nextProps.data &&
+      nextProps.data.length
     ) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState(this.updateScale(this.props));
+      this.setState(this.updateScale(nextProps));
     } else if (
-      this.props.width !== width ||
-      this.props.x !== x ||
-      this.props.travellerWidth !== travellerWidth
+      nextProps.width !== width ||
+      nextProps.x !== x ||
+      nextProps.travellerWidth !== travellerWidth
     ) {
-      this.scale.range([this.props.x, this.props.x + this.props.width - this.props.travellerWidth]);
+      this.scale.range([nextProps.x, nextProps.x + nextProps.width - nextProps.travellerWidth]);
       this.scaleValues = this.scale.domain().map(entry => this.scale(entry));
 
-      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
-        startX: this.scale(this.props.startIndex),
-        endX: this.scale(this.props.endIndex),
+        startX: this.scale(nextProps.startIndex),
+        endX: this.scale(nextProps.endIndex),
       });
     }
   }
@@ -454,7 +453,8 @@ class Brush extends PureComponent {
         {this.renderSlide(startX, endX)}
         {this.renderTraveller(startX, 'startX')}
         {this.renderTraveller(endX, 'endX')}
-        {(isTextActive || isSlideMoving || isTravellerMoving || alwaysShowText) && this.renderText()}
+        {(isTextActive || isSlideMoving || isTravellerMoving || alwaysShowText) &&
+          this.renderText()}
       </Layer>
     );
   }

--- a/src/cartesian/Line.js
+++ b/src/cartesian/Line.js
@@ -155,10 +155,11 @@ class Line extends PureComponent {
     this.setState({ totalLength });
   }
 
-  componentDidUpdate(prevProps) {
-    const { animationId, points } = prevProps;
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { animationId, points } = this.props;
 
-    if (this.props.animationId !== animationId) {
+    if (nextProps.animationId !== animationId) {
       this.cachePrevData(points);
     }
   }

--- a/src/cartesian/Scatter.js
+++ b/src/cartesian/Scatter.js
@@ -155,10 +155,11 @@ class Scatter extends PureComponent {
 
   state = { isAnimationFinished: false };
 
-  componentDidUpdate(prevProps) {
-    const { animationId, points } = prevProps;
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { animationId, points } = this.props;
 
-    if (this.props.animationId !== animationId) {
+    if (nextProps.animationId !== animationId) {
       this.cachePrevPoints(points);
     }
   }

--- a/src/chart/Sankey.js
+++ b/src/chart/Sankey.js
@@ -368,14 +368,14 @@ class Sankey extends PureComponent {
     this.state = this.constructor.createDefaultState(props);
   }
 
-  componentDidUpdate(prevProps) {
-    const { data, width, height, margin, iterations, nodeWidth, nodePadding, nameKey } = prevProps;
-    if (this.props.data !== data || this.props.width !== width ||
-      this.props.height !== height || !shallowEqual(this.props.margin, margin) ||
-      this.props.iterations !== iterations || this.props.nodeWidth !== nodeWidth ||
-      this.props.nodePadding !== nodePadding || this.props.nameKey !== nameKey) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState(this.constructor.createDefaultState(this.props));
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { data, width, height, margin, iterations, nodeWidth, nodePadding, nameKey } = this.props;
+    if (nextProps.data !== data || nextProps.width !== width ||
+      nextProps.height !== height || !shallowEqual(nextProps.margin, margin) ||
+      nextProps.iterations !== iterations || nextProps.nodeWidth !== nodeWidth ||
+      nextProps.nodePadding !== nodePadding || nextProps.nameKey !== nameKey) {
+      this.setState(this.constructor.createDefaultState(nextProps));
     }
   }
 

--- a/src/chart/Treemap.js
+++ b/src/chart/Treemap.js
@@ -281,8 +281,9 @@ class Treemap extends PureComponent {
     };
   }
 
-  componentDidUpdate(prevProps) {
-    const { type, width, height, data, dataKey, aspectRatio } = prevProps;
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { type, width, height, data, dataKey, aspectRatio } = nextProps;
 
     if (data !== this.props.data ||
       type !== this.props.type ||
@@ -292,7 +293,6 @@ class Treemap extends PureComponent {
       aspectRatio !== this.props.aspectRatio
     ) {
       const nextRoot = this.computeRoot({ type, width, height, data, dataKey, aspectRatio });
-      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
         ...this.constructor.createDefaultState(),
         ...nextRoot,
@@ -300,6 +300,7 @@ class Treemap extends PureComponent {
       });
     }
   }
+
 
   /**
    * Returns default, reset state for the treemap chart.

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -175,40 +175,39 @@ const generateCategoricalChart = ({
       }
     }
 
-    componentDidUpdate(prevProps) {
-      const { data, children, width, height, layout, stackOffset, margin } = prevProps;
+    // eslint-disable-next-line camelcase
+    UNSAFE_componentWillReceiveProps(nextProps) {
+      const { data, children, width, height, layout, stackOffset, margin } = this.props;
       const { updateId } = this.state;
 
-      if (this.props.data !== data || this.props.width !== width ||
-        this.props.height !== height || this.props.layout !== layout ||
-        this.props.stackOffset !== stackOffset || !shallowEqual(this.props.margin, margin)) {
-        const defaultState = this.constructor.createDefaultState(this.props);
-        // eslint-disable-next-line react/no-did-update-set-state
+      if (nextProps.data !== data || nextProps.width !== width ||
+        nextProps.height !== height || nextProps.layout !== layout ||
+        nextProps.stackOffset !== stackOffset || !shallowEqual(nextProps.margin, margin)) {
+        const defaultState = this.constructor.createDefaultState(nextProps);
         this.setState({ ...defaultState, updateId: updateId + 1,
           ...this.updateStateOfAxisMapsOffsetAndStackGroups(
-            { props: this.props, ...defaultState, updateId: updateId + 1 }) }
+            { props: nextProps, ...defaultState, updateId: updateId + 1 }) }
         );
-      } else if (!isChildrenEqual(this.props.children, children)) {
+      } else if (!isChildrenEqual(nextProps.children, children)) {
         // update configuration in chilren
-        const hasGlobalData = !_.isNil(this.props.data);
+        const hasGlobalData = !_.isNil(nextProps.data);
         const newUpdateId = hasGlobalData ? updateId : updateId + 1;
 
-        // eslint-disable-next-line react/no-did-update-set-state
         this.setState(prevState => ({
           updateId: newUpdateId,
           ...this.updateStateOfAxisMapsOffsetAndStackGroups({
-            props: this.props,
+            props: nextProps,
             ...prevState,
             updateId: newUpdateId,
           }),
         }));
       }
       // add syncId
-      if (_.isNil(this.props.syncId) && !_.isNil(this.props.syncId)) {
+      if (_.isNil(this.props.syncId) && !_.isNil(nextProps.syncId)) {
         this.addListener();
       }
       // remove syncId
-      if (!_.isNil(this.props.syncId) && _.isNil(this.props.syncId)) {
+      if (!_.isNil(this.props.syncId) && _.isNil(nextProps.syncId)) {
         this.removeListener();
       }
     }

--- a/src/numberAxis/Funnel.js
+++ b/src/numberAxis/Funnel.js
@@ -160,12 +160,13 @@ class Funnel extends PureComponent {
 
   state = { isAnimationFinished: false };
 
-  componentDidUpdate(prevProps) {
-    const { animationId, trapezoids, isAnimationActive } = prevProps;
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { animationId, trapezoids } = this.props;
 
-    if (this.props.isAnimationActive !== isAnimationActive) {
+    if (nextProps.isAnimationActive !== this.props.isAnimationActive) {
       this.cachePrevData([]);
-    } else if (this.props.animationId !== animationId) {
+    } else if (nextProps.animationId !== animationId) {
       this.cachePrevData(trapezoids);
     }
   }

--- a/src/polar/Pie.js
+++ b/src/polar/Pie.js
@@ -236,12 +236,13 @@ class Pie extends PureComponent {
 
   state = { isAnimationFinished: false };
 
-  componentDidUpdate(prevProps) {
-    const { animationId, sectors, isAnimationActive } = prevProps;
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { animationId, sectors } = this.props;
 
-    if (this.props.isAnimationActive !== isAnimationActive) {
+    if (nextProps.isAnimationActive !== this.props.isAnimationActive) {
       this.cachePrevData([]);
-    } else if (this.props.animationId !== animationId) {
+    } else if (nextProps.animationId !== animationId) {
       this.cachePrevData(sectors);
     }
   }

--- a/src/polar/Radar.js
+++ b/src/polar/Radar.js
@@ -96,10 +96,11 @@ class Radar extends PureComponent {
 
   state = { isAnimationFinished: false };
 
-  componentDidUpdate(prevProps) {
-    const { animationId, points } = prevProps;
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { animationId, points } = this.props;
 
-    if (this.props.animationId !== animationId) {
+    if (nextProps.animationId !== animationId) {
       this.cachePrevData(points);
     }
   }

--- a/src/polar/RadialBar.js
+++ b/src/polar/RadialBar.js
@@ -169,10 +169,11 @@ class RadialBar extends PureComponent {
     isAnimationFinished: false,
   };
 
-  componentDidUpdate(prevProps) {
-    const { animationId, data } = prevProps;
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { animationId, data } = this.props;
 
-    if (this.props.animationId !== animationId) {
+    if (nextProps.animationId !== animationId) {
       this.cachePrevData(data);
     }
   }

--- a/src/util/AnimationDecorator.js
+++ b/src/util/AnimationDecorator.js
@@ -19,11 +19,11 @@ export default function (WrappedComponent) {
       animationId: 0,
     };
 
-    componentDidUpdate(prevProps) {
-      const { animationId } = prevProps;
+    // eslint-disable-next-line camelcase
+    UNSAFE_componentWillReceiveProps(nextProps) {
+      const { animationId } = this.state;
 
-      if (this.props.data !== prevProps.data) {
-        // eslint-disable-next-line react/no-did-update-set-state
+      if (this.props.data !== nextProps.data) {
         this.setState({
           animationId: animationId + 1,
         });


### PR DESCRIPTION
Currently, recharts 1.18.x is really unstable. It happened because all `componentWillReceiveProps` are changed to `componentDidUpdate`.

Actually, it's a wrong choice for recharts. Because `componentWillReceiveProps` are called before `render` and `componentDidUpdate` is called after `render`. 

Currently, `componentWillReceiveProps` lifecycle methods are used to memoize values related to rendering things. 

So, they should be fixed with [`memoize-one`](https://github.com/alexreardon/memoize-one) or rewritten as functional components with hooks. 