### PR TITLE
[Breaking] Update react-resize-detector

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eventemitter3": "^4.0.1",
     "lodash": "^4.17.19",
     "react-is": "^16.10.2",
-    "react-resize-detector": "^6.6.3",
+    "react-resize-detector": "^7.0.0",
     "react-smooth": "^2.0.0",
     "recharts-scale": "^0.4.4",
     "reduce-css-calc": "^2.1.8"

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -4,7 +4,7 @@
 import classNames from 'classnames';
 import _ from 'lodash';
 import React, { ReactElement, forwardRef, cloneElement, useState, useImperativeHandle, useRef, useEffect } from 'react';
-import ReactResizeDetector from 'react-resize-detector/build/withPolyfill';
+import ReactResizeDetector from 'react-resize-detector';
 import { isPercent } from '../util/DataUtils';
 import { warn } from '../util/LogUtils';
 


### PR DESCRIPTION
Please treat this PR as a proposal. ResizeObserver [is supported](https://caniuse.com/resizeobserver) by modern browsers, but apparently that reaches only 91.32% of global users, so there is a non-negligible slice of users that still needs the polyfill. Things to consider:

* Is it possible for application developers to include the polyfill manually in their project even after this PR? Then maybe an item in the release notes would be enough to move this decision to application developers.
* Does recharts already have any compatibility guarantees / requirements? Perhaps those 8.7% of excluded users were already not supported for other dependencies/reasons in recharts.

The main motivation for moving away from the polyfill is that its repository is abandoned and the types (TypeScript) are broken.