### PR TITLE
Pass tickFormatter as a prop

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -419,6 +419,7 @@ class CartesianAxis extends Component<Props> {
         index: i,
         payload: entry,
         visibleTicksCount: finalTicks.length,
+        tickFormatter
       };
 
       return (


### PR DESCRIPTION
Currently custom tick has no access to the formatted value or even supplied `tickFormatter`. This change increases the composability of different charts that are able to share custom tick styling