### PR TITLE
Ensure LabelList generic extends Data interface

### DIFF
--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -25,9 +25,9 @@ interface LabelListProps<T extends Data> {
   formatter?: Function;
 }
 
-export type Props<T> = SVGProps<SVGElement> & LabelListProps<T>;
+export type Props<T extends Data> = SVGProps<SVGElement> & LabelListProps<T>;
 
-export type ImplicitLabelListType<T> =
+export type ImplicitLabelListType<T extends Data> =
   | boolean
   | ReactElement<SVGElement>
   | ((props: any) => ReactElement<SVGElement>)


### PR DESCRIPTION
This fixes errors I'm getting when upgrading my codebase to TypeScript 4.8:

```
node_modules/recharts/types/component/LabelList.d.ts:20:70 - error TS2344: Type 'T' does not satisfy the constraint 'Data'.

20 export declare type Props<T> = SVGProps<SVGElement> & LabelListProps<T>;
                                                                        ~

  node_modules/recharts/types/component/LabelList.d.ts:20:27
    20 export declare type Props<T> = SVGProps<SVGElement> & LabelListProps<T>;
                                 ~
    This type parameter might need an `extends Data` constraint.

node_modules/recharts/types/component/LabelList.d.ts:21:136 - error TS2344: Type 'T' does not satisfy the constraint 'Data'.

21 export declare type ImplicitLabelListType<T> = boolean | ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | Props<T>;
                                                                                                                                          ~

  node_modules/recharts/types/component/LabelList.d.ts:21:43
    21 export declare type ImplicitLabelListType<T> = boolean | ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | Props<T>;
                                                 ~
    This type parameter might need an `extends Data` constraint.
```