### PR TITLE
Fix for ComposedChart + Bar overflowing width

### DIFF
--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -623,9 +623,7 @@ export const parseScale = (axis: any, chartType: string) => {
     if (
       type === 'category' &&
       chartType &&
-      (chartType.indexOf('LineChart') >= 0 ||
-        chartType.indexOf('AreaChart') >= 0 ||
-        chartType.indexOf('ComposedChart') >= 0)
+      (chartType.indexOf('LineChart') >= 0 || chartType.indexOf('AreaChart') >= 0)
     ) {
       return { scale: d3Scales.scalePoint(), realScaleType: 'point' };
     }


### PR DESCRIPTION
Use 'band' scale for composed chart.

Related to: https://github.com/recharts/recharts/issues/2403