### PR TITLE
Allow axis line customization through axisLine prop

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -315,9 +315,10 @@ class CartesianAxis extends Component<Props> {
   }
 
   renderAxisLine() {
-    const { x, y, width, height, orientation, mirror } = this.props;
+    const { x, y, width, height, orientation, mirror, axisLine } = this.props;
     let props: PresentationAttributes<SVGLineElement> = {
       ...filterProps(this.props),
+      ...filterProps(axisLine),
       fill: 'none',
     };
 


### PR DESCRIPTION
Currently `axisLine` prop on `<XAxis />` is not respected. This change fixes that.