### PR TITLE
Fix type declaration errors when tsc

### DIFF
--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -60,6 +60,9 @@ interface RadarProps {
   onMouseLeave?: (props: any, e: MouseEvent<SVGPolygonElement>) => void;
 }
 
+type RadiusAxis = PolarRadiusAxisProps & { scale: (value: any) => number };
+type AngleAxis = PolarAngleAxisProps & { scale: (value: any) => number };
+
 export type Props = Omit<SVGProps<SVGElement>, 'onMouseEnter' | 'onMouseLeave'> & RadarProps;
 
 interface State {
@@ -92,8 +95,8 @@ export class Radar extends PureComponent<Props, State> {
     dataKey,
     bandSize,
   }: {
-    radiusAxis: PolarRadiusAxisProps & { scale: (value: any) => number };
-    angleAxis: PolarAngleAxisProps & { scale: (value: any) => number };
+    radiusAxis: RadiusAxis;
+    angleAxis: AngleAxis;
     displayedData: any[];
     dataKey: RadarProps['dataKey'];
     bandSize: number;


### PR DESCRIPTION
#2513

`$ npm run tsc`

`types/polar/Radar.d.ts`

#### Before

```ts
// Unused import types. why?
import { Props as PolarAngleAxisProps } from './PolarAngleAxis';
import { Props as PolarRadiusAxisProps } from './PolarRadiusAxis';
...
export declare class Radar extends PureComponent<Props, State> {
    ...
    static getComposedData: ({ radiusAxis, angleAxis, displayedData, dataKey, bandSize, }: {
        // Cause "TS2304: Cannot find name 'P'" and "TS2304: Cannot find name 'T'"
        radiusAxis: React.AriaAttributes & import("../util/types").DOMAttributesAdaptChildEvent<any, SVGElement> & Omit<React.SVGProps<SVGElement>, keyof import("../util/types").DOMAttributesAdaptChildEvent<P, T>> & import("./PolarRadiusAxis").PolarRadiusAxisProps & {
            scale: (value: any) => number;
        };
        angleAxis: React.AriaAttributes & import("../util/types").DOMAttributesAdaptChildEvent<any, SVGTextElement> & Omit<React.SVGProps<SVGTextElement>, keyof import("../util/types").DOMAttributesAdaptChildEvent<P, T>> & import("./PolarAngleAxis").PolarAngleAxisProps & {
            scale: (value: any) => number;
        };
        displayedData: any[];
        dataKey: RadarProps['dataKey'];
        bandSize: number;
    }) => {
        points: RadarPoint[];
        isRange: boolean;
        baseLinePoints: RadarPoint[];
    };
```

#### After
```ts
// Work fine!
import { Props as PolarAngleAxisProps } from './PolarAngleAxis';
import { Props as PolarRadiusAxisProps } from './PolarRadiusAxis';
...
declare type RadiusAxis = PolarRadiusAxisProps & {
    scale: (value: any) => number;
};
declare type AngleAxis = PolarAngleAxisProps & {
    scale: (value: any) => number;
};
...
export declare class Radar extends PureComponent<Props, State> {
    ...
    static getComposedData: ({ radiusAxis, angleAxis, displayedData, dataKey, bandSize, }: {
        radiusAxis: RadiusAxis;
        angleAxis: AngleAxis;
        displayedData: any[];
        dataKey: RadarProps['dataKey'];
        bandSize: number;
    }) => {
        points: RadarPoint[];
        isRange: boolean;
        baseLinePoints: RadarPoint[];
    };


```