### PR TITLE
Chore: use npm ci in gha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Install dependencies
-      run: npm install
+      run: npm ci
 
     - name: Test
       run: |


### PR DESCRIPTION
Use `npm ci` in GHA for increase test immutability.