### PR TITLE
Fix ReferenceArea: Cannot read property 'scale' of undefined

### DIFF
--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -44,6 +44,8 @@ export type Props = RectangleProps & ReferenceAreaProps;
 const getRect = (hasX1: boolean, hasX2: boolean, hasY1: boolean, hasY2: boolean, props: Props) => {
   const { x1: xValue1, x2: xValue2, y1: yValue1, y2: yValue2, xAxis, yAxis } = props;
 
+  if (!xAxis || !yAxis) return null;
+
   const scales = createLabeledScales({ x: xAxis.scale, y: yAxis.scale });
 
   const p1 = {


### PR DESCRIPTION
If `yAxisId` is not passed to `ReferenceArea`, the component will crash with an unhelpful error message:
> Cannot read property 'scale' of undefined

This is a simple fix to stop the error from occurring. Since both `xAxis` and `yAxis` are optional props, we should be making sure they exist before trying to access their properties.

**Codesandbox Demonstrating the Bug:**
https://codesandbox.io/s/highlight-zomm-line-chart-forked-v8mpi?file=/src/App.tsx
Instructions to reproduce: Click and drag anywhere on the chart.