### PR TITLE
feat: add onResize prop to ResponsiveContainer

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -19,6 +19,7 @@ export interface Props {
   debounce?: number;
   id?: string | number;
   className?: string | number;
+  onResize?: (width: number, height: number) => void;
 }
 
 interface State {
@@ -39,6 +40,7 @@ export const ResponsiveContainer = forwardRef(
       debounce = 0,
       id,
       className,
+      onResize,
     }: Props,
     ref,
   ) => {
@@ -75,6 +77,10 @@ export const ResponsiveContainer = forwardRef(
 
         if (containerWidth !== oldWidth || containerHeight !== oldHeight) {
           setSizes({ containerWidth, containerHeight });
+
+          if (onResize) {
+            onResize(containerWidth, containerHeight)
+          }
         }
       }
     };

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -79,7 +79,7 @@ export const ResponsiveContainer = forwardRef(
           setSizes({ containerWidth, containerHeight });
 
           if (onResize) {
-            onResize(containerWidth, containerHeight)
+            onResize(containerWidth, containerHeight);
           }
         }
       }

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -150,6 +150,10 @@ export const ResponsiveContainer = forwardRef(
 
         if (size) {
           setSizes(size);
+
+          if (onResize) {
+            onResize(size.containerWidth, size.containerHeight);
+          }
         }
       }
     }, [mounted]);


### PR DESCRIPTION
I need access to the width and height in pixels of my `recharts` graph. There is currently no way to get those in real time, e.g. when users resize the page. I tried wrapping the chart in a `ReactResizeDetector`, but that broke `recharts`. So since I ran out of options I decided to make a PR with a change that would solve my issue and would probably be useful for others, without being a breaking change :)