### PR TITLE
Remove core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "core-js": "^3.4.2",
     "d3-interpolate": "^1.3.0",
     "d3-scale": "^3.1.0",
     "d3-shape": "^1.3.5",
@@ -79,7 +78,6 @@
     "@babel/plugin-proposal-function-bind": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
     "@babel/plugin-transform-runtime": "^7.6.2",
-    "@babel/polyfill": "^7.6.0",
     "@babel/preset-env": "^7.6.3",
     "@babel/preset-react": "^7.6.3",
     "@babel/preset-typescript": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "jsnext:main": "es6/index",
   "types": "types/index.d.ts",
   "sideEffects": [
-    "./*/index.js",
-    "./*/polyfill.js"
+    "./*/index.js"
   ],
   "files": [
     "*.md",

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1596,7 +1596,7 @@ const generateCategoricalChart = ({
       const { xAxisMap, yAxisMap, offset } = this.state;
       const { width, height } = this.props;
       const xAxis = getAnyElementOfObject(xAxisMap);
-      const yAxisWithFiniteDomain = _.find(yAxisMap, axis => _.every(axis.domain, Number.isFinite));
+      const yAxisWithFiniteDomain = _.find(yAxisMap, axis => _.every(axis.domain, isFinite));
       const yAxis = yAxisWithFiniteDomain || getAnyElementOfObject(yAxisMap);
       const props = element.props || {};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import './polyfill';
-
 export { default as Surface } from './container/Surface';
 export { default as Layer } from './container/Layer';
 

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -1,2 +1,6 @@
-import 'core-js/es/math';
-import 'core-js/es/number';
+// Polyfill isFinite because IE does
+// not support it.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite#Polyfill
+if (Number.isFinite === undefined) Number.isFinite = function(value) {
+  return typeof value === 'number' && isFinite(value);
+}

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -1,6 +1,0 @@
-// Polyfill isFinite because IE does
-// not support it.
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite#Polyfill
-if (Number.isFinite === undefined) Number.isFinite = function(value) {
-  return typeof value === 'number' && isFinite(value);
-}

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -1,16 +1,2 @@
 import 'core-js/es/math';
 import 'core-js/es/number';
-/* eslint no-proto: 0 */
-const testObject = {} as any;
-
-if (!(Object.setPrototypeOf || testObject.__proto__)) {
-  const nativeGetPrototypeOf = Object.getPrototypeOf;
-
-  Object.getPrototypeOf = object => {
-    if (object.__proto__) {
-      return object.__proto__;
-    }
-
-    return nativeGetPrototypeOf.call(Object, object);
-  };
-}


### PR DESCRIPTION
This fixes Issue #2262 and #2195 as it increases portability.

It addresses usage of the `number` import in `core-js` as a polyfill. The first (`math`) has already been fixed  by @xile611  in 2017.

Thus, the entire `polyfill` module is not needed, and it is removed.

## core-js/es/math

`Math` polyfill is removed because `Math.sign` was already ported in [560dc6f81dfe94d13be34db5fab557174655f3bd](https://github.com/recharts/recharts/commit/560dc6f81dfe94d13be34db5fab557174655f3bd) 

https://github.com/recharts/recharts/blob/d08e0cfad24140bd47340fd07724226dc7c4b45d/src/util/DataUtils.ts#L3-L12

## core-js/es/number

`Number.isFinite` is still in use, so ~I added the reference polyfill from MDN~. EDIT: updated to just fix  1 line to use [`isFinite`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isFinite#Browser_compatibility) instead of qualified [`Number.isFinite`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite#Browser_compatibility) reference, which does not work in IE.

https://github.com/recharts/recharts/blob/d08e0cfad24140bd47340fd07724226dc7c4b45d/src/chart/generateCategoricalChart.tsx#L1599

**Note**: The package lockfile needs to be regenerated to reflect the removal of _core-js_. I can do this, but only using the new lock format in npm 7+.
