### PR TITLE
Fix: Add JSDoc to fix linter error

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -450,6 +450,8 @@ export class CartesianAxis extends Component<Props, IState> {
   /**
    * render the ticks
    * @param {Array} ticks The ticks to actually render (overrides what was passed in props)
+   * @param {string} fontSize Fontsize to consider for tick spacing
+   * @param {string} letterSpacing Letterspacing to consider for tick spacing
    * @return {ReactComponent} renderedTicks
    */
   renderTicks(ticks: CartesianTickItem[], fontSize: string, letterSpacing: string) {


### PR DESCRIPTION
This [PR](https://github.com/recharts/recharts/pull/2898) by @saghan broke the CI pipeline, which now fails due to a linter error. 

```
Run tsc --noEmit

> recharts@2.1.13 lint /home/runner/work/recharts/recharts
> eslint './src/**/*.?(ts|tsx)'


/home/runner/work/recharts/recharts/src/cartesian/CartesianAxis.tsx
Error:   450:3  error  Missing JSDoc for parameter 'fontSize'       valid-jsdoc
Error:   450:3  error  Missing JSDoc for parameter 'letterSpacing'  valid-jsdoc
```

Adding JSDoc for two arguments is sufficient to fix this. 