### PR TITLE
[2/3] Fix/squelch problems reported by linter

### DIFF
--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -96,6 +96,7 @@ function ErrorBar(props: Props) {
       // eslint-disable-next-line react/no-array-index-key
       <Layer className="recharts-errorBar" key={`bar-${i}`} {...svgProps}>
         {lineCoordinates.map((coordinates, index) => (
+          // eslint-disable-next-line react/no-array-index-key
           <line {...coordinates} key={`line-${index}`} />
         ))}
       </Layer>

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -274,6 +274,7 @@ class Line extends PureComponent<Props, State> {
 
     return errorBarItems.map((item: ReactElement<ErrorBarProps>, i: number) =>
       React.cloneElement(item, {
+        // eslint-disable-next-line react/no-array-index-key
         key: `bar-${i}`,
         data: points,
         xAxis,

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -1,6 +1,7 @@
 /**
  * @fileOverview X Axis
  */
+import type { FunctionComponent } from 'react';
 import { BaseAxisProps, AxisInterval, PresentationAttributes } from '../util/types';
 
 /** Define of XAxis props */
@@ -30,9 +31,7 @@ interface XAxisProps extends BaseAxisProps {
 
 export type Props = PresentationAttributes<SVGElement> & XAxisProps;
 
-function XAxis(props: Props): any {
-  return null;
-}
+const XAxis: FunctionComponent<Props> = () => null;
 
 XAxis.displayName = 'XAxis';
 XAxis.defaultProps = {

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -1,6 +1,7 @@
 /**
  * @fileOverview Y Axis
  */
+import type { FunctionComponent } from 'react';
 import { BaseAxisProps, AxisInterval, PresentationAttributes } from '../util/types';
 
 interface YAxisProps extends BaseAxisProps {
@@ -30,9 +31,7 @@ interface YAxisProps extends BaseAxisProps {
 
 export type Props = PresentationAttributes<SVGElement> & YAxisProps;
 
-function YAxis(props: Props): any {
-  return null;
-}
+const YAxis: FunctionComponent<Props> = () => null;
 
 YAxis.displayName = 'YAxis';
 YAxis.defaultProps = {

--- a/src/cartesian/ZAxis.tsx
+++ b/src/cartesian/ZAxis.tsx
@@ -1,6 +1,7 @@
 /**
  * @fileOverview Z Axis
  */
+import type { FunctionComponent } from 'react';
 import { ScaleType, DataKey, AxisDomain } from '../util/types';
 
 export interface Props {
@@ -20,9 +21,7 @@ export interface Props {
   domain?: AxisDomain;
 }
 
-function ZAxis(props: Props): any {
-  return null;
-}
+const ZAxis: FunctionComponent<Props> = () => null;
 
 ZAxis.displayName = 'ZAxis';
 ZAxis.defaultProps = {

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -66,6 +66,10 @@ import {
   adaptEventHandlers,
 } from '../util/types';
 
+// use legacy isFinite only if there is a problem (aka IE)
+// eslint-disable-next-line no-restricted-globals
+const isFinit = Number.isFinite ? Number.isFinite : isFinite;
+
 const ORIENT_MAP = {
   xAxis: ['bottom', 'top'],
   yAxis: ['left', 'right'],
@@ -1597,7 +1601,7 @@ const generateCategoricalChart = ({
       const { xAxisMap, yAxisMap, offset } = this.state;
       const { width, height } = this.props;
       const xAxis = getAnyElementOfObject(xAxisMap);
-      const yAxisWithFiniteDomain = _.find(yAxisMap, axis => _.every(axis.domain, isFinite));
+      const yAxisWithFiniteDomain = _.find(yAxisMap, axis => _.every(axis.domain, isFinit));
       const yAxis = yAxisWithFiniteDomain || getAnyElementOfObject(yAxisMap);
       const props = element.props || {};
 

--- a/src/component/Cell.tsx
+++ b/src/component/Cell.tsx
@@ -1,13 +1,13 @@
 /**
  * @fileOverview Cross
  */
+import type { FunctionComponent } from 'react';
 import { PresentationAttributes } from '../util/types';
 
 export type Props = PresentationAttributes<SVGElement>;
 
-function Cell(props: Props): null {
-  return null;
-}
+const Cell: FunctionComponent<Props> = () => null;
+
 Cell.displayName = 'Cell';
 
 export default Cell;

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -379,8 +379,6 @@ function Label(props: Props) {
 
   const positionAttrs = isPolarLabel ? getAttrsOfPolarLabel(props) : getAttrsOfCartesianLabel(props);
 
-  console.log('positionAttrs', positionAttrs);
-
   return (
     <Text className={classNames('recharts-label', className)} {...attrs} {...(positionAttrs as any)} breakAll={textBreakAll}>
       {label}

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -50,7 +50,7 @@ export type Props<TValue, TID> = DefaultProps<TValue, TID> & {
     right?: number;
   };
   payloadUniqBy?: UniqueOption<TValue, TID>;
-  onBBoxUpdate?: (box: ClientRect | DOMRect | null) => void;
+  onBBoxUpdate?: (box: DOMRect | null) => void;
 };
 
 interface State {

--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -85,8 +85,6 @@ const calculateWordsByLines = (
       result.push(newLine);
     }
 
-    console.log(result);
-
     return result;
   }, []);
 }
@@ -168,8 +166,6 @@ class Text extends Component<Props, State> {
       ...textProps
     } = this.props;
     const { wordsByLines } = this.state;
-
-    console.log(textProps.x, textProps.y, this.props.children, wordsByLines, this.props);
 
     if (!isNumOrStr(textProps.x) || !isNumOrStr(textProps.y)) {
       return null;

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Tooltip
  */
-import React, { PureComponent, CSSProperties, ReactNode, ReactElement, ReactText } from 'react';
+import React, { PureComponent, CSSProperties, ReactNode, ReactElement } from 'react';
 import { translateStyle } from 'react-smooth';
 import _ from 'lodash';
 import classNames from 'classnames';

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -192,7 +192,6 @@ class Pie extends PureComponent<Props, State> {
     const { cornerRadius, startAngle, endAngle, paddingAngle, dataKey, nameKey, valueKey, tooltipType } = item.props;
     const minAngle = Math.abs(item.props.minAngle);
     const coordinate = Pie.parseCoordinateOfPie(item, offset);
-    const len = pieData.length;
     const deltaAngle = Pie.parseDeltaAngle(startAngle, endAngle);
     const absDeltaAngle = Math.abs(deltaAngle);
     

--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -9,11 +9,6 @@ import Layer from '../container/Layer';
 import { polarToCartesian } from '../util/PolarUtils';
 import { PresentationAttributes, filterProps, BaseAxisProps, TickItem, adaptEventsOfChild } from '../util/types';
 
-interface TickIem {
-  value?: any;
-  coordinate?: number;
-}
-
 export interface PolarRadiusAxisProps extends BaseAxisProps {
   cx?: number;
   cy?: number;

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -746,7 +746,6 @@ export const offsetPositive = (series: any) => {
 
   for (let j = 0, m = series[0].length; j < m; ++j) {
     let positive = 0;
-    let negative = 0;
 
     for (let i = 0; i < n; ++i) {
       const value = _.isNaN(series[i][j][1]) ? series[i][j][0] : series[i][j][1];
@@ -759,7 +758,6 @@ export const offsetPositive = (series: any) => {
       } else {
         series[i][j][0] = 0;
         series[i][j][1] = 0;
-        negative = series[i][j][1];
       }
       /* eslint-enable prefer-destructuring */
     }

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -19,8 +19,6 @@ const REACT_BROWSER_EVENT_MAP: any = {
   touchstart: 'onTouchStart',
 };
 
-type eventFunc = (data: any, index: number, e: any) => {};
-
 export const SCALE_TYPES = [
   'auto',
   'linear',


### PR DESCRIPTION
This PR was split from #2361 to help make reviewing a little easier. It addresses unused variables, `console.log`, an unused type and a legacy type.

 * Manually address lint warnings without autofixers
 * remove console.log (#2363)
 * Remove `ClientRect` (causes errors after doing upgrades in #2361)
 * Remove a few unused variables and types

After these changes, eslint reports 0 errors and 0 warnings. (Previously 12 warnings).

----

 :information_source: reviewer note: This should be merged _before_ the third and final PR #2367 which converges on the module definition.