### PR TITLE
fix: linter error and update browserlist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17057,9 +17057,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001286",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz",
-      "integrity": "sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==",
+      "version": "1.0.30001436",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz",
+      "integrity": "sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==",
       "dev": true
     },
     "caseless": {

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -193,14 +193,13 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
         return Math.max(positive, viewBox[key]);
       }
       return Math.max(negative, viewBox[key]);
-    } else {
-      const tooltipBoundary = positive + tooltipDimension;
-      const viewBoxBoundary = viewBox[key] + viewBoxDimension;
-      if (tooltipBoundary > viewBoxBoundary) {
-        return Math.max(negative, viewBox[key]);
-      }
-      return Math.max(positive, viewBox[key]);
     }
+    const tooltipBoundary = positive + tooltipDimension;
+    const viewBoxBoundary = viewBox[key] + viewBoxDimension;
+    if (tooltipBoundary > viewBoxBoundary) {
+      return Math.max(negative, viewBox[key]);
+    }
+    return Math.max(positive, viewBox[key]);
   };
 
   render() {


### PR DESCRIPTION
This PR fixes the linter error causing CI builds to fail by removing the unneeded `else` statement in `Tooltip.tsx`. This is failing the CI builds upon PR/release/etc.

Example failed tests broken build is the latest release: https://github.com/recharts/recharts/actions/runs/3644937544/jobs/6154640009

I also ran `npx browserslist@latest --update-db` to update the browser list to the current recommended version. This is recommended to do regularly. Diff in the lockfile is only the `caniuse-lite` version.