### PR TITLE
Add ability to pass in custom legend icon.

### DIFF
--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -103,6 +103,9 @@ class DefaultLegendContent<TValue, TID> extends PureComponent<Props<TValue, TID>
         />
       );
     }
+    if (React.isValidElement(data.legendIcon)) {
+      return React.cloneElement(data.legendIcon);
+    }
 
     return (
       <Symbols


### PR DESCRIPTION
Allow user to pass in a custom legend icon when defining a cartesian component.

Example
```
<Line legendIcon={someCustomIcom} />
```