### PR TITLE
refactor(Label & LabelList): refine types and disable react/no-array-index-key to avoid warnings

### DIFF
--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -370,7 +370,8 @@ const getAttrsOfCartesianLabel = (props: Props) => {
   };
 };
 
-const isPolar = (viewBox: CartesianViewBox | PolarViewBox) => isNumber((viewBox as PolarViewBox).cx);
+const isPolar = (viewBox: CartesianViewBox | PolarViewBox): viewBox is PolarViewBox =>
+  'cx' in viewBox && isNumber(viewBox.cx);
 
 export function Label(props: Props) {
   const { viewBox, position, value, children, content, className = '', textBreakAll } = props;
@@ -420,7 +421,7 @@ Label.defaultProps = {
   offset: 5,
 };
 
-const parseViewBox = (props: any) => {
+const parseViewBox = (props: any): ViewBox => {
   const {
     cx,
     cy,
@@ -477,7 +478,7 @@ const parseViewBox = (props: any) => {
   return {};
 };
 
-const parseLabel = (label: any, viewBox: ViewBox) => {
+const parseLabel = (label: unknown, viewBox: ViewBox) => {
   if (!label) {
     return null;
   }
@@ -492,7 +493,7 @@ const parseLabel = (label: any, viewBox: ViewBox) => {
 
   if (isValidElement(label)) {
     if (label.type === Label) {
-      return cloneElement(label as any, { key: 'label-implicit', viewBox });
+      return cloneElement<LabelProps>(label, { key: 'label-implicit', viewBox });
     }
 
     return <Label key="label-implicit" content={label} viewBox={viewBox} />;
@@ -509,16 +510,21 @@ const parseLabel = (label: any, viewBox: ViewBox) => {
   return null;
 };
 
-const renderCallByParent = (parentProps: any, viewBox?: ViewBox, checkPropsLabel = true) => {
+const renderCallByParent = (
+  parentProps: { children?: ReactNode; label?: unknown },
+  viewBox?: ViewBox,
+  checkPropsLabel = true,
+): ReactElement[] | null => {
   if (!parentProps || (!parentProps.children && checkPropsLabel && !parentProps.label)) {
     return null;
   }
   const { children } = parentProps;
   const parentViewBox = parseViewBox(parentProps);
 
-  const explicitChildren = findAllByType(children, Label).map((child, index: number) =>
+  const explicitChildren = findAllByType(children, Label).map((child, index) =>
     cloneElement(child, {
       viewBox: viewBox || parentViewBox,
+      // eslint-disable-next-line react/no-array-index-key
       key: `label-${index}`,
     }),
   );

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, ReactElement, SVGProps } from 'react';
+import React, { cloneElement, ReactElement, ReactNode, SVGProps } from 'react';
 import _ from 'lodash';
 import { Label, ContentType, Props as LabelProps } from './Label';
 import { Layer } from '../container/Layer';
@@ -72,7 +72,7 @@ export function LabelList<T extends Data>(props: Props<T>) {
 
 LabelList.displayName = 'LabelList';
 
-function parseLabelList<T extends Data>(label: any, data: Array<T>) {
+function parseLabelList<T extends Data>(label: unknown, data: Array<T>) {
   if (!label) {
     return null;
   }
@@ -92,15 +92,20 @@ function parseLabelList<T extends Data>(label: any, data: Array<T>) {
   return null;
 }
 
-function renderCallByParent<T extends Data>(parentProps: any, data: Array<T>, checkPropsLabel = true) {
+function renderCallByParent<T extends Data>(
+  parentProps: { children?: ReactNode; label?: unknown },
+  data: Array<T>,
+  checkPropsLabel = true,
+) {
   if (!parentProps || (!parentProps.children && checkPropsLabel && !parentProps.label)) {
     return null;
   }
   const { children } = parentProps;
 
-  const explicitChildren = findAllByType(children, LabelList).map((child, index: number) =>
+  const explicitChildren = findAllByType(children, LabelList).map((child, index) =>
     cloneElement(child, {
       data,
+      // eslint-disable-next-line react/no-array-index-key
       key: `labelList-${index}`,
     }),
   );

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -359,7 +359,6 @@ export class RadialBar extends PureComponent<Props, State> {
     const backgroundProps = filterProps(this.props.background);
 
     return sectors.map((entry, i) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { value, background, ...rest } = entry;
 
       if (!background) {
@@ -398,14 +397,7 @@ export class RadialBar extends PureComponent<Props, State> {
 
         <Layer className="recharts-radial-bar-sectors">{this.renderSectors()}</Layer>
 
-        {(!isAnimationActive || isAnimationFinished) &&
-          LabelList.renderCallByParent(
-            {
-              ...this.props,
-              clockWise: this.getDeltaAngle() < 0,
-            },
-            data,
-          )}
+        {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent({ ...this.props }, data)}
       </Layer>
     );
   }


### PR DESCRIPTION
## Description
Added `// eslint-disable-next-line react/no-array-index-key` to `Label` and `LabelList` to get rid of the two related warnings.
So far there is no known issue so I don't think this should be a problem adding the disabled comment here like has been done in other files.

I also tried to refine types on Label and LabelList components.
I made few changes that shouldn't affect run time results:

1. On `Label` `isPolar` function now use `in` operator to avoid inline casting
2. On `RadialBar` I removed `clockWise` prop from `LabelList.renderCallByParent` invocation since the function uses only `label` and `children` props

## Related Issue
N/A

## Motivation and Context
N/A

## How Has This Been Tested?

`npm run test`
`npm run lint`

## Screenshots (if appropriate):
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
