### PR TITLE
fix: do not override zero brush end index on chart re-render 

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -539,7 +539,7 @@ const createDefaultState = (props: CategoricalChartProps): CategoricalChartState
   const brushItem = findChildByType(children, Brush.displayName);
   const startIndex = (brushItem && brushItem.props && brushItem.props.startIndex) || 0;
   const endIndex =
-    (brushItem && brushItem.props && brushItem.props.endIndex) || (props.data && props.data.length - 1) || 0;
+    brushItem?.props?.endIndex !== undefined ? brushItem?.props?.endIndex : (props.data && props.data.length - 1) || 0;
 
   return {
     chartX: 0,


### PR DESCRIPTION
Prioritize brush endIndex over props.data length, so it doesn't reset on chart re-render.

Fixes #3074