### PR TITLE
Add SyncMethod to categorical charts

### DIFF
--- a/demo/component/LineChartSyncId.tsx
+++ b/demo/component/LineChartSyncId.tsx
@@ -10,14 +10,14 @@ const data1 = [
   { name: 'Page F', uv: 189, pv: 4800, amt: 2400 },
 ];
 
-// Reversed of data1
+// X Axis mirrored
 const data2 = [
-  { name: 'Page F', uv: 189, pv: 4800, amt: 2400 },
-  { name: 'Page E', uv: 278, pv: 3908, amt: 2400 },
-  { name: 'Page D', uv: 200, pv: 9800, amt: 2400 },
-  { name: 'Page C', uv: 300, pv: 1398, amt: 2400 },
-  { name: 'Page B', uv: 300, pv: 4567, amt: 2400 },
-  { name: 'Page A', uv: 400, pv: 2400, amt: 2400 },
+  { name: 'Page F', uv: 500, pv: 4800, amt: 2400 },
+  { name: 'Page E', uv: 550, pv: 3908, amt: 2400 },
+  { name: 'Page D', uv: 800, pv: 9800, amt: 2400 },
+  { name: 'Page C', uv: 100, pv: 1398, amt: 2400 },
+  { name: 'Page B', uv: 678, pv: 4567, amt: 2400 },
+  { name: 'Page A', uv: 230, pv: 2400, amt: 2400 },
 ];
 
 const margin = { top: 20, right: 20, bottom: 20, left: 20 };
@@ -61,7 +61,9 @@ export default class Demo extends Component<any, any> {
         </button>
         <p>
           Sync Method used:
-          {syncMethod === 'value' || syncMethod === 'index' ? syncMethod : 'callback function'}
+          {!syncMethod || syncMethod === 'value' || syncMethod === 'index'
+            ? syncMethod
+            : 'callback function (index + 1)'}
         </p>
         <p>A simple LineChart with syncId = test</p>
         <div className="line-chart-wrapper">

--- a/demo/component/LineChartSyncId.tsx
+++ b/demo/component/LineChartSyncId.tsx
@@ -1,0 +1,88 @@
+import React, { Component } from 'react';
+import { LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
+
+const data1 = [
+  { name: 'Page A', uv: 400, pv: 2400, amt: 2400 },
+  { name: 'Page B', uv: 300, pv: 4567, amt: 2400 },
+  { name: 'Page C', uv: 300, pv: 1398, amt: 2400 },
+  { name: 'Page D', uv: 200, pv: 9800, amt: 2400 },
+  { name: 'Page E', uv: 278, pv: 3908, amt: 2400 },
+  { name: 'Page F', uv: 189, pv: 4800, amt: 2400 },
+];
+
+// Reversed of data1
+const data2 = [
+  { name: 'Page F', uv: 189, pv: 4800, amt: 2400 },
+  { name: 'Page E', uv: 278, pv: 3908, amt: 2400 },
+  { name: 'Page D', uv: 200, pv: 9800, amt: 2400 },
+  { name: 'Page C', uv: 300, pv: 1398, amt: 2400 },
+  { name: 'Page B', uv: 300, pv: 4567, amt: 2400 },
+  { name: 'Page A', uv: 400, pv: 2400, amt: 2400 },
+];
+
+const margin = { top: 20, right: 20, bottom: 20, left: 20 };
+const height = 400;
+const width = 400;
+
+const initialState = {
+  syncMethod: '',
+};
+
+// Example callback function that can be used to specify the algorithm
+const syncMethodFunction = (index: number, data: any) => index + 1;
+
+// eslint-disable-next-line import/no-default-export
+export default class Demo extends Component<any, any> {
+  static displayName = 'LineChartDemo Sync Method';
+
+  state: any = initialState;
+
+  setSyncMethodToValue = () => {
+    this.setState((prevState: { syncMethod: string }) => {
+      let method: any = 'index';
+      if (prevState.syncMethod === 'value') {
+        method = syncMethodFunction;
+      } else if (prevState.syncMethod === 'index') {
+        method = 'value';
+      }
+      return {
+        ...prevState,
+        syncMethod: method,
+      };
+    });
+  };
+
+  render() {
+    const { syncMethod } = this.state;
+    return (
+      <div className="line-charts">
+        <button type="button" onClick={this.setSyncMethodToValue}>
+          change sync Method
+        </button>
+        <p>
+          Sync Method used:
+          {syncMethod === 'value' || syncMethod === 'index' ? syncMethod : 'callback function'}
+        </p>
+        <p>A simple LineChart with syncId = test</p>
+        <div className="line-chart-wrapper">
+          <LineChart width={width} height={height} data={data1} margin={margin} syncId="test" syncMethod={syncMethod}>
+            <Line isAnimationActive={false} type="monotone" dataKey="uv" stroke="#ff7300" />
+            <Tooltip />
+            <XAxis dataKey="name" />
+            <YAxis />
+          </LineChart>
+        </div>
+
+        <p>A simple LineChart with syncId = test with axis labels in reverse order</p>
+        <div className="line-chart-wrapper">
+          <LineChart width={width} height={height} data={data2} margin={margin} syncId="test" syncMethod={syncMethod}>
+            <Line isAnimationActive={false} type="monotone" dataKey="uv" stroke="#ff7300" />
+            <Tooltip />
+            <XAxis dataKey="name" />
+            <YAxis />
+          </LineChart>
+        </div>
+      </div>
+    );
+  }
+}

--- a/demo/component/index.ts
+++ b/demo/component/index.ts
@@ -14,6 +14,7 @@ import Rectangle from './Rectangle';
 import Sector from './Sector';
 
 import LineChart from './LineChart';
+import LineChartSyncId from './LineChartSyncId';
 import AreaChart from './AreaChart';
 import BarChart from './BarChart';
 import ComposedChart from './ComposedChart';
@@ -33,6 +34,7 @@ import BugReproduce from './BugReproduce';
 export default {
   chartWrapper: {
     LineChart,
+    LineChartSyncId,
     AreaChart,
     BarChart,
     ComposedChart,

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1531,8 +1531,8 @@ export const generateCategoricalChart = ({
           // Set activeTooltipIndex to the index with the same value as data.activeLabel
           // For loop instead of findIndex because the latter is very slow in some browsers
           activeTooltipIndex = -1; // in case we cannot find the element
-          for(let i = 0; i < tooltipTicks.length; i++) {
-            if(tooltipTicks[i].value === data.activeLabel) {
+          for (let i = 0; i < tooltipTicks.length; i++) {
+            if (tooltipTicks[i].value === data.activeLabel) {
               activeTooltipIndex = i;
               break;
             }

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1529,11 +1529,14 @@ export const generateCategoricalChart = ({
           activeTooltipIndex = syncMethod(activeTooltipIndex, data);
         } else if (syncMethod === 'value') {
           // Set activeTooltipIndex to the index with the same value as data.activeLabel
-          tooltipTicks.forEach(({ value }: TickItem, index: number) => {
-            if (value === data.activeLabel) {
-              activeTooltipIndex = index;
+          // For loop instead of findIndex because the latter is very slow in some browsers
+          activeTooltipIndex = -1; // in case we cannot find the element
+          for(let i = 0; i < tooltipTicks.length; i++) {
+            if(tooltipTicks[i].value === data.activeLabel) {
+              activeTooltipIndex = i;
+              break;
             }
-          });
+          }
         }
         const viewBox: CartesianViewBox = { ...offset, x: offset.left, y: offset.top };
         // When a categotical chart is combined with another chart, the value of chartX

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -721,6 +721,7 @@ export interface CategoricalChartState {
 
 export interface CategoricalChartProps {
   syncId?: number | string;
+  syncMethod?: 'index' | 'value' | Function;
   compact?: boolean;
   width?: number;
   height?: number;
@@ -945,6 +946,7 @@ export const generateCategoricalChart = ({
       barGap: 4,
       margin: { top: 5, right: 5, bottom: 5, left: 5 } as Margin,
       reverseStackOrder: false,
+      syncMethod: 'index',
       ...defaultProps,
     };
 
@@ -1496,7 +1498,7 @@ export const generateCategoricalChart = ({
     }
 
     applySyncEvent(data: CategoricalChartState) {
-      const { layout } = this.props;
+      const { layout, syncMethod } = this.props;
       const { updateId } = this.state;
       const { dataStartIndex, dataEndIndex } = data;
 
@@ -1515,10 +1517,22 @@ export const generateCategoricalChart = ({
           ),
         });
       } else if (!_.isNil(data.activeTooltipIndex)) {
-        const { chartX, chartY, activeTooltipIndex } = data;
+        const { chartX, chartY } = data;
+        let { activeTooltipIndex } = data;
         const { offset, tooltipTicks } = this.state;
         if (!offset) {
           return;
+        }
+        if (typeof syncMethod === 'function') {
+          // Call a callback function. If there is an application specific algorithm
+          activeTooltipIndex = syncMethod(activeTooltipIndex, data);
+        } else if (syncMethod === 'value') {
+          // Set activeTooltipIndex to the index with the same value as data.activeLabel
+          tooltipTicks.forEach(({ value }: TickItem, index: number) => {
+            if (value === data.activeLabel) {
+              activeTooltipIndex = index;
+            }
+          });
         }
         const viewBox: CartesianViewBox = { ...offset, x: offset.left, y: offset.top };
         // When a categotical chart is combined with another chart, the value of chartX
@@ -1534,7 +1548,13 @@ export const generateCategoricalChart = ({
             }
           : originCoordinate;
 
-        this.setState({ ...data, activeLabel, activeCoordinate, activePayload });
+        this.setState({
+          ...data,
+          activeLabel,
+          activeCoordinate,
+          activePayload,
+          activeTooltipIndex,
+        });
       } else {
         this.setState(data);
       }

--- a/test/specs/chart/LineChartSpec.js
+++ b/test/specs/chart/LineChartSpec.js
@@ -514,14 +514,14 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
   const height = 400;
   const width = 400;
 
-  // Reversed of data
+  // X Axis mirrored
   const data2 = [
-    { name: "Page F", uv: 189, pv: 4800, amt: 2400 },
-    { name: "Page E", uv: 278, pv: 3908, amt: 2400 },
-    { name: "Page D", uv: 200, pv: 9800, amt: 2400 },
-    { name: "Page C", uv: 300, pv: 1398, amt: 2400 },
-    { name: "Page B", uv: 300, pv: 4567, amt: 2400 },
-    { name: "Page A", uv: 400, pv: 2400, amt: 2400 },
+    { name: 'Page F', uv: 500, pv: 4800, amt: 2400 },
+    { name: 'Page E', uv: 550, pv: 3908, amt: 2400 },
+    { name: 'Page D', uv: 800, pv: 9800, amt: 2400 },
+    { name: 'Page C', uv: 100, pv: 1398, amt: 2400 },
+    { name: 'Page B', uv: 678, pv: 4567, amt: 2400 },
+    { name: 'Page A', uv: 230, pv: 2400, amt: 2400 },
   ];
 
   it("should show tooltips for both charts synced by index on MouseEnter and hide on MouseLeave", () => {    
@@ -571,7 +571,7 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
 
     // make sure tooltips display the correct values, i.e. the value of the first item in the data
     expect(tooltipsValueWrapper.at(0).text()).to.equal("400");
-    expect(tooltipsValueWrapper.at(1).text()).to.equal("189"); 
+    expect(tooltipsValueWrapper.at(1).text()).to.equal("500"); 
 
     // Check the activeDots are highlighted
     const activeDotNodes = wrapper.find(".recharts-active-dot").hostNodes();
@@ -579,7 +579,7 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
 
     const activeDotWrapper = wrapper.find(ActiveDot);
     expect(activeDotWrapper.at(0).props().value).to.equal(400);
-    expect(activeDotWrapper.at(1).props().value).to.equal(189); 
+    expect(activeDotWrapper.at(1).props().value).to.equal(500); 
  
     // simulate leaving the area
     wrapper.find(LineChart).at(0).simulate("mouseLeave");
@@ -631,7 +631,7 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
 
     // make sure tooltips display the correct values, synced by data value
     expect(tooltipsValueWrapper.at(0).text()).to.equal("400");
-    expect(tooltipsValueWrapper.at(1).text()).to.equal("400");    
+    expect(tooltipsValueWrapper.at(1).text()).to.equal("230");    
 
     // Check the activeDots are highlighted
     const activeDotNodes = wrapper.find(".recharts-active-dot").hostNodes();
@@ -639,7 +639,7 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
 
     const activeDotWrapper = wrapper.find(ActiveDot);
     expect(activeDotWrapper.at(0).props().value).to.equal(400);
-    expect(activeDotWrapper.at(1).props().value).to.equal(400); 
+    expect(activeDotWrapper.at(1).props().value).to.equal(230); 
 
     // simulate leaving the area
     wrapper.find(LineChart).at(0).simulate("mouseLeave");
@@ -693,7 +693,7 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
 
     // make sure tooltips display the correct values, synced by data value
     expect(tooltipsValueWrapper.at(0).text()).to.equal("400");
-    expect(tooltipsValueWrapper.at(1).text()).to.equal("278");    
+    expect(tooltipsValueWrapper.at(1).text()).to.equal("550");    
 
     // Check the activeDots are highlighted
     const activeDotNodes = wrapper.find(".recharts-active-dot").hostNodes();
@@ -701,7 +701,7 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
 
     const activeDotWrapper = wrapper.find(ActiveDot);
     expect(activeDotWrapper.at(0).props().value).to.equal(400);
-    expect(activeDotWrapper.at(1).props().value).to.equal(278); 
+    expect(activeDotWrapper.at(1).props().value).to.equal(550); 
 
     // simulate leaving the area
     wrapper.find(LineChart).at(0).simulate("mouseLeave");

--- a/test/specs/chart/LineChartSpec.js
+++ b/test/specs/chart/LineChartSpec.js
@@ -524,9 +524,11 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
     { name: 'Page A', uv: 230, pv: 2400, amt: 2400 },
   ];
 
-  it("should show tooltips for both charts synced by index on MouseEnter and hide on MouseLeave", () => {    
+  const runAllPromises = () => new Promise(setImmediate);
+
+  it("should show tooltips for both charts synced by index on MouseEnter and hide on MouseLeave", async() => {    
     const ActiveDot = ({ cx, cy }) =>
-    <circle cx={cx} cy={cy} r={10} className="customized-active-dot" />;
+      <circle cx={cx} cy={cy} r={10} className="customized-active-dot" />;
 
     const chart1 = (
       <LineChart width={width} height={height} data={data} margin={margin} syncId="test">
@@ -563,6 +565,9 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
         pageY: height / 2,
       });
 
+    await runAllPromises();
+    wrapper.update();
+
     // There are two tooltips - one for each LineChart as they have the same syncId
     const tooltipCursors = wrapper.find(".recharts-tooltip-cursor").hostNodes();
     expect(tooltipCursors.length).to.equal(2);
@@ -586,9 +591,9 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
     expect(wrapper.find(".recharts-tooltip-cursor").hostNodes.length).to.equal(0);
   });
 
-  it("should show tooltips using syncMethod: 'value' for both charts on MouseEnter and hide on MouseLeave", () => {
+  it("should show tooltips using syncMethod: 'value' for both charts on MouseEnter and hide on MouseLeave", async() => {
     const ActiveDot = ({ cx, cy }) =>
-    <circle cx={cx} cy={cy} r={10} className="customized-active-dot" />;
+      <circle cx={cx} cy={cy} r={10} className="customized-active-dot" />;
 
     const chart1 = (
       <LineChart width={width} height={height} data={data} margin={margin} syncId="test" syncMethod="value">
@@ -622,9 +627,12 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
         pageX: margin.left + 0.1 * dotSpacing,
         pageY: height / 2,
       });
+    
+    await runAllPromises();
+    wrapper.update();
 
     // There are two tooltips - one for each LineChart as they have the same syncId
-    let tooltipCursors = wrapper.find(".recharts-tooltip-cursor").hostNodes();
+    const tooltipCursors = wrapper.find(".recharts-tooltip-cursor").hostNodes();
     expect(tooltipCursors.length).to.equal(2);
 
     const tooltipsValueWrapper = wrapper.find(".recharts-tooltip-item-value");
@@ -646,9 +654,9 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
     expect(wrapper.find(".recharts-tooltip-cursor").hostNodes.length).to.equal(0);
   });
 
-  it("should show tooltips using syncMethod: [function] for both charts on MouseEnter and hide on MouseLeave", () => {
+  it("should show tooltips using syncMethod: [function] for both charts on MouseEnter and hide on MouseLeave", async() => {
     const ActiveDot = ({ cx, cy }) =>
-    <circle cx={cx} cy={cy} r={10} className="customized-active-dot" />;
+      <circle cx={cx} cy={cy} r={10} className="customized-active-dot" />;
 
     const syncMethodFunction = index => index + 1;
 
@@ -684,9 +692,12 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
         pageX: margin.left + 0.1 * dotSpacing,
         pageY: height / 2,
       });
+    
+    await runAllPromises();
+    wrapper.update();
 
     // There are two tooltips - one for each LineChart as they have the same syncId
-    let tooltipCursors = wrapper.find(".recharts-tooltip-cursor").hostNodes();
+    const tooltipCursors = wrapper.find(".recharts-tooltip-cursor").hostNodes();
     expect(tooltipCursors.length).to.equal(2);
 
     const tooltipsValueWrapper = wrapper.find(".recharts-tooltip-item-value");

--- a/test/specs/chart/LineChartSpec.js
+++ b/test/specs/chart/LineChartSpec.js
@@ -508,3 +508,203 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
   });
 
 });
+
+describe("<LineChart /> - Rendering two line charts with syncId", () => {
+  const margin = { top: 20, right: 20, bottom: 20, left: 20 };
+  const height = 400;
+  const width = 400;
+
+  // Reversed of data
+  const data2 = [
+    { name: "Page F", uv: 189, pv: 4800, amt: 2400 },
+    { name: "Page E", uv: 278, pv: 3908, amt: 2400 },
+    { name: "Page D", uv: 200, pv: 9800, amt: 2400 },
+    { name: "Page C", uv: 300, pv: 1398, amt: 2400 },
+    { name: "Page B", uv: 300, pv: 4567, amt: 2400 },
+    { name: "Page A", uv: 400, pv: 2400, amt: 2400 },
+  ];
+
+  it("should show tooltips for both charts synced by index on MouseEnter and hide on MouseLeave", () => {    
+    const ActiveDot = ({ cx, cy }) =>
+    <circle cx={cx} cy={cy} r={10} className="customized-active-dot" />;
+
+    const chart1 = (
+      <LineChart width={width} height={height} data={data} margin={margin} syncId="test">
+        <Line activeDot={<ActiveDot />} type="monotone" dataKey="uv" stroke="#ff7300" />
+        <Tooltip />
+        <XAxis dataKey="name" />
+      </LineChart>
+    );
+
+    const chart2 = (
+      <LineChart width={width} height={height} data={data2} margin={margin} syncId="test">
+        <Line activeDot={<ActiveDot />} type="monotone" dataKey="uv" stroke="#ff7300" />
+        <Tooltip />
+        <XAxis dataKey="name" />
+      </LineChart>
+    );
+
+    const wrapper = mount(
+      <div>
+        {chart1}
+        {chart2}
+      </div>
+    );
+
+    const chartWidth = width - margin.left - margin.right;
+    const dotSpacing = chartWidth / (data.length - 1);
+
+    // simulate entering just past Page A of Chart1 to test snapping of the cursor line
+    expect(
+      wrapper.find(".recharts-tooltip-cursor").hostNodes().length
+    ).to.equal(0);
+    wrapper.find(LineChart).at(0).simulate("mouseEnter", {
+        pageX: margin.left + 0.1 * dotSpacing,
+        pageY: height / 2,
+      });
+
+    // There are two tooltips - one for each LineChart as they have the same syncId
+    const tooltipCursors = wrapper.find(".recharts-tooltip-cursor").hostNodes();
+    expect(tooltipCursors.length).to.equal(2);
+
+    const tooltipsValueWrapper = wrapper.find(".recharts-tooltip-item-value");
+
+    // make sure tooltips display the correct values, i.e. the value of the first item in the data
+    expect(tooltipsValueWrapper.at(0).text()).to.equal("400");
+    expect(tooltipsValueWrapper.at(1).text()).to.equal("189"); 
+
+    // Check the activeDots are highlighted
+    const activeDotNodes = wrapper.find(".recharts-active-dot").hostNodes();
+    expect(activeDotNodes.length).to.equal(2);
+
+    const activeDotWrapper = wrapper.find(ActiveDot);
+    expect(activeDotWrapper.at(0).props().value).to.equal(400);
+    expect(activeDotWrapper.at(1).props().value).to.equal(189); 
+ 
+    // simulate leaving the area
+    wrapper.find(LineChart).at(0).simulate("mouseLeave");
+    expect(wrapper.find(".recharts-tooltip-cursor").hostNodes.length).to.equal(0);
+  });
+
+  it("should show tooltips using syncMethod: 'value' for both charts on MouseEnter and hide on MouseLeave", () => {
+    const ActiveDot = ({ cx, cy }) =>
+    <circle cx={cx} cy={cy} r={10} className="customized-active-dot" />;
+
+    const chart1 = (
+      <LineChart width={width} height={height} data={data} margin={margin} syncId="test" syncMethod="value">
+        <Line activeDot={<ActiveDot />} type="monotone" dataKey="uv" stroke="#ff7300" />
+        <Tooltip />
+        <XAxis dataKey="name" />
+      </LineChart>
+    );
+    const chart2 = (
+      <LineChart width={width} height={height} data={data2} margin={margin} syncId="test" syncMethod="value">
+        <Line activeDot={<ActiveDot />} type="monotone" dataKey="uv" stroke="#ff7300" />
+        <Tooltip />
+        <XAxis dataKey="name" />
+      </LineChart>
+    );
+    const wrapper = mount(
+      <div>
+        {chart1}
+        {chart2}
+      </div>
+    );
+
+    const chartWidth = width - margin.left - margin.right;
+    const dotSpacing = chartWidth / (data.length - 1);
+
+    // simulate entering just past Page A of Chart1 to test snapping of the cursor line
+    expect(
+      wrapper.find(".recharts-tooltip-cursor").hostNodes().length
+    ).to.equal(0);
+    wrapper.find(LineChart).at(0).simulate("mouseEnter", {
+        pageX: margin.left + 0.1 * dotSpacing,
+        pageY: height / 2,
+      });
+
+    // There are two tooltips - one for each LineChart as they have the same syncId
+    let tooltipCursors = wrapper.find(".recharts-tooltip-cursor").hostNodes();
+    expect(tooltipCursors.length).to.equal(2);
+
+    const tooltipsValueWrapper = wrapper.find(".recharts-tooltip-item-value");
+
+    // make sure tooltips display the correct values, synced by data value
+    expect(tooltipsValueWrapper.at(0).text()).to.equal("400");
+    expect(tooltipsValueWrapper.at(1).text()).to.equal("400");    
+
+    // Check the activeDots are highlighted
+    const activeDotNodes = wrapper.find(".recharts-active-dot").hostNodes();
+    expect(activeDotNodes.length).to.equal(2);
+
+    const activeDotWrapper = wrapper.find(ActiveDot);
+    expect(activeDotWrapper.at(0).props().value).to.equal(400);
+    expect(activeDotWrapper.at(1).props().value).to.equal(400); 
+
+    // simulate leaving the area
+    wrapper.find(LineChart).at(0).simulate("mouseLeave");
+    expect(wrapper.find(".recharts-tooltip-cursor").hostNodes.length).to.equal(0);
+  });
+
+  it("should show tooltips using syncMethod: [function] for both charts on MouseEnter and hide on MouseLeave", () => {
+    const ActiveDot = ({ cx, cy }) =>
+    <circle cx={cx} cy={cy} r={10} className="customized-active-dot" />;
+
+    const syncMethodFunction = index => index + 1;
+
+    const chart1 = (
+      <LineChart width={width} height={height} data={data} margin={margin} syncId="test" syncMethod={syncMethodFunction}>
+        <Line activeDot={<ActiveDot />} type="monotone" dataKey="uv" stroke="#ff7300" />
+        <Tooltip />
+        <XAxis dataKey="name" />
+      </LineChart>
+    );
+    const chart2 = (
+      <LineChart width={width} height={height} data={data2} margin={margin} syncId="test" syncMethod={syncMethodFunction}>
+        <Line activeDot={<ActiveDot />} type="monotone" dataKey="uv" stroke="#ff7300" />
+        <Tooltip />
+        <XAxis dataKey="name" />
+      </LineChart>
+    );
+    const wrapper = mount(
+      <div>
+        {chart1}
+        {chart2}
+      </div>
+    );
+
+    const chartWidth = width - margin.left - margin.right;
+    const dotSpacing = chartWidth / (data.length - 1);
+
+    // simulate entering just past Page A of Chart1 to test snapping of the cursor line
+    expect(
+      wrapper.find(".recharts-tooltip-cursor").hostNodes().length
+    ).to.equal(0);
+    wrapper.find(LineChart).at(0).simulate("mouseEnter", {
+        pageX: margin.left + 0.1 * dotSpacing,
+        pageY: height / 2,
+      });
+
+    // There are two tooltips - one for each LineChart as they have the same syncId
+    let tooltipCursors = wrapper.find(".recharts-tooltip-cursor").hostNodes();
+    expect(tooltipCursors.length).to.equal(2);
+
+    const tooltipsValueWrapper = wrapper.find(".recharts-tooltip-item-value");
+
+    // make sure tooltips display the correct values, synced by data value
+    expect(tooltipsValueWrapper.at(0).text()).to.equal("400");
+    expect(tooltipsValueWrapper.at(1).text()).to.equal("278");    
+
+    // Check the activeDots are highlighted
+    const activeDotNodes = wrapper.find(".recharts-active-dot").hostNodes();
+    expect(activeDotNodes.length).to.equal(2);
+
+    const activeDotWrapper = wrapper.find(ActiveDot);
+    expect(activeDotWrapper.at(0).props().value).to.equal(400);
+    expect(activeDotWrapper.at(1).props().value).to.equal(278); 
+
+    // simulate leaving the area
+    wrapper.find(LineChart).at(0).simulate("mouseLeave");
+    expect(wrapper.find(".recharts-tooltip-cursor").hostNodes.length).to.equal(0);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/recharts/recharts/issues/1980 

Implementation based on comments from that issue

- Add syncMethod to categorical charts (Line, Bar, Area and Composed)
- syncMethod can be 'index' (by default if nothing is provided), 'value' or a function
- If it is not provided, syncMethod is defaulted to index so this is a non-breaking change
- If syncMethod is a function, call the function and return the index value
- If syncMethod is 'value', get the index that matches the label value
- Add tests
- Add a demo example. It is possible to change the syncMethod by pressing a button

Thanks