### PR TITLE
Update Examples section in the README, and typing state and setState

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,16 @@ The main purpose of this library is to help you to write charts in React applica
   margin={{ top: 5, right: 20, left: 10, bottom: 5 }}
 >
   <XAxis dataKey="name" />
+  <YAxis />
   <Tooltip />
+  <Legend />
   <CartesianGrid stroke="#f5f5f5" />
   <Line type="monotone" dataKey="uv" stroke="#ff7300" yAxisId={0} />
   <Line type="monotone" dataKey="pv" stroke="#387908" yAxisId={1} />
 </LineChart>
 ```
 
-All the components of Recharts are clearly separated. The lineChart is composed of x axis, tooltip, grid, and line items, and each of them is an independent React Component. The clear separation and composition of components is one of the principle Recharts follows.
+All the components of Recharts are clearly separated. The LineChart Component is composed of XAxis, YAxis, Tooltip, Legend, CartesianGrid, and Line items, each of which are independent React Components. The clear separation and composition of components is one of the principles Recharts follows.
 
 ## Installation
 

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -59,7 +59,11 @@ interface State {
   boxHeight: number;
 }
 
-export class Legend extends PureComponent<Props, State> {
+interface SetState {
+  (arg: State): null;
+}
+
+export class Legend extends PureComponent<Props, State, SetState> {
   static displayName = 'Legend';
 
   static defaultProps = {
@@ -70,6 +74,8 @@ export class Legend extends PureComponent<Props, State> {
   };
 
   private wrapperNode: HTMLDivElement;
+
+  private setState: SetState;
 
   static getWithHeight(item: any, chartWidth: number) {
     const { layout } = item.props;

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -26,7 +26,11 @@ interface State {
   containerHeight: number;
 }
 
-export class ResponsiveContainer extends Component<Props, State> {
+interface SetState {
+  (arg: State): null;
+}
+
+export class ResponsiveContainer extends Component<Props, State, SetState> {
   static defaultProps = {
     width: '100%',
     height: '100%',
@@ -38,6 +42,10 @@ export class ResponsiveContainer extends Component<Props, State> {
   private mounted: boolean;
 
   private container: HTMLDivElement;
+
+  private state: State;
+
+  private setState: SetState;
 
   constructor(props: Props) {
     super(props);


### PR DESCRIPTION
### README ###
Added more clarity to the Examples section of the README.

### /component ###
Included typing of the state and setState properties of ResponsiveContainer and Legend