### PR TITLE
Fix for #2742 Axis scale=band no longer works as of Recharts 2.x.x

### DIFF
--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -533,7 +533,10 @@ export const getTicksOfAxis = (axis: any, isGrid?: boolean, isAll?: boolean): Ti
   if (!axis) return null;
   const { scale } = axis;
   const { duplicateDomain, type, range } = axis;
-  let offset = (isGrid || isAll) && type === 'category' && scale.bandwidth ? scale.bandwidth() / 2 : 0;
+
+  const offsetForBand = axis.realScaleType === 'scaleBand' ? scale.bandwidth() / 2 : 2;
+  let offset = (isGrid || isAll) && type === 'category' && scale.bandwidth ? scale.bandwidth() / offsetForBand : 0;
+
   offset = axis.axisType === 'angleAxis' ? mathSign(range[0] - range[1]) * 2 * offset : offset;
 
   // The ticks setted by user should only affect the ticks adjacent to axis line


### PR DESCRIPTION
This is the fix to https://github.com/recharts/recharts/issues/2742

