### PR TITLE
storybook: default to light preview, add multi chart container example

### DIFF
--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -15,4 +15,7 @@ export const parameters = {
     container: DocsContainer,
     page: DocsPage,
   },
+  backgrounds: {
+    default: 'light',
+  },
 };

--- a/storybook/stories/Examples/ResponsiveContainer/MultiChartFlexbox.stories.tsx
+++ b/storybook/stories/Examples/ResponsiveContainer/MultiChartFlexbox.stories.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { useTheme } from '@storybook/theming';
+import {
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Area,
+  AreaChart,
+  LineChart,
+  Line,
+} from '../../../../src';
+import { pageData } from '../../data';
+import './style.css';
+
+export default {
+  component: AreaChart,
+};
+
+export const MultiChartFlexbox = {
+  render: (_args: Record<string, any>) => {
+    const theme = useTheme();
+    console.log(theme);
+
+    return (
+      <>
+        <p style={{ color: theme?.color?.defaultText }}>Resize the window to </p>
+        <div className="flex-parent">
+          <ResponsiveContainer width="100%" className="flex-child">
+            <AreaChart
+              data={pageData}
+              margin={{
+                top: 10,
+                right: 30,
+                left: 0,
+                bottom: 0,
+              }}
+            >
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Tooltip />
+              <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+            </AreaChart>
+          </ResponsiveContainer>
+          <ResponsiveContainer className="flex-child">
+            <LineChart
+              data={pageData}
+              margin={{
+                top: 10,
+                right: 30,
+                left: 0,
+                bottom: 0,
+              }}
+            >
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="amt" stroke="orange" />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </>
+    );
+  },
+  args: {},
+};

--- a/storybook/stories/Examples/ResponsiveContainer/MultiChartFlexbox.stories.tsx
+++ b/storybook/stories/Examples/ResponsiveContainer/MultiChartFlexbox.stories.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { useTheme } from '@storybook/theming';
 import {
   ResponsiveContainer,
   XAxis,
@@ -21,12 +19,9 @@ export default {
 
 export const MultiChartFlexbox = {
   render: (_args: Record<string, any>) => {
-    const theme = useTheme();
-    console.log(theme);
-
     return (
       <>
-        <p style={{ color: theme?.color?.defaultText }}>Resize the window to </p>
+        <p>Resize the window to test ResponsiveContainer</p>
         <div className="flex-parent">
           <ResponsiveContainer width="100%" className="flex-child">
             <AreaChart

--- a/storybook/stories/Examples/ResponsiveContainer/style.css
+++ b/storybook/stories/Examples/ResponsiveContainer/style.css
@@ -1,0 +1,10 @@
+.flex-parent {
+  display: flex;
+  flex-direction: row;
+  height: 500px;
+}
+
+.flex-child {
+  min-width: 0;
+  flex: 1;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The storybook doesn't currently look great when a user has darkmode on their machine. Until we can customize styles lets use the light background.

Many people want more than one chart in a container, add an example with responsive container that works with flexbox

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
see above

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Open and run the storybook

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
