### PR TITLE
Fixes #2636 - ResponsiveContainer makes legend overlapping with chart when re-rendering

### DIFF
--- a/demo/component/ResponsiveContainer.tsx
+++ b/demo/component/ResponsiveContainer.tsx
@@ -206,6 +206,7 @@ export default class Demo extends Component {
                 animationBegin={1300}
                 dot
               />
+              <Legend />
             </AreaChart>
           </ResponsiveContainer>
         </div>

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -49,7 +49,7 @@ export const ResponsiveContainer = forwardRef(
     const containerRef = useRef<HTMLDivElement>(null);
     useImperativeHandle(ref, () => containerRef, [containerRef]);
 
-    const mounted = useRef<boolean>(false);
+    const [mounted, setMounted] = useState<boolean>(false);
 
     const getContainerSize = () => {
       if (!containerRef.current) {
@@ -63,7 +63,7 @@ export const ResponsiveContainer = forwardRef(
     };
 
     const updateDimensionsImmediate = () => {
-      if (!mounted.current) {
+      if (!mounted) {
         return;
       }
 
@@ -139,11 +139,17 @@ export const ResponsiveContainer = forwardRef(
     };
 
     useEffect(() => {
-      mounted.current = true;
+      if (mounted) {
+        const size = getContainerSize();
 
-      return () => {
-        mounted.current = false;
-      };
+        if (size) {
+          setSizes(size);
+        }
+      }
+    }, [mounted]);
+
+    useEffect(() => {
+      setMounted(true);
     }, []);
 
     const style = { width, height, minWidth, minHeight, maxHeight };

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -141,12 +141,6 @@ export const ResponsiveContainer = forwardRef(
     useEffect(() => {
       mounted.current = true;
 
-      const size = getContainerSize();
-
-      if (size) {
-        setSizes(size);
-      }
-
       return () => {
         mounted.current = false;
       };


### PR DESCRIPTION
Fix demonstrated on `ResponsiveContainer` demo.  Prior to this change, the chart would overlap the legend item (`pv`) and only after resizing the window the `ResponsiveContainer` would re-render and fix the overlapping issue.

## Before (Legend overlap):
![image](https://user-images.githubusercontent.com/12204068/133913328-a2b06a01-7f87-4797-a1fc-6fe4f47c9acd.png)

## After (Legend no longer overlapping):
![image](https://user-images.githubusercontent.com/12204068/133913281-dbe6d8ff-6044-44ee-ac29-8d215dddd46b.png)

Note: I think due to way that `size` was set after mounting previously (as a class component, from version `2.0.10`), the previous size calculation took into account its children correctly as `renderChart()` was called subsequently after mounting.  When this was converted to a function component in `2.1.0`, this calculation happened sooner and didn't take into account its rendered children sizes, and never gets recalculated until after the component sized has changed (e.g. after a window resize).  This PR is effectively introduces a hack to re-render later, while doing so in a way that causes the current tests to still pass.