### PR TITLE
fix: filter out nil elements

### DIFF
--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -337,7 +337,7 @@ export const renderByOrder = (children: React.ReactElement[], renderMap: any) =>
     }
   });
 
-  return _.flattenDeep(elements).filter((element) => !_.isNil(element));
+  return _.flattenDeep(elements).filter(element => !_.isNil(element));
 };
 
 export const getReactEventByType = (e: any) => {

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -337,7 +337,7 @@ export const renderByOrder = (children: React.ReactElement[], renderMap: any) =>
     }
   });
 
-  return _.flatten(elements);
+  return _.flattenDeep(elements).filter((element) => !_.isNil(element));
 };
 
 export const getReactEventByType = (e: any) => {

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -337,7 +337,7 @@ export const renderByOrder = (children: React.ReactElement[], renderMap: any) =>
     }
   });
 
-  return _.flattenDeep(elements).filter(element => !_.isNil(element));
+  return _.flatten(elements).filter(element => !_.isNil(element));
 };
 
 export const getReactEventByType = (e: any) => {


### PR DESCRIPTION
Filter out nil elements in `renderByOrder`. Fixes #300 happening again since v2.0.0-beta.8