### PR TITLE
Get legend wrapper boundingRect to correctly compute legend offset

### DIFF
--- a/src/chart/generateCategoricalChart.js
+++ b/src/chart/generateCategoricalChart.js
@@ -878,7 +878,7 @@ const generateCategoricalChart = ({
       }
 
       if (legendItem && this.legendInstance) {
-        const legendBox = this.legendInstance.getBBox();
+        const legendBox = this.legendInstance.wrapperNode.getBoundingClientRect();
 
         offset = appendOffsetOfLegend(offset, graphicalItems, props, legendBox);
       }


### PR DESCRIPTION
xAxis is overflowing legend for first render, because `getBBox()` called on instance returns zero height. `wrapperNode` have already correct size so we should use `wrapperNode.getBoundingClientRect()` instead. 