### PR TITLE
TypeScript fix for allowing AreaChart to be valid child of ResponsiveContainer

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -15,7 +15,7 @@ export interface Props {
   minWidth?: string | number;
   minHeight?: string | number;
   maxHeight?: number;
-  children: ReactElement;
+  children: ReactElement | ReactElement[];
   debounce?: number;
   id?: string | number;
   className?: string | number;


### PR DESCRIPTION
AreaChart was not a valid child of ResponsiveContainer and would fail to compile in a TypeScript project. Changing the Props interface from `children: ReactElement;` to `children: ReactElement | ReactElement[];` fixes this.