### PR TITLE
ResponsiveContainer – weird animation fix

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -3,7 +3,17 @@
  */
 import classNames from 'classnames';
 import _ from 'lodash';
-import React, { ReactElement, forwardRef, cloneElement, useState, useImperativeHandle, useRef, useEffect } from 'react';
+import React, {
+  ReactElement,
+  forwardRef,
+  cloneElement,
+  useState,
+  useImperativeHandle,
+  useRef,
+  useEffect,
+  useCallback,
+  useMemo,
+} from 'react';
 import ReactResizeDetector from 'react-resize-detector';
 import { isPercent } from '../util/DataUtils';
 import { warn } from '../util/LogUtils';
@@ -19,11 +29,6 @@ export interface Props {
   debounce?: number;
   id?: string | number;
   className?: string | number;
-}
-
-interface State {
-  containerWidth: number;
-  containerHeight: number;
 }
 
 export const ResponsiveContainer = forwardRef(
@@ -42,16 +47,18 @@ export const ResponsiveContainer = forwardRef(
     }: Props,
     ref,
   ) => {
-    const [sizes, setSizes] = useState<State>({
+    const [sizes, setSizes] = useState<{
+      containerWidth: number;
+      containerHeight: number;
+    }>({
       containerWidth: -1,
       containerHeight: -1,
     });
+
     const containerRef = useRef<HTMLDivElement>(null);
     useImperativeHandle(ref, () => containerRef, [containerRef]);
 
-    const [mounted, setMounted] = useState<boolean>(false);
-
-    const getContainerSize = () => {
+    const getContainerSize = useCallback(() => {
       if (!containerRef.current) {
         return null;
       }
@@ -60,28 +67,31 @@ export const ResponsiveContainer = forwardRef(
         containerWidth: containerRef.current.clientWidth,
         containerHeight: containerRef.current.clientHeight,
       };
-    };
+    }, []);
 
-    const updateDimensionsImmediate = () => {
-      if (!mounted) {
-        return;
-      }
-
+    const updateDimensionsImmediate = useCallback(() => {
       const newSize = getContainerSize();
 
       if (newSize) {
-        const { containerWidth: oldWidth, containerHeight: oldHeight } = sizes;
         const { containerWidth, containerHeight } = newSize;
 
-        if (containerWidth !== oldWidth || containerHeight !== oldHeight) {
-          setSizes({ containerWidth, containerHeight });
-        }
+        setSizes(currentSizes => {
+          const { containerWidth: oldWidth, containerHeight: oldHeight } = currentSizes;
+          if (containerWidth !== oldWidth || containerHeight !== oldHeight) {
+            return { containerWidth, containerHeight };
+          }
+
+          return currentSizes;
+        });
       }
-    };
+    }, [getContainerSize]);
 
-    const handleResize = debounce > 0 ? _.debounce(updateDimensionsImmediate, debounce) : updateDimensionsImmediate;
+    const handleResize = useMemo(
+      () => (debounce > 0 ? _.debounce(updateDimensionsImmediate, debounce) : updateDimensionsImmediate),
+      [debounce, updateDimensionsImmediate],
+    );
 
-    const renderChart = () => {
+    const computedSizes = useMemo(() => {
       const { containerWidth, containerHeight } = sizes;
 
       if (containerWidth < 0 || containerHeight < 0) {
@@ -132,27 +142,21 @@ export const ResponsiveContainer = forwardRef(
         aspect,
       );
 
-      return cloneElement(children, {
+      return {
         width: calculatedWidth,
         height: calculatedHeight,
-      });
-    };
+      };
+    }, [aspect, height, maxHeight, minHeight, minWidth, sizes, width]);
 
     useEffect(() => {
-      if (mounted) {
-        const size = getContainerSize();
+      const size = getContainerSize();
 
-        if (size) {
-          setSizes(size);
-        }
+      if (size) {
+        setSizes(size);
       }
-    }, [mounted]);
+    }, [getContainerSize]);
 
-    useEffect(() => {
-      setMounted(true);
-    }, []);
-
-    const style = { width, height, minWidth, minHeight, maxHeight };
+    const style: React.CSSProperties = { width, height, minWidth, minHeight, maxHeight };
 
     return (
       <ReactResizeDetector handleWidth handleHeight onResize={handleResize} targetRef={containerRef}>
@@ -162,7 +166,7 @@ export const ResponsiveContainer = forwardRef(
           style={style}
           ref={containerRef}
         >
-          {renderChart()}
+          {cloneElement(children, computedSizes)}
         </div>
       </ReactResizeDetector>
     );

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -91,7 +91,7 @@ export const ResponsiveContainer = forwardRef(
       [debounce, updateDimensionsImmediate],
     );
 
-    const computedSizes = useMemo(() => {
+    const chartContent = useMemo(() => {
       const { containerWidth, containerHeight } = sizes;
 
       if (containerWidth < 0 || containerHeight < 0) {
@@ -142,11 +142,11 @@ export const ResponsiveContainer = forwardRef(
         aspect,
       );
 
-      return {
+      return cloneElement(children, {
         width: calculatedWidth,
         height: calculatedHeight,
-      };
-    }, [aspect, height, maxHeight, minHeight, minWidth, sizes, width]);
+      });
+    }, [aspect, children, height, maxHeight, minHeight, minWidth, sizes, width]);
 
     useEffect(() => {
       const size = getContainerSize();
@@ -166,7 +166,7 @@ export const ResponsiveContainer = forwardRef(
           style={style}
           ref={containerRef}
         >
-          {cloneElement(children, computedSizes)}
+          {chartContent}
         </div>
       </ReactResizeDetector>
     );


### PR DESCRIPTION

## Description

I implemented a fix for the animation issue caused by my memoizing the variables of `ResponsiveContainer`.

Basically I moved the `cloneElement` back inside the computation of the sizes.

I create two separate commits to easily view how this fix the issue.

## Related Issue

See comments in this [commit](https://github.com/recharts/recharts/commit/3214d1405d13d5ddcd3931d870634bcb80a52b22)


## Motivation and Context

See comments in this [commit](https://github.com/recharts/recharts/commit/3214d1405d13d5ddcd3931d870634bcb80a52b22)

## How Has This Been Tested?

- `npm run demo`
- open `http://127.0.0.1:3000/?group=chartWrapper&component=ComposedChart`

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
