### PR TITLE
Fix IconType type by replacing Omit utility type with Exclude

### DIFF
--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -16,7 +16,7 @@ import {
 
 const SIZE = 32;
 export type ContentType = ReactElement | ((props: Props) => ReactNode);
-export type IconType = Omit<LegendType, 'none'>;
+export type IconType = Exclude<LegendType, 'none'>;
 export type HorizontalAlignmentType = 'center' | 'left' | 'right';
 export type VerticalAlignmentType = 'top' | 'bottom' | 'middle';
 export type Formatter = (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `IconType` type used the `Omit` utility type to remove `'none'` from `LegendType`. This results in a wrong type since `Omit` only works on object types or interfaces. As a result, any string was accepted as value for `IconType`.
Using the `Exclude` utiltiy type instead, the type is defined as expected and allows all values from  `LegendType` apart from `'none'`.

## Related Issue

- #2963

## Motivation and Context

The `iconType` prop was not typesafe since the `IconType` type was wrong.

## How Has This Been Tested?

I did not write unit tests since the interesting ones would not compile.
I tested the fix by making sure that a TS error is thrown if I try to build a `Legend` component with `iconType="notavalidicontype". Before the fix, this did compile.

In addition I ran the demo app to see if the legends still work as expected.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
