### PR TITLE
allow react 17 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   },
   "homepage": "https://github.com/recharts/recharts",
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.0.0 || ^17.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.5",


### PR DESCRIPTION
React 17 doesn't have breaking changes, at least not for a project as new as v2 of this lib. Can't see why this would be a problem