### PR TITLE
test(jest): remove console error and warn from stdout in LogUtils and ReactUtils

### DIFF
--- a/test-jest/util/LogUtils.spec.ts
+++ b/test-jest/util/LogUtils.spec.ts
@@ -2,13 +2,13 @@ import { warn } from '../../src/util/LogUtils';
 
 describe('LogUtils', () => {
   test('dont log when condition is true', () => {
-    const logSpy = jest.spyOn(console, 'warn');
+    const logSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     warn(true, 'test');
     expect(logSpy).not.toHaveBeenCalledWith('test');
   });
 
   test('warn when condition is false', () => {
-    const logSpy = jest.spyOn(console, 'warn');
+    const logSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
     // log 'format'
     warn(false, 'format');
 

--- a/test-jest/util/ReactUtils.spec.tsx
+++ b/test-jest/util/ReactUtils.spec.tsx
@@ -51,7 +51,7 @@ describe('ReactUtils untest tests', () => {
       });
     });
 
-    test('should filter out "points" attribute when included wtesthout an svg type that explictestly uses "points"', () => {
+    test('should filter out "points" attribute when included without an svg type that explicitly uses "points"', () => {
       expect(filterProps({ test: '1234', points: '1234', onClick: jest.fn() }, true)).toEqual({
         onClick: expect.any(Function),
       });
@@ -241,14 +241,14 @@ describe('ReactUtils untest tests', () => {
       const childrenOne = [
         <>
           {['A'].map(value => {
-            return <Line dataKey={value} />;
+            return <Line key={value} dataKey={value} />;
           })}
         </>,
       ];
       const childrenTwo = [
         <>
           {['B'].map(value => {
-            return <Line dataKey={value} />;
+            return <Line key={value} dataKey={value} />;
           })}
         </>,
       ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

While working on the PR for #3132 I noticed that jest stout was printing some warning and errors.
I think we can remove them in the following way:

### LogUtils

add a mock implementation on the console spy

### ReactUtils

add key on the child of each element

## Related Issue

N/A

## Motivation and Context

Remove error and log warning from jest stdout

## How Has This Been Tested?

`npm run test`

## Screenshots (if appropriate):

<img width="927" alt="image" src="https://user-images.githubusercontent.com/24919330/210638856-02939b61-dbf2-4fe6-b202-b9ee00419add.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
