### PR TITLE
Fix trigger after mouse leave

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -225,6 +225,10 @@ const generateCategoricalChart = ({
       if (!_.isNil(this.props.syncId)) {
         this.removeListener();
       }
+      this.cancelThrottledTriggerAfterMouseMove();
+    }
+
+    cancelThrottledTriggerAfterMouseMove() {
       if (typeof (this.triggeredAfterMouseMove as any).cancel === 'function') {
         (this.triggeredAfterMouseMove as any).cancel();
       }
@@ -1055,6 +1059,8 @@ const generateCategoricalChart = ({
       if (_.isFunction(onMouseLeave)) {
         onMouseLeave(nextState, e);
       }
+
+      this.cancelThrottledTriggerAfterMouseMove();
     };
 
     handleOuterEvent = (e: any) => {


### PR DESCRIPTION
If we use throttle function for mouseMove event, there is a drawback. We only cancel the trailing throttled invocation when component unmounting, but we don`t handle it when leaving a chart.
So i extracted method for canceling throttled calling and put it in onMouseLeave handler.