### PR TITLE
Avoid using lodash.max & lodash.min which doesn't accept number string

### DIFF
--- a/src/cartesian/Area.js
+++ b/src/cartesian/Area.js
@@ -273,12 +273,12 @@ class Area extends PureComponent {
     const startX = points[0].x;
     const endX = points[points.length - 1].x;
     const width = alpha * Math.abs(startX - endX);
-    let maxY = _.max(points.map(entry => (entry.y || 0)));
+    let maxY = Math.max(...points.map(entry => (entry.y || 0)));
 
     if (isNumber(baseLine)) {
       maxY = Math.max(baseLine, maxY);
     } else if (baseLine && _.isArray(baseLine) && baseLine.length) {
-      maxY = Math.max(_.max(baseLine.map(entry => (entry.y || 0))), maxY);
+      maxY = Math.max(Math.max(...baseLine.map(entry => (entry.y || 0))), maxY);
     }
 
     if (isNumber(maxY)) {
@@ -300,12 +300,12 @@ class Area extends PureComponent {
     const startY = points[0].y;
     const endY = points[points.length - 1].y;
     const height = alpha * Math.abs(startY - endY);
-    let maxX = _.max(points.map(entry => (entry.x || 0)));
+    let maxX = Math.max(...points.map(entry => (entry.x || 0)));
 
     if (isNumber(baseLine)) {
       maxX = Math.max(baseLine, maxX);
     } else if (baseLine && _.isArray(baseLine) && baseLine.length) {
-      maxX = Math.max(_.max(baseLine.map(entry => (entry.x || 0))), maxX);
+      maxX = Math.max(Math.max(...baseLine.map(entry => (entry.x || 0))), maxX);
     }
 
     if (isNumber(maxX)) {

--- a/src/chart/Sankey.js
+++ b/src/chart/Sankey.js
@@ -138,7 +138,7 @@ const getDepthTree = (tree) => {
 };
 
 const updateYOfTree = (depthTree, height, nodePadding, links) => {
-  const yRatio = _.min(depthTree.map(nodes => (
+  const yRatio = Math.min(...depthTree.map(nodes => (
     (height - (nodes.length - 1) * nodePadding) / _.sumBy(nodes, getValue)
   )));
 

--- a/src/util/ChartUtils.js
+++ b/src/util/ChartUtils.js
@@ -33,7 +33,7 @@ export const getDomainOfDataByKey = (data, key, type, filterNil) => {
   if (type === 'number') {
     const domain = flattenData.filter(entry => isNumber(entry) || parseFloat(entry, 10));
 
-    return domain.length ? [_.min(domain), _.max(domain)] : [Infinity, -Infinity];
+    return domain.length ? [Math.min(...domain), Math.max(...domain)] : [Infinity, -Infinity];
   }
 
   const validateData = filterNil ?
@@ -351,7 +351,7 @@ export const getDomainOfErrorBars = (data, item, dataKey, axisType) => {
     return data.reduce((result, entry) => {
       const entryValue = getValueByDataKey(entry, dataKey, 0);
       const mainValue = _.isArray(entryValue) ?
-        [_.min(entryValue), _.max(entryValue)] : [entryValue, entryValue];
+        [Math.min(...entryValue), Math.max(...entryValue)] : [entryValue, entryValue];
       const errorDomain = keys.reduce((prevErrorArr, k) => {
         const errorValue = getValueByDataKey(entry, k, 0);
         const lowerValue = mainValue[0] - Math.abs(
@@ -744,7 +744,7 @@ export const getStackGroupsByAxisId = (
  */
 export const calculateDomainOfTicks = (ticks, type) => {
   if (type === 'number') {
-    return [_.min(ticks), _.max(ticks)];
+    return [Math.min(...ticks), Math.max(...ticks)];
   }
 
   return ticks;
@@ -852,8 +852,8 @@ export const getStackedDataOfItem = (item, stackGroups) => {
 
 const getDomainOfSingle = data => (
   data.reduce((result, entry) => [
-    _.min(entry.concat([result[0]]).filter(isNumber)),
-    _.max(entry.concat([result[1]]).filter(isNumber)),
+    Math.min(...entry.concat([result[0]]).filter(isNumber)),
+    Math.max(...entry.concat([result[1]]).filter(isNumber)),
   ], [Infinity, -Infinity])
 );
 


### PR DESCRIPTION
The max value of the Y-axis is not properly calculated currently.

Here's the reproduction code:

```jsx
import React from 'react';
import ReactDOM from 'react-dom';
import { LineChart, Line, Legend, CartesianGrid, XAxis, YAxis, Tooltip } from "recharts";

ReactDOM.render((<div>
  <LineChart width={1400} height={360} data={[ { x: 0, y: "1651.00" }, { x: 1, y: "6929.00" }, { x: 2, y: "16989.00" }]}>
    <Line type="monotone" dataKey="y" />

    <Tooltip />
    <CartesianGrid />
    <XAxis dataKey="x" />
    <YAxis dataKey="y" />
    <Legend />
  </LineChart>
</div>), document.getElementById('root'));
```

This results following graph:

![Screenshot: Max value is not calculated properly](https://user-images.githubusercontent.com/315601/68485405-978fa900-0282-11ea-8e9e-9b93c0e4c36b.png)

Although the max value of the Y-axis should be 16909.00, actually the max value is 8000 and the graph is only partially displayed.

In this case, `y` values are given as a string, not a float. The max value of Y-axis is correctly calculated and it works as expected if you give the `y` values as a float.
However, it is sometimes easier to develop if you don't need to convert string to float. For example, when you load data from CSV, some CSV parsing libraries give number data as strings.

This problem is caused by lodash's `_.max()`. ([here](https://github.com/recharts/recharts/blob/master/src/util/ChartUtils.js#L36))
If you give number string, `_.max()` doesn't work properly in some cases.
For example, `_.max([ "1651.00", "6929.00", "16989.00" ])` returns `"6929.00"`.

In this pull request, I reverted to use `Math.min()` and `Math.max()` which works properly when you give the data as string values.
According to the changelog, the core developers seem to have switched from `Math.min()` and `Math.max()` to `_.min()` and `_.max()` to avoid `.apply`, but you can use [destructuring syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) instead.