### PR TITLE
fix(ChartUtils): prevent rerender errors in ResponsiveContainer

### DIFF
--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -57,7 +57,7 @@ export function getDomainOfDataByKey<T>(data: Array<T>, key: string, type: strin
 
 export const calculateActiveTickIndex = (
   coordinate: number,
-  ticks: Array<TickItem>,
+  ticks: Array<TickItem> = [],
   unsortedTicks: Array<TickItem>,
   axis: BaseAxisProps,
 ) => {


### PR DESCRIPTION
default ticks array of `calculateActiveTickIndex` to an empty array to prevent `Cannot read property length of undefined` error.

I'm doubt that this really fixes the root cause, but as from my tests it prevented the error and in the next render cycle the chart looked like expected.

Fixes #2385 
Fixes #2402