### PR TITLE
Bugfix for undefined ticks

### DIFF
--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -62,7 +62,7 @@ export const calculateActiveTickIndex = (
   axis: BaseAxisProps,
 ) => {
   let index = -1;
-  const len = ticks.length;
+  const len = ticks?.length ?? 0;
 
   if (len > 1) {
     if (axis && axis.axisType === 'angleAxis' && Math.abs(Math.abs(axis.range[1] - axis.range[0]) - 360) <= 1e-6) {


### PR DESCRIPTION
Hi!

I ran into a problem using a bar chart within a `<ResponsiveContainer  ... />` that was in turn inside a tab. It turned out that `ticks` was undefined, which caused an exception in `calculateActiveTickIndex`. The changes provided by this PR fixed this problem for me. Would be great if you would pull it ASAP and publish a new version.