### PR TITLE
Adds react `^18.0.0`  as valid peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   },
   "homepage": "https://github.com/recharts/recharts",
   "peerDependencies": {
-    "react": "^16.0.0 || ^17.0.0",
-    "react-dom": "^16.0.0 || ^17.0.0"
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@types/d3-interpolate": "^2.0.0",


### PR DESCRIPTION
Addresses issue mentioned here with new version of react.
https://github.com/recharts/recharts/issues/2813

What are some other things that would need to be considered in order to allow react 18 as a peer dependency.