### PR TITLE
feat: allow axis domain to accept a callback

### DIFF
--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1046,6 +1046,10 @@ export const MIN_VALUE_REG = /^dataMin[\s]*-[\s]*([0-9]+([.]{1}[0-9]+){0,1})$/;
 export const MAX_VALUE_REG = /^dataMax[\s]*\+[\s]*([0-9]+([.]{1}[0-9]+){0,1})$/;
 
 export const parseSpecifiedDomain = (specifiedDomain: any, dataDomain: any, allowDataOverflow: boolean) => {
+  if (_.isFunction(specifiedDomain)) {
+    return specifiedDomain(dataDomain, allowDataOverflow);
+  }
+
   if (!_.isArray(specifiedDomain)) {
     return dataDomain;
   }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -985,7 +985,11 @@ export type D3Scale<T> = D3ScaleContinuousNumeric<T, number>;
 
 export type AxisDomainItem = string | number | Function | 'auto' | 'dataMin' | 'dataMax';
 /** The domain of axis */
-export type AxisDomain = string[] | number[] | [AxisDomainItem, AxisDomainItem];
+export type AxisDomain =
+  | string[]
+  | number[]
+  | [AxisDomainItem, AxisDomainItem]
+  | (([dataMin, dataMax]: [number, number], allowDataOverflow: boolean) => [number, number]);
 
 /** The props definition of base axis */
 export interface BaseAxisProps {

--- a/test/specs/util/ChartUtilsSpec.js
+++ b/test/specs/util/ChartUtilsSpec.js
@@ -44,17 +44,17 @@ describe('parseSpecifiedDomain', () => {
     expect(parseSpecifiedDomain(1, domain)).to.equal(domain);
   });
 
-  it('DataUtils.parseSpecifiedDomain(["auto", "auto"], domain) should return null ', () => {
+  it('DataUtils.parseSpecifiedDomain(["auto", "auto"], domain) should return domain ', () => {
     const result = parseSpecifiedDomain(['auto', 'auto'], domain);
     expect(result).to.deep.equal(domain);
   });
 
-  it('DataUtils.parseSpecifiedDomain([-1, 120], domain) should return null ', () => {
+  it('DataUtils.parseSpecifiedDomain([-1, 120], domain) should return input value ', () => {
     const result = parseSpecifiedDomain([-1, 120], domain);
     expect(result).to.deep.equal([-1, 120]);
   });
 
-  it('DataUtils.parseSpecifiedDomain(["dataMin - 10", "dataMax + 10"], domain) should return null ', () => {
+  it('DataUtils.parseSpecifiedDomain(["dataMin - 10", "dataMax + 10"], domain) should return computed value ', () => {
     const result = parseSpecifiedDomain(['dataMin - 10', 'dataMax + 10'], domain);
     expect(result).to.deep.equal([10, 110]);
   });
@@ -65,6 +65,14 @@ describe('parseSpecifiedDomain', () => {
       domain
     );
     expect(result).to.deep.equal([-20, 200]);
+  });
+
+  it('DataUtils.parseSpecifiedDomain(callback, domain) should execute the callback and return computed value ', () => {
+    const result = parseSpecifiedDomain(
+      ([dataMin, dataMax], _allowDataOverflow) => [dataMin / 4, dataMax * 4],
+      domain
+    );
+    expect(result).to.deep.equal([5, 400]);
   });
 });
 


### PR DESCRIPTION
We would like to generate the domain of an axis dynamically, based on the minimum and maximum data values.

This is not possible via the current API, where the minimum and maximum values can be calculated via callback independently. This PR adds a route for the entire domain (both min and max) to be calculated in one go.

The callback has access to the context relevant for `recharts` to calculate concrete domain values currently.

---

For a real world example, our sample use looks like:

```typescript
import { XAxis } from "recharts";
import { getNiceTickValues } from "recharts-scale";

const TICK_COUNT = 5;

function customDomain([dataMin, dataMax]: [number, number], _allowDataOverflow: boolean): [number, number] {
  const dataAbsMax = Math.max(Math.abs(dataMin), Math.abs(dataMax));
  const tickValues = getNiceTickValues([-dataAbsMax, dataAbsMax], TICK_COUNT, true);
  return [tickValues[0], tickValues[TICK_COUNT - 1]];
};

...

<XAxis type="number" domain={customDomain} />
```