### PR TITLE
Add payloadIndex to cursor props

### DIFF
--- a/demo/component/BarChart.js
+++ b/demo/component/BarChart.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import {
   BarChart, Bar, Brush, Cell, CartesianGrid, ReferenceLine, ReferenceArea,
-  XAxis, YAxis, Tooltip, Legend, ErrorBar, LabelList
+  XAxis, YAxis, Tooltip, Legend, ErrorBar, LabelList, Rectangle
 } from 'recharts';
 import { scaleOrdinal } from 'd3-scale';
 import { schemeCategory10 } from 'd3-scale-chromatic';
@@ -156,6 +156,11 @@ const CustomBar = (props) => {
 
   return null;
 };
+
+const CustomCursor = (props) => {
+  const { x, y, width, height, fill, payloadIndex } = props;
+  return (<Rectangle x={x} y={y} fill={fill} width={width} height={height} onMouseEnter={() => console.log(payloadIndex)} />);
+}
 
 class BarTwo extends Component {
   getPath() {
@@ -541,6 +546,18 @@ export default class Demo extends Component {
             <Bar dataKey="bmk" fill="#183a91">
               <LabelList position="insideTop" fill="#ffffff" invertNegativesOn="vertical" />
             </Bar>
+          </BarChart>
+        </div>
+
+        <p>Custom cursor with hover action</p>
+        <div className="bar-chart-wrapper">
+          <BarChart width={500} height={300} data={data} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip cursor={<CustomCursor />} />
+            <Legend />
+            <Bar dataKey="pv" fill="#8884d8" />
           </BarChart>
         </div>
 

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -315,7 +315,7 @@ const generateCategoricalChart = ({
         };
 
         const updatesToState = {
-          ...this.getTooltipData(),  // Update the current tooltip data (in case it changes without mouse interaction)
+          ...this.getTooltipData(), // Update the current tooltip data (in case it changes without mouse interaction)
           updateId: updateId + 1,
         };
 
@@ -329,7 +329,7 @@ const generateCategoricalChart = ({
           ...newState,
           ...this.updateStateOfAxisMapsOffsetAndStackGroups({
             props: nextProps,
-            ...newState
+            ...newState,
           }),
         });
       } else if (!isChildrenEqual(nextProps.children, children)) {
@@ -1490,7 +1490,7 @@ const generateCategoricalChart = ({
     }
 
     renderCursor = (element: any) => {
-      const { isTooltipActive, activeCoordinate, activePayload, offset } = this.state;
+      const { isTooltipActive, activeCoordinate, activePayload, offset, activeTooltipIndex } = this.state;
 
       if (!element || !element.props.cursor || !isTooltipActive || !activeCoordinate) {
         return null;
@@ -1528,6 +1528,7 @@ const generateCategoricalChart = ({
         ...restProps,
         ...filterProps(element.props.cursor),
         payload: activePayload,
+        payloadIndex: activeTooltipIndex,
         key,
         className: 'recharts-tooltip-cursor',
       };


### PR DESCRIPTION
Adding `payloadIndex: activeTooltipIndex` as a cursorProp so that one might be able to access the datas index in a custom cursor component.

My use case is that I will add a `onMouseEnter` event to my custom cursor component which updates a stored index as the mouse goes across each highlighted cursor area rather than only the bar itself.