### PR TITLE
Fix broken views in demo section

### DIFF
--- a/demo/component/CartesianAxis.tsx
+++ b/demo/component/CartesianAxis.tsx
@@ -24,9 +24,7 @@ export default class Demo extends Component<any, any> {
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
           ticks={ticks}
           label="test"
-        >
-          <Label>测试</Label>
-        </CartesianAxis>
+        />
         <CartesianAxis
           orientation="top"
           y={200}

--- a/demo/component/FunnelChart.tsx
+++ b/demo/component/FunnelChart.tsx
@@ -9,11 +9,11 @@ const colors1 = scaleOrdinal(schemeCategory10).range();
 const colors2 = scaleOrdinal(schemeCategory10).range();
 
 const data = [
-  { value: 100, name: '展现展现展现展现展现展现展现展现展现展现展现展现' },
-  { value: 80, name: '点击点击点击点击点击点击点击点击点击点击点击点击点击点击' },
-  { value: 50, name: '访问访问访问访问访问访问访问访问访问访问访问访问访问访问访问' },
-  { value: 40, name: '咨询咨询咨询咨询咨询咨询咨询咨询咨询咨询咨询咨询咨询咨询咨询' },
-  { value: 26, name: '订单订单订单订单订单订单订单订单订单订单订单订单订单订单订单订单' },
+  { value: 100, name: '展现' },
+  { value: 80, name: '点击' },
+  { value: 50, name: '访问' },
+  { value: 40, name: '咨询' },
+  { value: 26, name: '订单' },
 ];
 
 const data01 = [

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -450,6 +450,8 @@ export class CartesianAxis extends Component<Props, IState> {
   /**
    * render the ticks
    * @param {Array} ticks The ticks to actually render (overrides what was passed in props)
+   * @param {string} fontSize The ticks fontSize
+   * @param {string} letterSpacing The ticks letterSpacing
    * @return {ReactComponent} renderedTicks
    */
   renderTicks(ticks: CartesianTickItem[], fontSize: string, letterSpacing: string) {


### PR DESCRIPTION
There are some charts that look broken in the demo section. I think the broken views are only for testing purposes and do not need right now.

## Broken Views
![截圖 2022-09-01 下午1 36 19](https://user-images.githubusercontent.com/67775387/187842538-71b94548-57a8-4535-b45f-0e71ee3d8d28.png)
![截圖 2022-09-01 下午1 40 13](https://user-images.githubusercontent.com/67775387/187842544-de30d3d2-c50d-4edf-a564-05c96d94baa6.png)
