### PR TITLE
fix connectNulls={true} not working for stacked areachart

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -223,7 +223,10 @@ export class Area extends PureComponent<Props, State> {
         if (layout === 'horizontal') {
           return {
             x: entry.x,
-            y: !_.isNil(_.get(entry, 'value[0]')) ? yAxis.scale(_.get(entry, 'value[0]')) : null,
+            y:
+              !_.isNil(_.get(entry, 'value[0]')) && !_.isNil(_.get(entry, 'y'))
+                ? yAxis.scale(_.get(entry, 'value[0]'))
+                : null,
           };
         }
         return {


### PR DESCRIPTION
my attempt at fixing #2316 . i think the baseLine for the stacked areas was calculated wrong. this lead to an index mismatch in `Curve.tsx:112`, where the points and baseLine get filtered.