### PR TITLE
Fixes arc angles when `cornerIsExternal` is used.

### DIFF
--- a/src/shape/Sector.tsx
+++ b/src/shape/Sector.tsx
@@ -99,7 +99,9 @@ const getSectorWithCorner = ({
       cx, cy, radius: outerRadius, angle: endAngle, sign: -sign, cornerRadius,
       cornerIsExternal,
     });
-  const outerArcAngle = Math.abs(startAngle - endAngle) - sot - eot;
+    const outerArcAngle = cornerIsExternal
+      ? Math.abs(startAngle - endAngle) + sot + eot
+      : Math.abs(startAngle - endAngle) - sot - eot;
 
   if (outerArcAngle < 0) {
     if (forceCornerRadius) {
@@ -142,7 +144,9 @@ const getSectorWithCorner = ({
         cornerRadius,
         cornerIsExternal,
       });
-    const innerArcAngle = Math.abs(startAngle - endAngle) - sit - eit;
+      const innerArcAngle = cornerIsExternal
+        ? Math.abs(startAngle - endAngle) + sit + eit
+        : Math.abs(startAngle - endAngle) - sit - eit;
 
     if (innerArcAngle < 0) {
       return `${path}L${cx},${cy}Z`;


### PR DESCRIPTION
[This previous PR ](https://github.com/recharts/recharts/pull/1739) added the option to make the rounded corners being _added_ to the radial bar with the `cornerIsExternal` prop, however it failed to account for an edge case where the arc angle of the radial bar without the corners would be less than 180, but greater than 180 when adding the corners.

This PR fixes that. This is how it looked before the fix:

![Screen Shot 2020-02-27 at 15 55 52](https://user-images.githubusercontent.com/2023360/75479543-7f04e500-597e-11ea-9af7-188716d1b997.png)

And this is how it looks after the fix:

![Screen Shot 2020-02-27 at 15 57 46](https://user-images.githubusercontent.com/2023360/75479583-8b893d80-597e-11ea-8718-60f76596713e.png)
