### PR TITLE
Fix PropType typo in Tooltip

### DIFF
--- a/src/component/Tooltip.js
+++ b/src/component/Tooltip.js
@@ -29,8 +29,8 @@ const getUniqPaylod = (option, payload) => {
 
 const propTypes = {
   allowEscapeViewBox: PropTypes.shape({
-    x: PropTypes.boolean,
-    y: PropTypes.boolean,
+    x: PropTypes.bool,
+    y: PropTypes.bool,
   }),
   content: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   viewBox: PropTypes.shape({


### PR DESCRIPTION
`PropTypes.boolean` is `undefined`, use `PropTypes.bool`. [Source](https://github.com/facebook/prop-types#usage)