### PR TITLE
fix: error bar overflow chart area

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -411,7 +411,7 @@ export class Bar extends PureComponent<Props, State> {
     });
   }
 
-  renderErrorBar() {
+  renderErrorBar(needClip: boolean, clipPathId: string) {
     if (this.props.isAnimationActive && !this.state.isAnimationFinished) {
       return null;
     }
@@ -434,16 +434,24 @@ export class Bar extends PureComponent<Props, State> {
       };
     }
 
-    return errorBarItems.map((item: ReactElement<ErrorBarProps>, i: number) =>
-      React.cloneElement(item, {
-        key: `error-bar-${i}`, // eslint-disable-line react/no-array-index-key
-        data,
-        xAxis,
-        yAxis,
-        layout,
-        offset,
-        dataPointFormatter,
-      }),
+    const errorBarProps = {
+      clipPath: needClip ? `url(#clipPath-${clipPathId})` : null,
+    };
+
+    return (
+      <Layer {...errorBarProps}>
+        {errorBarItems.map((item: ReactElement<ErrorBarProps>, i: number) =>
+          React.cloneElement(item, {
+            key: `error-bar-${i}`, // eslint-disable-line react/no-array-index-key
+            data,
+            xAxis,
+            yAxis,
+            layout,
+            offset,
+            dataPointFormatter,
+          }),
+        )}
+      </Layer>
     );
   }
 
@@ -472,7 +480,7 @@ export class Bar extends PureComponent<Props, State> {
           {background ? this.renderBackground() : null}
           {this.renderRectangles()}
         </Layer>
-        {this.renderErrorBar()}
+        {this.renderErrorBar(needClip, clipPathId)}
         {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, data)}
       </Layer>
     );

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -251,7 +251,7 @@ export class Line extends PureComponent<Props, State> {
     }
   };
 
-  renderErrorBar() {
+  renderErrorBar(needClip: boolean, clipPathId: string) {
     if (this.props.isAnimationActive && !this.state.isAnimationFinished) {
       return null;
     }
@@ -272,16 +272,24 @@ export class Line extends PureComponent<Props, State> {
       };
     }
 
-    return errorBarItems.map((item: ReactElement<ErrorBarProps>, i: number) =>
-      React.cloneElement(item, {
-        // eslint-disable-next-line react/no-array-index-key
-        key: `bar-${i}`,
-        data: points,
-        xAxis,
-        yAxis,
-        layout,
-        dataPointFormatter,
-      }),
+    const errorBarProps = {
+      clipPath: needClip ? `url(#clipPath-${clipPathId})` : null,
+    };
+
+    return (
+      <Layer {...errorBarProps}>
+        {errorBarItems.map((item: ReactElement<ErrorBarProps>, i: number) =>
+          React.cloneElement(item, {
+            // eslint-disable-next-line react/no-array-index-key
+            key: `bar-${i}`,
+            data: points,
+            xAxis,
+            yAxis,
+            layout,
+            dataPointFormatter,
+          }),
+        )}
+      </Layer>
     );
   }
 
@@ -466,7 +474,7 @@ export class Line extends PureComponent<Props, State> {
           </defs>
         ) : null}
         {!hasSinglePoint && this.renderCurve(needClip, clipPathId)}
-        {this.renderErrorBar()}
+        {this.renderErrorBar(needClip, clipPathId)}
         {(hasSinglePoint || dot) && this.renderDots(needClip, clipPathId)}
         {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
       </Layer>


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- fix: error bar overflow chart area when set axis allow dataoverflow to true

## Related Issue

#2978 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

`Bar` and `Line` are not clip ErrorBarItems correspond to the chart area correctly.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- In local dev env `npm run demo`
- test the CodeSandbox example from #2978

## Screenshots (if appropriate):

CodeSandbox code provided in #2978 :
![image](https://user-images.githubusercontent.com/43896664/215302136-0c033563-0bd8-4882-bbcc-59508cddb9a1.png)

In dev demo env:
![image](https://user-images.githubusercontent.com/43896664/215302158-4034966e-ee29-4d2e-b251-80494ffcbba4.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
