### PR TITLE
feat: Add styling customization options to Brush

### DIFF
--- a/demo/component/LineChart.js
+++ b/demo/component/LineChart.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, ReferenceLine,
   ReferenceDot, Tooltip, CartesianGrid, Legend, Brush, ErrorBar, AreaChart, Area,
   Label, LabelList } from 'recharts';
@@ -351,6 +351,31 @@ const specifiedDomain = [0.01, 'auto'];
 const specifiedTicks = [0.01, 0.1, 1, 10, 100, 1000];
 const specifiedMargin = { top: 20, right: 20, bottom: 20, left: 20 };
 
+const customTraveler = ({ x, y, width, height, fill, stroke }) => {
+  const lineY = Math.floor(y + height / 2) - 1;
+  return (
+    <>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        fill={fill}
+        stroke={stroke}
+      />
+      <line
+        x1={x + 1}
+        y1={lineY}
+        x2={x + width - 1}
+        y2={lineY}
+        fill="none"
+        stroke="red"
+        strokeWidth={3}
+      />
+    </>
+  );
+};
+
 export default class Demo extends Component {
 
   static displayName = 'LineChartDemo';
@@ -547,7 +572,7 @@ export default class Demo extends Component {
           </LineChart>
         </div>
 
-        <p>LineChart with panoramic brush and custom tooltip styles</p>
+        <p>LineChart with panoramic brush, custom tooltip styles and custom traveller</p>
         <div className="line-chart-wrapper">
           <LineChart
             width={600} height={400} data={data03}
@@ -565,7 +590,14 @@ export default class Demo extends Component {
               labelStyle={{ fontWeight: 'bold', color: '#666666' }}
             />
             <Line dataKey="price" stroke="#ff7300" dot={false} />
-            <Brush dataKey="date" startIndex={data03.length - 40}>
+            <Brush
+              dataKey="date"
+              startIndex={data03.length - 40}
+              travellerWidth={15}
+              travellerContent={customTraveler}
+              backgroundStroke="none"
+              slideFill='blue'
+            >
               <AreaChart>
                 <CartesianGrid />
                 <YAxis hide domain={['auto', 'auto']} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "1.8.5",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5791,7 +5791,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5812,12 +5813,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5832,17 +5835,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5959,7 +5965,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5971,6 +5978,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5985,6 +5993,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5992,12 +6001,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6016,6 +6027,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6096,7 +6108,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6108,6 +6121,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6193,7 +6207,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6229,6 +6244,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6248,6 +6264,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6291,12 +6308,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "scripts": {
     "build": "npm run build-cjs && npm run build-es6 && rimraf umd && npm run build-umd && npm run build-min",
+    "check-types": "tsc",
     "build-cjs": "rimraf lib && cross-env NODE_ENV=commonjs babel ./src -d lib --extensions '.js,.ts,.tsx'",
     "build-es6": "rimraf es6 && cross-env NODE_ENV=es6 babel ./src -d es6 --extensions '.js,.ts,.tsx'",
     "build-umd": "cross-env NODE_ENV=development webpack src/index.js -o umd/Recharts.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "removeComments": true,
     "esModuleInterop": true,
     "sourceMap": true,
+    "declaration": true,
     "target": "es5"
   },
   "include": [


### PR DESCRIPTION
fix: Fix some TSC errors in Brush

Recently started to use Recharts and found that Brush lacks some customization options.

All changes are backward compatible and new props will only be used when explicitly specified.
This PR adds the following optional props to Brush:
- backgroundFill?: string;
- backgroundStroke?: string;
- slideFill?: string;
- slideStroke?: string;
- slideOpacity?: number;
- slideStrokeWidth?: number;
- travellerContent?: FC\<TravellerProps>;
- travellerFill?: string;
- travellerStroke?: string;

I additionally fixed some TSC errors in Brush, added script to check types and added an example in LineChart demo.

This also addresses #1600