### PR TITLE
fix(package.json): disable side effects explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "es6/index",
   "jsnext:main": "es6/index",
   "types": "types/index.d.ts",
+  "sideEffects": false,
   "files": [
     "*.md",
     "demo",


### PR DESCRIPTION
Somehow sideEffects config is removed. I guess this is when we remove the polyfill array .
The default is `true` or `true for array of file paths` so we need to explicitly specify `false` to make tree shaking work