### PR TITLE
chore: add missing backtick in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 
 ### feat
 
-- add props `reversed` to `<Funnel /> 
-- add `breakAll` props to `<Text />` to allow break all for chinese 
+- add props `reversed` to `<Funnel />`
+- add `breakAll` props to `<Text />` to allow break all for chinese
 - fix width of labelList in Funnel; fix #2056, #1866
 - support range RadarChart and add props `connectNulls` to <Radar />, fix #1890
 - add ability to pass in custom legend icon.
@@ -48,7 +48,7 @@
 - Fix flickering tooltip by keeping the isTooltipActive flag from the previous state
 - fix(AreaDot Type): add option to use a function that returns a react element
 - Fix typescript error in polar radar
-- Fix typos in Label.renderCallByParent 
+- Fix typos in Label.renderCallByParent
 - Add type definition for label prop on XAxis, YAxis and ZAxis
 
 ### feat
@@ -128,7 +128,7 @@
 - Fixes arc angles when `cornerIsExternal` is used
 - Invert cartesian label position based on negative values
 - Fix usage of hooks in Tooltip, Label, Legend and Customized
-- Move draging-end listener to the window for brush 
+- Move draging-end listener to the window for brush
 - Fix trigger after mouse leave
 - Added the angle as key which need to be used in the Label align
 - Rewrite index.js to index.ts, update scripts in package.json
@@ -143,7 +143,7 @@
 ### fix
 
 - fix error parameters in `appendOffsetOfLegend`
-- fix style of <Area /> 
+- fix style of <Area />
 
 ## 2.0.0-beta.0 (Dec 03, 2019)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
# The issue

A missing backtick (`` ` ``) in the `CHANGELOG.md` file prevents the text from showing in HTML.

# The solution

- Add missing backtick in `CHANGELOG.md`
- It seems like eslint running in my machine's VS Code has also removed some empty space characters at the end of several other lines in the `CHANGELOG.md` file
- Update `package-lock.json` file automatically when running `npm i` locally
  - The current version of this library has moved to `2.0.0`, which is now reflected in the `package-lock.json` file

# Visuals

Before | After
----- | -----
![recharts-changelog-0](https://user-images.githubusercontent.com/11624407/103369784-a9d53380-4a90-11eb-880b-b1f940291d94.png) | ![recharts-changelog-1](https://user-images.githubusercontent.com/11624407/103369799-ae015100-4a90-11eb-967f-6ad15005f95f.png)

# Test cases

1. Get this code
2. Open up `README.md` and preview the file using a markdown preview plugin for your text editor
    - Or you can trust the images above 😇 

