### PR TITLE
Refactor lodash imports to reduce bundle size by 34kb

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "cross-env NODE_ENV=test karma start test/karma.conf.js",
     "lint": "eslint './src/**/*.?(ts|tsx)'",
     "autofix": "eslint './src/**/*.?(ts|tsx)' --fix",
-    "analyse": "cross-env NODE_ENV=analyse webpack src/index.ts -o umd/Recharts.js",
+    "analyse": "cross-env NODE_ENV=analyse webpack ./src/index.ts -o umd/Recharts.js",
     "tsc": "tsc"
   },
   "pre-commit": [],

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "cross-env NODE_ENV=test karma start test/karma.conf.js",
     "lint": "eslint './src/**/*.?(ts|tsx)'",
     "autofix": "eslint './src/**/*.?(ts|tsx)' --fix",
-    "analyse": "cross-env NODE_ENV=analyse webpack ./src/index.ts -o umd/Recharts.js",
+    "analyse": "rimraf umd && cross-env NODE_ENV=analyse webpack ./src/index.ts -o umd/Recharts.js",
     "tsc": "tsc"
   },
   "pre-commit": [],

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -4,7 +4,13 @@
 import React, { PureComponent, ReactElement, SVGProps } from 'react';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
-import _ from 'lodash';
+import get from 'lodash/get';
+import isArray from 'lodash/isArray';
+import isFunction from 'lodash/isFunction';
+import isNil from 'lodash/isNil';
+import max from 'lodash/max';
+import _isNaN from 'lodash/isNaN';
+import isEqual from 'lodash/isEqual';
 import { Curve, CurveType, Point as CurvePoint } from '../shape/Curve';
 import { Dot, Props as DotProps } from '../shape/Dot';
 import { Layer } from '../container/Layer';
@@ -192,14 +198,14 @@ export class Area extends PureComponent<Props, State> {
       } else {
         value = originalValue;
 
-        if (!_.isArray(value)) {
+        if (!isArray(value)) {
           value = [baseValue, value];
         } else {
           isRange = true;
         }
       }
 
-      const isBreakPoint = _.isNil(value[1]) || (hasStack && _.isNil(originalValue));
+      const isBreakPoint = isNil(value[1]) || (hasStack && isNil(originalValue));
       if (layout === 'horizontal') {
         return {
           x: getCateCoordinateOfLine({ axis: xAxis, ticks: xAxisTicks, bandSize, entry, index }),
@@ -224,13 +230,13 @@ export class Area extends PureComponent<Props, State> {
           return {
             x: entry.x,
             y:
-              !_.isNil(_.get(entry, 'value[0]')) && !_.isNil(_.get(entry, 'y'))
-                ? yAxis.scale(_.get(entry, 'value[0]'))
+              !isNil(get(entry, 'value[0]')) && !isNil(get(entry, 'y'))
+                ? yAxis.scale(get(entry, 'value[0]'))
                 : null,
           };
         }
         return {
-          x: !_.isNil(_.get(entry, 'value[0]')) ? xAxis.scale(_.get(entry, 'value[0]')) : null,
+          x: !isNil(get(entry, 'value[0]')) ? xAxis.scale(get(entry, 'value[0]')) : null,
           y: entry.y,
         };
       });
@@ -248,7 +254,7 @@ export class Area extends PureComponent<Props, State> {
 
     if (React.isValidElement(option)) {
       dotItem = React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
+    } else if (isFunction(option)) {
       dotItem = option(props);
     } else {
       dotItem = <Dot {...props} className="recharts-area-dot" />;
@@ -288,7 +294,7 @@ export class Area extends PureComponent<Props, State> {
 
     this.setState({ isAnimationFinished: true });
 
-    if (_.isFunction(onAnimationEnd)) {
+    if (isFunction(onAnimationEnd)) {
       onAnimationEnd();
     }
   };
@@ -297,7 +303,7 @@ export class Area extends PureComponent<Props, State> {
     const { onAnimationStart } = this.props;
     this.setState({ isAnimationFinished: false });
 
-    if (_.isFunction(onAnimationStart)) {
+    if (isFunction(onAnimationStart)) {
       onAnimationStart();
     }
   };
@@ -345,12 +351,12 @@ export class Area extends PureComponent<Props, State> {
     const startX = points[0].x;
     const endX = points[points.length - 1].x;
     const width = alpha * Math.abs(startX - endX);
-    let maxY = _.max(points.map(entry => entry.y || 0));
+    let maxY = max(points.map(entry => entry.y || 0));
 
     if (isNumber(baseLine) && typeof baseLine === 'number') {
       maxY = Math.max(baseLine, maxY);
-    } else if (baseLine && _.isArray(baseLine) && baseLine.length) {
-      maxY = Math.max(_.max(baseLine.map(entry => entry.y || 0)), maxY);
+    } else if (baseLine && isArray(baseLine) && baseLine.length) {
+      maxY = Math.max(max(baseLine.map(entry => entry.y || 0)), maxY);
     }
 
     if (isNumber(maxY)) {
@@ -372,12 +378,12 @@ export class Area extends PureComponent<Props, State> {
     const startY = points[0].y;
     const endY = points[points.length - 1].y;
     const height = alpha * Math.abs(startY - endY);
-    let maxX = _.max(points.map(entry => entry.x || 0));
+    let maxX = max(points.map(entry => entry.x || 0));
 
     if (isNumber(baseLine) && typeof baseLine === 'number') {
       maxX = Math.max(baseLine, maxX);
-    } else if (baseLine && _.isArray(baseLine) && baseLine.length) {
-      maxX = Math.max(_.max(baseLine.map(entry => entry.x || 0)), maxX);
+    } else if (baseLine && isArray(baseLine) && baseLine.length) {
+      maxX = Math.max(max(baseLine.map(entry => entry.x || 0)), maxX);
     }
 
     if (isNumber(maxX)) {
@@ -457,7 +463,7 @@ export class Area extends PureComponent<Props, State> {
       animationId,
     } = this.props;
     const { prevPoints, prevBaseLine } = this.state;
-    // const clipPathId = _.isNil(id) ? this.id : id;
+    // const clipPathId = isNil(id) ? this.id : id;
 
     return (
       <Animate
@@ -492,7 +498,7 @@ export class Area extends PureComponent<Props, State> {
             if (isNumber(baseLine) && typeof baseLine === 'number') {
               const interpolator = interpolateNumber(prevBaseLine as number, baseLine);
               stepBaseLine = interpolator(t);
-            } else if (_.isNil(baseLine) || _.isNaN(baseLine)) {
+            } else if (isNil(baseLine) || _isNaN(baseLine)) {
               const interpolator = interpolateNumber(prevBaseLine as number, 0);
               stepBaseLine = interpolator(t);
             } else {
@@ -536,7 +542,7 @@ export class Area extends PureComponent<Props, State> {
       isAnimationActive &&
       points &&
       points.length &&
-      ((!prevPoints && totalLength > 0) || !_.isEqual(prevPoints, points) || !_.isEqual(prevBaseLine, baseLine))
+      ((!prevPoints && totalLength > 0) || !isEqual(prevPoints, points) || !isEqual(prevBaseLine, baseLine))
     ) {
       return this.renderAreaWithAnimation(needClip, clipPathId);
     }
@@ -555,7 +561,7 @@ export class Area extends PureComponent<Props, State> {
     const hasSinglePoint = points.length === 1;
     const layerClass = classNames('recharts-area', className);
     const needClip = (xAxis && xAxis.allowDataOverflow) || (yAxis && yAxis.allowDataOverflow);
-    const clipPathId = _.isNil(id) ? this.id : id;
+    const clipPathId = isNil(id) ? this.id : id;
 
     return (
       <Layer className={layerClass}>

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -4,7 +4,10 @@
 import React, { PureComponent, ReactElement } from 'react';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
+import isNil from 'lodash/isNil';
+import isEqual from 'lodash/isEqual';
+import isArray from 'lodash/isArray';
 import { Rectangle, Props as RectangleProps } from '../shape/Rectangle';
 import { Layer } from '../container/Layer';
 import { ErrorBar, Props as ErrorBarProps } from './ErrorBar';
@@ -177,7 +180,7 @@ export class Bar extends PureComponent<Props, State> {
       } else {
         value = getValueByDataKey(entry, dataKey);
 
-        if (!_.isArray(value)) {
+        if (!isArray(value)) {
           value = [baseValue, value];
         }
       }
@@ -284,7 +287,7 @@ export class Bar extends PureComponent<Props, State> {
 
     if (React.isValidElement(option)) {
       rectangle = React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
+    } else if (isFunction(option)) {
       rectangle = option(props);
     } else {
       rectangle = <Rectangle {...props} />;
@@ -385,7 +388,7 @@ export class Bar extends PureComponent<Props, State> {
     const { data, isAnimationActive } = this.props;
     const { prevData } = this.state;
 
-    if (isAnimationActive && data && data.length && (!prevData || !_.isEqual(prevData, data))) {
+    if (isAnimationActive && data && data.length && (!prevData || !isEqual(prevData, data))) {
       return this.renderRectanglesWithAnimation();
     }
 
@@ -477,7 +480,7 @@ export class Bar extends PureComponent<Props, State> {
     const { isAnimationFinished } = this.state;
     const layerClass = classNames('recharts-bar', className);
     const needClip = (xAxis && xAxis.allowDataOverflow) || (yAxis && yAxis.allowDataOverflow);
-    const clipPathId = _.isNil(id) ? this.id : id;
+    const clipPathId = isNil(id) ? this.id : id;
 
     return (
       <Layer className={layerClass}>

--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -4,7 +4,8 @@
 import React, { PureComponent, Children, ReactText, MouseEvent, ReactElement, TouchEvent, SVGProps } from 'react';
 import classNames from 'classnames';
 import { scalePoint, ScalePoint } from 'd3-scale';
-import _ from 'lodash';
+import range from 'lodash/range';
+import isFunction from 'lodash/isFunction';
 import { Layer } from '../container/Layer';
 import { Text } from '../component/Text';
 import { getValueByDataKey } from '../util/ChartUtils';
@@ -92,7 +93,7 @@ const createScale = ({
 
   const len = data.length;
   const scale = scalePoint<number>()
-    .domain(_.range(0, len))
+    .domain(range(0, len))
     .range([x, x + width - travellerWidth]);
   const scaleValues = scale.domain().map(entry => scale(entry));
 
@@ -160,7 +161,7 @@ export class Brush extends PureComponent<Props, State> {
 
     if (React.isValidElement(option)) {
       rectangle = React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
+    } else if (isFunction(option)) {
       rectangle = option(props);
     } else {
       rectangle = Brush.renderDefaultTraveller(props);
@@ -252,7 +253,7 @@ export class Brush extends PureComponent<Props, State> {
     const { data, tickFormatter, dataKey } = this.props;
     const text = getValueByDataKey(data[index], dataKey, index);
 
-    return _.isFunction(tickFormatter) ? tickFormatter(text, index) : text;
+    return isFunction(tickFormatter) ? tickFormatter(text, index) : text;
   }
 
   handleDrag = (e: React.Touch | MouseEvent<SVGGElement>) => {

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -2,7 +2,8 @@
  * @fileOverview Cartesian Axis
  */
 import React, { ReactElement, ReactNode, Component, SVGProps } from 'react';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
+import get from 'lodash/get';
 import classNames from 'classnames';
 import { shallowEqual } from '../util/ShallowEqual';
 import { getStringSize } from '../util/DOMUtils';
@@ -159,7 +160,7 @@ export class CartesianAxis extends Component<Props> {
     if (preserveEnd) {
       // Try to guarantee the tail to be displayed
       let tail = ticks[len - 1];
-      const tailContent = _.isFunction(tickFormatter) ? tickFormatter(tail.value, len - 1) : tail.value;
+      const tailContent = isFunction(tickFormatter) ? tickFormatter(tail.value, len - 1) : tail.value;
       const tailSize = getStringSize(tailContent)[sizeKey] + unitSize;
       const tailGap = sign * (tail.coordinate + (sign * tailSize) / 2 - end);
       result[len - 1] = tail = {
@@ -180,7 +181,7 @@ export class CartesianAxis extends Component<Props> {
     const count = preserveEnd ? len - 1 : len;
     for (let i = 0; i < count; i++) {
       let entry = result[i];
-      const content = _.isFunction(tickFormatter) ? tickFormatter(entry.value, i) : entry.value;
+      const content = isFunction(tickFormatter) ? tickFormatter(entry.value, i) : entry.value;
       const size = getStringSize(content)[sizeKey] + unitSize;
 
       if (i === 0) {
@@ -227,7 +228,7 @@ export class CartesianAxis extends Component<Props> {
 
     for (let i = len - 1; i >= 0; i--) {
       let entry = result[i];
-      const content = _.isFunction(tickFormatter) ? tickFormatter(entry.value, len - i - 1) : entry.value;
+      const content = isFunction(tickFormatter) ? tickFormatter(entry.value, len - i - 1) : entry.value;
       const size = getStringSize(content)[sizeKey] + unitSize;
 
       if (i === len - 1) {
@@ -375,7 +376,7 @@ export class CartesianAxis extends Component<Props> {
       };
     }
 
-    return <line {...props} className={classNames('recharts-cartesian-axis-line', _.get(axisLine, 'className'))} />;
+    return <line {...props} className={classNames('recharts-cartesian-axis-line', get(axisLine, 'className'))} />;
   }
 
   static renderTickItem(option: Props['tick'], props: any, value: ReactNode) {
@@ -383,7 +384,7 @@ export class CartesianAxis extends Component<Props> {
 
     if (React.isValidElement(option)) {
       tickItem = React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
+    } else if (isFunction(option)) {
       tickItem = option(props);
     } else {
       tickItem = (
@@ -439,14 +440,14 @@ export class CartesianAxis extends Component<Props> {
             <line
               {...tickLineProps}
               {...lineCoord}
-              className={classNames('recharts-cartesian-axis-tick-line', _.get(tickLine, 'className'))}
+              className={classNames('recharts-cartesian-axis-tick-line', get(tickLine, 'className'))}
             />
           )}
           {tick &&
             CartesianAxis.renderTickItem(
               tick,
               tickProps,
-              `${_.isFunction(tickFormatter) ? tickFormatter(entry.value, i) : entry.value}${unit || ''}`,
+              `${isFunction(tickFormatter) ? tickFormatter(entry.value, i) : entry.value}${unit || ''}`,
             )}
         </Layer>
       );
@@ -465,7 +466,7 @@ export class CartesianAxis extends Component<Props> {
     const { ticks, ...noTicksProps } = this.props;
     let finalTicks = ticks;
 
-    if (_.isFunction(ticksGenerator)) {
+    if (isFunction(ticksGenerator)) {
       finalTicks = ticks && ticks.length > 0 ? ticksGenerator(this.props) : ticksGenerator(noTicksProps);
     }
 

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Cartesian Grid
  */
 import React, { PureComponent, ReactElement, SVGProps } from 'react';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
 import { isNumber } from '../util/DataUtils';
 import { ChartOffset, D3Scale, filterProps } from '../util/types';
 
@@ -63,7 +63,7 @@ export class CartesianGrid extends PureComponent<Props> {
 
     if (React.isValidElement(option)) {
       lineItem = React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
+    } else if (isFunction(option)) {
       lineItem = option(props);
     } else {
       const { x1, y1, x2, y2, key, ...others } = props;
@@ -271,12 +271,12 @@ export class CartesianGrid extends PureComponent<Props> {
     let { horizontalPoints, verticalPoints } = this.props;
 
     // No horizontal points are specified
-    if ((!horizontalPoints || !horizontalPoints.length) && _.isFunction(horizontalCoordinatesGenerator)) {
+    if ((!horizontalPoints || !horizontalPoints.length) && isFunction(horizontalCoordinatesGenerator)) {
       horizontalPoints = horizontalCoordinatesGenerator({ yAxis, width: chartWidth, height: chartHeight, offset });
     }
 
     // No vertical points are specified
-    if ((!verticalPoints || !verticalPoints.length) && _.isFunction(verticalCoordinatesGenerator)) {
+    if ((!verticalPoints || !verticalPoints.length) && isFunction(verticalCoordinatesGenerator)) {
       verticalPoints = verticalCoordinatesGenerator({ xAxis, width: chartWidth, height: chartHeight, offset });
     }
 

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -4,7 +4,9 @@
 import React, { PureComponent, ReactElement } from 'react';
 import Animate from 'react-smooth';
 import classNames from 'classnames';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
+import isNil from 'lodash/isNil';
+import isEqual from 'lodash/isEqual';
 import { Curve, CurveType, Props as CurveProps, Point as CurvePoint } from '../shape/Curve';
 import { Dot, Props as DotProps } from '../shape/Dot';
 import { Layer } from '../container/Layer';
@@ -144,14 +146,14 @@ export class Line extends PureComponent<Props, State> {
       if (layout === 'horizontal') {
         return {
           x: getCateCoordinateOfLine({ axis: xAxis, ticks: xAxisTicks, bandSize, entry, index }),
-          y: _.isNil(value) ? null : yAxis.scale(value),
+          y: isNil(value) ? null : yAxis.scale(value),
           value,
           payload: entry,
         };
       }
 
       return {
-        x: _.isNil(value) ? null : xAxis.scale(value),
+        x: isNil(value) ? null : xAxis.scale(value),
         y: getCateCoordinateOfLine({ axis: yAxis, ticks: yAxisTicks, bandSize, entry, index }),
         value,
         payload: entry,
@@ -297,7 +299,7 @@ export class Line extends PureComponent<Props, State> {
 
     if (React.isValidElement(option)) {
       dotItem = React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
+    } else if (isFunction(option)) {
       dotItem = option(props);
     } else {
       const className = classNames('recharts-line-dot', option ? (option as DotProps).className : '');
@@ -443,7 +445,7 @@ export class Line extends PureComponent<Props, State> {
       isAnimationActive &&
       points &&
       points.length &&
-      ((!prevPoints && totalLength > 0) || !_.isEqual(prevPoints, points))
+      ((!prevPoints && totalLength > 0) || !isEqual(prevPoints, points))
     ) {
       return this.renderCurveWithAnimation(needClip, clipPathId);
     }
@@ -462,7 +464,7 @@ export class Line extends PureComponent<Props, State> {
     const hasSinglePoint = points.length === 1;
     const layerClass = classNames('recharts-line', className);
     const needClip = (xAxis && xAxis.allowDataOverflow) || (yAxis && yAxis.allowDataOverflow);
-    const clipPathId = _.isNil(id) ? this.id : id;
+    const clipPathId = isNil(id) ? this.id : id;
 
     return (
       <Layer className={layerClass}>

--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Reference Line
  */
 import React, { ReactElement } from 'react';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
 import classNames from 'classnames';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelType, Label } from '../component/Label';
@@ -113,7 +113,7 @@ ReferenceArea.renderRect = (option: ReferenceAreaProps['shape'], props: any) => 
 
   if (React.isValidElement(option)) {
     rect = React.cloneElement(option, props);
-  } else if (_.isFunction(option)) {
+  } else if (isFunction(option)) {
     rect = option(props);
   } else {
     rect = <Rectangle {...props} className="recharts-reference-area-rect" />;

--- a/src/cartesian/ReferenceDot.tsx
+++ b/src/cartesian/ReferenceDot.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Reference Dot
  */
 import React, { ReactElement } from 'react';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
 import classNames from 'classnames';
 import { Layer } from '../container/Layer';
 import { Dot, Props as DotProps } from '../shape/Dot';
@@ -112,7 +112,7 @@ ReferenceDot.renderDot = (option: Props['shape'], props: any) => {
 
   if (React.isValidElement(option)) {
     dot = React.cloneElement(option, props);
-  } else if (_.isFunction(option)) {
+  } else if (isFunction(option)) {
     dot = option(props);
   } else {
     dot = <Dot {...props} cx={props.cx} cy={props.cy} className="recharts-reference-dot-dot" />;

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -2,7 +2,8 @@
  * @fileOverview Reference Line
  */
 import React, { ReactElement, SVGProps } from 'react';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
+import some from 'lodash/some';
 import classNames from 'classnames';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelType, Label } from '../component/Label';
@@ -50,7 +51,7 @@ const renderLine = (option: ReferenceLineProps['shape'], props: any) => {
 
   if (React.isValidElement(option)) {
     line = React.cloneElement(option, props);
-  } else if (_.isFunction(option)) {
+  } else if (isFunction(option)) {
     line = option(props);
   } else {
     line = <line {...props} className="recharts-reference-line-line" />;
@@ -105,7 +106,7 @@ const getEndPoints = (scales: any, isFixedX: boolean, isFixedY: boolean, isSegme
 
     const points = segment.map(p => scales.apply(p, { position }));
 
-    if (ifOverflowMatches(props, 'discard') && _.some(points, p => !scales.isInRange(p))) {
+    if (ifOverflowMatches(props, 'discard') && some(points, p => !scales.isInRange(p))) {
       return null;
     }
 

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -4,7 +4,9 @@
 import React, { PureComponent, ReactElement } from 'react';
 import Animate from 'react-smooth';
 import classNames from 'classnames';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
+import isNil from 'lodash/isNil';
+import isEqual from 'lodash/isEqual';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelListType, LabelList } from '../component/LabelList';
 import { findAllByType } from '../util/ReactUtils';
@@ -142,8 +144,8 @@ export class Scatter extends PureComponent<Props, State> {
   }) => {
     const { tooltipType } = item.props;
     const cells = findAllByType(item.props.children, Cell.displayName);
-    const xAxisDataKey = _.isNil(xAxis.dataKey) ? item.props.dataKey : xAxis.dataKey;
-    const yAxisDataKey = _.isNil(yAxis.dataKey) ? item.props.dataKey : yAxis.dataKey;
+    const xAxisDataKey = isNil(xAxis.dataKey) ? item.props.dataKey : xAxis.dataKey;
+    const yAxisDataKey = isNil(yAxis.dataKey) ? item.props.dataKey : yAxis.dataKey;
     const zAxisDataKey = zAxis && zAxis.dataKey;
     const defaultRangeZ = zAxis ? zAxis.range : ZAxis.defaultProps.range;
     const defaultZ = defaultRangeZ && defaultRangeZ[0];
@@ -152,10 +154,10 @@ export class Scatter extends PureComponent<Props, State> {
     const points = displayedData.map((entry, index) => {
       const x = getValueByDataKey(entry, xAxisDataKey);
       const y = getValueByDataKey(entry, yAxisDataKey);
-      const z = (!_.isNil(zAxisDataKey) && getValueByDataKey(entry, zAxisDataKey)) || '-';
+      const z = (!isNil(zAxisDataKey) && getValueByDataKey(entry, zAxisDataKey)) || '-';
       const tooltipPayload = [
         {
-          name: _.isNil(xAxis.dataKey) ? item.props.name : xAxis.name || xAxis.dataKey,
+          name: isNil(xAxis.dataKey) ? item.props.name : xAxis.name || xAxis.dataKey,
           unit: xAxis.unit || '',
           value: x,
           payload: entry,
@@ -163,7 +165,7 @@ export class Scatter extends PureComponent<Props, State> {
           type: tooltipType,
         },
         {
-          name: _.isNil(yAxis.dataKey) ? item.props.name : yAxis.name || yAxis.dataKey,
+          name: isNil(yAxis.dataKey) ? item.props.name : yAxis.name || yAxis.dataKey,
           unit: yAxis.unit || '',
           value: y,
           payload: entry,
@@ -261,7 +263,7 @@ export class Scatter extends PureComponent<Props, State> {
 
     if (React.isValidElement(option)) {
       symbol = React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
+    } else if (isFunction(option)) {
       symbol = option(props);
     } else if (typeof option === 'string') {
       symbol = <Symbols {...props} type={option} />;
@@ -337,7 +339,7 @@ export class Scatter extends PureComponent<Props, State> {
     const { points, isAnimationActive } = this.props;
     const { prevPoints } = this.state;
 
-    if (isAnimationActive && points && points.length && (!prevPoints || !_.isEqual(prevPoints, points))) {
+    if (isAnimationActive && points && points.length && (!prevPoints || !isEqual(prevPoints, points))) {
       return this.renderSymbolsWithAnimation();
     }
 
@@ -415,7 +417,7 @@ export class Scatter extends PureComponent<Props, State> {
 
     if (React.isValidElement(line)) {
       lineItem = React.cloneElement(line as any, lineProps);
-    } else if (_.isFunction(line)) {
+    } else if (isFunction(line)) {
       lineItem = line(lineProps);
     } else {
       lineItem = <Curve {...lineProps} type={lineJointType} />;
@@ -436,7 +438,7 @@ export class Scatter extends PureComponent<Props, State> {
     const { isAnimationFinished } = this.state;
     const layerClass = classNames('recharts-scatter', className);
     const needClip = (xAxis && xAxis.allowDataOverflow) || (yAxis && yAxis.allowDataOverflow);
-    const clipPathId = _.isNil(id) ? this.id : id;
+    const clipPathId = isNil(id) ? this.id : id;
 
     return (
       <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -3,7 +3,11 @@
  */
 import React, { PureComponent, ReactElement, SVGProps } from 'react';
 import classNames from 'classnames';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
+import maxBy from 'lodash/maxBy';
+import min from 'lodash/min';
+import get from 'lodash/get';
+import sumBy from 'lodash/sumBy';
 import { Surface } from '../container/Surface';
 import { Layer } from '../container/Layer';
 import { Tooltip } from '../component/Tooltip';
@@ -96,7 +100,7 @@ const getNodesTree = ({ nodes, links }: SankeyData, width: number, nodeWidth: nu
       updateDepthOfTargets(tree, node);
     }
   }
-  const maxDepth = _.maxBy(tree, (entry: SankeyNode) => entry.depth).depth;
+  const maxDepth = maxBy(tree, (entry: SankeyNode) => entry.depth).depth;
 
   if (maxDepth >= 1) {
     const childWidth = (width - nodeWidth) / maxDepth;
@@ -131,8 +135,8 @@ const getDepthTree = (tree: any): any[] => {
 };
 
 const updateYOfTree = (depthTree: any, height: number, nodePadding: number, links: any) => {
-  const yRatio: number = _.min(
-    depthTree.map((nodes: any) => (height - (nodes.length - 1) * nodePadding) / _.sumBy(nodes, getValue)),
+  const yRatio: number = min(
+    depthTree.map((nodes: any) => (height - (nodes.length - 1) * nodePadding) / sumBy(nodes, getValue)),
   );
 
   for (let d = 0, maxDepth = depthTree.length; d < maxDepth; d++) {
@@ -512,7 +516,7 @@ export class Sankey extends PureComponent<Props, State> {
     if (React.isValidElement(option)) {
       return React.cloneElement(option, props);
     }
-    if (_.isFunction(option)) {
+    if (isFunction(option)) {
       return option(props);
     }
 
@@ -536,8 +540,8 @@ export class Sankey extends PureComponent<Props, State> {
 
   renderLinks(links: SankeyLink[], nodes: SankeyNode[]) {
     const { linkCurvature, link: linkContent, margin } = this.props;
-    const top = _.get(margin, 'top') || 0;
-    const left = _.get(margin, 'left') || 0;
+    const top = get(margin, 'top') || 0;
+    const left = get(margin, 'left') || 0;
 
     return (
       <Layer className="recharts-sankey-links" key="recharts-sankey-links">
@@ -588,7 +592,7 @@ export class Sankey extends PureComponent<Props, State> {
     if (React.isValidElement(option)) {
       return React.cloneElement(option, props);
     }
-    if (_.isFunction(option)) {
+    if (isFunction(option)) {
       return option(props);
     }
 
@@ -597,8 +601,8 @@ export class Sankey extends PureComponent<Props, State> {
 
   renderNodes(nodes: SankeyNode[]) {
     const { node: nodeContent, margin } = this.props;
-    const top = _.get(margin, 'top') || 0;
-    const left = _.get(margin, 'left') || 0;
+    const top = get(margin, 'top') || 0;
+    const left = get(margin, 'left') || 0;
 
     return (
       <Layer className="recharts-sankey-nodes" key="recharts-sankey-nodes">

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -5,7 +5,9 @@
 import React, { PureComponent } from 'react';
 import Smooth from 'react-smooth';
 import classNames from 'classnames';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
+import omit from 'lodash/omit';
+import get from 'lodash/get';
 import { Surface } from '../container/Surface';
 import { Layer } from '../container/Layer';
 import { Rectangle } from '../shape/Rectangle';
@@ -46,7 +48,7 @@ const computeNode = ({
     nodeValue = computedChildren.reduce((result: any, child: TreemapNode) => result + child[NODE_VALUE_KEY], 0);
   } else {
     // TODO need to verify valueKey
-    nodeValue = _.isNaN(node[valueKey as string]) || node[valueKey as string] <= 0 ? 0 : node[valueKey as string];
+    nodeValue = isNaN(node[valueKey as string]) || node[valueKey as string] <= 0 ? 0 : node[valueKey as string];
   }
 
   return {
@@ -69,7 +71,7 @@ const getAreaOfChildren = (children: TreemapNode[], areaValueRatio: number) => {
 
     return {
       ...child,
-      area: _.isNaN(area) || area <= 0 ? 0 : area,
+      area: isNaN(area) || area <= 0 ? 0 : area,
     };
   });
 };
@@ -402,7 +404,7 @@ export class Treemap extends PureComponent<Props, State> {
     const { onAnimationEnd } = this.props;
     this.setState({ isAnimationFinished: true });
 
-    if (_.isFunction(onAnimationEnd)) {
+    if (isFunction(onAnimationEnd)) {
       onAnimationEnd();
     }
   };
@@ -411,7 +413,7 @@ export class Treemap extends PureComponent<Props, State> {
     const { onAnimationStart } = this.props;
     this.setState({ isAnimationFinished: false });
 
-    if (_.isFunction(onAnimationStart)) {
+    if (isFunction(onAnimationStart)) {
       onAnimationStart();
     }
   };
@@ -566,7 +568,7 @@ export class Treemap extends PureComponent<Props, State> {
     if (React.isValidElement(content)) {
       return React.cloneElement(content, nodeProps);
     }
-    if (_.isFunction(content)) {
+    if (isFunction(content)) {
       return content(nodeProps);
     }
     // optimize default shape
@@ -599,7 +601,7 @@ export class Treemap extends PureComponent<Props, State> {
         <Rectangle
           fill={nodeProps.depth < 2 ? colors[index % colors.length] : 'rgba(255,255,255,0)'}
           stroke="#fff"
-          {..._.omit(nodeProps, 'children')}
+          {...omit(nodeProps, 'children')}
         />
         {arrow}
         {text}
@@ -687,12 +689,12 @@ export class Treemap extends PureComponent<Props, State> {
       <div className="recharts-treemap-nest-index-wrapper" style={{ marginTop: '8px', textAlign: 'center' }}>
         {nestIndex.map((item: TreemapNode, i: number) => {
           // TODO need to verify nameKey type
-          const name = _.get(item, nameKey as string, 'root');
+          const name = get(item, nameKey as string, 'root');
           let content = null;
           if (React.isValidElement(nestIndexContent)) {
             content = React.cloneElement(nestIndexContent, item, i);
           }
-          if (_.isFunction(nestIndexContent)) {
+          if (isFunction(nestIndexContent)) {
             content = nestIndexContent(item, i);
           } else {
             content = name;

--- a/src/component/Customized.tsx
+++ b/src/component/Customized.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Customized
  */
 import React, { isValidElement, cloneElement, createElement, Component, FunctionComponent, ReactElement } from 'react';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
 import { Layer } from '../container/Layer';
 import { warn } from '../util/LogUtils';
 
@@ -19,7 +19,7 @@ export function Customized<P, C extends Comp<P>>({ component, ...props }: Props<
   let child;
   if (isValidElement(component)) {
     child = cloneElement(component, props);
-  } else if (_.isFunction(component)) {
+  } else if (isFunction(component)) {
     child = createElement(component, props as any);
   } else {
     warn(false, "Customized's props `component` must be React.element or Function, but got %s.", typeof component);

--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -1,13 +1,15 @@
 /**
  * @fileOverview Default Tooltip Content
  */
-import _ from 'lodash';
+ import isArray from 'lodash/isArray';
+ import sortBy from 'lodash/sortBy';
+ import isNil from 'lodash/isNil';
 import React, { PureComponent, CSSProperties, ReactNode } from 'react';
 import classNames from 'classnames';
 import { isNumOrStr } from '../util/DataUtils';
 
 function defaultFormatter<T>(value: T) {
-  return _.isArray(value) && isNumOrStr(value[0]) && isNumOrStr(value[1]) ? value.join(' ~ ') : value;
+  return isArray(value) && isNumOrStr(value[0]) && isNumOrStr(value[1]) ? value.join(' ~ ') : value;
 }
 
 export type TooltipType = 'none';
@@ -64,7 +66,7 @@ export class DefaultTooltipContent<TValue extends ValueType, TName extends NameT
     if (payload && payload.length) {
       const listStyle = { padding: 0, margin: 0 };
 
-      const items = (itemSorter ? _.sortBy(payload, itemSorter) : payload).map((entry, i) => {
+      const items = (itemSorter ? sortBy(payload, itemSorter) : payload).map((entry, i) => {
         if (entry.type === 'none') {
           return null;
         }
@@ -121,7 +123,7 @@ export class DefaultTooltipContent<TValue extends ValueType, TName extends NameT
       margin: 0,
       ...labelStyle,
     };
-    const hasLabel = !_.isNil(label);
+    const hasLabel = !isNil(label);
     let finalLabel = hasLabel ? label : '';
     const wrapperCN = classNames('recharts-default-tooltip', wrapperClassName);
     const labelCN = classNames('recharts-tooltip-label', labelClassName);

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -1,5 +1,7 @@
 import React, { cloneElement, isValidElement, ReactNode, ReactElement, createElement, SVGProps } from 'react';
-import _ from 'lodash';
+import isObject from 'lodash/isObject';
+import isFunction from 'lodash/isFunction';
+import isNil from 'lodash/isNil';
 import classNames from 'classnames';
 import { Text } from './Text';
 import { findAllByType } from '../util/ReactUtils';
@@ -16,31 +18,31 @@ interface LabelProps {
   value?: number | string;
   offset?: number;
   position?:
-    | 'top'
-    | 'left'
-    | 'right'
-    | 'bottom'
-    | 'inside'
-    | 'outside'
-    | 'insideLeft'
-    | 'insideRight'
-    | 'insideTop'
-    | 'insideBottom'
-    | 'insideTopLeft'
-    | 'insideBottomLeft'
-    | 'insideTopRight'
-    | 'insideBottomRight'
-    | 'insideStart'
-    | 'insideEnd'
-    | 'end'
-    | 'center'
-    | 'centerTop'
-    | 'centerBottom'
-    | 'middle'
-    | {
-        x?: number;
-        y?: number;
-      };
+  | 'top'
+  | 'left'
+  | 'right'
+  | 'bottom'
+  | 'inside'
+  | 'outside'
+  | 'insideLeft'
+  | 'insideRight'
+  | 'insideTop'
+  | 'insideBottom'
+  | 'insideTopLeft'
+  | 'insideBottomLeft'
+  | 'insideTopRight'
+  | 'insideBottomRight'
+  | 'insideStart'
+  | 'insideEnd'
+  | 'end'
+  | 'center'
+  | 'centerTop'
+  | 'centerBottom'
+  | 'middle'
+  | {
+    x?: number;
+    y?: number;
+  };
   children?: ReactNode;
   className?: string;
   content?: ContentType;
@@ -60,9 +62,9 @@ export type ImplicitLabelType =
 
 const getLabel = (props: Props) => {
   const { value, formatter } = props;
-  const label = _.isNil(props.children) ? value : props.children;
+  const label = isNil(props.children) ? value : props.children;
 
-  if (_.isFunction(formatter)) {
+  if (isFunction(formatter)) {
     return formatter(label);
   }
 
@@ -102,7 +104,7 @@ const renderRadialLabel = (labelProps: Props, label: ReactNode, attrs: SVGProps<
   const path = `M${startPoint.x},${startPoint.y}
     A${radius},${radius},0,1,${direction ? 0 : 1},
     ${endPoint.x},${endPoint.y}`;
-  const id = _.isNil(labelProps.id) ? uniqueId('recharts-radial-line-') : labelProps.id;
+  const id = isNil(labelProps.id) ? uniqueId('recharts-radial-line-') : labelProps.id;
 
   return (
     <text {...attrs} dominantBaseline="central" className={classNames('recharts-radial-bar-label', className)}>
@@ -196,9 +198,9 @@ const getAttrsOfCartesianLabel = (props: Props) => {
       ...attrs,
       ...(parentViewBox
         ? {
-            height: Math.max(y - (parentViewBox as CartesianViewBox).y, 0),
-            width,
-          }
+          height: Math.max(y - (parentViewBox as CartesianViewBox).y, 0),
+          width,
+        }
         : {}),
     };
   }
@@ -215,12 +217,12 @@ const getAttrsOfCartesianLabel = (props: Props) => {
       ...attrs,
       ...(parentViewBox
         ? {
-            height: Math.max(
-              (parentViewBox as CartesianViewBox).y + (parentViewBox as CartesianViewBox).height - (y + height),
-              0,
-            ),
-            width,
-          }
+          height: Math.max(
+            (parentViewBox as CartesianViewBox).y + (parentViewBox as CartesianViewBox).height - (y + height),
+            0,
+          ),
+          width,
+        }
         : {}),
     };
   }
@@ -237,9 +239,9 @@ const getAttrsOfCartesianLabel = (props: Props) => {
       ...attrs,
       ...(parentViewBox
         ? {
-            width: Math.max(attrs.x - (parentViewBox as CartesianViewBox).x, 0),
-            height,
-          }
+          width: Math.max(attrs.x - (parentViewBox as CartesianViewBox).x, 0),
+          height,
+        }
         : {}),
     };
   }
@@ -255,12 +257,12 @@ const getAttrsOfCartesianLabel = (props: Props) => {
       ...attrs,
       ...(parentViewBox
         ? {
-            width: Math.max(
-              (parentViewBox as CartesianViewBox).x + (parentViewBox as CartesianViewBox).width - attrs.x,
-              0,
-            ),
-            height,
-          }
+          width: Math.max(
+            (parentViewBox as CartesianViewBox).x + (parentViewBox as CartesianViewBox).width - attrs.x,
+            0,
+          ),
+          height,
+        }
         : {}),
     };
   }
@@ -348,7 +350,7 @@ const getAttrsOfCartesianLabel = (props: Props) => {
   }
 
   if (
-    _.isObject(position) &&
+    isObject(position) &&
     (isNumber(position.x) || isPercent(position.x)) &&
     (isNumber(position.y) || isPercent(position.y))
   ) {
@@ -375,7 +377,7 @@ const isPolar = (viewBox: CartesianViewBox | PolarViewBox) => isNumber((viewBox 
 export function Label(props: Props) {
   const { viewBox, position, value, children, content, className = '', textBreakAll } = props;
 
-  if (!viewBox || (_.isNil(value) && _.isNil(children) && !isValidElement(content) && !_.isFunction(content))) {
+  if (!viewBox || (isNil(value) && isNil(children) && !isValidElement(content) && !isFunction(content))) {
     return null;
   }
 
@@ -384,7 +386,7 @@ export function Label(props: Props) {
   }
 
   let label: ReactNode;
-  if (_.isFunction(content)) {
+  if (isFunction(content)) {
     label = createElement(content as any, props);
 
     if (isValidElement(label)) {
@@ -498,11 +500,11 @@ const parseLabel = (label: any, viewBox: ViewBox) => {
     return <Label key="label-implicit" content={label} viewBox={viewBox} />;
   }
 
-  if (_.isFunction(label)) {
+  if (isFunction(label)) {
     return <Label key="label-implicit" content={label} viewBox={viewBox} />;
   }
 
-  if (_.isObject(label)) {
+  if (isObject(label)) {
     return <Label viewBox={viewBox} {...label} key="label-implicit" />;
   }
 

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -1,5 +1,9 @@
 import React, { cloneElement, ReactElement, SVGProps } from 'react';
-import _ from 'lodash';
+import isObject from 'lodash/isObject';
+import isFunction from 'lodash/isFunction';
+import isNil from 'lodash/isNil';
+import last from 'lodash/last';
+import isArray from 'lodash/isArray';
 import { Label, ContentType, Props as LabelProps } from './Label';
 import { Layer } from '../container/Layer';
 import { findAllByType } from '../util/ReactUtils';
@@ -34,7 +38,7 @@ export type ImplicitLabelListType<T> =
   | Props<T>;
 
 const defaultProps = {
-  valueAccessor: (entry: Data) => (_.isArray(entry.value) ? _.last(entry.value) : entry.value),
+  valueAccessor: (entry: Data) => (isArray(entry.value) ? last(entry.value) : entry.value),
 };
 
 export function LabelList<T extends Data>(props: Props<T>) {
@@ -47,10 +51,10 @@ export function LabelList<T extends Data>(props: Props<T>) {
   return (
     <Layer className="recharts-label-list">
       {data.map((entry, index) => {
-        const value = _.isNil(dataKey)
+        const value = isNil(dataKey)
           ? valueAccessor(entry, index)
           : getValueByDataKey(entry && entry.payload, dataKey);
-        const idProps = _.isNil(id) ? {} : { id: `${id}-${index}` };
+        const idProps = isNil(id) ? {} : { id: `${id}-${index}` };
 
         return (
           <Label
@@ -61,7 +65,7 @@ export function LabelList<T extends Data>(props: Props<T>) {
             index={index}
             value={value}
             textBreakAll={textBreakAll}
-            viewBox={Label.parseViewBox(_.isNil(clockWise) ? entry : { ...entry, clockWise })}
+            viewBox={Label.parseViewBox(isNil(clockWise) ? entry : { ...entry, clockWise })}
             key={`label-${index}`} // eslint-disable-line react/no-array-index-key
           />
         );
@@ -81,11 +85,11 @@ function parseLabelList<T extends Data>(label: any, data: Array<T>) {
     return <LabelList key="labelList-implicit" data={data} />;
   }
 
-  if (React.isValidElement(label) || _.isFunction(label)) {
+  if (React.isValidElement(label) || isFunction(label)) {
     return <LabelList key="labelList-implicit" data={data} content={label} />;
   }
 
-  if (_.isObject(label)) {
+  if (isObject(label)) {
     return <LabelList data={data} {...label} key="labelList-implicit" />;
   }
 

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -2,7 +2,8 @@
  * @fileOverview Legend
  */
 import React, { PureComponent, CSSProperties } from 'react';
-import _ from 'lodash';
+import uniqBy from 'lodash/uniqBy';
+import isFunction from 'lodash/isFunction';
 import { DefaultLegendContent, Payload, Props as DefaultProps, ContentType } from './DefaultLegendContent';
 
 import { isNumber } from '../util/DataUtils';
@@ -13,11 +14,11 @@ function defaultUniqBy(entry: Payload) {
 }
 function getUniqPayload(option: UniqueOption, payload: Array<Payload>) {
   if (option === true) {
-    return _.uniqBy(payload, defaultUniqBy);
+    return uniqBy(payload, defaultUniqBy);
   }
 
-  if (_.isFunction(option)) {
-    return _.uniqBy(payload, option);
+  if (isFunction(option)) {
+    return uniqBy(payload, option);
   }
 
   return payload;
@@ -27,7 +28,7 @@ function renderContent(content: ContentType, props: Props) {
   if (React.isValidElement(content)) {
     return React.cloneElement(content, props);
   }
-  if (_.isFunction(content)) {
+  if (isFunction(content)) {
     return React.createElement(content as any, props);
   }
 

--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -1,7 +1,7 @@
 import React, { Component, CSSProperties, SVGProps } from 'react';
 import reduceCSSCalc from 'reduce-css-calc';
 import classNames from 'classnames';
-import _ from 'lodash';
+import isNil from 'lodash/isNil';
 import { isNumber, isNumOrStr } from '../util/DataUtils';
 import { Global } from '../util/Global';
 import { filterProps } from '../util/types';
@@ -22,7 +22,7 @@ interface CalculatedWordWidths {
 const calculateWordWidths = (props: Props): CalculatedWordWidths => {
   try {
     let words: string[] = [];
-    if (!_.isNil(props.children)) {
+    if (!isNil(props.children)) {
       if (props.breakAll) {
         words = props.children.toString().split('');
       } else {
@@ -156,7 +156,7 @@ const calculateWordsByLines = (
 };
 
 const getWordsWithoutCalculate = (children: React.ReactNode): Array<Words> => {
-  const words = !_.isNil(children) ? children.toString().split(BREAKING_SPACES) : [];
+  const words = !isNil(children) ? children.toString().split(BREAKING_SPACES) : [];
   return [{ words }];
 };
 

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -3,7 +3,9 @@
  */
 import React, { PureComponent, CSSProperties, ReactNode, ReactElement, SVGProps } from 'react';
 import { translateStyle } from 'react-smooth';
-import _ from 'lodash';
+import isNil from 'lodash/isNil';
+import uniqBy from 'lodash/uniqBy';
+import isFunction from 'lodash/isFunction';
 import classNames from 'classnames';
 import { DefaultTooltipContent, ValueType, NameType, Payload, Props as DefaultProps } from './DefaultTooltipContent';
 
@@ -28,11 +30,11 @@ function getUniqPayload<TValue extends ValueType, TName extends NameType>(
   payload: Array<Payload<TValue, TName>>,
 ) {
   if (option === true) {
-    return _.uniqBy(payload, defaultUniqBy);
+    return uniqBy(payload, defaultUniqBy);
   }
 
-  if (_.isFunction(option)) {
-    return _.uniqBy(payload, option);
+  if (isFunction(option)) {
+    return uniqBy(payload, option);
   }
 
   return payload;
@@ -45,7 +47,7 @@ function renderContent<TValue extends ValueType, TName extends NameType>(
   if (React.isValidElement(content)) {
     return React.cloneElement(content, props);
   }
-  if (_.isFunction(content)) {
+  if (isFunction(content)) {
     return React.createElement(content as any, props);
   }
 
@@ -180,7 +182,7 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
     const { payload, isAnimationActive, animationDuration, animationEasing, filterNull, payloadUniqBy } = this.props;
     const finalPayload = getUniqPayload(
       payloadUniqBy,
-      filterNull && payload && payload.length ? payload.filter(entry => !_.isNil(entry.value)) : payload,
+      filterNull && payload && payload.length ? payload.filter(entry => !isNil(entry.value)) : payload,
     );
     const hasPayload = finalPayload && finalPayload.length;
     const { content, viewBox, coordinate, position, active, wrapperStyle } = this.props;

--- a/src/numberAxis/Funnel.tsx
+++ b/src/numberAxis/Funnel.tsx
@@ -4,7 +4,12 @@
 import React, { PureComponent, ReactElement } from 'react';
 import Animate from 'react-smooth';
 import classNames from 'classnames';
-import _ from 'lodash';
+import isNumber from 'lodash/isNumber';
+import isString from 'lodash/isString';
+import isFunction from 'lodash/isFunction';
+import omit from 'lodash/omit';
+import isPlainObject from 'lodash/isPlainObject';
+import isEqual from 'lodash/isEqual';
 import { Layer } from '../container/Layer';
 import { Trapezoid, Props as TrapezoidProps } from '../shape/Trapezoid';
 import { LabelList } from '../component/LabelList';
@@ -111,9 +116,9 @@ export class Funnel extends PureComponent<Props, State> {
     const realHeight = height;
     let realWidth = width;
 
-    if (_.isNumber(customWidth)) {
+    if (isNumber(customWidth)) {
       realWidth = customWidth;
-    } else if (_.isString(customWidth)) {
+    } else if (isString(customWidth)) {
       realWidth = (realWidth * parseFloat(customWidth)) / 100;
     }
 
@@ -180,7 +185,7 @@ export class Funnel extends PureComponent<Props, State> {
         val,
         tooltipPayload,
         tooltipPosition,
-        ..._.omit(entry, 'width'),
+        ...omit(entry, 'width'),
         payload: entry,
         parentViewBox,
         labelViewBox: {
@@ -239,7 +244,7 @@ export class Funnel extends PureComponent<Props, State> {
     const { onAnimationEnd } = this.props;
     this.setState({ isAnimationFinished: true });
 
-    if (_.isFunction(onAnimationEnd)) {
+    if (isFunction(onAnimationEnd)) {
       onAnimationEnd();
     }
   };
@@ -248,7 +253,7 @@ export class Funnel extends PureComponent<Props, State> {
     const { onAnimationStart } = this.props;
     this.setState({ isAnimationFinished: false });
 
-    if (_.isFunction(onAnimationStart)) {
+    if (isFunction(onAnimationStart)) {
       onAnimationStart();
     }
   };
@@ -267,10 +272,10 @@ export class Funnel extends PureComponent<Props, State> {
     if (React.isValidElement(option)) {
       return React.cloneElement(option, props);
     }
-    if (_.isFunction(option)) {
+    if (isFunction(option)) {
       return option(props);
     }
-    if (_.isPlainObject(option)) {
+    if (isPlainObject(option)) {
       return <Trapezoid {...props} {...option} />;
     }
 
@@ -372,7 +377,7 @@ export class Funnel extends PureComponent<Props, State> {
       isAnimationActive &&
       trapezoids &&
       trapezoids.length &&
-      (!prevTrapezoids || !_.isEqual(prevTrapezoids, trapezoids))
+      (!prevTrapezoids || !isEqual(prevTrapezoids, trapezoids))
     ) {
       return this.renderTrapezoidsWithAnimation();
     }

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -4,7 +4,11 @@
 import React, { PureComponent, ReactElement, ReactNode, SVGProps } from 'react';
 import Animate from 'react-smooth';
 import classNames from 'classnames';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
+import isPlainObject from 'lodash/isPlainObject';
+import isNil from 'lodash/isNil';
+import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 import { Layer } from '../container/Layer';
 import { Sector, Props as SectorProps } from '../shape/Sector';
 import { Curve } from '../shape/Curve';
@@ -203,14 +207,14 @@ export class Pie extends PureComponent<Props, State> {
 
     let realDataKey = dataKey;
 
-    if (_.isNil(dataKey) && _.isNil(valueKey)) {
+    if (isNil(dataKey) && isNil(valueKey)) {
       warn(
         false,
         `Use "dataKey" to specify the value of pie,
       the props "valueKey" will be deprecated in 1.1.0`,
       );
       realDataKey = 'value';
-    } else if (_.isNil(dataKey)) {
+    } else if (isNil(dataKey)) {
       warn(
         false,
         `Use "dataKey" to specify the value of pie,
@@ -353,7 +357,7 @@ export class Pie extends PureComponent<Props, State> {
       isAnimationFinished: true,
     });
 
-    if (_.isFunction(onAnimationEnd)) {
+    if (isFunction(onAnimationEnd)) {
       onAnimationEnd();
     }
   };
@@ -365,7 +369,7 @@ export class Pie extends PureComponent<Props, State> {
       isAnimationFinished: false,
     });
 
-    if (_.isFunction(onAnimationStart)) {
+    if (isFunction(onAnimationStart)) {
       onAnimationStart();
     }
   };
@@ -374,7 +378,7 @@ export class Pie extends PureComponent<Props, State> {
     if (React.isValidElement(option)) {
       return React.cloneElement(option, props);
     }
-    if (_.isFunction(option)) {
+    if (isFunction(option)) {
       return option(props);
     }
 
@@ -386,7 +390,7 @@ export class Pie extends PureComponent<Props, State> {
       return React.cloneElement(option, props);
     }
     let label = value;
-    if (_.isFunction(option)) {
+    if (isFunction(option)) {
       label = option(props);
       if (React.isValidElement(label)) {
         return label;
@@ -436,9 +440,9 @@ export class Pie extends PureComponent<Props, State> {
       };
       let realDataKey = dataKey;
       // TODO: compatible to lower versions
-      if (_.isNil(dataKey) && _.isNil(valueKey)) {
+      if (isNil(dataKey) && isNil(valueKey)) {
         realDataKey = 'value';
-      } else if (_.isNil(dataKey)) {
+      } else if (isNil(dataKey)) {
         realDataKey = valueKey;
       }
 
@@ -458,10 +462,10 @@ export class Pie extends PureComponent<Props, State> {
     if (React.isValidElement(option)) {
       return React.cloneElement(option, props);
     }
-    if (_.isFunction(option)) {
+    if (isFunction(option)) {
       return option(props);
     }
-    if (_.isPlainObject(option)) {
+    if (isPlainObject(option)) {
       return <Sector {...props} {...option} />;
     }
 
@@ -513,7 +517,7 @@ export class Pie extends PureComponent<Props, State> {
 
           sectors.forEach((entry, index) => {
             const prev = prevSectors && prevSectors[index];
-            const paddingAngle = index > 0 ? _.get(entry, 'paddingAngle', 0) : 0;
+            const paddingAngle = index > 0 ? get(entry, 'paddingAngle', 0) : 0;
 
             if (prev) {
               const angleIp = interpolateNumber(prev.endAngle - prev.startAngle, entry.endAngle - entry.startAngle);
@@ -550,7 +554,7 @@ export class Pie extends PureComponent<Props, State> {
     const { sectors, isAnimationActive } = this.props;
     const { prevSectors } = this.state;
 
-    if (isAnimationActive && sectors && sectors.length && (!prevSectors || !_.isEqual(prevSectors, sectors))) {
+    if (isAnimationActive && sectors && sectors.length && (!prevSectors || !isEqual(prevSectors, sectors))) {
       return this.renderSectorsWithAnimation();
     }
     return this.renderSectorsStatically(sectors);

--- a/src/polar/PolarAngleAxis.tsx
+++ b/src/polar/PolarAngleAxis.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Axis of radial direction
  */
 import React, { PureComponent } from 'react';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
 import { Layer } from '../container/Layer';
 import { Dot } from '../shape/Dot';
 import { Polygon } from '../shape/Polygon';
@@ -110,7 +110,7 @@ export class PolarAngleAxis extends PureComponent<Props> {
 
     if (React.isValidElement(option)) {
       tickItem = React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
+    } else if (isFunction(option)) {
       tickItem = option(props);
     } else {
       tickItem = (

--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -2,7 +2,9 @@
  * @fileOverview The axis of polar coordinate system
  */
 import React, { PureComponent } from 'react';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
+import maxBy from 'lodash/maxBy';
+import minBy from 'lodash/minBy';
 import { Text } from '../component/Text';
 import { Label } from '../component/Label';
 import { Layer } from '../container/Layer';
@@ -80,8 +82,8 @@ export class PolarRadiusAxis extends PureComponent<Props> {
 
   getViewBox() {
     const { cx, cy, angle, ticks } = this.props;
-    const maxRadiusTick = _.maxBy(ticks, (entry: TickItem) => entry.coordinate || 0);
-    const minRadiusTick = _.minBy(ticks, (entry: TickItem) => entry.coordinate || 0);
+    const maxRadiusTick = maxBy(ticks, (entry: TickItem) => entry.coordinate || 0);
+    const minRadiusTick = minBy(ticks, (entry: TickItem) => entry.coordinate || 0);
 
     return {
       cx,
@@ -120,7 +122,7 @@ export class PolarRadiusAxis extends PureComponent<Props> {
 
     if (React.isValidElement(option)) {
       tickItem = React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
+    } else if (isFunction(option)) {
       tickItem = option(props);
     } else {
       tickItem = (

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -4,7 +4,12 @@
 import React, { PureComponent, ReactElement, MouseEvent, SVGProps } from 'react';
 import Animate from 'react-smooth';
 import classNames from 'classnames';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
+import isArray from 'lodash/isArray';
+import last from 'lodash/last';
+import isNil from 'lodash/isNil';
+import first from 'lodash/first';
+import isEqual from 'lodash/isEqual';
 import { interpolateNumber } from '../util/DataUtils';
 import { Global } from '../util/Global';
 import { polarToCartesian } from '../util/PolarUtils';
@@ -106,10 +111,10 @@ export class Radar extends PureComponent<Props, State> {
       const name = getValueByDataKey(entry, angleAxis.dataKey, i);
       const value = getValueByDataKey(entry, dataKey);
       const angle = angleAxis.scale(name) + (bandSize || 0);
-      const pointValue = _.isArray(value) ? _.last(value) : value;
-      const radius = _.isNil(pointValue) ? undefined : radiusAxis.scale(pointValue);
+      const pointValue = isArray(value) ? last(value) : value;
+      const radius = isNil(pointValue) ? undefined : radiusAxis.scale(pointValue);
 
-      if (_.isArray(value) && value.length >= 2) {
+      if (isArray(value) && value.length >= 2) {
         isRange = true;
       }
 
@@ -128,9 +133,9 @@ export class Radar extends PureComponent<Props, State> {
 
     if (isRange) {
       points.forEach(point => {
-        if (_.isArray(point.value)) {
-          const baseValue = _.first(point.value);
-          const radius = _.isNil(baseValue) ? undefined : radiusAxis.scale(baseValue);
+        if (isArray(point.value)) {
+          const baseValue = first(point.value);
+          const radius = isNil(baseValue) ? undefined : radiusAxis.scale(baseValue);
 
           baseLinePoints.push({
             ...point,
@@ -169,7 +174,7 @@ export class Radar extends PureComponent<Props, State> {
     const { onAnimationEnd } = this.props;
     this.setState({ isAnimationFinished: true });
 
-    if (_.isFunction(onAnimationEnd)) {
+    if (isFunction(onAnimationEnd)) {
       onAnimationEnd();
     }
   };
@@ -179,7 +184,7 @@ export class Radar extends PureComponent<Props, State> {
 
     this.setState({ isAnimationFinished: false });
 
-    if (_.isFunction(onAnimationStart)) {
+    if (isFunction(onAnimationStart)) {
       onAnimationStart();
     }
   };
@@ -205,7 +210,7 @@ export class Radar extends PureComponent<Props, State> {
 
     if (React.isValidElement(option)) {
       dotItem = React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
+    } else if (isFunction(option)) {
       dotItem = option(props);
     } else {
       dotItem = <Dot {...props} className="recharts-radar-dot" />;
@@ -244,7 +249,7 @@ export class Radar extends PureComponent<Props, State> {
     let radar;
     if (React.isValidElement(shape)) {
       radar = React.cloneElement(shape, { ...this.props, points } as any);
-    } else if (_.isFunction(shape)) {
+    } else if (isFunction(shape)) {
       radar = shape({ ...this.props, points });
     } else {
       radar = (
@@ -319,7 +324,7 @@ export class Radar extends PureComponent<Props, State> {
     const { points, isAnimationActive, isRange } = this.props;
     const { prevPoints } = this.state;
 
-    if (isAnimationActive && points && points.length && !isRange && (!prevPoints || !_.isEqual(prevPoints, points))) {
+    if (isAnimationActive && points && points.length && !isRange && (!prevPoints || !isEqual(prevPoints, points))) {
       return this.renderPolygonWithAnimation();
     }
 

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -4,7 +4,9 @@
 import React, { PureComponent, ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
+import isArray from 'lodash/isArray';
+import isEqual from 'lodash/isEqual';
 import { Sector, Props as SectorProps } from '../shape/Sector';
 import { Layer } from '../container/Layer';
 import { findAllByType } from '../util/ReactUtils';
@@ -146,7 +148,7 @@ export class RadialBar extends PureComponent<Props, State> {
         value = truncateByDomain(stackedData[dataStartIndex + index], stackedDomain);
       } else {
         value = getValueByDataKey(entry, dataKey);
-        if (!_.isArray(value)) {
+        if (!isArray(value)) {
           value = [baseValue, value];
         }
       }
@@ -253,7 +255,7 @@ export class RadialBar extends PureComponent<Props, State> {
     const { onAnimationEnd } = this.props;
     this.setState({ isAnimationFinished: true });
 
-    if (_.isFunction(onAnimationEnd)) {
+    if (isFunction(onAnimationEnd)) {
       onAnimationEnd();
     }
   };
@@ -263,7 +265,7 @@ export class RadialBar extends PureComponent<Props, State> {
 
     this.setState({ isAnimationFinished: false });
 
-    if (_.isFunction(onAnimationStart)) {
+    if (isFunction(onAnimationStart)) {
       onAnimationStart();
     }
   };
@@ -273,7 +275,7 @@ export class RadialBar extends PureComponent<Props, State> {
 
     if (React.isValidElement(shape)) {
       sectorShape = React.cloneElement(shape, props);
-    } else if (_.isFunction(shape)) {
+    } else if (isFunction(shape)) {
       sectorShape = shape(props);
     } else {
       sectorShape = React.createElement(Sector, props);
@@ -348,7 +350,7 @@ export class RadialBar extends PureComponent<Props, State> {
     const { data, isAnimationActive } = this.props;
     const { prevData } = this.state;
 
-    if (isAnimationActive && data && data.length && (!prevData || !_.isEqual(prevData, data))) {
+    if (isAnimationActive && data && data.length && (!prevData || !isEqual(prevData, data))) {
       return this.renderSectorsWithAnimation();
     }
 

--- a/src/shape/Curve.tsx
+++ b/src/shape/Curve.tsx
@@ -19,7 +19,9 @@ import {
   curveStepBefore,
 } from 'd3-shape';
 import classNames from 'classnames';
-import _ from 'lodash';
+import isFunction from 'lodash/isFunction';
+import isArray from 'lodash/isArray';
+import upperFirst from 'lodash/upperFirst';
 import { LayoutType, PresentationAttributesWithProps, adaptEventHandlers, filterProps } from '../util/types';
 import { isNumber } from '../util/DataUtils';
 
@@ -66,11 +68,11 @@ const getX = (p: Point) => p.x;
 const getY = (p: Point) => p.y;
 
 const getCurveFactory = (type: CurveType, layout: LayoutType) => {
-  if (_.isFunction(type)) {
+  if (isFunction(type)) {
     return type;
   }
 
-  const name = `curve${_.upperFirst(type)}`;
+  const name = `curve${upperFirst(type)}`;
 
   if (name === 'curveMonotone' && layout) {
     return CURVE_FACTORIES[`${name}${layout === 'vertical' ? 'Y' : 'X'}`];
@@ -108,7 +110,7 @@ export class Curve extends PureComponent<Props> {
     const formatPoints = connectNulls ? points.filter(entry => defined(entry)) : points;
     let lineFunction;
 
-    if (_.isArray(baseLine)) {
+    if (isArray(baseLine)) {
       const formatBaseLine = connectNulls ? baseLine.filter(base => defined(base)) : baseLine;
       const areaPoints = formatPoints.map((entry, index) => ({ ...entry, base: formatBaseLine[index] }));
       if (layout === 'vertical') {

--- a/src/shape/Symbols.tsx
+++ b/src/shape/Symbols.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Curve
  */
 import React, { PureComponent, SVGProps } from 'react';
-import _ from 'lodash';
+import upperFirst from 'lodash/upperFirst';
 import {
   symbol as shapeSymbol,
   symbolCircle,
@@ -35,7 +35,7 @@ const symbolFactories: SymbolFactory = {
 const RADIAN = Math.PI / 180;
 
 const getSymbolFactory = (type: SymbolType) => {
-  const name = `symbol${_.upperFirst(type)}`;
+  const name = `symbol${upperFirst(type)}`;
 
   return symbolFactories[name] || symbolCircle;
 };
@@ -85,7 +85,7 @@ export class Symbols extends PureComponent<Props> {
   };
 
   static registerSymbol = (key: string, factory: D3SymbolType) => {
-    symbolFactories[`symbol${_.upperFirst(key)}`] = factory;
+    symbolFactories[`symbol${upperFirst(key)}`] = factory;
   };
 
   /**

--- a/src/util/CartesianUtils.ts
+++ b/src/util/CartesianUtils.ts
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import mapValues from 'lodash/mapValues';
+import every from 'lodash/every';
 import { getTicksOfScale, parseScale, checkDomainOfScale, getBandSizeOfAxis } from './ChartUtils';
 import { findChildByType } from './ReactUtils';
 import { Coordinate, AxisType } from './types';
@@ -71,9 +72,9 @@ export const formatAxisMap = (props: any, axisMap: any, offset: any, axisType: A
         layout === 'horizontal'
           ? [offset.top + offset.height - (padding.bottom || 0), offset.top + (padding.top || 0)]
           : [
-              offset.top + (padding.top || 0) + (calculatedPadding || 0),
-              offset.top + offset.height - (padding.bottom || 0) - (calculatedPadding || 0),
-            ];
+            offset.top + (padding.top || 0) + (calculatedPadding || 0),
+            offset.top + offset.height - (padding.bottom || 0) - (calculatedPadding || 0),
+          ];
     } else {
       ({ range } = axis);
     }
@@ -229,11 +230,11 @@ export const createLabeledScales = (options: Record<string, any>): LabeledScales
   return {
     ...scales,
     apply(coord: any, { bandAware, position }: any = {}) {
-      return _.mapValues(coord, (value, label) => scales[label].apply(value, { bandAware, position }));
+      return mapValues(coord, (value, label) => scales[label].apply(value, { bandAware, position }));
     },
 
     isInRange(coord: any) {
-      return _.every(coord, (value, label) => scales[label].isInRange(value));
+      return every(coord, (value, label) => scales[label].isInRange(value));
     },
   } as LabeledScales<Record<string, any>>;
 };

--- a/src/util/DataUtils.ts
+++ b/src/util/DataUtils.ts
@@ -1,4 +1,8 @@
-import _ from 'lodash';
+import get from 'lodash/get';
+import _isNaN from 'lodash/isNaN';
+import _isNumber from 'lodash/isNumber';
+import isArray from 'lodash/isArray';
+import isString from 'lodash/isString';
 
 export const mathSign = (value: number) => {
   if (value === 0) {
@@ -11,11 +15,11 @@ export const mathSign = (value: number) => {
   return -1;
 };
 
-export const isPercent = (value: string | number) => _.isString(value) && value.indexOf('%') === value.length - 1;
+export const isPercent = (value: string | number) => isString(value) && value.indexOf('%') === value.length - 1;
 
-export const isNumber = (value: any) => _.isNumber(value) && !_.isNaN(value);
+export const isNumber = (value: any) => _isNumber(value) && !_isNaN(value);
 
-export const isNumOrStr = (value: number | string) => isNumber(value as number) || _.isString(value);
+export const isNumOrStr = (value: number | string) => _isNumber(value as number) || isString(value);
 
 let idCounter = 0;
 export const uniqueId = (prefix?: string) => {
@@ -32,7 +36,7 @@ export const uniqueId = (prefix?: string) => {
  * @return {Number} value
  */
 export const getPercentValue = (percent: number | string, totalValue: number, defaultValue = 0, validate = false) => {
-  if (!isNumber(percent as number) && !_.isString(percent)) {
+  if (!isNumber(percent as number) && !isString(percent)) {
     return defaultValue;
   }
 
@@ -45,7 +49,7 @@ export const getPercentValue = (percent: number | string, totalValue: number, de
     value = +percent;
   }
 
-  if (_.isNaN(value)) {
+  if (_isNaN(value)) {
     value = defaultValue;
   }
 
@@ -71,7 +75,7 @@ export const getAnyElementOfObject = (obj: any) => {
 };
 
 export const hasDuplicate = (ary: Array<any>) => {
-  if (!_.isArray(ary)) {
+  if (!isArray(ary)) {
     return false;
   }
 
@@ -109,7 +113,7 @@ export function findEntryInArray<T>(
   return ary.find(
     entry =>
       entry &&
-      (typeof specifiedKey === 'function' ? specifiedKey(entry) : _.get(entry, specifiedKey)) === specifiedValue,
+      (typeof specifiedKey === 'function' ? specifiedKey(entry) : get(entry, specifiedKey)) === specifiedValue,
   );
 }
 

--- a/src/util/PolarUtils.ts
+++ b/src/util/PolarUtils.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import isNil from 'lodash/isNil';
 import { getPercentValue } from './DataUtils';
 import { parseScale, checkDomainOfScale, getTicksOfScale } from './ChartUtils';
 import { Coordinate, ChartOffset, GeometrySector } from './types';
@@ -59,7 +59,7 @@ export const formatAxisMap = (
     const { domain, reversed } = axis;
     let range;
 
-    if (_.isNil(axis.range)) {
+    if (isNil(axis.range)) {
       if (axisType === 'angleAxis') {
         range = [startAngle, endAngle];
       } else if (axisType === 'radiusAxis') {

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -1,5 +1,9 @@
 import React, { Children, ReactNode } from 'react';
-import _ from 'lodash';
+import isArray from 'lodash/isArray';
+import get from 'lodash/get';
+import isNil from 'lodash/isNil';
+import isString from 'lodash/isString';
+import flatten from 'lodash/flatten';
 import { isFragment } from 'react-is';
 
 import { isNumber } from './DataUtils';
@@ -80,7 +84,7 @@ export const findAllByType = (
   let result: React.DetailedReactHTMLElement<any, HTMLElement>[] = [];
   let types: string[] = [];
 
-  if (_.isArray(type)) {
+  if (isArray(type)) {
     types = type.map(t => getDisplayName(t));
   } else {
     types = [getDisplayName(type)];
@@ -90,7 +94,7 @@ export const findAllByType = (
     if (isFragment(child)) {
       result = result.concat(findAllByType(child.props.children, type));
     }
-    const childType = _.get(child, 'type.displayName') || _.get(child, 'type.name');
+    const childType = get(child, 'type.displayName') || get(child, 'type.name');
     if (types.indexOf(childType) !== -1) {
       result.push(child);
     }
@@ -118,14 +122,14 @@ export const withoutType = (children: ReactNode, type: string) => {
   const newChildren: ReactNode[] = [];
   let types: string[];
 
-  if (_.isArray(type)) {
+  if (isArray(type)) {
     types = type.map(t => getDisplayName(t));
   } else {
     types = [getDisplayName(type)];
   }
 
   React.Children.forEach(children, child => {
-    const displayName = _.get(child, 'type.displayName');
+    const displayName = get(child, 'type.displayName');
 
     if (displayName && types.indexOf(displayName) !== -1) {
       return;
@@ -236,7 +240,7 @@ const SVG_TAGS: string[] = [
   'vkern',
 ];
 
-const isSvgElement = (child: any) => child && child.type && _.isString(child.type) && SVG_TAGS.indexOf(child.type) >= 0;
+const isSvgElement = (child: any) => child && child.type && isString(child.type) && SVG_TAGS.indexOf(child.type) >= 0;
 
 /**
  * Filter all the svg elements of children
@@ -277,8 +281,8 @@ export const isChildrenEqual = (nextChildren: React.ReactElement[], prevChildren
   if (count === 1) {
     // eslint-disable-next-line no-use-before-define,@typescript-eslint/no-use-before-define
     return isSingleChildEqual(
-      _.isArray(nextChildren) ? nextChildren[0] : nextChildren,
-      _.isArray(prevChildren) ? prevChildren[0] : prevChildren,
+      isArray(nextChildren) ? nextChildren[0] : nextChildren,
+      isArray(prevChildren) ? prevChildren[0] : prevChildren,
     );
   }
 
@@ -286,7 +290,7 @@ export const isChildrenEqual = (nextChildren: React.ReactElement[], prevChildren
     const nextChild: any = nextChildren[i];
     const prevChild: any = prevChildren[i];
 
-    if (_.isArray(nextChild) || _.isArray(prevChild)) {
+    if (isArray(nextChild) || isArray(prevChild)) {
       if (!isChildrenEqual(nextChild, prevChild)) {
         return false;
       }
@@ -300,10 +304,10 @@ export const isChildrenEqual = (nextChildren: React.ReactElement[], prevChildren
 };
 
 export const isSingleChildEqual = (nextChild: React.ReactElement, prevChild: React.ReactElement): boolean => {
-  if (_.isNil(nextChild) && _.isNil(prevChild)) {
+  if (isNil(nextChild) && isNil(prevChild)) {
     return true;
   }
-  if (!_.isNil(nextChild) && !_.isNil(prevChild)) {
+  if (!isNil(nextChild) && !isNil(prevChild)) {
     const { children: nextChildren, ...nextProps } = nextChild.props || {};
     const { children: prevChildren, ...prevProps } = prevChild.props || {};
 
@@ -341,7 +345,7 @@ export const renderByOrder = (children: React.ReactElement[], renderMap: any) =>
     }
   });
 
-  return _.flatten(elements).filter(element => !_.isNil(element));
+  return flatten(elements).filter(element => !isNil(element));
 };
 
 export const getReactEventByType = (e: any) => {

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -21,7 +21,7 @@ import {
   FunctionComponent,
   ReactElement,
 } from 'react';
-import _ from 'lodash';
+import isObject from 'lodash/isObject';
 import { ScaleContinuousNumeric as D3ScaleContinuousNumeric } from 'd3-scale';
 
 export type StackOffsetType = 'sign' | 'expand' | 'none' | 'wiggle' | 'silhouette';
@@ -1089,7 +1089,7 @@ export const filterProps = (
     inputProps = props.props as Record<string, any>;
   }
 
-  if (!_.isObject(inputProps)) {
+  if (!isObject(inputProps)) {
     return null;
   }
 
@@ -1123,7 +1123,7 @@ export const adaptEventHandlers = (
     inputProps = props.props as Record<string, any>;
   }
 
-  if (!_.isObject(inputProps)) {
+  if (!isObject(inputProps)) {
     return null;
   }
 
@@ -1149,7 +1149,7 @@ export const adaptEventsOfChild = (
   data: any,
   index: number,
 ): Record<string, (e?: Event) => any> => {
-  if (!_.isObject(props) || typeof props !== 'object') {
+  if (!isObject(props) || typeof props !== 'object') {
     return null;
   }
 


### PR DESCRIPTION
This is a refactor of `lodash` import to reduce the size of the bundle by 34kb.
- `lodash `overall size down to 34kb from 68kb according to `npm run analyse`
- fix `analyse` script in `package.json`


