### PR TITLE
Add formatter function type to tooltip props

### DIFF
--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -37,7 +37,7 @@ export interface Props<TValue extends ValueType, TName extends NameType> {
   separator?: string;
   wrapperClassName?: string;
   labelClassName?: string;
-  formatter?: Function;
+  formatter?: Formatter<TValue, TName>;
   contentStyle?: CSSProperties;
   itemStyle?: CSSProperties;
   labelStyle?: CSSProperties;


### PR DESCRIPTION
This updates the prop validation of a tooltip `formatter` prop to not allow any arbitrary function.