### PR TITLE
Fix typing of <Area type /> prop

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -83,7 +83,7 @@ interface AreaProps extends InternalAreaProps {
   id?: string;
 }
 
-export type Props = SVGProps<SVGElement> & AreaProps;
+export type Props = Omit<SVGProps<SVGElement>, 'type'> & AreaProps;
 
 interface State {
   prevAnimationId?: number;


### PR DESCRIPTION
Currently we can't pass `curve: CurveFactory` as `<Area type={curve} />` because the prop is unintentionally intersected with `SVGProps<SVGElement>["type"] == string | undefined`. This PR fixes the problem.