### PR TITLE
Fix rendering of a single bar when maxBarSize is absent and barSize is present

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -791,7 +791,7 @@ export const generateCategoricalChart = ({
       if (itemIsBar) {
         // 如果是bar，计算bar的位置
         const maxBarSize = _.isNil(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
-        const barBandSize = getBandSizeOfAxis(cateAxis, cateTicks, true) || maxBarSize;
+        const barBandSize = getBandSizeOfAxis(cateAxis, cateTicks, true) ?? maxBarSize ?? 0;
         barPosition = getBarPosition({
           barGap,
           barCategoryGap,

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1112,7 +1112,7 @@ export const getBandSizeOfAxis = (axis: any, ticks?: Array<TickItem>, isBar?: bo
     return bandSize === Infinity ? 0 : bandSize;
   }
 
-  return 0;
+  return isBar ? undefined : 0;
 };
 /**
  * parse the domain of a category axis when a domain is specified

--- a/test/specs/chart/BarChartSpec.js
+++ b/test/specs/chart/BarChartSpec.js
@@ -166,4 +166,46 @@ describe('<BarChart />', () => {
     expect(wrapper.find('.customized-shape').length).to.equal(4);
   });
 
+  describe('1 bar', () => {
+    const onePointData = [
+      { number: 1, name: 'food', uv: 400, pv: 2400 },
+    ];
+
+    it('renders a bar if size is specified', () => {
+      const wrapper = mount(
+        <BarChart width={100} height={50} data={onePointData} barSize={20}>
+          <XAxis dataKey="number" type="number" />
+          <Bar dataKey="uv" name="uv" isAnimationActive={false} />
+        </BarChart>
+      );
+
+      console.log(wrapper.debug());
+      const rectangles = wrapper.find('Rectangle');
+      expect(rectangles.length).to.equal(1);
+
+      const rectangleProps = rectangles.at(0).props();
+      expect(rectangleProps).to.have.property('x', 85);
+      expect(rectangleProps).to.have.property('y', 5);
+      expect(rectangleProps).to.have.property('width', 20);
+      expect(rectangleProps).to.have.property('height', 10);
+    });
+
+    it('renders a bar if size is limited', () => {
+      const wrapper = mount(
+        <BarChart width={100} height={50} data={onePointData}>
+          <XAxis dataKey="number" type="number" />
+          <Bar dataKey="uv" name="uv" isAnimationActive={false} maxBarSize={40} />
+        </BarChart>
+      );
+
+      const rectangles = wrapper.find('Rectangle');
+      expect(rectangles.length).to.equal(1);
+
+      const rectangleProps = rectangles.at(0).props();
+      expect(rectangleProps).to.have.property('x', 79);
+      expect(rectangleProps).to.have.property('y', 5);
+      expect(rectangleProps).to.have.property('width', 32);
+      expect(rectangleProps).to.have.property('height', 10);
+    });
+  });
 });


### PR DESCRIPTION
Addresses #2601
Fixes a regression added in #2512

This PR does not fully resolve issue with a single bar. Bar is rendered when either `barSize` or `maxBarSize` is specified. Otherwise a bar is still not rendered.