### PR TITLE
chore: move type deps into devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "2.1.9",
       "license": "MIT",
       "dependencies": {
-        "@types/d3-interpolate": "^2.0.0",
-        "@types/d3-scale": "^3.0.0",
-        "@types/d3-shape": "^2.0.0",
         "classnames": "^2.2.5",
         "d3-interpolate": "^2.0.0",
         "d3-scale": "^3.0.0",
@@ -38,6 +35,9 @@
         "@babel/preset-typescript": "^7.6.0",
         "@babel/runtime": "^7.6.3",
         "@types/classnames": "^2.2.9",
+        "@types/d3-interpolate": "^2.0.0",
+        "@types/d3-scale": "^3.0.0",
+        "@types/d3-shape": "^2.0.0",
         "@types/lodash": "^4.14.144",
         "@types/react": "^16.0.0",
         "@types/react-dom": "^16.0.0",
@@ -1768,12 +1768,14 @@
     "node_modules/@types/d3-color": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
-      "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w=="
+      "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w==",
+      "dev": true
     },
     "node_modules/@types/d3-interpolate": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-2.0.2.tgz",
       "integrity": "sha512-lElyqlUfIPyWG/cD475vl6msPL4aMU7eJvx1//Q177L8mdXoVPFl1djIESF2FKnc0NyaHvQlJpWwKJYwAhUoCw==",
+      "dev": true,
       "dependencies": {
         "@types/d3-color": "^2"
       }
@@ -1781,12 +1783,14 @@
     "node_modules/@types/d3-path": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.1.tgz",
-      "integrity": "sha512-6K8LaFlztlhZO7mwsZg7ClRsdLg3FJRzIIi6SZXDWmmSJc2x8dd2VkESbLXdk3p8cuvz71f36S0y8Zv2AxqvQw=="
+      "integrity": "sha512-6K8LaFlztlhZO7mwsZg7ClRsdLg3FJRzIIi6SZXDWmmSJc2x8dd2VkESbLXdk3p8cuvz71f36S0y8Zv2AxqvQw==",
+      "dev": true
     },
     "node_modules/@types/d3-scale": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz",
       "integrity": "sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==",
+      "dev": true,
       "dependencies": {
         "@types/d3-time": "^2"
       }
@@ -1795,6 +1799,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
       "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
+      "dev": true,
       "dependencies": {
         "@types/d3-path": "^2"
       }
@@ -1802,7 +1807,8 @@
     "node_modules/@types/d3-time": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.0.0.tgz",
-      "integrity": "sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ=="
+      "integrity": "sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "7.2.7",
@@ -15333,12 +15339,14 @@
     "@types/d3-color": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
-      "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w=="
+      "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w==",
+      "dev": true
     },
     "@types/d3-interpolate": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-2.0.2.tgz",
       "integrity": "sha512-lElyqlUfIPyWG/cD475vl6msPL4aMU7eJvx1//Q177L8mdXoVPFl1djIESF2FKnc0NyaHvQlJpWwKJYwAhUoCw==",
+      "dev": true,
       "requires": {
         "@types/d3-color": "^2"
       }
@@ -15346,12 +15354,14 @@
     "@types/d3-path": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.1.tgz",
-      "integrity": "sha512-6K8LaFlztlhZO7mwsZg7ClRsdLg3FJRzIIi6SZXDWmmSJc2x8dd2VkESbLXdk3p8cuvz71f36S0y8Zv2AxqvQw=="
+      "integrity": "sha512-6K8LaFlztlhZO7mwsZg7ClRsdLg3FJRzIIi6SZXDWmmSJc2x8dd2VkESbLXdk3p8cuvz71f36S0y8Zv2AxqvQw==",
+      "dev": true
     },
     "@types/d3-scale": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.2.tgz",
       "integrity": "sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==",
+      "dev": true,
       "requires": {
         "@types/d3-time": "^2"
       }
@@ -15360,6 +15370,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.3.tgz",
       "integrity": "sha512-HAhCel3wP93kh4/rq+7atLdybcESZ5bRHDEZUojClyZWsRuEMo3A52NGYJSh48SxfxEU6RZIVbZL2YFZ2OAlzQ==",
+      "dev": true,
       "requires": {
         "@types/d3-path": "^2"
       }
@@ -15367,7 +15378,8 @@
     "@types/d3-time": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.0.0.tgz",
-      "integrity": "sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ=="
+      "integrity": "sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ==",
+      "dev": true
     },
     "@types/eslint": {
       "version": "7.2.7",

--- a/package.json
+++ b/package.json
@@ -54,9 +54,6 @@
     "react-dom": "^16.0.0 || ^17.0.0"
   },
   "dependencies": {
-    "@types/d3-interpolate": "^2.0.0",
-    "@types/d3-scale": "^3.0.0",
-    "@types/d3-shape": "^2.0.0",
     "classnames": "^2.2.5",
     "d3-interpolate": "^2.0.0",
     "d3-scale": "^3.0.0",
@@ -83,6 +80,9 @@
     "@babel/preset-typescript": "^7.6.0",
     "@babel/runtime": "^7.6.3",
     "@types/classnames": "^2.2.9",
+    "@types/d3-interpolate": "^2.0.0",
+    "@types/d3-scale": "^3.0.0",
+    "@types/d3-shape": "^2.0.0",
     "@types/lodash": "^4.14.144",
     "@types/react": "^16.0.0",
     "@types/react-dom": "^16.0.0",


### PR DESCRIPTION
Types dependencies are usefull only to build the package and check types.

Move @types/d3* into devDependencies