### PR TITLE
Update ref to use the implicit ref type when consuming LineProps

### DIFF
--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -75,7 +75,7 @@ interface LineProps extends InternalLineProps {
   id?: string;
 }
 
-export type Props = Omit<CurveProps, 'points' | 'pathRef'> & LineProps;
+export type Props = Omit<CurveProps, 'points' | 'pathRef' | 'ref'> & LineProps & Record<'ref', React.Ref<Line>>;
 
 interface State {
   isAnimationFinished?: boolean;


### PR DESCRIPTION
Kind of a working idea. I made these changes and cross-tested them in a separate repository as well, TypeError went away and `ref` could be used properly. Can't really create a proper test for this in Karma because I only saw `.js` files?

Error:
```
No overload matches this call.
  Overload 1 of 2, '(props: Props | Readonly<Props>): Line', gave the following error.
    Type '{ string?: string | number | undefined; type: CurveType; className?: string | undefined; color?: string | undefined; height?: number | undefined; id?: string | undefined; ... 486 more ...; yAxis?: (Omit<...> & { ...; }) | undefined; }' is not assignable to type 'IntrinsicClassAttributes<Line>'.
      Types of property 'ref' are incompatible.
        Type 'LegacyRef<SVGPathElement> | undefined' is not assignable to type 'LegacyRef<Line> | undefined'.
          Type '(instance: SVGPathElement | null) => void' is not assignable to type 'LegacyRef<Line> | undefined'.
            Type '(instance: SVGPathElement | null) => void' is not assignable to type '(instance: Line | null) => void'.
              Types of parameters 'instance' and 'instance' are incompatible.
                Type 'Line | null' is not assignable to type 'SVGPathElement | null'.
                  Type 'Line' is missing the following properties from type 'SVGPathElement': addEventListener, removeEventListener, pathLength, getPointAtLength, and 263 more.
  Overload 2 of 2, '(props: Props, context: any): Line', gave the following error.
    Type '{ string?: string | number | undefined; type: CurveType; className?: string | undefined; color?: string | undefined; height?: number | undefined; id?: string | undefined; ... 486 more ...; yAxis?: (Omit<...> & { ...; }) | undefined; }' is not assignable to type 'IntrinsicClassAttributes<Line>'.
      Types of property 'ref' are incompatible.
        Type 'LegacyRef<SVGPathElement> | undefined' is not assignable to type 'LegacyRef<Line> | undefined'.
```

Reproduction

```ts
import { LineProps } from 'recharts';

interface SomeLibraryComponent {
  line: LineProps
}

const SomeComponent: SomeLibraryComponent = ({line}) => {
  return (
    <Line // Error location of above
      {...line}
    />
  )
}
```

Find it kind of strange for the `ref` object to be the actual class.. would an `any` work better in this case?