### PR TITLE
fix: remove deprecated alwaysShow

### DIFF
--- a/demo/component/ScatterChart.tsx
+++ b/demo/component/ScatterChart.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-script-url */
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { Component } from 'react';
 import {
   ScatterChart,
@@ -86,9 +88,7 @@ export default class Demo extends Component {
   };
 
   renderSquare = (props: any) => {
-    const { cx, cy, size, xAxis, yAxis, zAxis } = props;
-    const xBandSize = xAxis.bandSize;
-    const yBandSize = yAxis.bandSize;
+    const { cx, cy, size, xAxis, yAxis } = props;
 
     return (
       <rect
@@ -103,8 +103,6 @@ export default class Demo extends Component {
   };
 
   render() {
-    const { data01, data02, data03, data04 } = this.state;
-
     return (
       <div className="scatter-charts">
         <a href="javascript: void(0);" className="btn update" onClick={this.handleChangeData}>
@@ -134,7 +132,7 @@ export default class Demo extends Component {
             <Scatter name="B school" data={data02} fill="#347300" />
             <Tooltip trigger="click" />
             <Legend />
-            <ReferenceArea x1={250} x2={300} alwaysShow label="any label" />
+            <ReferenceArea x1={250} x2={300} label="any label" />
             <ReferenceLine x={159} stroke="red" />
             <ReferenceLine y={237.5} stroke="red" />
             <ReferenceDot x={170} y={290} r={15} label="AB" stroke="none" fill="red" isFront />

--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -9,7 +9,6 @@ import { ImplicitLabelType, Label } from '../component/Label';
 import { createLabeledScales, rectWithPoints } from '../util/CartesianUtils';
 import { ifOverflowMatches } from '../util/IfOverflowMatches';
 import { isNumOrStr } from '../util/DataUtils';
-import { warn } from '../util/LogUtils';
 import { Rectangle, Props as RectangleProps } from '../shape/Rectangle';
 import { CartesianViewBox, D3Scale } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
@@ -26,7 +25,6 @@ interface InternalReferenceAreaProps {
 
 interface ReferenceAreaProps extends InternalReferenceAreaProps {
   isFront?: boolean;
-  alwaysShow?: boolean;
   ifOverflow?: 'hidden' | 'visible' | 'discard' | 'extendDomain';
   x1?: number | string;
   x2?: number | string;
@@ -67,9 +65,7 @@ const getRect = (hasX1: boolean, hasX2: boolean, hasY1: boolean, hasY2: boolean,
 };
 
 export function ReferenceArea(props: Props) {
-  const { x1, x2, y1, y2, className, alwaysShow, clipPathId } = props;
-
-  warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
+  const { x1, x2, y1, y2, className, clipPathId } = props;
 
   const hasX1 = isNumOrStr(x1);
   const hasX2 = isNumOrStr(x2);

--- a/src/cartesian/ReferenceDot.tsx
+++ b/src/cartesian/ReferenceDot.tsx
@@ -10,7 +10,6 @@ import { ImplicitLabelType, Label } from '../component/Label';
 import { isNumOrStr } from '../util/DataUtils';
 import { ifOverflowMatches } from '../util/IfOverflowMatches';
 import { createLabeledScales } from '../util/CartesianUtils';
-import { warn } from '../util/LogUtils';
 import { D3Scale } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { Props as XAxisProps } from './XAxis';
@@ -26,7 +25,6 @@ interface ReferenceDotProps extends InternalReferenceDotProps {
   r?: number;
 
   isFront?: boolean;
-  alwaysShow?: boolean;
   ifOverflow?: 'hidden' | 'visible' | 'discard' | 'extendDomain';
   x?: number | string;
   y?: number | string;
@@ -54,11 +52,9 @@ const getCoordinate = (props: Props) => {
 };
 
 export function ReferenceDot(props: Props) {
-  const { x, y, r, alwaysShow, clipPathId } = props;
+  const { x, y, r, clipPathId } = props;
   const isX = isNumOrStr(x);
   const isY = isNumOrStr(y);
-
-  warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
 
   if (!isX || !isY) {
     return null;

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -9,7 +9,6 @@ import { ImplicitLabelType, Label } from '../component/Label';
 import { ifOverflowMatches } from '../util/IfOverflowMatches';
 import { isNumOrStr } from '../util/DataUtils';
 import { createLabeledScales, rectWithCoords } from '../util/CartesianUtils';
-import { warn } from '../util/LogUtils';
 import { CartesianViewBox, D3Scale } from '../util/types';
 import { Props as XAxisProps } from './XAxis';
 import { Props as YAxisProps } from './YAxis';
@@ -24,7 +23,6 @@ interface InternalReferenceLineProps {
 
 interface ReferenceLineProps extends InternalReferenceLineProps {
   isFront?: boolean;
-  alwaysShow?: boolean;
   ifOverflow?: 'hidden' | 'visible' | 'discard' | 'extendDomain';
 
   x?: number | string;
@@ -117,9 +115,7 @@ const getEndPoints = (scales: any, isFixedX: boolean, isFixedY: boolean, isSegme
 };
 
 export function ReferenceLine(props: Props) {
-  const { x: fixedX, y: fixedY, segment, xAxis, yAxis, shape, className, alwaysShow, clipPathId } = props;
-
-  warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
+  const { x: fixedX, y: fixedY, segment, xAxis, yAxis, shape, className, clipPathId } = props;
 
   const scales = createLabeledScales({ x: xAxis.scale, y: yAxis.scale });
 

--- a/test-jest/cartesian/ReferenceArea.spec.tsx
+++ b/test-jest/cartesian/ReferenceArea.spec.tsx
@@ -99,25 +99,6 @@ describe('<ReferenceArea />', () => {
     expect(container.querySelectorAll('.recharts-label')).toHaveLength(0);
   });
 
-  test('Render line and label when alwaysShow is true in ReferenceArea', () => {
-    const { container } = render(
-      <BarChart
-        width={1100}
-        height={250}
-        barGap={2}
-        barSize={6}
-        data={data}
-        margin={{ top: 20, right: 60, bottom: 0, left: 20 }}
-      >
-        <XAxis dataKey="name" />
-        <YAxis tickCount={7} />
-        <Bar dataKey="uv" />
-        <ReferenceArea y1={200} y2={300} fill="#666" alwaysShow />
-      </BarChart>,
-    );
-    expect(container.querySelectorAll('.recharts-reference-area-rect')).toHaveLength(1);
-  });
-
   test('Render 1 line and 1 label when label is set to be a function in ReferenceArea', () => {
     const renderLabel = (props: LabelProps) => {
       const { x, y } = props;
@@ -181,7 +162,7 @@ describe('<ReferenceArea />', () => {
         <XAxis dataKey="name" />
         <YAxis tickCount={7} />
         <Bar dataKey="uv" />
-        <ReferenceArea x1="201106" x2="201110" fill="#666" label={<Label text="Custom Text" />} alwaysShow />
+        <ReferenceArea x1="201106" x2="201110" fill="#666" label={<Label text="Custom Text" />} />
       </BarChart>,
     );
     expect(screen.findByText('Custom Text')).toBeTruthy();

--- a/test-jest/cartesian/ReferenceDot.spec.tsx
+++ b/test-jest/cartesian/ReferenceDot.spec.tsx
@@ -57,26 +57,6 @@ describe('<ReferenceDot />', () => {
     expect(container.querySelectorAll('.recharts-label')).toHaveLength(0);
   });
 
-  test('Render 1 line and 1 label when alwaysShow is true in ReferenceDot', () => {
-    const { container } = render(
-      <BarChart
-        width={1100}
-        height={250}
-        barGap={2}
-        barSize={6}
-        data={data}
-        margin={{ top: 20, right: 60, bottom: 0, left: 20 }}
-      >
-        <XAxis dataKey="name" />
-        <YAxis tickCount={7} />
-        <Bar dataKey="uv" />
-        <ReferenceDot x="201106" y={20} stroke="#666" label="201106" alwaysShow />
-      </BarChart>,
-    );
-    expect(container.querySelectorAll('.recharts-reference-dot-dot')).toHaveLength(1);
-    expect(container.querySelectorAll('.recharts-label')).toHaveLength(1);
-  });
-
   test('Render custom lable when label is set to be a react element', () => {
     const Label = ({ text, ...props }: { text: string }) => (
       <text className="customized-label" {...props}>
@@ -95,7 +75,7 @@ describe('<ReferenceDot />', () => {
         <XAxis dataKey="name" />
         <YAxis tickCount={7} />
         <Bar dataKey="uv" />
-        <ReferenceDot x="201106" y={20} stroke="#666" label={<Label text="Custom Text" />} alwaysShow />
+        <ReferenceDot x="201106" y={20} stroke="#666" label={<Label text="Custom Text" />} />
       </BarChart>,
     );
     expect(screen.findByText('Custom Text')).toBeTruthy();
@@ -119,7 +99,7 @@ describe('<ReferenceDot />', () => {
         <XAxis dataKey="name" />
         <YAxis tickCount={7} />
         <Bar dataKey="uv" />
-        <ReferenceDot x="201106" y={20} stroke="#666" label={renderLabel} alwaysShow />
+        <ReferenceDot x="201106" y={20} stroke="#666" label={renderLabel} />
       </BarChart>,
     );
     expect(screen.findByText('Custom Text')).toBeTruthy();
@@ -138,7 +118,7 @@ describe('<ReferenceDot />', () => {
         <XAxis dataKey="name" />
         <YAxis tickCount={7} />
         <Bar dataKey="uv" />
-        <ReferenceDot x="201106" y={20} stroke="#666" label={{}} alwaysShow />
+        <ReferenceDot x="201106" y={20} stroke="#666" label={{}} />
       </BarChart>,
     );
     expect(container.querySelectorAll('.recharts-label')).toHaveLength(0);
@@ -157,8 +137,8 @@ describe('<ReferenceDot />', () => {
         <XAxis dataKey="name" />
         <YAxis tickCount={7} />
         <Bar dataKey="uv" />
-        <ReferenceDot x="201106" stroke="#666" alwaysShow />
-        <ReferenceDot y={20} stroke="#666" alwaysShow />
+        <ReferenceDot x="201106" stroke="#666" />
+        <ReferenceDot y={20} stroke="#666" />
       </BarChart>,
     );
     expect(container.querySelectorAll('.recharts-reference-dot-dot')).toHaveLength(0);

--- a/test-jest/cartesian/ReferenceLine.spec.tsx
+++ b/test-jest/cartesian/ReferenceLine.spec.tsx
@@ -143,27 +143,6 @@ describe('<ReferenceLine />', () => {
     expect(container.querySelectorAll('.recharts-label')).toHaveLength(2);
   });
 
-  test('Render line and label when (deprecated) alwaysShow is true in ReferenceLine', () => {
-    const { container } = render(
-      <BarChart
-        width={1100}
-        height={250}
-        barGap={2}
-        barSize={6}
-        data={data}
-        margin={{ top: 20, right: 60, bottom: 0, left: 20 }}
-      >
-        <XAxis dataKey="name" />
-        <YAxis tickCount={7} />
-        <Bar dataKey="uv" />
-        <ReferenceLine x="201102" label="test" stroke="#666" />
-        <ReferenceLine y={20} stroke="#666" label="20" alwaysShow />
-      </BarChart>,
-    );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(2);
-    expect(container.querySelectorAll('.recharts-label')).toHaveLength(2);
-  });
-
   test('Render 1 line and 1 label when label is set to be a function in ReferenceLine', () => {
     const renderLabel = (props: any) => {
       const { x, y } = props;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I confirmed that it was deprecated for two reasons.

First, I searched it in editor. I've confirmed that alwaysShow is only passed as props and destructuring, not used inside components.
Second, the warn code created by xile611 3 years ago also indicates that alwaysShow is deprecated.
https://github.com/recharts/recharts/blob/0af7f7f5c0bb7d9c1445cee15b9c52eec731e75c/src/cartesian/ReferenceArea.tsx#L72

<!--- Describe your changes in detail -->

## Related Issue
#3274
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![캡처_2023_01_24_21_43_01_742](https://user-images.githubusercontent.com/19148682/214313576-2df78ecd-b5a0-4b09-aa86-1b2523e2e5dc.png)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
