### PR TITLE
fix: allow dragging brush/traveller when the mouse is outside of brush area

### DIFF
--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Brush
  */
-import React, { PureComponent, Children, ReactText, MouseEvent, ReactElement, TouchEvent, SVGProps } from 'react';
+import React, { PureComponent, Children, ReactText, ReactElement, TouchEvent, SVGProps } from 'react';
 import classNames from 'classnames';
 import { scalePoint, ScalePoint } from 'd3-scale';
 import _ from 'lodash';
@@ -107,7 +107,7 @@ const createScale = ({
   };
 };
 
-const isTouch = (e: TouchEvent<SVGElement> | MouseEvent<SVGElement>): e is TouchEvent<SVGElement> =>
+const isTouch = (e: TouchEvent<SVGElement> | React.MouseEvent<SVGElement>): e is TouchEvent<SVGElement> =>
   (e as TouchEvent<SVGElement>).changedTouches && !!(e as TouchEvent<SVGElement>).changedTouches.length;
 
 export class Brush extends PureComponent<Props, State> {
@@ -139,7 +139,7 @@ export class Brush extends PureComponent<Props, State> {
 
   travellerDragStartHandlers?: Record<
     BrushTravellerId,
-    (event: MouseEvent<SVGGElement> | TouchEvent<SVGGElement>) => void
+    (event: React.MouseEvent<SVGGElement> | TouchEvent<SVGGElement>) => void
   >;
 
   static renderDefaultTraveller(props: any) {
@@ -255,7 +255,7 @@ export class Brush extends PureComponent<Props, State> {
     return _.isFunction(tickFormatter) ? tickFormatter(text, index) : text;
   }
 
-  handleDrag = (e: React.Touch | MouseEvent<SVGGElement>) => {
+  handleDrag = (e: React.Touch | React.MouseEvent<SVGGElement> | MouseEvent) => {
     if (this.leaveTimer) {
       clearTimeout(this.leaveTimer);
       this.leaveTimer = null;
@@ -277,11 +277,13 @@ export class Brush extends PureComponent<Props, State> {
   attachDragEndListener() {
     window.addEventListener('mouseup', this.handleDragEnd, true);
     window.addEventListener('touchend', this.handleDragEnd, true);
+    window.addEventListener('mousemove', this.handleDrag, true);
   }
 
   detachDragEndListener() {
     window.removeEventListener('mouseup', this.handleDragEnd, true);
     window.removeEventListener('touchend', this.handleDragEnd, true);
+    window.removeEventListener('mousemove', this.handleDrag, true);
   }
 
   handleDragEnd = () => {
@@ -310,7 +312,7 @@ export class Brush extends PureComponent<Props, State> {
     });
   };
 
-  handleSlideDragStart = (e: TouchEvent<SVGRectElement> | MouseEvent<SVGRectElement>) => {
+  handleSlideDragStart = (e: TouchEvent<SVGRectElement> | React.MouseEvent<SVGRectElement>) => {
     const event = isTouch(e) ? e.changedTouches[0] : e;
 
     this.setState({
@@ -322,7 +324,7 @@ export class Brush extends PureComponent<Props, State> {
     this.attachDragEndListener();
   };
 
-  handleSlideDrag(e: React.Touch | MouseEvent<SVGGElement>) {
+  handleSlideDrag(e: React.Touch | React.MouseEvent<SVGGElement> | MouseEvent) {
     const { slideMoveStartX, startX, endX } = this.state;
     const { x, width, travellerWidth, startIndex, endIndex, onChange } = this.props;
     let delta = e.pageX - slideMoveStartX;
@@ -348,7 +350,7 @@ export class Brush extends PureComponent<Props, State> {
     });
   }
 
-  handleTravellerDragStart(id: BrushTravellerId, e: MouseEvent<SVGGElement> | TouchEvent<SVGGElement>) {
+  handleTravellerDragStart(id: BrushTravellerId, e: React.MouseEvent<SVGGElement> | TouchEvent<SVGGElement>) {
     const event = isTouch(e) ? e.changedTouches[0] : e;
 
     this.setState({
@@ -361,7 +363,7 @@ export class Brush extends PureComponent<Props, State> {
     this.attachDragEndListener();
   }
 
-  handleTravellerMove(e: React.Touch | MouseEvent<SVGGElement>) {
+  handleTravellerMove(e: React.Touch | React.MouseEvent<SVGGElement> | MouseEvent) {
     const { brushMoveStartX, movingTravellerId, endX, startX } = this.state;
     const prevValue = this.state[movingTravellerId];
 
@@ -538,7 +540,6 @@ export class Brush extends PureComponent<Props, State> {
     return (
       <Layer
         className={layerClass}
-        onMouseMove={this.handleDrag}
         onMouseLeave={this.handleLeaveWrapper}
         onTouchMove={this.handleTouchMove}
         style={style}


### PR DESCRIPTION
Currently, it's not possible to drag a brush or traveller when mouse leaves traveller area, The fix allows to drag brush and traveller even when the mouse is outside of the brush component.

Fixes #2570 