### PR TITLE
Fix typescript error in polar radar

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test": "cross-env NODE_ENV=test karma start test/karma.conf.js",
     "lint": "eslint './src/**/*.?(ts|tsx)'",
     "autofix": "eslint './src/**/*.?(ts|tsx)' --fix",
-    "analyse": "cross-env NODE_ENV=analyse webpack src/index.ts -o umd/Recharts.js"
+    "analyse": "cross-env NODE_ENV=analyse webpack src/index.ts -o umd/Recharts.js",
+    "tsc": "tsc"
   },
   "pre-commit": [],
   "pre-push": [

--- a/src/polar/PolarAngleAxis.tsx
+++ b/src/polar/PolarAngleAxis.tsx
@@ -12,7 +12,7 @@ import { polarToCartesian } from '../util/PolarUtils';
 
 const RADIAN = Math.PI / 180;
 const eps = 1e-5;
-interface PolarAngleAxisProps extends BaseAxisProps {
+export interface PolarAngleAxisProps extends BaseAxisProps {
   angleAxisId?: string | number;
   cx?: number;
   cy?: number;

--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -14,7 +14,7 @@ interface TickIem {
   coordinate?: number;
 }
 
-interface PolarRadiusAxisProps extends BaseAxisProps {
+export interface PolarRadiusAxisProps extends BaseAxisProps {
   cx?: number;
   cy?: number;
   radiusAxisId?: string | number;


### PR DESCRIPTION
This fixes a typescript error in `src/polar/Radar.tsx`

The error was:

```
src/polar/Radar.tsx:82:10 - error TS4026: Public static property 'getComposedData' of exported class has or is using name 'PolarAngleAxisProps' from external module "/Users/mbraak/recharts/src/polar/PolarAngleAxis" but cannot be named.

82   static getComposedData = ({
            ~~~~~~~~~~~~~~~

src/polar/Radar.tsx:82:10 - error TS4026: Public static property 'getComposedData' of exported class has or is using name 'PolarRadiusAxisProps' from external module "/Users/mbraak/recharts/src/polar/PolarRadiusAxis" but cannot be named.

82   static getComposedData = ({
```

The fix is to export `PolarAngleAxis` and `PolarRadiusAxis`.

To reproduce this: `npm run tsc`
NB: the `tsc` command is added in this pr

We noticed the error because the file `types/polar/Radar` was missing from the npm package.