### PR TITLE
Rebase on upstream 1.x branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "scripts": {
     "build": "npm run build-cjs && npm run build-es6 && rimraf umd && npm run build-umd && npm run build-min",
+    "build-for-nutshell": "yarn run build-cjs && yarn run build-es6",
     "build-cjs": "rimraf lib && cross-env NODE_ENV=commonjs babel ./src -d lib",
     "build-es6": "rimraf es6 && cross-env NODE_ENV=es6 babel ./src -d es6",
     "build-umd": "cross-env NODE_ENV=development webpack src/index.js -o umd/Recharts.js",
@@ -33,7 +34,8 @@
     "test": "cross-env NODE_ENV=test karma start test/karma.conf.js",
     "lint": "eslint src",
     "autofix": "eslint src --fix",
-    "analyse": "cross-env NODE_ENV=analyse webpack src/index.js -o umd/Recharts.js"
+    "analyse": "cross-env NODE_ENV=analyse webpack src/index.js -o umd/Recharts.js",
+    "prepare": "yarn run build-for-nutshell"
   },
   "pre-commit": [],
   "pre-push": [

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -649,6 +649,7 @@ const generateCategoricalChart = ({
       return {
         stroke: 'none',
         fill: '#ccc',
+        pointerEvents: 'all',
         x: layout === 'horizontal' ? activeCoordinate.x - halfSize : offset.left + 0.5,
         y: layout === 'horizontal' ? offset.top + 0.5 : activeCoordinate.y - halfSize,
         width: layout === 'horizontal' ? tooltipAxisBandSize : offset.width - 1,

--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -1175,7 +1175,7 @@ const generateCategoricalChart = ({
       if (chartName === 'ScatterChart') {
         restProps = activeCoordinate;
         cursorComp = Cross;
-      } else if (chartName === 'BarChart') {
+      } else if (chartName === 'BarChart' || chartName === 'ComposedChart') {
         restProps = this.getCursorRectangle();
         cursorComp = Rectangle;
       } else if (layout === 'radial') {


### PR DESCRIPTION
This keeps the changes we made in our fork, but pulls us up to the latest 1.x commit.  2.0 seems to indeed have some breaking changes, so we're not quite ready for that.

This also removes the `postinstall-build` package, opting instead for using the `prepare` step that is baked into npm and yarn.