### PR TITLE
Fixed ResponsiveContainer ref

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -47,7 +47,7 @@ export const ResponsiveContainer = forwardRef(
       containerHeight: -1,
     });
     const containerRef = useRef<HTMLDivElement>(null);
-    useImperativeHandle(ref, () => containerRef, [containerRef]);
+    useImperativeHandle(ref, () => containerRef.current, [containerRef]);
 
     const [mounted, setMounted] = useState<boolean>(false);
 


### PR DESCRIPTION
Until now, if user wanted to access a ref object, they had to use `ref.current.current`.

This was unfriendly and not clear, so I fixed it.

