### PR TITLE
Add property 'legendIcon' on type Payload

### DIFF
--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -24,6 +24,7 @@ export interface Payload<TValue, TID> {
   };
   formatter?: Formatter<TValue, TID>;
   inactive?: boolean;
+  legendIcon?: ReactElement;
 }
 
 export interface Props<TValue, TID> {
@@ -143,7 +144,7 @@ class DefaultLegendContent<TValue, TID> extends PureComponent<Props<TValue, TID>
       if (entry.type === 'none') {
         return null;
       }
-      
+
       const color = entry.inactive ? inactiveColor : entry.color;
 
       return (
@@ -156,7 +157,7 @@ class DefaultLegendContent<TValue, TID> extends PureComponent<Props<TValue, TID>
           <Surface width={iconSize} height={iconSize} viewBox={viewBox} style={svgStyle}>
             {this.renderIcon(entry)}
           </Surface>
-          <span className="recharts-legend-item-text" style={{color}}>
+          <span className="recharts-legend-item-text" style={{ color }}>
             {finalFormatter ? finalFormatter(entry.value, entry, i) : entry.value}
           </span>
         </li>


### PR DESCRIPTION
This fixes a typescript error in src/component/DefaultLegendContent.tsx
and also modified chore things - formatting code with prettier 

You can check this error using `npm run tsc`

```
src/component/DefaultLegendContent.tsx:106:35 - error TS2339: Property 'legendIcon' does not exist on type 'Payload<TValue, TID>'.

106     if (React.isValidElement(data.legendIcon)) {
                                      ~~~~~~~~~~

src/component/DefaultLegendContent.tsx:107:38 - error TS2339: Property 'legendIcon' does not exist on type 'Payload<TValue, TID>'.

107       return React.cloneElement(data.legendIcon);
                                         ~~~~~~~~~~
```
