### PR TITLE
feat: add onResize callback fn

### DIFF
--- a/demo/component/ResponsiveContainer.tsx
+++ b/demo/component/ResponsiveContainer.tsx
@@ -193,6 +193,10 @@ export default class Demo extends Component {
     this.setState(() => _.mapValues(initialState, changeNumberOfData));
   };
 
+  resizeListener = (width: string, height: string) => {
+    console.log(`height is: ${height}, width is: ${width}`);
+  };
+
   render() {
     const { data, data01, data02 } = this.state;
 
@@ -235,7 +239,7 @@ export default class Demo extends Component {
 
         <p>A simple LineChart</p>
         <div className="line-chart-wrapper" style={{ width: '100%', height: '400px', backgroundColor: '#f5f5f5' }}>
-          <ResponsiveContainer>
+          <ResponsiveContainer onResize={this.resizeListener}>
             <LineChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
               <CartesianGrid stroke="#f5f5f5" />
               <XAxis />

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -28,6 +28,7 @@ export interface Props {
   debounce?: number;
   id?: string | number;
   className?: string | number;
+  onResize?: (width: number, height: number) => void;
 }
 
 export const ResponsiveContainer = forwardRef(
@@ -43,6 +44,7 @@ export const ResponsiveContainer = forwardRef(
       debounce = 0,
       id,
       className,
+      onResize,
     }: Props,
     ref,
   ) => {
@@ -73,6 +75,7 @@ export const ResponsiveContainer = forwardRef(
 
       if (newSize) {
         const { containerWidth, containerHeight } = newSize;
+        if (onResize) onResize(containerWidth, containerHeight);
 
         setSizes(currentSizes => {
           const { containerWidth: oldWidth, containerHeight: oldHeight } = currentSizes;

--- a/test/component/ResponsiveContainer.spec.tsx
+++ b/test/component/ResponsiveContainer.spec.tsx
@@ -190,4 +190,29 @@ describe('<ResponsiveContainer />', () => {
     expect(element).toHaveAttribute('width', '100');
     expect(element).toHaveAttribute('height', '100');
   });
+
+  it('should call onResize when ResizeObserver notifies one or many changes', () => {
+    const onResize = jest.fn();
+
+    const { container } = render(
+      <ResponsiveContainer width="100%" height={200} onResize={onResize}>
+        <div data-testid="inside" />
+      </ResponsiveContainer>,
+    );
+
+    const element = container.querySelector('.recharts-responsive-container');
+    expect(element).not.toHaveAttribute('width');
+    expect(element).not.toHaveAttribute('height');
+
+    notifyResizeObserverChange([{ contentRect: { width: 100, height: 100 } }]);
+
+    expect(element).toHaveAttribute('width', '100');
+    expect(element).toHaveAttribute('height', '100');
+
+    expect(onResize).toHaveBeenCalledTimes(1);
+
+    notifyResizeObserverChange([{ contentRect: { width: 200, height: 200 } }]);
+
+    expect(onResize).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Exposes `onResize` function 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/3326

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This easily adds an optional non-breaking onResize callback that notifies the caller of current container width and height

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Unit testing
* Add test to demo
   - only called when there is an update and called _after_ debounce time
* Test typescript types and usage in 

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/25180830/218552607-ad9fafae-3a8e-4015-88ae-b96d9df03996.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
  - I will follow up and add to the docs in the other repo
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
