### PR TITLE
Add activeChild to tooltip info to identify the specific item being hovered

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -239,8 +239,8 @@ const getTooltipData = (state: CategoricalChartState, chartData: any[], layout: 
     const activePayload = getTooltipContent(state, chartData, activeIndex, activeLabel);
     const activeCoordinate = getActiveCoordinate(layout, ticks, activeIndex, rangeData);
 
-    const { x: mouseX, y: mouseY } = rangeObj;
-    const getActiveEntry = (o) => _.get(o, ['props', 'data', activeIndex]);
+    const { x: mouseX, y: mouseY } = rangeData;
+    const getActiveEntry = (o: object) => _.get(o, ['props', 'data', activeIndex]);
     let activeChild = _.find(formatedGraphicalItems, (entry) => {
         const activeEntry = getActiveEntry(entry);
         if (activeEntry) {

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -241,21 +241,21 @@ const getTooltipData = (state: CategoricalChartState, chartData: any[], layout: 
 
     const { x: mouseX, y: mouseY } = rangeData;
     const getActiveEntry = (o: object) => _.get(o, ['props', 'data', activeIndex]);
-    let activeChild = _.find(formatedGraphicalItems, (entry) => {
-        const activeEntry = getActiveEntry(entry);
-        if (activeEntry) {
-            const { x, width, y, height } = activeEntry;
+    let activeChild = _.find(formatedGraphicalItems, entry => {
+      const activeEntry = getActiveEntry(entry);
+      if (activeEntry) {
+        const { x, width, y, height } = activeEntry;
 
-            const includeX = width >= 0 ? mouseX >= x && mouseX < x + width : mouseX + width >= x && mouseX < x;
-            const includeY = height >= 0 ? mouseY >= y && mouseY < y + height : mouseY + height >= y && mouseY < y;
+        const includeX = width >= 0 ? mouseX >= x && mouseX < x + width : mouseX + width >= x && mouseX < x;
+        const includeY = height >= 0 ? mouseY >= y && mouseY < y + height : mouseY + height >= y && mouseY < y;
 
-            return includeX && includeY;
-        }
+        return includeX && includeY;
+      }
 
-        return false;
+      return false;
     });
     if (activeChild) {
-        activeChild = { item: activeChild.item, payload: getActiveEntry(activeChild) };
+      activeChild = { item: activeChild.item, payload: getActiveEntry(activeChild) };
     }
 
     return {

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -230,7 +230,7 @@ const getTooltipData = (state: CategoricalChartState, chartData: any[], layout: 
   const rangeData = rangeObj || { x: state.chartX, y: state.chartY };
 
   const pos = calculateTooltipPos(rangeData, layout);
-  const { orderedTooltipTicks: ticks, tooltipAxis: axis, tooltipTicks } = state;
+  const { orderedTooltipTicks: ticks, tooltipAxis: axis, tooltipTicks, formatedGraphicalItems } = state;
 
   const activeIndex = calculateActiveTickIndex(pos, ticks, tooltipTicks, axis);
 
@@ -239,11 +239,31 @@ const getTooltipData = (state: CategoricalChartState, chartData: any[], layout: 
     const activePayload = getTooltipContent(state, chartData, activeIndex, activeLabel);
     const activeCoordinate = getActiveCoordinate(layout, ticks, activeIndex, rangeData);
 
+    const { x: mouseX, y: mouseY } = rangeObj;
+    const getActiveEntry = (o) => _.get(o, ['props', 'data', activeIndex]);
+    let activeChild = _.find(formatedGraphicalItems, (entry) => {
+        const activeEntry = getActiveEntry(entry);
+        if (activeEntry) {
+            const { x, width, y, height } = activeEntry;
+
+            const includeX = width >= 0 ? mouseX >= x && mouseX < x + width : mouseX + width >= x && mouseX < x;
+            const includeY = height >= 0 ? mouseY >= y && mouseY < y + height : mouseY + height >= y && mouseY < y;
+
+            return includeX && includeY;
+        }
+
+        return false;
+    });
+    if (activeChild) {
+        activeChild = { item: activeChild.item, payload: getActiveEntry(activeChild) };
+    }
+
     return {
       activeTooltipIndex: activeIndex,
       activeLabel,
       activePayload,
       activeCoordinate,
+      activeChild,
     };
   }
 


### PR DESCRIPTION
There might be a better way to get this info, but the point is to have the information to identify the specific item that's hovered over, so information about just that piece can be shown in the tooltip rather than the information about the entire bar.