### PR TITLE
DefaultTooltipContent.tsx Solving type error for entry.value and entry.name

### DIFF
--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -78,8 +78,8 @@ export class DefaultTooltipContent<TValue extends ValueType, TName extends NameT
           ...itemStyle,
         };
         const finalFormatter = entry.formatter || formatter || defaultFormatter;
-        let { name, value } = entry;
-        if (finalFormatter) {
+        let { value, name } = entry;
+        if (finalFormatter && value && name) {
           const formatted = finalFormatter(value, name, entry, i, payload);
           if (Array.isArray(formatted)) {
             [value, name] = formatted as [TValue, TName];


### PR DESCRIPTION
**Error for entry.value**

let value: TValue | undefined
Argument of type 'TValue | undefined' is not assignable to parameter of type 'TValue'.
  'TValue' could be instantiated with an arbitrary type which could be unrelated to 'TValue | undefined'.
  
  
**Error for entry.name**

let name: TName | undefined
Argument of type 'TName | undefined' is not assignable to parameter of type 'TName'.
  'TName' could be instantiated with an arbitrary type which could be unrelated to 'TName | undefined'.