### PR TITLE
Adjust rounding to avoid hairline cracks in cartesian grid

### DIFF
--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -144,14 +144,16 @@ export class CartesianGrid extends PureComponent<Props> {
     }
 
     const { fillOpacity, x, y, width, height } = this.props;
-    const verticalPointsUpdated = verticalPoints.slice().sort((a, b) => a - b);
+    const roundedSortedVerticalPoints = verticalPoints.map(e => Math.round(e + x - x)).sort((a, b) => a - b);
 
-    if (x !== verticalPointsUpdated[0]) {
-      verticalPointsUpdated.unshift(0);
+    if (x !== roundedSortedVerticalPoints[0]) {
+      roundedSortedVerticalPoints.unshift(0);
     }
 
-    const items = verticalPointsUpdated.map((entry, i) => {
-      const lineWidth = verticalPointsUpdated[i + 1] ? verticalPointsUpdated[i + 1] - entry : x + width - entry;
+    const items = roundedSortedVerticalPoints.map((entry, i) => {
+      const lastStripe = !roundedSortedVerticalPoints[i + 1];
+      const lineWidth = lastStripe ? x + width - entry : roundedSortedVerticalPoints[i + 1] - entry;
+
       if (lineWidth <= 0) {
         return null;
       }
@@ -159,7 +161,7 @@ export class CartesianGrid extends PureComponent<Props> {
       return (
         <rect
           key={`react-${i}`} // eslint-disable-line react/no-array-index-key
-          x={Math.round(entry + x - x)}
+          x={entry}
           y={y}
           width={lineWidth}
           height={height}
@@ -186,13 +188,14 @@ export class CartesianGrid extends PureComponent<Props> {
     }
 
     const { fillOpacity, x, y, width, height } = this.props;
-    const horizontalPointsUpdated = horizontalPoints.slice().sort((a, b) => a - b);
-    if (y !== horizontalPointsUpdated[0]) {
-      horizontalPointsUpdated.unshift(0);
+    const roundedSortedHorizontalPoints = horizontalPoints.map(e => Math.round(e + y - y)).sort((a, b) => a - b);
+    if (y !== roundedSortedHorizontalPoints[0]) {
+      roundedSortedHorizontalPoints.unshift(0);
     }
 
-    const items = horizontalPointsUpdated.map((entry, i) => {
-      const lineHeight = horizontalPointsUpdated[i + 1] ? horizontalPointsUpdated[i + 1] - entry : y + height - entry;
+    const items = roundedSortedHorizontalPoints.map((entry, i) => {
+      const lastStripe = !roundedSortedHorizontalPoints[i + 1];
+      const lineHeight = lastStripe ? y + height - entry : roundedSortedHorizontalPoints[i + 1] - entry;
       if (lineHeight <= 0) {
         return null;
       }
@@ -200,7 +203,7 @@ export class CartesianGrid extends PureComponent<Props> {
       return (
         <rect
           key={`react-${i}`} // eslint-disable-line react/no-array-index-key
-          y={Math.round(entry + y - y)}
+          y={entry}
           x={x}
           height={lineHeight}
           width={width}


### PR DESCRIPTION
When using vertical striping in a `CartesianGrid`, I noticed two issues that I think will be fixed by the rounding changes in this PR:

<img width="777" alt="Screen Shot 2022-11-30 at 11 26 28 PM" src="https://user-images.githubusercontent.com/1226543/204966279-597503d4-86e5-419a-81f0-9cd71bf6f81c.png">

I think this PR is safe because we'll still end up with stripes covering the whole grid, even if they change alignment by a pixel one way or the other.


### Floating point "nearly there" comparison leading to overflow
At some screen widths, the check on line 149 will fire incorrectly, due to what seems like int <> float comparison problems. See for example:
<img width="462" alt="Screen Shot 2022-11-30 at 11 29 28 PM" src="https://user-images.githubusercontent.com/1226543/204966094-c30ddecf-9d80-4401-9cc0-de59de2d4637.png">

The "x" of this rectangle is 0 and the width is just a smidge under 5, suggesting that the first entry of `verticalPointsUpdated` was `4.999999999999943`

### Hairline cracks at some widths
The width of each stripe is computed against the unrounded values, but then uses a rounded value as its base. In the picture above, the third stripe starts at 5 and has a width of 142.57 but isn't rendered covering the whole distance to the next stripe, which, starts at 148. Computing the widths of each stripe against the _rounded_ start location of the next stripe (in this case, that would give 143) will lead making sure the whole space is covered.

### This PR
 - I made the change in the `horizonalStripes` function too even though I only am observing this in the vertical striping
 - I kept the `+ x - x` code in the Math.round — I'm not sure why it's there (and naively, I'm not sure it does anything?) but there might be a javascript-specific reason to have that.
