### PR TITLE
Allow Duplicated Category for bar charts not using correct entries for custom tool tips

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -764,7 +764,8 @@ const generateCategoricalChart = ({
 
         if (tooltipAxis.dataKey && !tooltipAxis.allowDuplicatedCategory) {
           // graphic child has data props
-          payload = findEntryInArray(data || displayedData, tooltipAxis.dataKey, activeLabel);
+          const entries = (data === undefined) ? displayedData : data;
+          payload = findEntryInArray(entries, tooltipAxis.dataKey, activeLabel);
         } else {
           payload = (data && data[activeIndex]) || displayedData[activeIndex];
         }


### PR DESCRIPTION
You can see this issue re-created in issues #2348 and #2206.

When trying to use an axes that has the "allowDuplicatedCategory" prop set to false and a custom tool tip defined:
```html
<BarChart>
...
<XAxis AllowDuplicatedCategory={false} />
<Tooltip content={<CustomTooltip />} />
...
</BarChart>
```
the user will get back "property=[]" and the tooltip just won't appear.

This is due to a coalescing that we use in our typescript that is just not evaluating correctly. With this pull request I change how we perform our coalescing and now the values all begin to pull correctly.

