### PR TITLE
Fix XAxis scale property type

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -29,7 +29,7 @@ interface XAxisProps extends BaseAxisProps {
   tickMargin?: number;
 }
 
-export type Props = SVGProps<SVGElement> & XAxisProps;
+export type Props = Omit<SVGProps<SVGElement>, 'scale'> & XAxisProps;
 
 export const XAxis: FunctionComponent<Props> = () => null;
 


### PR DESCRIPTION
Currently we can't pass function to XAxis scale property because we get `is not assignable to type 'number & Function'` error from typescript
Omitting scale prop fixes this issue (it's already done for YAxis https://github.com/recharts/recharts/blob/master/src/cartesian/YAxis.tsx#L32)