### PR TITLE
Fixes outerArcAngle and innerArcAngle when cornerIsExternal == true

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -196,7 +196,7 @@ class Area extends PureComponent<Props, State> {
       if (layout === 'horizontal') {
         return {
           x: getCateCoordinateOfLine({ axis: xAxis, ticks: xAxisTicks, bandSize, entry, index }),
-          y: isBreakPoint? null : yAxis.scale(value[1]),
+          y: isBreakPoint ? null : yAxis.scale(value[1]),
           value,
           payload: entry,
         };

--- a/src/shape/Sector.tsx
+++ b/src/shape/Sector.tsx
@@ -106,7 +106,7 @@ const getSectorWithCorner = ({
     cornerIsExternal,
   });
   const outerArcAngle = cornerIsExternal
-    ? Math.abs(startAngle - endAngle) + sot + eot
+    ? Math.abs(startAngle - endAngle)
     : Math.abs(startAngle - endAngle) - sot - eot;
 
   if (outerArcAngle < 0) {
@@ -154,7 +154,7 @@ const getSectorWithCorner = ({
       cornerIsExternal,
     });
     const innerArcAngle = cornerIsExternal
-      ? Math.abs(startAngle - endAngle) + sit + eit
+      ? Math.abs(startAngle - endAngle)
       : Math.abs(startAngle - endAngle) - sit - eit;
 
     if (innerArcAngle < 0) {


### PR DESCRIPTION
[In this previous PR](https://github.com/recharts/recharts/pull/2039) I correctly identified the problem caused by the radial bar nearing 180 degrees when using the `cornerIsExternal` prop.

The fix, however, was flawed, as the `startAngle` and `endAngle` already take into account the angles for the circle tangency of the rounded corner. By adding again those angles I was just moving the bug to another smaller radial bar value.

This is the correct fix for the issue.