### PR TITLE
fix: zoom functionality, generate categoricalDomain if categorical chart

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -327,6 +327,13 @@ const getAxisMapByAxes = (
      */
     if (isDomainSpecifiedByUser(child.props.domain, allowDataOverflow, type)) {
       domain = parseSpecifiedDomain(child.props.domain, null, allowDataOverflow);
+      /* The chart can be categorical and have the domain specified in numbers
+       * we still need to calculate the categorical domain
+       * TODO: refactor this more
+       */
+      if (isCategorical && (type === 'number' || scale !== 'auto')) {
+        categoricalDomain = getDomainOfDataByKey(displayedData, dataKey, 'category');
+      }
     }
 
     // we didn't create the domain from user's props above, so we need to calculate it


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
https://github.com/recharts/recharts/pull/3293 broke generation of categoricalDomain by short circuting its creation when the data is numerical. This broke zoom functionality in our demos.

This will need some follow up work, these functions are very fragile

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/3369

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes https://github.com/recharts/recharts/issues/3369
Fixes demos


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://user-images.githubusercontent.com/25180830/218962623-7ea4ef95-0e67-4387-a3f8-7d21780d739f.mov
- debugger - check values of categoricalDomain

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
