### PR TITLE
https://github.com/recharts/recharts/issues/2718

### DIFF
--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -340,7 +340,7 @@ export class Treemap extends PureComponent<Props, State> {
       const formatRoot = squarify(root, nextProps.aspectRatio);
 
       return {
-        ...defaultState,
+        ...prevState,
         formatRoot,
         currentRoot: root,
         nestIndex: [root],


### PR DESCRIPTION
https://github.com/recharts/recharts/issues/2718
Issue:
Underlying issue is when props change -> it calls getDerivedStateFromProps which reset the state to defaultState.
Resolution:
getDerivedStateFromProps should use previous state instead of defaultState.