### PR TITLE
Fix type of Brush Props

### DIFF
--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -48,7 +48,7 @@ interface BrushProps extends InternalBrushProps {
   alwaysShowText?: boolean;
 }
 
-export type Props = SVGProps<SVGElement> & BrushProps;
+export type Props = Omit<SVGProps<SVGElement>, 'onChange'> & BrushProps;
 
 type BrushTravellerId = 'startX' | 'endX';
 


### PR DESCRIPTION
## Description
Fixed type of the the props for the Brush component.
`onChange` will always have the type defined in `BrushProps`

## Related Issue
 Issue #2480

## Motivation and Context

This issue fixes a Typescript error when using the onChange prop of Brush

## How Has This Been Tested?

- Built the project
- Ran test suites
- Tested using the Component in a separate project 

## Screenshots (if appropriate):

## Types of changes

Partially omitted a type from a type union

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
