### PR TITLE
fix: Customized component has no key

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1994,14 +1994,12 @@ export const generateCategoricalChart = ({
       return [graphicalItem, null];
     };
 
-    renderCustomized = (element: React.ReactElement, displayName: string, index: number): React.ReactElement => (
-      <React.Fragment key={`recharts-customized-${index}`}>
-        {cloneElement(element, {
-          ...this.props,
-          ...this.state,
-        })}
-      </React.Fragment>
-    );
+    renderCustomized = (element: React.ReactElement, displayName: string, index: number): React.ReactElement =>
+      cloneElement(element, {
+        key: `recharts-customized-${index}`,
+        ...this.props,
+        ...this.state,
+      });
 
     renderClipPath() {
       const { clipPathId } = this;

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1994,11 +1994,14 @@ export const generateCategoricalChart = ({
       return [graphicalItem, null];
     };
 
-    renderCustomized = (element: React.ReactElement): React.ReactElement =>
-      cloneElement(element, {
-        ...this.props,
-        ...this.state,
-      });
+    renderCustomized = (element: React.ReactElement, displayName: string, index: number): React.ReactElement => (
+      <React.Fragment key={`recharts-customized-${index}`}>
+        {cloneElement(element, {
+          ...this.props,
+          ...this.state,
+        })}
+      </React.Fragment>
+    );
 
     renderClipPath() {
       const { clipPathId } = this;


### PR DESCRIPTION
Solves #2633 (<Customized/> component triggers warning during render)

The rendering implementation of generateCategoricalChart renders child elements in lists. <Customized/> elements are added without keys, causing React to warn against needing a key prop. 

Please let me know if this can lead to unexpected behavior.
 