### PR TITLE
Export Tooltip props TypeScript types

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -16,7 +16,7 @@ const CLS_PREFIX = 'recharts-tooltip-wrapper';
 const EPS = 1;
 export type ContentType<TValue extends ValueType, TName extends NameType> =
   | ReactElement
-  | ((props: Props<TValue, TName>) => ReactNode);
+  | ((props: TooltipProps<TValue, TName>) => ReactNode);
 
 type UniqueFunc<TValue extends ValueType, TName extends NameType> = (entry: Payload<TValue, TName>) => unknown;
 type UniqueOption<TValue extends ValueType, TName extends NameType> = boolean | UniqueFunc<TValue, TName>;
@@ -40,7 +40,7 @@ function getUniqPayload<TValue extends ValueType, TName extends NameType>(
 
 function renderContent<TValue extends ValueType, TName extends NameType>(
   content: ContentType<TValue, TName>,
-  props: Props<TValue, TName>,
+  props: TooltipProps<TValue, TName>,
 ) {
   if (React.isValidElement(content)) {
     return React.cloneElement(content, props);
@@ -52,7 +52,7 @@ function renderContent<TValue extends ValueType, TName extends NameType>(
   return <DefaultTooltipContent {...props} />;
 }
 
-type Props<TValue extends ValueType, TName extends NameType> = DefaultProps<TValue, TName> & {
+export type TooltipProps<TValue extends ValueType, TName extends NameType> = DefaultProps<TValue, TName> & {
   allowEscapeViewBox?: {
     x?: boolean;
     y?: boolean;
@@ -91,7 +91,7 @@ type Props<TValue extends ValueType, TName extends NameType> = DefaultProps<TVal
   useTranslate3d?: boolean;
 };
 
-class Tooltip<TValue extends ValueType, TName extends NameType> extends PureComponent<Props<TValue, TName>> {
+class Tooltip<TValue extends ValueType, TName extends NameType> extends PureComponent<TooltipProps<TValue, TName>> {
   static displayName = 'Tooltip';
 
   static defaultProps = {


### PR DESCRIPTION
By doing this, these typings can be used when creating a Tooltip content component.