### PR TITLE
fix: filter out functions in filterProps, remove type from valid SVGElementPropKeys

### DIFF
--- a/demo/component/AreaChart.tsx
+++ b/demo/component/AreaChart.tsx
@@ -15,6 +15,7 @@ import {
   Label,
 } from 'recharts';
 import { changeNumberOfData } from './utils';
+import { curveCardinal } from 'victory-vendor/d3-shape';
 
 const data = [
   { name: 'Page A', uv: 4000, pv: 2400, amt: 2400, time: 1 },
@@ -118,6 +119,9 @@ const renderLabel = (props: any) => {
     </text>
   );
 };
+
+// custom curve cardinal `type` prop
+const stepAround = curveCardinal.tension(0.5);
 
 export default class AreaChartDemo extends React.Component<any, any> {
   static displayName = 'AreaChartDemo';
@@ -269,16 +273,14 @@ export default class AreaChartDemo extends React.Component<any, any> {
 
         <p>Tiny AreaChart</p>
         <div className="area-chart-wrapper">
-          <AreaChart width={100} height={50} data={data.slice(0, 1)} margin={{ top: 5, right: 0, left: 0, bottom: 5 }}
-          >
+          <AreaChart width={100} height={50} data={data.slice(0, 1)} margin={{ top: 5, right: 0, left: 0, bottom: 5 }}>
             <Area type="monotone" dataKey="uv" stroke="#ff7300" fill="#ff7300" />
           </AreaChart>
         </div>
 
         <p>AreaChart with three y-axes</p>
         <div className="area-chart-wrapper">
-          <AreaChart width={600} height={400} data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
-          >
+          <AreaChart width={600} height={400} data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
             <YAxis type="number" yAxisId={0} stroke="#ff7300">
               <Label position="top" offset={10}>
                 uv
@@ -313,18 +315,15 @@ export default class AreaChartDemo extends React.Component<any, any> {
             <YAxis type="category" dataKey="name" />
             <XAxis type="number" xAxisId={0} orientation="top" />
             <XAxis type="number" xAxisId={1} orientation="bottom" />
-            <Area dataKey="uv" type="monotone" stroke="#ff7300" fill="#ff7300" strokeWidth={2} xAxisId={0}
-            />
-            <Area dataKey="pv" type="monotone" stroke="#387908" fill="#387908" strokeWidth={2} xAxisId={1}
-            />
+            <Area dataKey="uv" type="monotone" stroke="#ff7300" fill="#ff7300" strokeWidth={2} xAxisId={0} />
+            <Area dataKey="pv" type="monotone" stroke="#387908" fill="#387908" strokeWidth={2} xAxisId={1} />
             <Tooltip />
           </AreaChart>
         </div>
 
         <p>AreaChart with custom tooltip</p>
         <div className="area-chart-wrapper">
-          <AreaChart width={900} height={250} data={data} margin={{ top: 10, right: 30, bottom: 10, left: 10 }}
-          >
+          <AreaChart width={900} height={250} data={data} margin={{ top: 10, right: 30, bottom: 10, left: 10 }}>
             <XAxis dataKey="name" />
             <YAxis tickCount={7} />
             <Tooltip content={<CustomTooltip external={data} />} />
@@ -332,8 +331,7 @@ export default class AreaChartDemo extends React.Component<any, any> {
             <ReferenceArea x1="Page A" x2="Page E" />
             <ReferenceLine y={7500} stroke="#387908" />
             <ReferenceDot x="Page C" y={1398} r={10} fill="#387908" isFront />
-            <Area type="monotone" dataKey="pv" stroke="#ff7300" fill="#ff7300" fillOpacity={0.9}
-            />
+            <Area type={stepAround} dataKey="pv" stroke="#ff7300" fill="#ff7300" fillOpacity={0.9} />
           </AreaChart>
         </div>
 
@@ -370,8 +368,7 @@ export default class AreaChartDemo extends React.Component<any, any> {
 
         <p>AreaChart of discrete values</p>
         <div className="area-chart-wrapper">
-          <AreaChart
-width={400} height={400} data={data01} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+          <AreaChart width={400} height={400} data={data01} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
             <XAxis dataKey="day" />
             <YAxis type="category" />
             <Tooltip />

--- a/demo/component/LineChart.tsx
+++ b/demo/component/LineChart.tsx
@@ -1,24 +1,19 @@
 import React, { Component } from 'react';
 import {
-  ResponsiveContainer,
   LineChart,
   Line,
   XAxis,
   YAxis,
-  ReferenceLine,
-  ReferenceArea,
-  ReferenceDot,
   Tooltip,
   CartesianGrid,
   Legend,
   Brush,
-  ErrorBar,
   AreaChart,
   Area,
   Label,
   LabelList,
 } from 'recharts';
-import { scalePow, scaleLog } from 'victory-vendor/d3-scale';
+import { scaleLog } from 'victory-vendor/d3-scale';
 import * as _ from 'lodash';
 import CustomLineDot from './CustomLineDot';
 import { changeNumberOfData } from './utils';

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -583,8 +583,14 @@ export const SVGElementPropKeys = [
   'min',
   'name',
   'style',
+  /*
+   * removed 'type' SVGElementPropKey because we do not currently use any SVG elements
+   * that can use it and it conflicts with the recharts prop 'type'
+   * https://github.com/recharts/recharts/pull/3327
+   * https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/type
+   */
+  // 'type',
   'target',
-  'type',
   'width',
   'role',
   'tabIndex',

--- a/storybook/stories/API/chart/AreaChart.stories.tsx
+++ b/storybook/stories/API/chart/AreaChart.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { curveCardinal } from 'victory-vendor/d3-shape';
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip } from '../../../../src';
-import { dateData, TimeSeriesData } from '../../data';
+import { dateData, pageData, TimeSeriesData } from '../../data';
 
 export default {
   component: AreaChart,
@@ -28,5 +29,22 @@ export const Simple = {
   },
   args: {
     data,
+  },
+};
+
+const stepAround = curveCardinal.tension(0.5);
+
+export const CustomType = {
+  render: (args: Record<string, any>) => {
+    return (
+      <ResponsiveContainer width="100%" height={400}>
+        <AreaChart data={args.data}>
+          <Area type={stepAround} dataKey="pv" stroke="#ff7300" fill="#ff7300" fillOpacity={0.9} />
+        </AreaChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    data: pageData,
   },
 };

--- a/test/util/ReactUtils.spec.tsx
+++ b/test/util/ReactUtils.spec.tsx
@@ -8,6 +8,7 @@ import {
   findAllByType,
   getDisplayName,
   isChildrenEqual,
+  isValidSpreadableProp,
   toArray,
   validateWidthHeight,
   withoutType,
@@ -67,6 +68,28 @@ describe('ReactUtils untest tests', () => {
       expect(Object.keys(result ?? {})).toContain('stroke');
       expect(Object.keys(result ?? {})).toContain('fill');
       expect(Object.keys(result ?? {})).toContain('r');
+    });
+  });
+
+  describe('isValidSpreadableProp', () => {
+    test('return true for valid SVG element attribute', () => {
+      const isValid = isValidSpreadableProp(42, 'height');
+      expect(isValid).toBeTruthy();
+    });
+
+    test('return false for invalid SVG element attribute', () => {
+      const isValid = isValidSpreadableProp(42, 'type');
+      expect(isValid).toBeFalsy();
+    });
+
+    test('return true for event when includeEvents is true', () => {
+      const isValid = isValidSpreadableProp(() => true, 'onClick', true);
+      expect(isValid).toBeTruthy();
+    });
+
+    test('return true for valid SVGElementType', () => {
+      const isValid = isValidSpreadableProp('00 00 00 00', 'points', false, 'polyline');
+      expect(isValid).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Recharts has a `filterProps` function which was intended to filter out all properties that are not valid SVGProps or events that need passed down to children.

Multiple times we have come across issues where Recharts defined props such as `type` (in the past `points`) overlap with traditional SVGProps (https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute)

In these cases props get spread onto SVG elements that aren't intended or valid.

In this case the `type` prop [is a valid SVG attribute](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/type). This never caused error in the past because the DOM will ignore attributes that are strings or numbers, but when adding a line or area `type` property that is custom `CurveFactory` from d3 such as
```
const stepAround = curveCardinal.tension(0.5);
```
the DOM will throw an error "Invalid value for prop type on <path> tag" because functions are not valid on HTML elements in the DOM.

- remove `type` from valid `SVGElementAttributes` - we do not use any elements that need it
- add an `isFunction` check within `filterProps` for attributes that are supposed to be one of `SVGElementAttributes` - these should never be functions
- detail comment within `filterProps`
- adds an example using a `CurveFactory` in AreaChart demo

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/3310

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Resolve above described error. Prevent more errors with `type` in the future.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The true `type` SVG attribute can only be used with the following tags: 

![image](https://user-images.githubusercontent.com/25180830/216709142-dc93d508-de1b-43c6-a1be-0afeb3467a7a.png)

None of which we use in Recharts.

- In demo slightly modify an example to use a `CurveFactory` - ensure the new curve factory type is displayed correctly and that the error is not thrown.
  - `type` is passed down explicitly by the chart so it is okay that it gets filtered out in `filterProps`
- check functionality of other chart types and `CurveType` values such as `monotone` and `linear`


## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/25180830/216709982-a73e2436-2f2f-4332-a9dc-d6d4deb808fd.png)

^ No error thrown like in issue but curve still reflects the given `CurveFactory`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
