### PR TITLE
bug fix: when you change the syncId from undefined to a value the sync does not work

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1071,7 +1071,7 @@ export const generateCategoricalChart = ({
         this.addListener();
       }
       // remove syncId
-      if (!_.isNil(this.props.syncId) && _.isNil(prevProps.syncId)) {
+      if (!_.isNil(prevProps.syncId) && _.isNil(this.props.syncId)) {
         this.removeListener();
       }
     }


### PR DESCRIPTION
If you look at line 1070, there is a condition to add the listeners to make it work sync functionality. If you look at the condition in line 1074(which should remove the listeners), it is actually doing the same as line 1070(only switched), which leads to a bug that when you change the `syncId` from nil to a value, it never works the sync functionality(because it adds and removes the listeners at the same time).