### PR TITLE
Remove @types/react-resize-detector dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1468,15 +1468,6 @@
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.0.tgz",
       "integrity": "sha512-A0DQ1YWZ0RG2+PV7neAotNCIh8gZ3z7tQnDJyS2xRPDNtAtSPcJ9YyfMP8be36Ha0kQRzbZCrrTMznA4blqO5g==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
-    "@types/react-resize-detector": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react-resize-detector/-/react-resize-detector-5.0.0.tgz",
-      "integrity": "sha512-JTqR0G+RcC6Guqi/JXQBq3jewflumUGd4fDUucmZN9L1d8TZuRHzDTtrmgYWrgLvRTBTV6FjegmLeV1UnrIuzw==",
       "dev": true,
       "requires": {
         "@types/react": "*"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "@types/react": "^16.9.9",
     "@types/react-dom": "^16.9.2",
     "@types/react-is": "^17.0.0",
-    "@types/react-resize-detector": "^5.0.0",
     "@types/react-router-dom": "^5.1.7",
     "@typescript-eslint/eslint-plugin": "^4.11.0",
     "@typescript-eslint/parser": "^4.11.0",


### PR DESCRIPTION
From https://github.com/maslianok/react-resize-detector documentation:
> TypeScript-lovers notice: starting from v6.0.0 you may safely remove @types/react-resize-detector from you deps list.
