### PR TITLE
fix: ResponsiveContainer debounce updating early

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -2,7 +2,6 @@
  * @fileOverview Wrapper component to make charts adapt to the size of parent * DOM
  */
 import classNames from 'classnames';
-import _ from 'lodash';
 import React, {
   ReactElement,
   forwardRef,
@@ -86,11 +85,6 @@ export const ResponsiveContainer = forwardRef(
       }
     }, [getContainerSize]);
 
-    const handleResize = useMemo(
-      () => (debounce > 0 ? _.debounce(updateDimensionsImmediate, debounce) : updateDimensionsImmediate),
-      [debounce, updateDimensionsImmediate],
-    );
-
     const chartContent = useMemo(() => {
       const { containerWidth, containerHeight } = sizes;
 
@@ -159,7 +153,14 @@ export const ResponsiveContainer = forwardRef(
     const style: React.CSSProperties = { width, height, minWidth, minHeight, maxHeight };
 
     return (
-      <ReactResizeDetector handleWidth handleHeight onResize={handleResize} targetRef={containerRef}>
+      <ReactResizeDetector
+        handleWidth
+        handleHeight
+        onResize={updateDimensionsImmediate}
+        targetRef={containerRef}
+        refreshMode={debounce > 0 ? 'debounce' : undefined}
+        refreshRate={debounce}
+      >
         <div
           {...(id != null ? { id: `${id}` } : {})}
           className={classNames('recharts-responsive-container', className)}

--- a/test-jest/component/ResponsiveContainer.spec.tsx
+++ b/test-jest/component/ResponsiveContainer.spec.tsx
@@ -152,7 +152,7 @@ describe('<ResponsiveContainer />', () => {
     expect(container.querySelector('.recharts-responsive-container')).toHaveAttribute('id', 'testing-id-attr');
   });
 
-  it.only('should resize when ResizeObserver notify a change', () => {
+  it('should resize when ResizeObserver notify a change', () => {
     const { container } = render(
       <ResponsiveContainer id="testing-id-attr" width="100%" height={200}>
         <div data-testid="inside" />
@@ -164,6 +164,28 @@ describe('<ResponsiveContainer />', () => {
     expect(element).not.toHaveAttribute('height');
 
     notifyResizeObserverChange([{ contentRect: { width: 100, height: 100 } }]);
+
+    expect(element).toHaveAttribute('width', '100');
+    expect(element).toHaveAttribute('height', '100');
+  });
+
+  it('should resize when debounced', () => {
+    jest.useFakeTimers('modern');
+    const { container } = render(
+      <ResponsiveContainer id="testing-id-attr" width="100%" height={200} debounce={200}>
+        <div data-testid="inside" />
+      </ResponsiveContainer>,
+    );
+
+    const element = container.querySelector('.recharts-responsive-container');
+
+    notifyResizeObserverChange([{ contentRect: { width: 50, height: 50 } }]);
+    jest.advanceTimersByTime(100);
+    expect(element).not.toHaveAttribute('width');
+    expect(element).not.toHaveAttribute('height');
+
+    notifyResizeObserverChange([{ contentRect: { width: 100, height: 100 } }]);
+    jest.runAllTimers();
 
     expect(element).toHaveAttribute('width', '100');
     expect(element).toHaveAttribute('height', '100');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Passing a debounce value to `ResponsiveContainer` currently only debounces the `handleResize` callback in `ResponsiveContainer` but not the callback in `ReactResizeDetector`. Since `ReactResizeDetector` tracks the updated height and width locally and passes it to its child, sizes are still updated for every call. Since this can result in expensive state updates, it introduces a race condition where `ResizeObserver` sometimes fires a "ResizeObserver loop limit exceeded" error on the `window` object. 

The fix is to use `ReactResizeDetector`'s debounce behavior so that it's internal callback is also debounced.

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/recharts/recharts/issues/3029
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
