### PR TITLE
fix: ensures `id="undefined"` is not rendered to the DOM

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -162,7 +162,7 @@ export class ResponsiveContainer extends Component<Props, State> {
     return (
       <ReactResizeDetector handleWidth handleHeight onResize={this.handleResize} targetRef={this.containerRef}>
         <div
-          id={`${id}`}
+          {...(id != null ? { id: `${id}` } : {})}
           className={classNames('recharts-responsive-container', className)}
           style={style}
           ref={this.containerRef}

--- a/test/specs/component/ResponsiveContainerSpec.js
+++ b/test/specs/component/ResponsiveContainerSpec.js
@@ -86,4 +86,14 @@ describe('<ResponsiveContainer />', () => {
     expect(wrapper.find('.inside')).to.have.attr('height').equal('50');
   });
 
+  it('Renders without an id attribute when not passed', () => {
+    const wrapper = mount(
+      <ResponsiveContainer>
+        <div className="inside">Inside</div>
+      </ResponsiveContainer>
+    );
+
+    expect(wrapper.find('#undefined')).to.not.exist;
+  });
+
 });


### PR DESCRIPTION
See #2445