### PR TITLE
fix: remove points attribute from SVGProps for Radar component for correct typing

### DIFF
--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -64,7 +64,7 @@ interface RadarProps {
 type RadiusAxis = PolarRadiusAxisProps & { scale: (value: any) => number };
 type AngleAxis = PolarAngleAxisProps & { scale: (value: any) => number };
 
-export type Props = Omit<SVGProps<SVGElement>, 'onMouseEnter' | 'onMouseLeave'> & RadarProps;
+export type Props = Omit<SVGProps<SVGElement>, 'onMouseEnter' | 'onMouseLeave' | 'points'> & RadarProps;
 
 interface State {
   isAnimationFinished?: boolean;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Omit `points` from `SVGProps` for `Radar` because it conflicts with Radar's `points` prop and doesn't allow passing the correct type of `points` without type narrowing

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A - Jest migration task here https://github.com/recharts/recharts/issues/3236

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This enables Radar to be used in TS files without casting to `any`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Before 
![image](https://user-images.githubusercontent.com/25180830/214109260-eac107b8-a69d-46ff-9124-3b3dea17a3d6.png)


After:
![image](https://user-images.githubusercontent.com/25180830/214109182-6499c5a1-1cbd-4cce-97f2-77ea948421e3.png)


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [Y] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [Y] My code follows the code style of this project.
- [N] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [N/A] I have added tests to cover my changes.
- [Y] All new and existing tests passed.
