### PR TITLE
Remove prop types

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ The UMD build is also available on unpkg.com:
 ```html
  <script src="https://unpkg.com/react/umd/react.production.min.js"></script>
  <script src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"></script>
- <script src="https://unpkg.com/prop-types/prop-types.min.js"></script>
  <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
 ```
 

--- a/demo/component/DemoSankeyLink.js
+++ b/demo/component/DemoSankeyLink.js
@@ -1,23 +1,9 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { Tooltip, Layer } from 'recharts';
+import { Layer } from 'recharts';
 
 export default class Demo extends Component {
 
   static displayName = 'SankeyLinkDemo';
-
-  static propTypes = {
-    sourceX: PropTypes.number,
-    targetX: PropTypes.number,
-    sourceY: PropTypes.number,
-    targetY: PropTypes.number,
-    sourceControlX: PropTypes.number,
-    targetControlX: PropTypes.number,
-    sourceRelativeY: PropTypes.number,
-    targetRelativeY: PropTypes.number,
-    linkWidth: PropTypes.number,
-    index: PropTypes.number,
-  }
 
   state = {
     fill: 'url(#linkGradient)',
@@ -27,7 +13,6 @@ export default class Demo extends Component {
     const { sourceX, targetX,
       sourceY, targetY,
       sourceControlX, targetControlX,
-      sourceRelativeY, targetRelativeY,
       linkWidth,
       index,
     } = this.props;

--- a/demo/component/DemoTreemapItem.js
+++ b/demo/component/DemoTreemapItem.js
@@ -1,20 +1,7 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 
 export default class Demo extends Component {
   static displayName = 'TreemapItemDemo';
-
-  static propTypes = {
-    root: PropTypes.object,
-    depth: PropTypes.number,
-    x: PropTypes.number,
-    y: PropTypes.number,
-    width: PropTypes.number,
-    height: PropTypes.number,
-    index: PropTypes.number,
-    payload: PropTypes.object,
-    bgColors: PropTypes.arrayOf(PropTypes.string),
-  };
 
   static defaultProps = {};
 
@@ -23,7 +10,7 @@ export default class Demo extends Component {
   }
 
   render() {
-    const { root, depth, x, y, width, height, index, rank, name, bgColors } = this.props;
+    const { depth, x, y, width, height, index, name, bgColors } = this.props;
 
     return (
       <g>

--- a/demo/container/App.js
+++ b/demo/container/App.js
@@ -1,14 +1,8 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import PropTypes from 'prop-types';
 import components from '../component/index';
 
 class App extends Component {
-  static propTypes = {
-    params: PropTypes.object,
-    location: PropTypes.object,
-  };
-
   renderList() {
     const items = Object.keys(components).map(key => {
       const group = components[key];

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "d3-scale": "^3.1.0",
     "d3-shape": "^1.3.5",
     "lodash": "^4.17.5",
-    "prop-types": "^15.6.0",
     "react-resize-detector": "^4.2.1",
     "react-smooth": "^1.0.5",
     "recharts-scale": "^0.4.2",

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -1,19 +1,10 @@
 import React, { cloneElement } from 'react';
-import PropTypes from 'prop-types';
 import _ from 'lodash';
 import Label, { ContentType } from './Label';
 import Layer from '../container/Layer';
 import { findAllByType } from '../util/ReactUtils';
 import { getValueByDataKey } from '../util/ChartUtils';
 import { filterProps, DataKey } from '../util/types';
-
-const propTypes = {
-  id: PropTypes.string,
-  data: PropTypes.arrayOf(PropTypes.object),
-  valueAccessor: PropTypes.func,
-  clockWise: PropTypes.bool,
-  dataKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.func]),
-};
 
 interface Data {
   value?: number | string | Array<number | string>;
@@ -64,7 +55,6 @@ function LabelList<T extends Data>(props: Props<T>) {
   );
 }
 
-LabelList.propTypes = propTypes;
 LabelList.displayName = 'LabelList';
 
 function parseLabelList<T extends Data>(label: any, data: Array<T>) {

--- a/test/specs/chart/AreaChartSpec.js
+++ b/test/specs/chart/AreaChartSpec.js
@@ -5,7 +5,7 @@ import { AreaChart, Area, XAxis, YAxis, Tooltip, Brush, Legend, CartesianAxis } 
 import { mount, render } from 'enzyme';
 import sinon from 'sinon';
 
-/* eslint-disable max-len, react/prop-types */
+/* eslint-disable max-len */
 
 const data = [{ name: 'Page A', uv: 400, pv: 2400, amt: 2400 },
   { name: 'Page B', uv: 300, pv: 4567, amt: 2400 },

--- a/test/specs/chart/FunnelChartSpec.js
+++ b/test/specs/chart/FunnelChartSpec.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { FunnelChart, Funnel, Tooltip } from 'recharts';
 import { render } from 'enzyme';
 
-/* eslint-disable max-len, react/prop-types */
+/* eslint-disable max-len */
 
 const data = [
   { value: 100, name: '展现' },

--- a/test/specs/chart/LineChartSpec.js
+++ b/test/specs/chart/LineChartSpec.js
@@ -1,4 +1,4 @@
-/* eslint-disable max-len, react/prop-types */
+/* eslint-disable max-len */
 import React from 'react';
 import { expect } from 'chai';
 // eslint-disable-next-line import/no-unresolved


### PR DESCRIPTION
 * codebase uses Typescript now
 * removes need to manage `prop-types`  as a dependency or peer-dependency