### PR TITLE
Add chart type to tooltip payload

### DIFF
--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -30,6 +30,7 @@ export interface Payload<TValue extends ValueType, TName extends NameType> {
   unit?: ReactNode;
   dataKey?: string | number;
   payload?: any;
+  chartType?: string;
 }
 
 export interface Props<TValue extends ValueType, TName extends NameType> {

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1138,7 +1138,7 @@ export const parseDomainOfCategoryAxis = (
 };
 
 export const getTooltipItem = (graphicalItem: any, payload: any) => {
-  const { dataKey, name, unit, formatter, tooltipType } = graphicalItem.props;
+  const { dataKey, name, unit, formatter, tooltipType, chartType } = graphicalItem.props;
 
   return {
     ...filterProps(graphicalItem),
@@ -1150,5 +1150,6 @@ export const getTooltipItem = (graphicalItem: any, payload: any) => {
     value: getValueByDataKey(payload, dataKey),
     type: tooltipType,
     payload,
+    chartType,
   };
 };


### PR DESCRIPTION
This is a small PR that adds the type of chart to the tooltip item generated by the `getTooltipItem()`. 
This allows a custom tooltip content component to have access to the type of chart the entry comes from, and render content conditionally. For example, in a custom content, we may want to:

```javascript
{entry.chartType === 'line' ? <SvgLine /> : <SvgRect />}
<span >{entry.name}</span>
<span >{props.separator}</span>
```