### PR TITLE
fix(types): add zIndex as valid AxisType, remove CategoricalChartOptions assertions

### DIFF
--- a/src/chart/AreaChart.tsx
+++ b/src/chart/AreaChart.tsx
@@ -6,7 +6,6 @@ import { Area } from '../cartesian/Area';
 import { XAxis } from '../cartesian/XAxis';
 import { YAxis } from '../cartesian/YAxis';
 import { formatAxisMap } from '../util/CartesianUtils';
-import { CategoricalChartOptions } from '../util/types';
 
 export const AreaChart = generateCategoricalChart({
   chartName: 'AreaChart',
@@ -16,4 +15,4 @@ export const AreaChart = generateCategoricalChart({
     { axisType: 'yAxis', AxisComp: YAxis },
   ],
   formatAxisMap,
-} as CategoricalChartOptions);
+});

--- a/src/chart/BarChart.tsx
+++ b/src/chart/BarChart.tsx
@@ -6,7 +6,6 @@ import { Bar } from '../cartesian/Bar';
 import { XAxis } from '../cartesian/XAxis';
 import { YAxis } from '../cartesian/YAxis';
 import { formatAxisMap } from '../util/CartesianUtils';
-import { CategoricalChartOptions } from '../util/types';
 
 export const BarChart = generateCategoricalChart({
   chartName: 'BarChart',
@@ -18,4 +17,4 @@ export const BarChart = generateCategoricalChart({
     { axisType: 'yAxis', AxisComp: YAxis },
   ],
   formatAxisMap,
-} as CategoricalChartOptions);
+});

--- a/src/chart/ComposedChart.tsx
+++ b/src/chart/ComposedChart.tsx
@@ -10,7 +10,6 @@ import { XAxis } from '../cartesian/XAxis';
 import { YAxis } from '../cartesian/YAxis';
 import { ZAxis } from '../cartesian/ZAxis';
 import { formatAxisMap } from '../util/CartesianUtils';
-import { CategoricalChartOptions } from '../util/types';
 
 export const ComposedChart = generateCategoricalChart({
   chartName: 'ComposedChart',
@@ -21,4 +20,4 @@ export const ComposedChart = generateCategoricalChart({
     { axisType: 'zAxis', AxisComp: ZAxis },
   ],
   formatAxisMap,
-} as CategoricalChartOptions);
+});

--- a/src/chart/FunnelChart.tsx
+++ b/src/chart/FunnelChart.tsx
@@ -3,7 +3,6 @@
  */
 import { generateCategoricalChart } from './generateCategoricalChart';
 import { Funnel } from '../numberAxis/Funnel';
-import { CategoricalChartOptions } from '../util/types';
 
 export const FunnelChart = generateCategoricalChart({
   chartName: 'FunnelChart',
@@ -14,4 +13,4 @@ export const FunnelChart = generateCategoricalChart({
   defaultProps: {
     layout: 'centric',
   },
-} as CategoricalChartOptions);
+});

--- a/src/chart/LineChart.tsx
+++ b/src/chart/LineChart.tsx
@@ -6,7 +6,6 @@ import { Line } from '../cartesian/Line';
 import { XAxis } from '../cartesian/XAxis';
 import { YAxis } from '../cartesian/YAxis';
 import { formatAxisMap } from '../util/CartesianUtils';
-import { CategoricalChartOptions } from '../util/types';
 
 export const LineChart = generateCategoricalChart({
   chartName: 'LineChart',
@@ -16,4 +15,4 @@ export const LineChart = generateCategoricalChart({
     { axisType: 'yAxis', AxisComp: YAxis },
   ],
   formatAxisMap,
-} as CategoricalChartOptions);
+});

--- a/src/chart/PieChart.tsx
+++ b/src/chart/PieChart.tsx
@@ -6,7 +6,6 @@ import { PolarAngleAxis } from '../polar/PolarAngleAxis';
 import { PolarRadiusAxis } from '../polar/PolarRadiusAxis';
 import { formatAxisMap } from '../util/PolarUtils';
 import { Pie } from '../polar/Pie';
-import { CategoricalChartOptions } from '../util/types';
 
 export const PieChart = generateCategoricalChart({
   chartName: 'PieChart',
@@ -28,4 +27,4 @@ export const PieChart = generateCategoricalChart({
     innerRadius: 0,
     outerRadius: '80%',
   },
-} as CategoricalChartOptions);
+});

--- a/src/chart/RadarChart.tsx
+++ b/src/chart/RadarChart.tsx
@@ -6,7 +6,6 @@ import { Radar } from '../polar/Radar';
 import { PolarAngleAxis } from '../polar/PolarAngleAxis';
 import { PolarRadiusAxis } from '../polar/PolarRadiusAxis';
 import { formatAxisMap } from '../util/PolarUtils';
-import { CategoricalChartOptions } from '../util/types';
 
 export const RadarChart = generateCategoricalChart({
   chartName: 'RadarChart',
@@ -25,4 +24,4 @@ export const RadarChart = generateCategoricalChart({
     innerRadius: 0,
     outerRadius: '80%',
   },
-} as CategoricalChartOptions);
+});

--- a/src/chart/RadialBarChart.tsx
+++ b/src/chart/RadialBarChart.tsx
@@ -6,7 +6,6 @@ import { PolarAngleAxis } from '../polar/PolarAngleAxis';
 import { PolarRadiusAxis } from '../polar/PolarRadiusAxis';
 import { formatAxisMap } from '../util/PolarUtils';
 import { RadialBar } from '../polar/RadialBar';
-import { CategoricalChartOptions } from '../util/types';
 
 export const RadialBarChart = generateCategoricalChart({
   chartName: 'RadialBarChart',
@@ -28,4 +27,4 @@ export const RadialBarChart = generateCategoricalChart({
     innerRadius: 0,
     outerRadius: '80%',
   },
-} as CategoricalChartOptions);
+});

--- a/src/chart/ScatterChart.tsx
+++ b/src/chart/ScatterChart.tsx
@@ -7,7 +7,6 @@ import { XAxis } from '../cartesian/XAxis';
 import { YAxis } from '../cartesian/YAxis';
 import { ZAxis } from '../cartesian/ZAxis';
 import { formatAxisMap } from '../util/CartesianUtils';
-import { CategoricalChartOptions } from '../util/types';
 
 export const ScatterChart = generateCategoricalChart({
   chartName: 'ScatterChart',
@@ -20,4 +19,4 @@ export const ScatterChart = generateCategoricalChart({
     { axisType: 'zAxis', AxisComp: ZAxis },
   ],
   formatAxisMap,
-} as CategoricalChartOptions);
+});

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -27,7 +27,7 @@ import { ScaleContinuousNumeric as D3ScaleContinuousNumeric } from 'd3-scale';
 export type StackOffsetType = 'sign' | 'expand' | 'none' | 'wiggle' | 'silhouette';
 export type LayoutType = 'horizontal' | 'vertical' | 'centric' | 'radial';
 export type PolarLayoutType = 'radial' | 'centric';
-export type AxisType = 'xAxis' | 'yAxis' | 'angleAxis' | 'radiusAxis';
+export type AxisType = 'xAxis' | 'yAxis' | 'zAxis' | 'angleAxis' | 'radiusAxis';
 export type DataKey<T> = string | number | ((obj: T) => any);
 export type PresentationAttributesWithProps<P, T> = AriaAttributes &
   DOMAttributesWithProps<P, T> &


### PR DESCRIPTION
Follow-on from https://github.com/recharts/recharts/pull/3103

Adds 'zIndex' to the AxisType union type, which means we can avoid the type 
assertion in `ComposedChart.tsx` and `ScatterChart.tsx`.

I've also removed the unnecessary type assertion to `CategoricalChartOptions` in other chart components, which should improve type safety a little.