### PR TITLE
Remove overlapping legend for categorical charts (#2704)

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1283,7 +1283,7 @@ export const generateCategoricalChart = ({
     };
 
     handleLegendBBoxUpdate = (box: any) => {
-      if (box && this.legendInstance) {
+      if (box) {
         const { dataStartIndex, dataEndIndex, updateId } = this.state;
 
         this.setState({


### PR DESCRIPTION
Fixes issue with overlapping legend in categorical charts introduced in 2.0.3, as described in #2704.