### PR TITLE
Add reversed prop for PolarRadiusAxis

### DIFF
--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -17,6 +17,7 @@ export interface PolarRadiusAxisProps extends Omit<BaseAxisProps, 'unit'> {
   angle?: number;
   orientation?: 'left' | 'right' | 'middle';
   ticks?: TickItem[];
+  reversed?: boolean;
 }
 
 export type Props = PresentationAttributesAdaptChildEvent<any, SVGElement> & PolarRadiusAxisProps;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In JS it was possible to set the `reversed` prop on the PolarRadiusAxis component. However, the `PolarRadiusAxisProps` type does not contain this prop which results in a TS error when using the prop. 
This PR adds the prop to the prop type.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- #2966 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes a type related bug and makes the reversed feature for the PolarRadiusAxis more explicit.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested to set the reversed prop on a PolarRadiusAxis in the demo app and made sure the reversed functionality still works as expected.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (https://github.com/recharts/recharts.org/pull/225)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
