### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
 name: Node.js CI
 
-on: [push, pull_request]
+on:
+  [push, pull_request]
 
 jobs:
   build:
@@ -9,23 +13,22 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 15.x]
+        node-version: [14.x, 16.x, 18.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install packages
-      run: sudo apt-get install firefox xvfb
-
-    - name: Setup node ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-
+        cache: 'npm'
     - name: Install dependencies
-      run: npm install --legacy-peer-deps
-
+      run: npm ci
+    - name: Run build
+      run: npm run build --if-present
     - name: Test
       run: |
         tsc --noEmit
         npm run lint
-        xvfb-run --auto-servernum -- ./node_modules/karma/bin/karma start test/karma.conf.js --browsers Firefox --single-run --no-auto-watch --capture-timeout 60000
+         npm test -- --watch=false --single-run --browsers=ChromeHeadless

--- a/package-lock.json
+++ b/package-lock.json
@@ -3527,14 +3527,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001286",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz",
-      "integrity": "sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==",
+      "version": "1.0.30001436",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz",
+      "integrity": "sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/caseless": {
       "version": "0.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17057,9 +17057,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001286",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz",
-      "integrity": "sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==",
+      "version": "1.0.30001436",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz",
+      "integrity": "sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==",
       "dev": true
     },
     "caseless": {

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -193,14 +193,13 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
         return Math.max(positive, viewBox[key]);
       }
       return Math.max(negative, viewBox[key]);
-    } else {
-      const tooltipBoundary = positive + tooltipDimension;
-      const viewBoxBoundary = viewBox[key] + viewBoxDimension;
-      if (tooltipBoundary > viewBoxBoundary) {
-        return Math.max(negative, viewBox[key]);
-      }
-      return Math.max(positive, viewBox[key]);
     }
+    const tooltipBoundary = positive + tooltipDimension;
+    const viewBoxBoundary = viewBox[key] + viewBoxDimension;
+    if (tooltipBoundary > viewBoxBoundary) {
+      return Math.max(negative, viewBox[key]);
+    }
+    return Math.max(positive, viewBox[key]);
   };
 
   render() {


### PR DESCRIPTION
Recharts CI has been "broken" for a while. This updates the CI template to be a bit more modern and easier to read.

* Fixes linter error in `Tooltip.tsx` - unneeded `else` statement
* updates browserlist with `npx browserslist@latest --update-db`
* Updates `ci.yml`
  * Use headless chrome as our test runner
  * Use Node 14, 16, 18 instead of 14, 15
  * Update GH actions versions
  * Add a build step