### PR TITLE
(Fix) Add touch event transformation for outer events handler

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1316,6 +1316,10 @@ const generateCategoricalChart = ({
 
       const event = _.get(this.props, `${eventName}`);
       if (eventName && _.isFunction(event)) {
+        if (/.*touch.*/i.test(eventName)) {
+          e = e.changedTouches[0];
+        }
+
         const mouse = this.getMouseInfo(e);
         const handler = event;
 

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1316,7 +1316,13 @@ const generateCategoricalChart = ({
 
       const event = _.get(this.props, `${eventName}`);
       if (eventName && _.isFunction(event)) {
-        const mouse = this.getMouseInfo(e);
+        let mouse;
+        if (/.*touch.*/i.test(eventName)) {
+          mouse = this.getMouseInfo(e.changedTouches[0]);
+        } else {
+          mouse = this.getMouseInfo(e);
+        }
+
         const handler = event;
 
         handler(mouse, e);

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1316,10 +1316,6 @@ const generateCategoricalChart = ({
 
       const event = _.get(this.props, `${eventName}`);
       if (eventName && _.isFunction(event)) {
-        if (/.*touch.*/i.test(eventName)) {
-          e = e.changedTouches[0];
-        }
-
         const mouse = this.getMouseInfo(e);
         const handler = event;
 


### PR DESCRIPTION
Touch events can't be handled as mouse events, because position parameters are contained in Touch objects. So I add automatic transformation for TouchEvent in this case.