### PR TITLE
Allow array value for final data element of funnel chart

### DIFF
--- a/demo/component/FunnelChart.js
+++ b/demo/component/FunnelChart.js
@@ -29,7 +29,7 @@ const data02 = [
   { value: 50, name: '点击' },
   { value: 30, name: '访问' },
   { value: 20, name: '咨询' },
-  { value: 6, name: '订单' },
+  { value: [10, 5], name: '订单' },
 ];
 
 

--- a/src/numberAxis/Funnel.tsx
+++ b/src/numberAxis/Funnel.tsx
@@ -142,11 +142,23 @@ class Funnel extends PureComponent<Props, State> {
     const rowHeight = realHeight / len;
 
     const trapezoids = funnelData.map((entry: any, i: number) => {
-      const val = getValueByDataKey(entry, dataKey, 0);
+      const rawVal = getValueByDataKey(entry, dataKey, 0);
       const name = getValueByDataKey(entry, nameKey, i);
-      let nextVal = 0;
+      let val = rawVal;
+      let nextVal;
+
       if (i !== len - 1) {
         nextVal = getValueByDataKey(funnelData[i + 1], dataKey, 0);
+
+        if (nextVal instanceof Array) {
+          nextVal = nextVal[0];
+        }
+      }
+      else if (rawVal instanceof Array && rawVal.length === 2) {
+        [val, nextVal] = rawVal;
+      }
+      else {
+        nextVal = 0;
       }
 
       const x = ((maxValue - val) * realWidth) / (2 * maxValue) + top + 25 + offsetX;


### PR DESCRIPTION
For original issue see:
https://github.com/recharts/recharts/issues/2214

After digging through some code I established the docs were out of whack, but I reeeeeally wanted the feature.

This PR allows for the final element in the Funnel component's data prop to be a 2 element array, the first element representing the normal value, and the second element determining the final width of the funnel, which is currently hard-coded to 0.