### PR TITLE
fix: remove axis domain default prop and calculate it dynamically

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -44,7 +44,6 @@ XAxis.defaultProps = {
   xAxisId: 0,
   tickCount: 5,
   type: 'category',
-  domain: [0, 'auto'],
   padding: { left: 0, right: 0 },
   allowDataOverflow: false,
   scale: 'auto',

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -45,7 +45,6 @@ YAxis.defaultProps = {
   yAxisId: 0,
   tickCount: 5,
   type: 'number',
-  domain: [0, 'auto'],
   padding: { top: 0, bottom: 0 },
   allowDataOverflow: false,
   scale: 'auto',

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -197,6 +197,10 @@ function isDomainSpecifiedByUser(domain: AxisDomain, allowDataOverflow: boolean,
   return false;
 }
 
+function getDefaultDomainByAxisType(axisType: 'number' | string) {
+  return axisType === 'number' ? [0, 'auto'] : undefined;
+}
+
 /**
  * Get the content to be displayed in the tooltip
  * @param  {Object} state          Current state
@@ -327,7 +331,7 @@ const getAxisMapByAxes = (
 
     // we didn't create the domain from user's props above, so we need to calculate it
     if (!domain || domain.length === 0) {
-      const childDomain = child.props.domain ?? (type === 'number' ? [0, 'auto'] : undefined);
+      const childDomain = child.props.domain ?? getDefaultDomainByAxisType(type);
 
       if (dataKey) {
         // has dataKey in <Axis />
@@ -468,7 +472,7 @@ const getAxisMapByItems = (
   const axisMap = graphicalItems.reduce((result: any, child: any) => {
     const axisId = child.props[axisIdKey];
 
-    const originalDomain = Axis.defaultProps.domain ?? [0, 'auto'];
+    const originalDomain = getDefaultDomainByAxisType('number');
 
     if (!result[axisId]) {
       index++;

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -327,6 +327,8 @@ const getAxisMapByAxes = (
 
     // we didn't create the domain from user's props above, so we need to calculate it
     if (!domain || domain.length === 0) {
+      const childDomain = child.props.domain ?? (type === 'number' ? [0, 'auto'] : undefined);
+
       if (dataKey) {
         // has dataKey in <Axis />
         domain = getDomainOfDataByKey(displayedData, dataKey, type);
@@ -341,7 +343,7 @@ const getAxisMapByAxes = (
             domain = _.range(0, len);
           } else if (!allowDuplicatedCategory) {
             // remove duplicated category
-            domain = parseDomainOfCategoryAxis(child.props.domain, domain, child).reduce(
+            domain = parseDomainOfCategoryAxis(childDomain, domain, child).reduce(
               (finalDomain: any, entry: any) =>
                 finalDomain.indexOf(entry) >= 0 ? finalDomain : [...finalDomain, entry],
               [],
@@ -350,7 +352,7 @@ const getAxisMapByAxes = (
         } else if (type === 'category') {
           // the field type is category data and this axis is numerical axis
           if (!allowDuplicatedCategory) {
-            domain = parseDomainOfCategoryAxis(child.props.domain, domain, child).reduce(
+            domain = parseDomainOfCategoryAxis(childDomain, domain, child).reduce(
               (finalDomain: any, entry: any) =>
                 finalDomain.indexOf(entry) >= 0 || entry === '' || _.isNil(entry)
                   ? finalDomain
@@ -402,14 +404,14 @@ const getAxisMapByAxes = (
         // To detect wether there is any reference lines whose props alwaysShow is true
         domain = detectReferenceElementsDomain(children, domain, axisId, axisType, ticks);
 
-        if (child.props.domain) {
-          domain = parseSpecifiedDomain(child.props.domain, domain, allowDataOverflow);
+        if (childDomain) {
+          domain = parseSpecifiedDomain(childDomain, domain, allowDataOverflow);
         }
-      } else if (type === 'category' && child.props.domain) {
-        const axisDomain = child.props.domain;
-        const isDomainValidate = domain.every((entry: string | number) => axisDomain.indexOf(entry) >= 0);
+      } else if (type === 'category' && childDomain) {
+        const axisDomain = childDomain;
+        const isDomainValid = domain.every((entry: string | number) => axisDomain.indexOf(entry) >= 0);
 
-        if (isDomainValidate) {
+        if (isDomainValid) {
           domain = axisDomain;
         }
       }
@@ -466,6 +468,8 @@ const getAxisMapByItems = (
   const axisMap = graphicalItems.reduce((result: any, child: any) => {
     const axisId = child.props[axisIdKey];
 
+    const originalDomain = Axis.defaultProps.domain ?? [0, 'auto'];
+
     if (!result[axisId]) {
       index++;
       let domain;
@@ -477,7 +481,7 @@ const getAxisMapByItems = (
         domain = detectReferenceElementsDomain(children, domain, axisId, axisType);
       } else {
         domain = parseSpecifiedDomain(
-          Axis.defaultProps.domain,
+          originalDomain,
           getDomainOfItemsWithSameAxis(
             displayedData,
             graphicalItems.filter((item: any) => item.props[axisIdKey] === axisId && !item.props.hide),
@@ -497,7 +501,7 @@ const getAxisMapByItems = (
           hide: true,
           orientation: _.get(ORIENT_MAP, `${axisType}.${index % 2}`, null),
           domain,
-          originalDomain: Axis.defaultProps.domain,
+          originalDomain,
           isCategorical,
           layout,
           // specify scale when no Axis

--- a/src/polar/PolarAngleAxis.tsx
+++ b/src/polar/PolarAngleAxis.tsx
@@ -36,7 +36,6 @@ export class PolarAngleAxis extends PureComponent<Props> {
     scale: 'auto',
     cx: 0,
     cy: 0,
-    domain: [0, 'auto'],
     orientation: 'outer',
     axisLine: true,
     tickLine: true,

--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -38,7 +38,6 @@ export class PolarRadiusAxis extends PureComponent<Props> {
     axisLine: true,
     tick: true,
     tickCount: 5,
-    domain: [0, 'auto'],
     allowDataOverflow: false,
     scale: 'auto',
     allowDuplicatedCategory: true,

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -162,4 +162,16 @@ describe('<XAxis />', () => {
     const bar = container.querySelector('.recharts-rectangle');
     expect(parseInt(bar?.getAttribute('x') as string, 10)).toEqual(66);
   });
+
+  test('Render no ticks if type is category and data is empty', () => {
+    const { container } = render(
+      <BarChart width={300} height={300} data={[]}>
+        <Bar dataKey="y" isAnimationActive={false} />
+        <XAxis dataKey="x" />
+        <YAxis dataKey="y" />
+      </BarChart>,
+    );
+
+    expect(container.querySelectorAll('.recharts-xAxis .recharts-cartesian-axis-tick')).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixes #2593.

I removed the `domain` prop from the default props for all axis components. As described in the issue comments, those default props do not take the axis type into account and thereby use unsuitable domains in some cases. This results in the bug.

Instead of using the component default props, the fallback domain is now determined when the axis map is created. At this point the type of the axis is known and is used to determine which fallback domain to use.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#2593

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Solves a bug.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added a unit test for the BarChart component, as this specific case was mentioned in the bug ticket.
I also tested charts with all the modified axis in the demo and storybook. Both with and without specified domain.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
