### PR TITLE
Add aria-hidden to measurementSpan

### DIFF
--- a/src/util/DOMUtils.ts
+++ b/src/util/DOMUtils.ts
@@ -90,6 +90,7 @@ export const getStringSize = (text: string | number, style: CSSProperties = {}) 
     if (!measurementSpan) {
       measurementSpan = document.createElement('span');
       measurementSpan.setAttribute('id', MEASUREMENT_SPAN_ID);
+      measurementSpan.setAttribute('aria-hidden', 'true');
       document.body.appendChild(measurementSpan);
     }
     // Need to use CSS Object Model (CSSOM) to be able to comply with Content Security Policy (CSP)


### PR DESCRIPTION
This span should not be available to screen readers as it provides irrelevant information as well as potentially causes massive layout shifts.