### PR TITLE
Do word line calculation only when needed

### DIFF
--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -111,13 +111,13 @@ class Text extends Component<Props, State> {
         } else {
           return this.getWordsWithoutCalculate(props);
         }
-      }
 
-      return this.calculateWordsByLines(
-        wordsWithComputedWidth,
-        spaceWidth,
-        props.width
-      );
+        return this.calculateWordsByLines(
+          wordsWithComputedWidth,
+          spaceWidth,
+          props.width
+        );
+      }
     }
     return this.getWordsWithoutCalculate(props);
   }


### PR DESCRIPTION
Currently calculateWordsByLines is called with null values, if `needCalculate` is `false`. This results in undefined behavior (in practice disappearing labels)