### PR TITLE
Adding SVG passthrough props to axis prop types

### DIFF
--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -45,6 +45,7 @@ interface LabelProps {
   children?: ReactNode;
   className?: string;
   content?: ContentType;
+  angle?: number;
 }
 
 type Props = Omit<PresentationAttributes<SVGTextElement>, 'viewBox'> & LabelProps;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -480,6 +480,9 @@ export interface BaseAxisProps {
   range?: Array<number>;
   /** axis react component */
   AxisComp?: any;
+  /** SVG passthrough props. Note: this isn't exhaustive */
+  fontFamily?: string;
+  fontSize?: string | number;
 };
 
 export type AxisInterval = number | 'preserveStart' | 'preserveEnd' | 'preserveStartEnd';


### PR DESCRIPTION
In `CartisianAxis.tsx:361` it's passing props that on line 392 include the props given to the axis. Thus, if you give `fontSize` and `fontFamily` to an `XAxis`, it will properly apply those attributes to the underlying `<text>` elements of the axis labels. However, the type def for `BaseAxisProps` doesn't include any SVGElement props.

These are the two that I need. Instead of trying to add an exhaustive list I figure people can request them or make their own PRs.