### PR TITLE
fix: defer when syncing to other charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1198,7 +1198,7 @@ const generateCategoricalChart = ({
       }
     };
 
-    handleReceiveSyncEvent = (cId: any, chartId: any, data: any) => {
+    handleReceiveSyncEvent = (cId: number | string, chartId: string, data: CategoricalChartState) => {
       const { syncId, layout } = this.props;
       const { updateId } = this.state;
 
@@ -1425,7 +1425,7 @@ const generateCategoricalChart = ({
       }
     };
 
-    triggerSyncEvent(data: any) {
+    triggerSyncEvent(data: CategoricalChartState) {
       const { syncId } = this.props;
 
       if (!_.isNil(syncId)) {

--- a/src/util/Events.ts
+++ b/src/util/Events.ts
@@ -1,6 +1,12 @@
 import EventEmitter from 'eventemitter3';
 
-const eventCenter: any = new EventEmitter();
+type CategoricalChartState = import('../chart/generateCategoricalChart').CategoricalChartState;
+
+interface EventCenter extends EventEmitter<EventTypes> {
+  setMaxListeners?(maxListeners: number): void;
+  _maxListeners?: number;
+}
+const eventCenter: EventCenter = new EventEmitter();
 
 if (eventCenter.setMaxListeners) {
   eventCenter.setMaxListeners(10);
@@ -8,3 +14,8 @@ if (eventCenter.setMaxListeners) {
 
 export { eventCenter };
 export const SYNC_EVENT = 'recharts.syncMouseEvents';
+
+type SYNC_EVENT = typeof SYNC_EVENT;
+interface EventTypes {
+  [SYNC_EVENT](syncId: number | string, uniqueChartId: string, data: CategoricalChartState): void;
+}


### PR DESCRIPTION
With 8 charts syncing, i noticed some serious jank with the `Line` and `Tooltip`. Simple fix by yielding the event loop. Debouncing could also be effective.

Also includes some typescript typing improvements.

If desired, I'm also open to contributing more typing improvements.