### PR TITLE
Fixing Pie Charts rendering SVG Paths without inner arc commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5794,7 +5794,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5815,12 +5816,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5835,17 +5838,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5962,7 +5968,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5974,6 +5981,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5988,6 +5996,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5995,12 +6004,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6019,6 +6030,7 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -6080,7 +6092,8 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -6108,7 +6121,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6120,6 +6134,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6197,7 +6212,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6233,6 +6249,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6252,6 +6269,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6295,12 +6313,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/shape/Sector.tsx
+++ b/src/shape/Sector.tsx
@@ -157,7 +157,7 @@ const getSectorWithCorner = ({
       ? Math.abs(startAngle - endAngle)
       : Math.abs(startAngle - endAngle) - sit - eit;
 
-    if (innerArcAngle < 0) {
+    if (innerArcAngle < 0 && cornerRadius === 0) {
       return `${path}L${cx},${cy}Z`;
     }
 


### PR DESCRIPTION
When the render functionality for the Pie component is generating its' sector SVG paths, if a developer has specified "corner radius" in the props of the Pie component, the SVG path won't include the inner arc commands in certain situations.

You can see this issue demonstrated [here](https://github.com/recharts/recharts/issues/2330), by setting the AnimationDuration prop on the pie component to a large value like "10000".

This commit will fix the jumping animation effects we see when rendering a Pie Chart with round corners and an inner radius defined.
