### PR TITLE
Visibility of Radial Lines in Radar Charts

### DIFF
--- a/demo/component/PolarGrid.js
+++ b/demo/component/PolarGrid.js
@@ -20,6 +20,7 @@ export default class Demo extends Component {
           height={500}
           polarAngles={polarAngles}
           polarRadius={polarRadius}
+          radialLines={true}
         />
       </Surface>
     );

--- a/demo/component/RadarChart.js
+++ b/demo/component/RadarChart.js
@@ -50,7 +50,7 @@ export default class Demo extends Component {
         <br/>
         <p>A simple RadarChart</p>
         <RadarChart cx={300} cy={250} outerRadius={150} width={600} height={500} data={data}>
-          <PolarGrid />
+          <PolarGrid radialLines={true} />
           <PolarAngleAxis dataKey="subject" />
           <Radar name="Mike" dataKey="A" stroke="#8884d8" fill="#8884d8" fillOpacity={0.6} />
         </RadarChart>
@@ -64,7 +64,7 @@ export default class Demo extends Component {
           height={500}
           data={data}
         >
-          <PolarGrid />
+          <PolarGrid radialLines={true} />
           <Tooltip />
           <Radar
             name="Mike"
@@ -90,7 +90,7 @@ export default class Demo extends Component {
         <div style={{ width: '100%', height: '100%' }}>
           <ResponsiveContainer>
             <RadarChart data={data}>
-              <PolarGrid />
+              <PolarGrid radialLines={true}/>
               <PolarAngleAxis dataKey="subject" />
               <PolarRadiusAxis />
               <Tooltip />

--- a/demo/component/ResponsiveContainer.js
+++ b/demo/component/ResponsiveContainer.js
@@ -308,7 +308,7 @@ export default class Demo extends Component {
           <ResponsiveContainer>
             <RadarChart outerRadius={150} data={data05}>
               <Radar name="Mike" dataKey="A" stroke="#8884d8" fill="#8884d8" fillOpacity={0.6} />
-              <PolarGrid />
+              <PolarGrid radialLines={true} />
               <PolarAngleAxis dataKey="subject" />
               <PolarRadiusAxis />
             </RadarChart>

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1618,6 +1618,7 @@ const generateCategoricalChart = ({
     };
 
     renderPolarGrid = (element: React.ReactElement): React.ReactElement => {
+      const { radialLines } = element.props;
       const { radiusAxisMap, angleAxisMap } = this.state;
       const radiusAxis = getAnyElementOfObject(radiusAxisMap);
       const angleAxis = getAnyElementOfObject(angleAxisMap);
@@ -1631,6 +1632,7 @@ const generateCategoricalChart = ({
         innerRadius,
         outerRadius,
         key: element.key || 'polar-grid',
+        radialLines
       });
     };
 

--- a/src/polar/PolarGrid.tsx
+++ b/src/polar/PolarGrid.tsx
@@ -14,6 +14,7 @@ interface PolarGridProps {
   polarAngles?: number[];
   polarRadius?: number[];
   gridType?: 'polygon' | 'circle';
+  radialLines: boolean;
 }
 type Props = PresentationAttributes<SVGPathElement> & PolarGridProps;
 
@@ -26,6 +27,7 @@ class PolarGrid extends PureComponent<Props> {
     innerRadius: 0,
     outerRadius: 0,
     gridType: 'polygon',
+    radialLines: true,
   };
 
   getPolygonPath(radius: number) {
@@ -35,7 +37,7 @@ class PolarGrid extends PureComponent<Props> {
 
     polarAngles.forEach((angle, i) => {
       const point = polarToCartesian(cx, cy, radius, angle);
-
+      
       if (i) {
         path += `L ${point.x},${point.y}`;
       } else {
@@ -52,9 +54,9 @@ class PolarGrid extends PureComponent<Props> {
    * @return {[type]} The lines
    */
   renderPolarAngles() {
-    const { cx, cy, innerRadius, outerRadius, polarAngles } = this.props;
+    const { cx, cy, innerRadius, outerRadius, polarAngles, radialLines } = this.props;
 
-    if (!polarAngles || !polarAngles.length) {
+    if (!polarAngles || !polarAngles.length || !radialLines) {
       return null;
     }
     const props = {


### PR DESCRIPTION
This pull request is in relation to issue #2323.

The developer on the issue is requesting to control the visibility of radial lines on a radar component:
 
> The **lines that go from the center to each corner** of the polygon should not be displayed when providing an empty array as value for the polarAngles prop...

but we are unable to do this because our polarAngles prop controls the visibility of our circular lines along with our radial lines in a radar component, thus controlling the visibility of the radial lines through the polarAngles prop is not possible.

Instead I've made a radialLines prop on the PolarGrid component, that can be used like this:
```html
<RadarChart>
...
<PolarGrid radialLines={false}> // radialLines can be set to true or false, but defaults to true
...
</RadarChart>
```

Below are our demo examples with radialLines set to either true or false
|True|False|
| --- | --- |
| ![image](https://user-images.githubusercontent.com/3454995/102868505-e1444000-43ff-11eb-8a0a-2e8a826eac26.png) | ![image](https://user-images.githubusercontent.com/3454995/102868650-0cc72a80-4400-11eb-8b5e-f17eab2b40bf.png) |
| ![image](https://user-images.githubusercontent.com/3454995/102868776-3da75f80-4400-11eb-82f9-3017986f5c7a.png) | ![image](https://user-images.githubusercontent.com/3454995/102868847-59ab0100-4400-11eb-9184-576208cc791b.png) |
| ![image](https://user-images.githubusercontent.com/3454995/102868936-7c3d1a00-4400-11eb-9650-b22ab4d107ba.png) | ![image](https://user-images.githubusercontent.com/3454995/102868986-94149e00-4400-11eb-9d61-2d263f6e065e.png) |
| ![image](https://user-images.githubusercontent.com/3454995/102869037-ab538b80-4400-11eb-8483-183f4c2bf73d.png) | ![image](https://user-images.githubusercontent.com/3454995/102869126-c6260000-4400-11eb-99ba-24816fb0e308.png) |
