### PR TITLE
在图表数据更新前将前置的动画标志设置为已完成动画

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -305,6 +305,7 @@ export class Pie extends PureComponent<Props, State> {
         prevAnimationId: nextProps.animationId,
         curSectors: nextProps.sectors,
         prevSectors: [],
+        isAnimationFinished: true,
       };
     }
     if (nextProps.isAnimationActive && nextProps.animationId !== prevState.prevAnimationId) {
@@ -312,11 +313,13 @@ export class Pie extends PureComponent<Props, State> {
         prevAnimationId: nextProps.animationId,
         curSectors: nextProps.sectors,
         prevSectors: prevState.curSectors,
+        isAnimationFinished: true,
       };
     }
     if (nextProps.sectors !== prevState.curSectors) {
       return {
         curSectors: nextProps.sectors,
+        isAnimationFinished: true,
       };
     }
 


### PR DESCRIPTION
当图表两次切换的数据相同时，会进行静态渲染，不走动画渲染。
这可能会导致上一次的动画在未执行完毕时就被销毁，导致isAnimationFinished始终为true，在这种情况下Label会出现不渲染的现象。
如果描述有不清楚可以加我的wx：yyqkn555