### PR TITLE
fix: treemap error(non boolean attribute z)

### DIFF
--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -109,7 +109,7 @@ const horizontalPosition = (row: any, parentSize: number, parentRect: TreemapNod
     curX += child.width;
   }
   // what's z
-  child.z = true;
+  child.z = 'true';
   // add the remain x to the last one of row
   child.width += parentRect.x + parentRect.width - curX;
 
@@ -138,7 +138,7 @@ const verticalPosition = (row: any, parentSize: number, parentRect: TreemapNode,
     curY += child.height;
   }
   if (child) {
-    child.z = false;
+    child.z = 'false';
     child.height += parentRect.y + parentRect.height - curY;
   }
 

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -108,8 +108,6 @@ const horizontalPosition = (row: any, parentSize: number, parentRect: TreemapNod
     child.width = Math.min(rowHeight ? Math.round(child.area / rowHeight) : 0, parentRect.x + parentRect.width - curX);
     curX += child.width;
   }
-  // what's z
-  child.z = 'true';
   // add the remain x to the last one of row
   child.width += parentRect.x + parentRect.width - curX;
 
@@ -138,7 +136,6 @@ const verticalPosition = (row: any, parentSize: number, parentRect: TreemapNode,
     curY += child.height;
   }
   if (child) {
-    child.z = 'false';
     child.height += parentRect.y + parentRect.height - curY;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
That variable assignment gives the attribute z to the path element in the svg.
However, the expression is not valid because svg cannot set the z-value.
https://www.w3.org/TR/SVG2/render.html#RenderingOrder
<!--- Describe your changes in detail -->

## Related Issue
#2952
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
