### PR TITLE
fix: readd sign support for stacks

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -137,7 +137,7 @@ export interface CategoricalChartProps {
   height?: number;
   data?: any[];
   layout?: LayoutType;
-  stackOffset?: 'sign' | 'expand' | 'none' | 'wiggle' | 'silhouette' | 'diverging';
+  stackOffset?: 'sign' | 'expand' | 'none' | 'wiggle' | 'silhouette';
   throttleDelay?: number;
   margin?: Margin;
   barCategoryGap?: number | string;

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -137,7 +137,7 @@ export interface CategoricalChartProps {
   height?: number;
   data?: any[];
   layout?: LayoutType;
-  stackOffset?: 'sign' | 'expand' | 'none' | 'wiggle' | 'silhouette';
+  stackOffset?: 'sign' | 'expand' | 'none' | 'wiggle' | 'silhouette' | 'diverging';
   throttleDelay?: number;
   margin?: Margin;
   barCategoryGap?: number | string;

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -4,6 +4,7 @@ import * as d3Scales from 'd3-scale';
 import {
   stack as shapeStack,
   stackOrderNone,
+  stackOffsetDiverging,
   stackOffsetExpand,
   stackOffsetNone,
   stackOffsetSilhouette,
@@ -739,6 +740,7 @@ export const offsetSign = (series: any) => {
 
 const STACK_OFFSET_MAP: Record<string, any> = {
   sign: offsetSign,
+  diverging: stackOffsetDiverging,
   expand: stackOffsetExpand,
   none: stackOffsetNone,
   silhouette: stackOffsetSilhouette,

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -4,7 +4,6 @@ import * as d3Scales from 'd3-scale';
 import {
   stack as shapeStack,
   stackOrderNone,
-  stackOffsetDiverging,
   stackOffsetExpand,
   stackOffsetNone,
   stackOffsetSilhouette,
@@ -716,13 +715,12 @@ export const offsetSign = (series: any) => {
     return;
   }
 
-  for (let j = 0, m = series[0].length; j < m; ++j) {
+  for (let j = 0; j < series[0].length; ++j) {
     let positive = 0;
     let negative = 0;
 
     for (let i = 0; i < n; ++i) {
       const value = _.isNaN(series[i][j][1]) ? series[i][j][0] : series[i][j][1];
-
       /* eslint-disable prefer-destructuring */
       if (value >= 0) {
         series[i][j][0] = positive;
@@ -740,18 +738,17 @@ export const offsetSign = (series: any) => {
 
 const STACK_OFFSET_MAP: Record<string, any> = {
   sign: offsetSign,
-  diverging: stackOffsetDiverging,
   expand: stackOffsetExpand,
   none: stackOffsetNone,
   silhouette: stackOffsetSilhouette,
   wiggle: stackOffsetWiggle,
-};
+} as const;
 
-export const getStackedData = (data: any, stackItems: any, offsetType: string) => {
+export const getStackedData = (data: any, stackItems: any, offsetType: keyof typeof STACK_OFFSET_MAP) => {
   const dataKeys = stackItems.map((item: any) => item.props.dataKey);
   const stack = shapeStack()
     .keys(dataKeys)
-    .value((d, key) => Math.max(+getValueByDataKey(d, key, 0), 0))
+    .value((d, key) => getValueByDataKey(d, key, 0))
     .order(stackOrderNone)
     .offset(STACK_OFFSET_MAP[offsetType]);
 


### PR DESCRIPTION
Currently area charts which are stacked on v2 are not able to be plotted diverging.
When looking trough the code i found "sign" which seems to be similar, but doesn't work in version 2.
https://codesandbox.io/s/wandering-feather-meu6s?file=/src/Chart.js

Not sure i it would make sense to drop the custom "sign" code in favor of "diverging"(that's how it's called in d3 as i get it).

With this patch:
![image](https://user-images.githubusercontent.com/4396533/94622297-3fa2cc00-02b2-11eb-9994-7517ef0d33e3.png)

Examples from the docs like: http://recharts.org/en-US/examples/BarChartStackedBySign are completely broken on vs atm