### PR TITLE
fix: add some missing payload properties that might be needed in custom tooltip, parity with definitely typed

### DIFF
--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -31,6 +31,9 @@ export interface Payload<TValue extends ValueType, TName extends NameType> {
   dataKey?: string | number;
   payload?: any;
   chartType?: string;
+  stroke?: string;
+  strokeDasharray?: string | number;
+  strokeWidth?: number | string;
 }
 
 export interface Props<TValue extends ValueType, TName extends NameType> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add `stroke` `strokeDasharray` and `strokeWidth` as optional properties on tooltip `Payload`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #3033 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Some consumers want typed access to more properties that might get added to a chart component such as `stroke` `strokeDasharray` and `strokeWidth`

Add these to `Payload` types - creates parity with DefinitelyTyped which already has these
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62852

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- all optional properties added
- checked demos that the properties were passed when added on a chart

## Screenshots (if appropriate):
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
   - we need to add more docs on `Payload` but nothing to add to for now
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
