### PR TITLE
Wrap ResponsiveContainer with forwardRef

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "cross-env NODE_ENV=test karma start test/karma.conf.js",
     "lint": "eslint './src/**/*.?(ts|tsx)'",
     "autofix": "eslint './src/**/*.?(ts|tsx)' --fix",
-    "analyse": "cross-env NODE_ENV=analyse webpack src/index.ts -o umd/Recharts.js",
+    "analyse": "cross-env NODE_ENV=analyse webpack ./src/index.ts -o umd/Recharts.js",
     "tsc": "tsc"
   },
   "pre-commit": [],


### PR DESCRIPTION
_Why?_

Would be nice to have a reference to the Element that wraps the graphs in ResponsiveContainer. 
For example, it would be nice to use in conjunction with [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to render a chart only when it comes into view.

```javascript
export const BarChart = ({ data,  ...chartProps }: BarChartProps) => {
  const { isVisible, setNode } = useIntersectionObserver();
  return (
      isVisible
      ? <ResponsiveContainer debounce={1} ref={setNode} >
        <BarChart data={data} {...chartProps}>
          <CartesianGrid />
          <XAxis  />
          <YAxis />
          <Tooltip  />
        <BarChart>
      </ResponsiveContainer>
     : null
    )
}
```

Also rewrote ResponsiveContainer as function component.