### PR TITLE
Added index to tickFormatter

### DIFF
--- a/demo/component/BarChart.js
+++ b/demo/component/BarChart.js
@@ -1,7 +1,9 @@
 /* eslint-disable react/no-multi-comp */
 import React, { Component } from 'react';
-import { BarChart, Bar, Brush, Cell, CartesianGrid, ReferenceLine, ReferenceDot,
-  XAxis, YAxis, Tooltip, Legend, ErrorBar, LabelList } from 'recharts';
+import {
+  BarChart, Bar, Brush, Cell, CartesianGrid, ReferenceLine, ReferenceDot,
+  XAxis, YAxis, Tooltip, Legend, ErrorBar, LabelList
+} from 'recharts';
 import { scaleOrdinal } from 'd3-scale';
 import { schemeCategory10 } from 'd3-scale-chromatic';
 import _ from 'lodash';
@@ -367,6 +369,19 @@ export default class Demo extends Component {
         <div className="bar-chart-wrapper">
           <BarChart width={150} height={40} data={data}>
             <Bar dataKey="uv" fill="#ff7300" onClick={this.handlePvBarClick} background />
+          </BarChart>
+        </div>
+
+        <p>BarChart with tickFormatter</p>
+        <div className="bar-chart-wrapper">
+          <BarChart width={500} height={300} data={data} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" tickFormatter={(value, i) => `${value}.${i}`} />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey="pv" fill="#8884d8" />
+            <Bar dataKey="uv" fill="#82ca9d" />
           </BarChart>
         </div>
 

--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -37,7 +37,7 @@ interface BrushProps extends InternalBrushProps {
   dataKey?: DataKey<any>;
   startIndex?: number;
   endIndex?: number;
-  tickFormatter?: (value: any) => ReactText;
+  tickFormatter?: (value: any, index: number) => ReactText;
 
   children?: ReactElement;
 
@@ -166,7 +166,7 @@ class Brush extends PureComponent<Props, State> {
     const { data, tickFormatter, dataKey } = this.props;
     const text = getValueByDataKey(data[index], dataKey, index);
 
-    return _.isFunction(tickFormatter) ? tickFormatter(text) : text;
+    return _.isFunction(tickFormatter) ? tickFormatter(text, index) : text;
   }
 
   handleDrag = (e: React.Touch | MouseEvent<SVGGElement>) => {

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -40,7 +40,7 @@ export interface CartesianAxisProps {
   ticks?: CartesianTickItem[];
   tickSize?: number;
   /** The formatter function of tick */ 
-  tickFormatter?: (value: any) => string;
+  tickFormatter?: (value: any, index: number) => string;
   ticksGenerator?: (props?: CartesianAxisProps) => CartesianTickItem[];
   interval?: number | 'preserveStart' | 'preserveEnd' | 'preserveStartEnd';
 };
@@ -128,7 +128,7 @@ class CartesianAxis extends Component<Props> {
     if (preserveEnd) {
       // Try to guarantee the tail to be displayed
       let tail = ticks[len - 1];
-      const tailContent = _.isFunction(tickFormatter) ? tickFormatter(tail.value) : tail.value;
+      const tailContent = _.isFunction(tickFormatter) ? tickFormatter(tail.value, len - 1) : tail.value;
       const tailSize = getStringSize(tailContent)[sizeKey] + unitSize;
       const tailGap = sign * (tail.coordinate + sign * tailSize / 2 - end);
       result[len - 1] = tail = {
@@ -148,7 +148,7 @@ class CartesianAxis extends Component<Props> {
     const count = preserveEnd ? len - 1 : len;
     for (let i = 0; i < count; i++) {
       let entry = result[i];
-      const content = _.isFunction(tickFormatter) ? tickFormatter(entry.value) : entry.value;
+      const content = _.isFunction(tickFormatter) ? tickFormatter(entry.value, i) : entry.value;
       const size = getStringSize(content)[sizeKey] + unitSize;
 
       if (i === 0) {
@@ -194,7 +194,7 @@ class CartesianAxis extends Component<Props> {
 
     for (let i = len - 1; i >= 0; i--) {
       let entry = result[i];
-      const content = _.isFunction(tickFormatter) ? tickFormatter(entry.value) : entry.value;
+      const content = _.isFunction(tickFormatter) ? tickFormatter(entry.value, len - i -1) : entry.value;
       const size = getStringSize(content)[sizeKey] + unitSize;
 
       if (i === len - 1) {
@@ -409,7 +409,7 @@ class CartesianAxis extends Component<Props> {
           {tick && CartesianAxis.renderTickItem(
             tick,
             tickProps,
-            `${_.isFunction(tickFormatter) ? tickFormatter(entry.value) : entry.value}${unit || ''}`
+            `${_.isFunction(tickFormatter) ? tickFormatter(entry.value, i) : entry.value}${unit || ''}`
           )}
         </Layer>
       );

--- a/src/polar/PolarAngleAxis.tsx
+++ b/src/polar/PolarAngleAxis.tsx
@@ -169,7 +169,7 @@ class PolarAngleAxis extends PureComponent<Props> {
             />
           )}
           {tick && PolarAngleAxis.renderTickItem(
-            tick, tickProps, tickFormatter ? tickFormatter(entry.value) : entry.value
+            tick, tickProps, tickFormatter ? tickFormatter(entry.value, i) : entry.value
           )}
         </Layer>
       );

--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -162,7 +162,7 @@ class PolarRadiusAxis extends PureComponent<Props> {
           {...adaptEventsOfChild(this.props, entry, i)}
         >
           {PolarRadiusAxis.renderTickItem(
-            tick, tickProps, tickFormatter ? tickFormatter(entry.value) : entry.value
+            tick, tickProps, tickFormatter ? tickFormatter(entry.value, i) : entry.value
           )}
         </Layer>
       );

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -408,7 +408,7 @@ export interface BaseAxisProps {
   /** The size of tick line */
   tickSize?: number;
   /** The formatter function of tick */ 
-  tickFormatter?: (value: any) => string;
+  tickFormatter?: (value: any, index: number) => string;
   /**
    * When domain of the axis is specified and the type of the axis is 'number', 
    * if allowDataOverflow is set to be false, 

--- a/test/specs/cartesian/XAxisSpec.js
+++ b/test/specs/cartesian/XAxisSpec.js
@@ -64,15 +64,25 @@ describe('<XAxis />', () => {
     expect(wrapper.find('.xAxis .recharts-cartesian-axis-tick').length).to.equal(2);
   });
 
+  it('Render ticks with tickFormatter', () => {
+    const wrapper = render(
+      <LineChart width={400} height={400} data={lineData} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+        <XAxis dataKey="name" tickFormatter={(value, i) => `${i}`} />
+        <Line type="monotone" dataKey="uv" stroke="#ff7300" />
+      </LineChart>
+    );
+    expect(wrapper.find('.xAxis .recharts-cartesian-axis-tick').first()).text().to.equal('0');
+  });
+
   it('Render duplicated ticks of XAxis', () => {
     const lineData = [
-      {name: "03/07/2017", balance: 23126.11},
-      {name: "03/02/2017", balance: 23137.39},
-      {name: "03/01/2017", balance: 24609.55},
-      {name: "03/01/2017", balance: 26827.66},
-      {name: "02/24/2017", balance: 26807.66},
-      {name: "02/21/2017", balance: 23835.62},
-      {name: "02/16/2017", balance: 23829.62}
+      { name: "03/07/2017", balance: 23126.11 },
+      { name: "03/02/2017", balance: 23137.39 },
+      { name: "03/01/2017", balance: 24609.55 },
+      { name: "03/01/2017", balance: 26827.66 },
+      { name: "02/24/2017", balance: 26807.66 },
+      { name: "02/21/2017", balance: 23835.62 },
+      { name: "02/16/2017", balance: 23829.62 }
     ];
 
     const wrapper = render(
@@ -80,11 +90,11 @@ describe('<XAxis />', () => {
         width={600}
         height={300}
         data={lineData}
-        margin={{top: 5, right: 30, left: 20, bottom: 5}}
+        margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
       >
         <XAxis dataKey="name" interval={0} />
-        <YAxis/>
-        <Line type="monotone" dataKey="balance" stroke="#8884d8" activeDot={{r: 8}}/>
+        <YAxis />
+        <Line type="monotone" dataKey="balance" stroke="#8884d8" activeDot={{ r: 8 }} />
       </LineChart>
     );
     expect(wrapper.find('.recharts-xAxis .recharts-cartesian-axis-tick').length).to.equal(lineData.length);
@@ -92,13 +102,13 @@ describe('<XAxis />', () => {
 
   it('Render duplicated ticks of XAxis', () => {
     const lineData = [
-      {name: "03/07/2017", balance: 23126.11},
-      {name: "03/02/2017", balance: 23137.39},
-      {name: "03/01/2017", balance: 24609.55},
-      {name: "03/01/2017", balance: 26827.66},
-      {name: "02/24/2017", balance: 26807.66},
-      {name: "02/21/2017", balance: 23835.62},
-      {name: "02/16/2017", balance: 23829.62}
+      { name: "03/07/2017", balance: 23126.11 },
+      { name: "03/02/2017", balance: 23137.39 },
+      { name: "03/01/2017", balance: 24609.55 },
+      { name: "03/01/2017", balance: 26827.66 },
+      { name: "02/24/2017", balance: 26807.66 },
+      { name: "02/21/2017", balance: 23835.62 },
+      { name: "02/16/2017", balance: 23829.62 }
     ];
 
     const wrapper = render(
@@ -106,11 +116,11 @@ describe('<XAxis />', () => {
         width={600}
         height={300}
         data={lineData}
-        margin={{top: 5, right: 30, left: 20, bottom: 5}}
+        margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
       >
         <XAxis dataKey="name" scale="time" interval={0} />
-        <YAxis/>
-        <Line type="monotone" dataKey="balance" stroke="#8884d8" activeDot={{r: 8}}/>
+        <YAxis />
+        <Line type="monotone" dataKey="balance" stroke="#8884d8" activeDot={{ r: 8 }} />
       </LineChart>
     );
     expect(wrapper.find('.recharts-xAxis .recharts-cartesian-axis-tick').length).to.equal(lineData.length);


### PR DESCRIPTION
### Summary
In some cases, an index is required on the tickFormatter on the x and y axis.
So I added an index to the tickFormatter and examples.

```tsx
 <XAxis dataKey="name" tickFormatter={(value, i) => `${value}.${i}`} />
```