### PR TITLE
Revert "Fix typing of default tooltip formatter (#2924)"

### DIFF
--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -6,8 +6,8 @@ import React, { PureComponent, CSSProperties, ReactNode } from 'react';
 import classNames from 'classnames';
 import { isNumOrStr } from '../util/DataUtils';
 
-function defaultFormatter<TValue extends ValueType>(value: TValue) {
-  return _.isArray(value) && isNumOrStr(value[0]) && isNumOrStr(value[1]) ? (value.join(' ~ ') as TValue) : value;
+function defaultFormatter<T>(value: T) {
+  return _.isArray(value) && isNumOrStr(value[0]) && isNumOrStr(value[1]) ? value.join(' ~ ') : value;
 }
 
 export type TooltipType = 'none';
@@ -19,7 +19,7 @@ export type Formatter<TValue extends ValueType, TName extends NameType> = (
   item: Payload<TValue, TName>,
   index: number,
   payload: Array<Payload<TValue, TName>>,
-) => [TValue, TName] | TValue;
+) => [ReactNode, ReactNode] | ReactNode;
 
 export interface Payload<TValue extends ValueType, TName extends NameType> {
   type?: TooltipType;
@@ -82,7 +82,7 @@ export class DefaultTooltipContent<TValue extends ValueType, TName extends NameT
         if (finalFormatter && value != null && name != null) {
           const formatted = finalFormatter(value, name, entry, i, payload);
           if (Array.isArray(formatted)) {
-            [value, name] = formatted as [TValue, TName];
+            [value, name] = formatted;
           } else {
             value = formatted;
           }

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -258,12 +258,8 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
     });
 
     return (
-      // ESLint is disabled to allow listening to the `Escape` key. Refer to
-      // https://github.com/recharts/recharts/pull/2925
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
       <div
-        tabIndex={-1}
-        role="dialog"
+        tabIndex={0}
         onKeyDown={event => {
           if (event.key === 'Escape') {
             this.setState({


### PR DESCRIPTION
This reverts commit da6b9e2394cd55169ecdf31baf51bfa021eedb18.

See https://github.com/recharts/recharts/issues/3008 for more information. This change does not appear to be working as intended. This sums it up best (emphasis added):

> Moreover, the goal of a formatter is to provide a **different** representation for `ValueType`.