### PR TITLE
Return default bandSize and change Xaxis default domain

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -44,7 +44,7 @@ XAxis.defaultProps = {
   xAxisId: 0,
   tickCount: 5,
   type: 'category',
-  domain: [0, 'auto'],
+  domain: ['dataMin', 'dataMax'],
   padding: { left: 0, right: 0 },
   allowDataOverflow: false,
   scale: 'auto',

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1112,7 +1112,7 @@ export const getBandSizeOfAxis = (axis: any, ticks?: Array<TickItem>, isBar?: bo
     return bandSize === Infinity ? 0 : bandSize;
   }
 
-  return 0;
+  return axis?.width ?? 0;
 };
 /**
  * parse the domain of a category axis when a domain is specified


### PR DESCRIPTION
Attempts to solve #2601 (no drawing for single data points)

In the reproducible example of the above issue, changing the XAxis type to category, or removing the type prop seems to work. By passing number to type, and because the default number of ticks is 5, it produces 5 ticks, being the value of dataKey the last of those 5. By passing to XAxis domain={['dataMin', 'dataMax']} it only calculates one tick and centers it properly, however the issue of bars not being drawn persists.
As an user, when there's only one single data point in a linear xaxis scale, I would prefer to se an XAxis with one single tick and centered.

`getBandSizeOfAxis()` could just return something sensible like axis.width instead of 0. 

 The XAxis default props include:
```
  tickCount: 5,
  type: 'category',
  domain: [0, 'auto'],
```
In a numeric type of axis, this forces, unless overriden, a single data point array to have 5 ticks starting from 0. If I change domain to `['dataMin', 'dataMax']` + the change to getBandSizeOfAxis() I mention above, now I get a nicely centered single data point tick with both bars drawn.

I think the sensible thing to do is setting ['dataMin', 'dataMax'] as default and allow the user to set [0, 'dataMax'] to have a numeric/linear axis starting from 0 when type is numeric.