### PR TITLE
Revert "chore: move type deps into devDependencies (#2843)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "2.1.12",
       "license": "MIT",
       "dependencies": {
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
         "classnames": "^2.2.5",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
@@ -35,9 +38,6 @@
         "@babel/preset-typescript": "^7.6.0",
         "@babel/runtime": "^7.6.3",
         "@types/classnames": "^2.2.9",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
         "@types/lodash": "^4.14.144",
         "@types/react": "^16.0.0",
         "@types/react-dom": "^16.0.0",
@@ -1769,14 +1769,12 @@
     "node_modules/@types/d3-color": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
-      "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w==",
-      "dev": true
+      "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w=="
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
-      "dev": true,
       "dependencies": {
         "@types/d3-color": "*"
       }
@@ -1784,14 +1782,12 @@
     "node_modules/@types/d3-path": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.1.tgz",
-      "integrity": "sha512-6K8LaFlztlhZO7mwsZg7ClRsdLg3FJRzIIi6SZXDWmmSJc2x8dd2VkESbLXdk3p8cuvz71f36S0y8Zv2AxqvQw==",
-      "dev": true
+      "integrity": "sha512-6K8LaFlztlhZO7mwsZg7ClRsdLg3FJRzIIi6SZXDWmmSJc2x8dd2VkESbLXdk3p8cuvz71f36S0y8Zv2AxqvQw=="
     },
     "node_modules/@types/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
-      "dev": true,
       "dependencies": {
         "@types/d3-time": "*"
       }
@@ -1800,7 +1796,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.0.tgz",
       "integrity": "sha512-jYIYxFFA9vrJ8Hd4Se83YI6XF+gzDL1aC5DCsldai4XYYiVNdhtpGbA/GM6iyQ8ayhSp3a148LY34hy7A4TxZA==",
-      "dev": true,
       "dependencies": {
         "@types/d3-path": "*"
       }
@@ -1808,8 +1803,7 @@
     "node_modules/@types/d3-time": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.0.0.tgz",
-      "integrity": "sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ==",
-      "dev": true
+      "integrity": "sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ=="
     },
     "node_modules/@types/eslint": {
       "version": "7.2.7",
@@ -15367,14 +15361,12 @@
     "@types/d3-color": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.3.tgz",
-      "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w==",
-      "dev": true
+      "integrity": "sha512-+0EtEjBfKEDtH9Rk3u3kLOUXM5F+iZK+WvASPb0MhIZl8J8NUvGeZRwKCXl+P3HkYx5TdU4YtcibpqHkSR9n7w=="
     },
     "@types/d3-interpolate": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
-      "dev": true,
       "requires": {
         "@types/d3-color": "*"
       }
@@ -15382,14 +15374,12 @@
     "@types/d3-path": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.1.tgz",
-      "integrity": "sha512-6K8LaFlztlhZO7mwsZg7ClRsdLg3FJRzIIi6SZXDWmmSJc2x8dd2VkESbLXdk3p8cuvz71f36S0y8Zv2AxqvQw==",
-      "dev": true
+      "integrity": "sha512-6K8LaFlztlhZO7mwsZg7ClRsdLg3FJRzIIi6SZXDWmmSJc2x8dd2VkESbLXdk3p8cuvz71f36S0y8Zv2AxqvQw=="
     },
     "@types/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
-      "dev": true,
       "requires": {
         "@types/d3-time": "*"
       }
@@ -15398,7 +15388,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.0.tgz",
       "integrity": "sha512-jYIYxFFA9vrJ8Hd4Se83YI6XF+gzDL1aC5DCsldai4XYYiVNdhtpGbA/GM6iyQ8ayhSp3a148LY34hy7A4TxZA==",
-      "dev": true,
       "requires": {
         "@types/d3-path": "*"
       }
@@ -15406,8 +15395,7 @@
     "@types/d3-time": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.0.0.tgz",
-      "integrity": "sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ==",
-      "dev": true
+      "integrity": "sha512-Abz8bTzy8UWDeYs9pCa3D37i29EWDjNTjemdk0ei1ApYVNqulYlGUKip/jLOpogkPSsPz/GvZCYiC7MFlEk0iQ=="
     },
     "@types/eslint": {
       "version": "7.2.7",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
+    "@types/d3-interpolate": "^3.0.1",
+    "@types/d3-scale": "^4.0.2",
+    "@types/d3-shape": "^3.1.0",
     "classnames": "^2.2.5",
     "d3-interpolate": "^3.0.1",
     "d3-scale": "^4.0.2",
@@ -81,9 +84,6 @@
     "@babel/preset-typescript": "^7.6.0",
     "@babel/runtime": "^7.6.3",
     "@types/classnames": "^2.2.9",
-    "@types/d3-interpolate": "^3.0.1",
-    "@types/d3-scale": "^4.0.2",
-    "@types/d3-shape": "^3.1.0",
     "@types/lodash": "^4.14.144",
     "@types/react": "^16.0.0",
     "@types/react-dom": "^16.0.0",


### PR DESCRIPTION
This reverts commit cbff5da35968adf31868827951c0901ad9015d2f.

This fixes https://github.com/recharts/recharts/issues/2889

Follow-up from https://github.com/recharts/recharts/pull/2897 which was closed after an update of the packages this commit moves (sorry for the delay, I've been away traveling).