### PR TITLE
fix(Sankey): update tooltip active state by trigger props(hover/click)

### DIFF
--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -467,10 +467,11 @@ export class Sankey extends PureComponent<Props, State> {
 
     if (tooltipItem) {
       this.setState(
-        {
-          activeElement: el,
-          activeElementType: type,
-          isTooltipActive: true,
+        prev => {
+          if (tooltipItem.props.trigger === 'hover') {
+            return { ...prev, activeElement: el, activeElementType: type, isTooltipActive: true };
+          }
+          return prev;
         },
         () => {
           if (onMouseEnter) {
@@ -489,8 +490,11 @@ export class Sankey extends PureComponent<Props, State> {
 
     if (tooltipItem) {
       this.setState(
-        {
-          isTooltipActive: false,
+        prev => {
+          if (tooltipItem.props.trigger === 'hover') {
+            return { ...prev, activeElement: undefined, activeElementType: undefined, isTooltipActive: false };
+          }
+          return prev;
         },
         () => {
           if (onMouseLeave) {
@@ -504,7 +508,26 @@ export class Sankey extends PureComponent<Props, State> {
   }
 
   handleClick(el: React.ReactElement, type: string, e: any) {
-    const { onClick } = this.props;
+    const { onClick, children } = this.props;
+    const tooltipItem = findChildByType(children, Tooltip.displayName);
+
+    if (tooltipItem && tooltipItem.props.trigger === 'click') {
+      if (this.state.isTooltipActive) {
+        this.setState(prev => {
+          return { ...prev, activeElement: undefined, activeElementType: undefined, isTooltipActive: false };
+        });
+      } else {
+        this.setState(prev => {
+          return {
+            ...prev,
+            activeElement: el,
+            activeElementType: type,
+            isTooltipActive: true,
+          };
+        });
+      }
+    }
+
     if (onClick) onClick(el, type, e);
   }
 


### PR DESCRIPTION
Fixed the issue that does not change rendering of `Tooltip` component by trigger props.

**[PROBLEM]**
In Example below, `Tooltip` should be rendered when user click the node in Sankey chart. But whatever the trigger props, `Tooltip` be rendered when mouse hover.
```js
// example
<Sankey width={960} height={500} data={data}>
    <Tooltip trigger="click" />
</Sankey>
```