### PR TITLE
Revert "fix: remove deprecated alwaysShow"

### DIFF
--- a/demo/component/ScatterChart.tsx
+++ b/demo/component/ScatterChart.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-script-url */
-/* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { Component } from 'react';
 import {
   ScatterChart,
@@ -88,7 +86,9 @@ export default class Demo extends Component {
   };
 
   renderSquare = (props: any) => {
-    const { cx, cy, size, xAxis, yAxis } = props;
+    const { cx, cy, size, xAxis, yAxis, zAxis } = props;
+    const xBandSize = xAxis.bandSize;
+    const yBandSize = yAxis.bandSize;
 
     return (
       <rect
@@ -103,6 +103,8 @@ export default class Demo extends Component {
   };
 
   render() {
+    const { data01, data02, data03, data04 } = this.state;
+
     return (
       <div className="scatter-charts">
         <a href="javascript: void(0);" className="btn update" onClick={this.handleChangeData}>
@@ -132,7 +134,7 @@ export default class Demo extends Component {
             <Scatter name="B school" data={data02} fill="#347300" />
             <Tooltip trigger="click" />
             <Legend />
-            <ReferenceArea x1={250} x2={300} label="any label" />
+            <ReferenceArea x1={250} x2={300} alwaysShow label="any label" />
             <ReferenceLine x={159} stroke="red" />
             <ReferenceLine y={237.5} stroke="red" />
             <ReferenceDot x={170} y={290} r={15} label="AB" stroke="none" fill="red" isFront />

--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -9,6 +9,7 @@ import { ImplicitLabelType, Label } from '../component/Label';
 import { createLabeledScales, rectWithPoints } from '../util/CartesianUtils';
 import { ifOverflowMatches } from '../util/IfOverflowMatches';
 import { isNumOrStr } from '../util/DataUtils';
+import { warn } from '../util/LogUtils';
 import { Rectangle, Props as RectangleProps } from '../shape/Rectangle';
 import { CartesianViewBox, D3Scale } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
@@ -25,6 +26,8 @@ interface InternalReferenceAreaProps {
 
 interface ReferenceAreaProps extends InternalReferenceAreaProps {
   isFront?: boolean;
+  /** @deprecated use ifOverflow="extendDomain"  */
+  alwaysShow?: boolean;
   ifOverflow?: 'hidden' | 'visible' | 'discard' | 'extendDomain';
   x1?: number | string;
   x2?: number | string;
@@ -90,7 +93,9 @@ export function ReferenceArea({
     ...restProps,
   };
 
-  const { x1, x2, y1, y2, className, clipPathId } = props;
+  const { x1, x2, y1, y2, className, alwaysShow, clipPathId } = props;
+
+  warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
 
   const hasX1 = isNumOrStr(x1);
   const hasX2 = isNumOrStr(x2);

--- a/src/cartesian/ReferenceDot.tsx
+++ b/src/cartesian/ReferenceDot.tsx
@@ -10,6 +10,7 @@ import { ImplicitLabelType, Label } from '../component/Label';
 import { isNumOrStr } from '../util/DataUtils';
 import { ifOverflowMatches } from '../util/IfOverflowMatches';
 import { createLabeledScales } from '../util/CartesianUtils';
+import { warn } from '../util/LogUtils';
 import { D3Scale } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { Props as XAxisProps } from './XAxis';
@@ -25,6 +26,8 @@ interface ReferenceDotProps extends InternalReferenceDotProps {
   r?: number;
 
   isFront?: boolean;
+  /** @deprecated use ifOverflow="extendDomain"  */
+  alwaysShow?: boolean;
   ifOverflow?: 'hidden' | 'visible' | 'discard' | 'extendDomain';
   x?: number | string;
   y?: number | string;
@@ -52,9 +55,11 @@ const getCoordinate = (props: Props) => {
 };
 
 export function ReferenceDot(props: Props) {
-  const { x, y, r, clipPathId } = props;
+  const { x, y, r, alwaysShow, clipPathId } = props;
   const isX = isNumOrStr(x);
   const isY = isNumOrStr(y);
+
+  warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
 
   if (!isX || !isY) {
     return null;

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -9,6 +9,7 @@ import { ImplicitLabelType, Label } from '../component/Label';
 import { ifOverflowMatches } from '../util/IfOverflowMatches';
 import { isNumOrStr } from '../util/DataUtils';
 import { createLabeledScales, rectWithCoords } from '../util/CartesianUtils';
+import { warn } from '../util/LogUtils';
 import { CartesianViewBox, D3Scale } from '../util/types';
 import { Props as XAxisProps } from './XAxis';
 import { Props as YAxisProps } from './YAxis';
@@ -23,6 +24,8 @@ interface InternalReferenceLineProps {
 
 interface ReferenceLineProps extends InternalReferenceLineProps {
   isFront?: boolean;
+  /** @deprecated use ifOverflow="extendDomain"  */
+  alwaysShow?: boolean;
   ifOverflow?: 'hidden' | 'visible' | 'discard' | 'extendDomain';
 
   x?: number | string;
@@ -140,7 +143,9 @@ export function ReferenceLine({
     ...restProps,
   };
 
-  const { x: fixedX, y: fixedY, segment, xAxis, yAxis, shape, className, clipPathId } = props;
+  const { x: fixedX, y: fixedY, segment, xAxis, yAxis, shape, className, alwaysShow, clipPathId } = props;
+
+  warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
 
   const scales = createLabeledScales({ x: xAxis.scale, y: yAxis.scale });
 

--- a/test/cartesian/ReferenceLine.spec.tsx
+++ b/test/cartesian/ReferenceLine.spec.tsx
@@ -149,6 +149,28 @@ describe('<ReferenceLine />', () => {
     expect(container.querySelectorAll('.recharts-label')).toHaveLength(2);
   });
 
+  test('Render line and label when (deprecated) alwaysShow is true in ReferenceLine', () => {
+    const { container } = render(
+      <BarChart
+        width={1100}
+        height={250}
+        barGap={2}
+        barSize={6}
+        data={data}
+        margin={{ top: 20, right: 60, bottom: 0, left: 20 }}
+      >
+        <XAxis dataKey="name" />
+        <YAxis tickCount={7} />
+        <Bar dataKey="uv" />
+        <ReferenceLine x="201102" label="test" stroke="#666" />
+        <ReferenceLine y={20} stroke="#666" label="20" alwaysShow />
+      </BarChart>,
+    );
+    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(2);
+    expect(container.querySelectorAll('.recharts-label')).toHaveLength(2);
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
   test('Render line and label when ifOverflow is "extendDomain" in ReferenceLine', () => {
     const { container } = render(
       <BarChart


### PR DESCRIPTION
Mistakenly merged a breaking change. We shall only do this with 3.0 
While the property was not used, removing it from the API would still be a breaking change.

Reverts recharts/recharts#3287