### PR TITLE
Invert cartesian label position based on negative values

### DIFF
--- a/demo/component/BarChart.js
+++ b/demo/component/BarChart.js
@@ -10,10 +10,10 @@ import { changeNumberOfData } from './utils';
 const colors = scaleOrdinal(schemeCategory10).range();
 
 const data = [
-  { name: 'food', uv: 2000, pv: 2013, amt: 4500, time: 1, uvError: [100, 50], pvError: [110, 20] },
-  { name: 'cosmetic', uv: 3300, pv: 2000, amt: 6500, time: 2, uvError: 120, pvError: 50 },
-  { name: 'storage', uv: 3200, pv: 1398, amt: 5000, time: 3, uvError: [120, 80], pvError: [200, 100] },
-  { name: 'digital', uv: 2800, pv: 2800, amt: 4000, time: 4, uvError: 100, pvError: 30 },
+  { name: 'food', uv: -2000, pv: -2013, amt: -4500, bmk: -4301, time: 1, uvError: [100, 50], pvError: [110, 20] },
+  { name: 'cosmetic', uv: 3300, pv: 2000, amt: 6500, bmk: 2000, time: 2, uvError: 120, pvError: 50 },
+  { name: 'storage', uv: 3200, pv: 1398, amt: 5000, bmk: 3000, time: 3, uvError: [120, 80], pvError: [200, 100] },
+  { name: 'digital', uv: 2800, pv: 2800, amt: 4000, bmk: 1500, time: 4, uvError: 100, pvError: 30 },
 ];
 
 const data01 = [
@@ -433,7 +433,7 @@ export default class Demo extends Component {
           </BarChart>
         </div>
 
-        <p>Horziontal BarChart</p>
+        <p>Vertical BarChart</p>
         <div className="area-chart-wrapper">
           <BarChart
             width={1400}
@@ -447,6 +447,56 @@ export default class Demo extends Component {
             <Tooltip />
             <Bar dataKey="uv" fill="#ff7300" maxBarSize={20} label radius={[10, 10, 10, 10]} />
             <Bar dataKey="pv" fill="#387908" />
+          </BarChart>
+        </div>
+
+        <p>Label alignment on Vertical BarChart</p>
+        <div className="area-chart-wrapper">
+          <BarChart
+            width={800}
+            height={800}
+            data={data}
+            margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+            layout="vertical"
+          >
+            <XAxis type="number" />
+            <YAxis dataKey="name" type="category" />
+            <Tooltip />
+            <Bar dataKey="uv" fill="#ff7300" label />
+            <Bar dataKey="pv" fill="#387908">
+              <LabelList position="right" invertNegativesOn="horizontal" />
+            </Bar>
+            <Bar dataKey="amt" fill="#683a98">
+              <LabelList position="left" />
+            </Bar>
+            <Bar dataKey="bmk" fill="#183a91">
+              <LabelList position="insideRight" fill="#ffffff" invertNegativesOn="horizontal" />
+            </Bar>
+          </BarChart>
+        </div>
+
+        <p>Label alignment on Horizontal BarChart</p>
+        <div className="area-chart-wrapper">
+          <BarChart
+            width={1000}
+            height={400}
+            data={data}
+            margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+            layout="horizontal"
+          >
+            <YAxis type="number" />
+            <XAxis dataKey="name" type="category" />
+            <Tooltip />
+            <Bar dataKey="uv" fill="#ff7300" label />
+            <Bar dataKey="pv" fill="#387908">
+              <LabelList position="top" invertNegativesOn="vertical" />
+            </Bar>
+            <Bar dataKey="amt" fill="#683a98">
+              <LabelList position="bottom" />
+            </Bar>
+            <Bar dataKey="bmk" fill="#183a91">
+              <LabelList position="insideTop" fill="#ffffff" invertNegativesOn="vertical" />
+            </Bar>
           </BarChart>
         </div>
 

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -162,58 +162,69 @@ const getAttrsOfPolarLabel = (props: Props) => {
 const getAttrsOfCartesianLabel = (props: Props) => {
   const { viewBox, offset, position } = props;
   const { x, y, width, height } = (viewBox as CartesianViewBox);
-  const sign = height >= 0 ? 1 : -1;
+	
+	// Define vertical offsets and position inverts based on the value being positive or negative
+	const verticalSign = height >= 0 ? 1 : -1;
+	const verticalOffset = verticalSign * offset;
+	const verticalEnd = verticalSign > 0 ? 'end' : 'start';
+	const verticalStart = verticalSign > 0 ? 'start' : 'end';
+
+	// Define horizontal offsets and position inverts based on the value being positive or negative
+	const horizontalSign = width >= 0 ? 1 : -1;
+	const horizontalOffset = horizontalSign * offset;
+	const horizontalEnd = horizontalSign > 0 ? 'end' : 'start';
+	const horizontalStart = horizontalSign > 0 ? 'start' : 'end';
 
   if (position === 'top') {
     return {
       x: x + width / 2,
-      y: y - sign * offset,
+      y: y - verticalSign * offset,
       textAnchor: 'middle',
-      verticalAnchor: sign > 0 ? 'end' : 'start',
+      verticalAnchor: verticalEnd,
     };
   }
 
   if (position === 'bottom') {
     return {
       x: x + width / 2,
-      y: y + height + sign * offset,
+      y: y + height + verticalOffset,
       textAnchor: 'middle',
-      verticalAnchor: 'start',
+      verticalAnchor: verticalStart,
     };
   }
 
   if (position === 'left') {
     return {
-      x: x - offset,
+      x: x - horizontalOffset,
       y: y + height / 2,
-      textAnchor: 'end',
+      textAnchor: horizontalEnd,
       verticalAnchor: 'middle',
     };
   }
 
   if (position === 'right') {
     return {
-      x: x + width + offset,
+      x: x + width + horizontalOffset,
       y: y + height / 2,
-      textAnchor: 'start',
+      textAnchor: horizontalStart,
       verticalAnchor: 'middle',
     };
   }
 
   if (position === 'insideLeft') {
     return {
-      x: x + offset,
+      x: x + horizontalOffset,
       y: y + height / 2,
-      textAnchor: 'start',
+      textAnchor: horizontalStart,
       verticalAnchor: 'middle',
     };
   }
 
   if (position === 'insideRight') {
     return {
-      x: x + width - offset,
+      x: x + width - horizontalOffset,
       y: y + height / 2,
-      textAnchor: 'end',
+      textAnchor: horizontalEnd,
       verticalAnchor: 'middle',
     };
   }
@@ -221,54 +232,54 @@ const getAttrsOfCartesianLabel = (props: Props) => {
   if (position === 'insideTop') {
     return {
       x: x + width / 2,
-      y: y + sign * offset,
+      y: y + verticalOffset,
       textAnchor: 'middle',
-      verticalAnchor: 'start',
+      verticalAnchor: verticalStart,
     };
   }
 
   if (position === 'insideBottom') {
     return {
       x: x + width / 2,
-      y: y + height - sign * offset,
+      y: y + height - verticalOffset,
       textAnchor: 'middle',
-      verticalAnchor: 'end',
+      verticalAnchor: verticalEnd,
     };
   }
 
   if (position === 'insideTopLeft') {
     return {
-      x: x + offset,
-      y: y + sign * offset,
-      textAnchor: 'start',
-      verticalAnchor: 'start',
+      x: x + horizontalOffset,
+      y: y + verticalOffset,
+      textAnchor: horizontalStart,
+      verticalAnchor: verticalStart,
     };
   }
 
   if (position === 'insideTopRight') {
     return {
-      x: x + width - offset,
-      y: y + sign * offset,
-      textAnchor: 'end',
-      verticalAnchor: 'start',
+      x: x + width - horizontalOffset,
+      y: y + verticalOffset,
+      textAnchor: horizontalEnd,
+      verticalAnchor: verticalStart,
     };
   }
 
   if (position === 'insideBottomLeft') {
     return {
-      x: x + offset,
-      y: y + height - sign * offset,
-      textAnchor: 'start',
-      verticalAnchor: 'end',
+      x: x + horizontalOffset,
+      y: y + height - verticalOffset,
+      textAnchor: horizontalStart,
+      verticalAnchor: verticalEnd,
     };
   }
 
   if (position === 'insideBottomRight') {
     return {
-      x: x + width - offset,
-      y: y + height - sign * offset,
-      textAnchor: 'end',
-      verticalAnchor: 'end',
+      x: x + width - horizontalOffset,
+      y: y + height - verticalOffset,
+      textAnchor: horizontalEnd,
+      verticalAnchor: verticalEnd,
     };
   }
 


### PR DESCRIPTION
### Summary
I have been running into an issue where my Bar Chart labels do not render as expected when the layout is set to vertical. eg. where the label position is set to "right" - all bars that are positive, display with the label on the outside right-aligned to the bar, but all negative bars display the label on the inside left of the bar.

I would expect the label on the negative bars to display on outside of the bar and to the left of the bar, as it would be the inverse of the positive label position.

After some digging, I found that @tmikoss had a fix for the same issue but only for horizontal bar charts:
see https://github.com/recharts/recharts/pull/1346.

The solution I applied here extends its solution to apply to all [position options](http://recharts.org/en-US/api/Label#position).

**Note**: I have also added two bar charts to the demo/component/BarChart.js to demonstrate the usage of the labels (but I am fine with removing them).

Resolves #1058

![image](https://user-images.githubusercontent.com/1819122/74157059-48aa3480-4c20-11ea-8236-40ae52f3e752.png)