### PR TITLE
fix: babel warnings, remove unneeded babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,6 @@
   "plugins": [
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-export-namespace-from",
-    ["@babel/plugin-proposal-class-properties", { "loose": true }],
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-function-bind",
     "babel-plugin-lodash"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "@babel/cli": "^7.6.4",
         "@babel/core": "^7.20.5",
         "@babel/eslint-parser": "^7.19.1",
-        "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-export-namespace-from": "^7.0.0",
         "@babel/plugin-proposal-function-bind": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@babel/cli": "^7.6.4",
     "@babel/core": "^7.20.5",
     "@babel/eslint-parser": "^7.19.1",
-    "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-export-default-from": "^7.0.0",
     "@babel/plugin-proposal-export-namespace-from": "^7.0.0",
     "@babel/plugin-proposal-function-bind": "^7.0.0",


### PR DESCRIPTION
Upon upgrading to `"@babel/core": "^7.20.5",` we have started printing the warning:
```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-property-in-object. The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding ["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```

This is because `@babel/plugin-proposal-class-properties` and the listed other config items are included in `@babel/preset-env` as per [the docs](https://babeljs.io/docs/en/babel-plugin-proposal-private-methods#references). 

Looking through the git history, it looks like the `loose` option here was added to support the legacy decorators plugin (reference for breakage https://github.com/babel/babel/discussions/14133). That has since been removed. After reading the [consequences](https://2ality.com/2012/08/property-definition-assignment.html). I am unable to find any that pertain to recharts or this removal

