### PR TITLE
fix: let formatter function run even when value is falsy

### DIFF
--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -79,7 +79,7 @@ export class DefaultTooltipContent<TValue extends ValueType, TName extends NameT
         };
         const finalFormatter = entry.formatter || formatter || defaultFormatter;
         let { value, name } = entry;
-        if (finalFormatter ?? value ?? name) {
+        if (finalFormatter && value != null && name != null) {
           const formatted = finalFormatter(value, name, entry, i, payload);
           if (Array.isArray(formatted)) {
             [value, name] = formatted as [TValue, TName];

--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -79,7 +79,7 @@ export class DefaultTooltipContent<TValue extends ValueType, TName extends NameT
         };
         const finalFormatter = entry.formatter || formatter || defaultFormatter;
         let { value, name } = entry;
-        if (finalFormatter && value && name) {
+        if (finalFormatter ?? value ?? name) {
           const formatted = finalFormatter(value, name, entry, i, payload);
           if (Array.isArray(formatted)) {
             [value, name] = formatted as [TValue, TName];


### PR DESCRIPTION
Changed the logical AND operators (&&) added in c6cf8dc to nullish coalescing operators (??) to allow formatter function to run even when value is falsy. 0 is a falsy value that still ought to let the formatter function run