### PR TITLE
ci: update nodejs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8.5.0"
+  - "8.10.0"
 services:
   - xvfb
 before_script:


### PR DESCRIPTION
Minimum version of 8.10.0 is required by typescript-eslint, see https://github.com/typescript-eslint/typescript-eslint/issues/1608#issuecomment-589815732