### PR TITLE
ReactUtils – find by type – refactor using generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage
 npm-debug.log
 *.orig
 .idea/
+.vscode/
 .justconf/
 types
 build

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -166,7 +166,7 @@ export class Bar extends PureComponent<Props, State> {
     const numericAxis = layout === 'horizontal' ? yAxis : xAxis;
     const stackedDomain = stackedData ? numericAxis.scale.domain() : null;
     const baseValue = getBaseValueOfBar({ numericAxis });
-    const cells = findAllByType(children, Cell.displayName);
+    const cells = findAllByType(children, Cell);
 
     const rects = displayedData.map((entry, index) => {
       let value, x, y, width, height, background;
@@ -417,7 +417,7 @@ export class Bar extends PureComponent<Props, State> {
     }
 
     const { data, xAxis, yAxis, layout, children } = this.props;
-    const errorBarItems = findAllByType(children, ErrorBar.displayName);
+    const errorBarItems = findAllByType(children, ErrorBar);
 
     if (!errorBarItems) {
       return null;

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -257,7 +257,7 @@ export class Line extends PureComponent<Props, State> {
     }
 
     const { points, xAxis, yAxis, layout, children } = this.props;
-    const errorBarItems = findAllByType(children, ErrorBar.displayName);
+    const errorBarItems = findAllByType(children, ErrorBar);
 
     if (!errorBarItems) {
       return null;

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -12,7 +12,7 @@ import { Global } from '../util/Global';
 import { ZAxis, Props as ZAxisProps } from './ZAxis';
 import { Curve, Props as CurveProps, CurveType } from '../shape/Curve';
 import { Symbols, Props as SymbolsProps } from '../shape/Symbols';
-import { ErrorBar, Props as ErrorBarProps } from './ErrorBar';
+import { ErrorBar } from './ErrorBar';
 import { Cell } from '../component/Cell';
 import { uniqueId, interpolateNumber, getLinearRegression } from '../util/DataUtils';
 import { getValueByDataKey, getCateCoordinateOfLine } from '../util/ChartUtils';
@@ -140,7 +140,7 @@ export class Scatter extends PureComponent<Props, State> {
     offset: ChartOffset;
   }) => {
     const { tooltipType } = item.props;
-    const cells = findAllByType(item.props.children, Cell.displayName);
+    const cells = findAllByType(item.props.children, Cell);
     const xAxisDataKey = _.isNil(xAxis.dataKey) ? item.props.dataKey : xAxis.dataKey;
     const yAxisDataKey = _.isNil(yAxis.dataKey) ? item.props.dataKey : yAxis.dataKey;
     const zAxisDataKey = zAxis && zAxis.dataKey;
@@ -351,7 +351,7 @@ export class Scatter extends PureComponent<Props, State> {
     }
 
     const { points, xAxis, yAxis, children } = this.props;
-    const errorBarItems = findAllByType(children, ErrorBar.displayName);
+    const errorBarItems = findAllByType(children, ErrorBar);
 
     if (!errorBarItems) {
       return null;
@@ -375,7 +375,7 @@ export class Scatter extends PureComponent<Props, State> {
       };
     }
 
-    return errorBarItems.map((item: ReactElement<ErrorBarProps>, i: number) => {
+    return errorBarItems.map((item, i: number) => {
       const { direction } = item.props;
 
       return React.cloneElement(item, {

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -463,7 +463,7 @@ export class Sankey extends PureComponent<Props, State> {
 
   handleMouseEnter(el: React.ReactElement, type: string, e: any) {
     const { onMouseEnter, children } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip.displayName);
+    const tooltipItem = findChildByType(children, Tooltip);
 
     if (tooltipItem) {
       this.setState(
@@ -486,7 +486,7 @@ export class Sankey extends PureComponent<Props, State> {
 
   handleMouseLeave(el: React.ReactElement, type: string, e: any) {
     const { onMouseLeave, children } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip.displayName);
+    const tooltipItem = findChildByType(children, Tooltip);
 
     if (tooltipItem) {
       this.setState(
@@ -509,7 +509,7 @@ export class Sankey extends PureComponent<Props, State> {
 
   handleClick(el: React.ReactElement, type: string, e: any) {
     const { onClick, children } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip.displayName);
+    const tooltipItem = findChildByType(children, Tooltip);
 
     if (tooltipItem && tooltipItem.props.trigger === 'click') {
       if (this.state.isTooltipActive) {
@@ -657,7 +657,7 @@ export class Sankey extends PureComponent<Props, State> {
 
   renderTooltip() {
     const { children, width, height, nameKey } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip.displayName);
+    const tooltipItem = findChildByType(children, Tooltip);
 
     if (!tooltipItem) {
       return null;

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -358,7 +358,7 @@ export class Treemap extends PureComponent<Props, State> {
 
   handleMouseEnter(node: TreemapNode, e: any) {
     const { onMouseEnter, children } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip.displayName);
+    const tooltipItem = findChildByType(children, Tooltip);
 
     if (tooltipItem) {
       this.setState(
@@ -379,7 +379,7 @@ export class Treemap extends PureComponent<Props, State> {
 
   handleMouseLeave(node: TreemapNode, e: any) {
     const { onMouseLeave, children } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip.displayName);
+    const tooltipItem = findChildByType(children, Tooltip);
 
     if (tooltipItem) {
       this.setState(
@@ -644,7 +644,7 @@ export class Treemap extends PureComponent<Props, State> {
 
   renderTooltip(): React.ReactElement {
     const { children, nameKey } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip.displayName);
+    const tooltipItem = findChildByType(children, Tooltip);
 
     if (!tooltipItem) {
       return null;

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -534,7 +534,7 @@ const tooltipTicksGenerator = (axisMap: any) => {
  */
 const createDefaultState = (props: CategoricalChartProps): CategoricalChartState => {
   const { children, defaultShowTooltip } = props;
-  const brushItem = findChildByType(children, Brush.displayName);
+  const brushItem = findChildByType(children, Brush);
   const startIndex = (brushItem && brushItem.props && brushItem.props.startIndex) || 0;
   const endIndex =
     brushItem?.props?.endIndex !== undefined ? brushItem?.props?.endIndex : (props.data && props.data.length - 1) || 0;
@@ -590,8 +590,8 @@ const calculateOffset = (
 ) => {
   const { width, height, children } = props;
   const margin = props.margin || {};
-  const brushItem = findChildByType(children, Brush.displayName);
-  const legendItem = findChildByType(children, Legend.displayName);
+  const brushItem = findChildByType(children, Brush);
+  const legendItem = findChildByType(children, Legend);
 
   const offsetH = Object.keys(yAxisMap).reduce(
     (result: any, id: any) => {
@@ -1095,7 +1095,7 @@ export const generateCategoricalChart = ({
     }
 
     getTooltipEventType() {
-      const tooltipItem = findChildByType(this.props.children, Tooltip.displayName);
+      const tooltipItem = findChildByType(this.props.children, Tooltip);
 
       if (tooltipItem && isBoolean(tooltipItem.props.shared)) {
         const eventType = tooltipItem.props.shared ? 'axis' : 'item';
@@ -1233,7 +1233,7 @@ export const generateCategoricalChart = ({
     parseEventsOfWrapper() {
       const { children } = this.props;
       const tooltipEventType = this.getTooltipEventType();
-      const tooltipItem = findChildByType(children, Tooltip.displayName);
+      const tooltipItem = findChildByType(children, Tooltip);
       let tooltipEvents: any = {};
 
       if (tooltipItem && tooltipEventType === 'axis') {
@@ -1812,7 +1812,7 @@ export const generateCategoricalChart = ({
      */
     renderTooltip = (): React.ReactElement => {
       const { children } = this.props;
-      const tooltipItem = findChildByType(children, Tooltip.displayName);
+      const tooltipItem = findChildByType(children, Tooltip);
 
       if (!tooltipItem) {
         return null;
@@ -1936,7 +1936,7 @@ export const generateCategoricalChart = ({
       const tooltipEventType = this.getTooltipEventType();
       const { isTooltipActive, tooltipAxis, activeTooltipIndex, activeLabel } = this.state;
       const { children } = this.props;
-      const tooltipItem = findChildByType(children, Tooltip.displayName);
+      const tooltipItem = findChildByType(children, Tooltip);
       const { points, isRange, baseLine } = item.props;
       const { activeDot, hide } = item.item.props;
       const hasActive = !hide && isTooltipActive && tooltipItem && activeDot && activeTooltipIndex >= 0;

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -516,7 +516,7 @@ const renderCallByParent = (parentProps: any, viewBox?: ViewBox, checkPropsLabel
   const { children } = parentProps;
   const parentViewBox = parseViewBox(parentProps);
 
-  const explicitChildren = findAllByType(children, Label.displayName).map((child: any, index: number) =>
+  const explicitChildren = findAllByType(children, Label).map((child, index: number) =>
     cloneElement(child, {
       viewBox: viewBox || parentViewBox,
       key: `label-${index}`,

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -98,7 +98,7 @@ function renderCallByParent<T extends Data>(parentProps: any, data: Array<T>, ch
   }
   const { children } = parentProps;
 
-  const explicitChildren = findAllByType(children, LabelList.displayName).map((child: any, index: number) =>
+  const explicitChildren = findAllByType(children, LabelList).map((child, index: number) =>
     cloneElement(child, {
       data,
       key: `labelList-${index}`,

--- a/src/numberAxis/Funnel.tsx
+++ b/src/numberAxis/Funnel.tsx
@@ -86,7 +86,7 @@ export class Funnel extends PureComponent<Props, State> {
   static getRealFunnelData = (item: Funnel) => {
     const { data, children } = item.props;
     const presentationProps = filterProps(item.props);
-    const cells = findAllByType(children, Cell.displayName);
+    const cells = findAllByType(children, Cell);
 
     if (data && data.length) {
       return data.map((entry: any, index: number) => ({

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -164,7 +164,7 @@ export class Pie extends PureComponent<Props, State> {
   static getRealPieData = (item: Pie) => {
     const { data, children } = item.props;
     const presentationProps = filterProps(item.props);
-    const cells = findAllByType(children, Cell.displayName);
+    const cells = findAllByType(children, Cell);
 
     if (data && data.length) {
       return data.map((entry, index) => ({

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -137,7 +137,7 @@ export class RadialBar extends PureComponent<Props, State> {
     const numericAxis = layout === 'radial' ? angleAxis : radiusAxis;
     const stackedDomain = stackedData ? numericAxis.scale.domain() : null;
     const baseValue = getBaseValueOfBar({ numericAxis });
-    const cells = findAllByType(children, Cell.displayName);
+    const cells = findAllByType(children, Cell);
     const sectors = displayedData.map((entry: any, index: number) => {
       let value, innerRadius, outerRadius, startAngle, endAngle, backgroundSector;
 

--- a/src/util/CartesianUtils.ts
+++ b/src/util/CartesianUtils.ts
@@ -3,6 +3,7 @@ import { getTicksOfScale, parseScale, checkDomainOfScale, getBandSizeOfAxis } fr
 import { findChildByType } from './ReactUtils';
 import { Coordinate, AxisType } from './types';
 import { getPercentValue } from './DataUtils';
+import { Bar } from '../cartesian/Bar';
 
 /**
  * Calculate the scale function, position, width, height of axes
@@ -26,7 +27,7 @@ export const formatAxisMap = (props: any, axisMap: any, offset: any, axisType: A
     bottom: height - offset.bottom,
     bottomMirror: height - offset.bottom,
   };
-  const hasBar = !!findChildByType(children, 'Bar');
+  const hasBar = !!findChildByType(children, Bar);
 
   return ids.reduce((result, id) => {
     const axis = axisMap[id];

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -387,7 +387,7 @@ export const appendOffsetOfLegend = (offset: any, items: Array<FormattedGraphica
     const box = legendBox || {};
     const { align, verticalAlign, layout } = legendProps;
 
-    if ((layout === 'vertical' || (layout === 'horizontal' && verticalAlign === 'center')) && isNumber(offset[align])) {
+    if ((layout === 'vertical' || (layout === 'horizontal' && verticalAlign === 'middle')) && isNumber(offset[align])) {
       newOffset = { ...offset, [align]: newOffset[align] + (box.width || 0) };
     }
 

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -11,8 +11,8 @@ import _ from 'lodash';
 import { ReactElement, ReactNode } from 'react';
 import { getNiceTickValues, getTickValuesFixedDomain } from 'recharts-scale';
 
+import { ErrorBar } from '../cartesian/ErrorBar';
 import { Legend } from '../component/Legend';
-
 import { findEntryInArray, getPercentValue, isNumber, isNumOrStr, mathSign, uniqueId } from './DataUtils';
 import { filterProps, findAllByType, findChildByType, getDisplayName } from './ReactUtils';
 // TODO: Cause of circular dependency. Needs refactor.
@@ -24,8 +24,8 @@ export function getValueByDataKey<T>(obj: T, dataKey: DataKey<any>, defaultValue
     return defaultValue;
   }
 
-  if (isNumOrStr(dataKey as string)) {
-    return _.get(obj, dataKey as string, defaultValue);
+  if (isNumOrStr(dataKey)) {
+    return _.get(obj, dataKey, defaultValue);
   }
 
   if (_.isFunction(dataKey)) {
@@ -181,7 +181,7 @@ export const getLegendProps = ({
   legendWidth: number;
   legendContent?: any;
 }) => {
-  const legendItem = findChildByType(children, Legend.displayName);
+  const legendItem = findChildByType(children, Legend);
   if (!legendItem) {
     return null;
   }
@@ -429,7 +429,7 @@ export const getDomainOfErrorBars = (
   axisType?: AxisType,
 ) => {
   const { children } = item.props;
-  const errorBars = findAllByType(children, 'ErrorBar').filter((errorBarChild: any) =>
+  const errorBars = findAllByType(children, ErrorBar).filter(errorBarChild =>
     isErrorBarRelevantForAxis(layout, axisType, errorBarChild.props.direction),
   );
 

--- a/src/util/DetectReferenceElementsDomain.ts
+++ b/src/util/DetectReferenceElementsDomain.ts
@@ -13,10 +13,10 @@ export const detectReferenceElementsDomain = (
   axisType: string,
   specifiedTicks?: any[],
 ) => {
-  const lines = findAllByType(children, ReferenceLine.displayName);
-  const dots = findAllByType(children, ReferenceDot.displayName);
-  const elements = lines.concat(dots);
-  const areas = findAllByType(children, ReferenceArea.displayName);
+  const lines = findAllByType(children, ReferenceLine);
+  const dots = findAllByType(children, ReferenceDot);
+  const elements = [...lines, ...dots];
+  const areas = findAllByType(children, ReferenceArea);
   const idKey = `${axisType}Id`;
   const valueKey = axisType[0];
   let finalDomain = domain;

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -60,7 +60,7 @@ export const TOOLTIP_TYPES = ['none'];
  * @param  {Object} Comp Specified Component
  * @return {String}      Display name of Component
  */
-export const getDisplayName = (Comp: any) => {
+export const getDisplayName = (Comp: React.ComponentType | string) => {
   if (typeof Comp === 'string') {
     return Comp;
   }
@@ -94,14 +94,14 @@ export const toArray = <T extends ReactNode>(children: T | T[]): T[] => {
 };
 
 /*
- * Find and return all matched children by type. `type` can be a React element class or
- * string
+ * Find and return all matched children by type.
+ * `type` must be a React.ComponentType
  */
-export const findAllByType = (
-  children: ReactNode,
-  type: string | string[],
-): React.DetailedReactHTMLElement<any, HTMLElement>[] => {
-  const result: React.DetailedReactHTMLElement<any, HTMLElement>[] = [];
+export function findAllByType<
+  ComponentType extends React.ComponentType,
+  DetailedElement = React.DetailedReactHTMLElement<React.ComponentProps<ComponentType>, HTMLElement>,
+>(children: ReactNode, type: ComponentType | ComponentType[]): DetailedElement[] {
+  const result: DetailedElement[] = [];
   let types: string[] = [];
 
   if (_.isArray(type)) {
@@ -110,27 +110,28 @@ export const findAllByType = (
     types = [getDisplayName(type)];
   }
 
-  toArray(children).forEach((child: React.DetailedReactHTMLElement<any, HTMLElement>) => {
+  toArray(children).forEach(child => {
     const childType = _.get(child, 'type.displayName') || _.get(child, 'type.name');
     if (types.indexOf(childType) !== -1) {
-      result.push(child);
+      result.push(child as DetailedElement);
     }
   });
 
   return result;
-};
+}
+
 /*
  * Return the first matched child by type, return null otherwise.
- * `type` can be a React element class or string.
+ * `type` must be a React.ComponentType
  */
-export const findChildByType = (
+export function findChildByType<ComponentType extends React.ComponentType>(
   children: ReactNode[],
-  type: string,
-): React.DetailedReactHTMLElement<any, HTMLElement> => {
+  type: ComponentType | ComponentType[],
+) {
   const result = findAllByType(children, type);
 
   return result && result[0];
-};
+}
 
 /*
  * Create a new array of children excluding the ones matched the type


### PR DESCRIPTION
## Description

In order to reduce the `any` types in the code I change the implementation of `findAllByType` and `findChildByType` to use generic to better infer component props in the return value:

<img width="499" alt="Screenshot 2023-01-06 at 13 55 24" src="https://user-images.githubusercontent.com/24919330/211016624-2b59d711-2a2e-4dbd-9674-41e4559618c3.png">

To achieve this now these two functions only accepts `React.ComponentType` parameter instead of `string` in order to retrieve the `Props`. 
All invocation of the function have been changed. Most of them was using `Component.displayName` so since `getDisplayName` accounts for both `string` and `React.ComponentType` this should't be a problem.

---

While doing this I encountered an error in `appendOffsetOfLegend` function which was comparing `verticalAlign` `Legend` props with `"center"`.  It looks like it isn't a valid value so I changed it to `"middle"` since `VerticalAlignmentType ` values are 
```ts
'top' | 'bottom' | 'middle'
```

[Commit reference](https://github.com/recharts/recharts/commit/5a4a9874f2b6f20877cc73b4338dbfd06c2745fe)

---

Let me know if you prefer to have two separate PR for the issue and the refactor.

## Related Issue
N/A

## Motivation and Context
Improve code navigation and reference

## How Has This Been Tested?

`npm run build`
`npm run test`

## Screenshots (if appropriate):
N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
