### PR TITLE
fix: originalDomain not set when getting default domain

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -292,7 +292,7 @@ const getTooltipData = (state: CategoricalChartState, chartData: any[], layout: 
  * @param {Number} dataEndIndex   The end index of the data series when a brush is applied
  * @return {Object}      Configuration
  */
-const getAxisMapByAxes = (
+export const getAxisMapByAxes = (
   props: CategoricalChartProps,
   { axes, graphicalItems, axisType, axisIdKey, stackGroups, dataStartIndex, dataEndIndex }: any,
 ) => {
@@ -336,9 +336,12 @@ const getAxisMapByAxes = (
       }
     }
 
+    // if the domain is defaulted we need this for `originalDomain` as well
+    const defaultDomain = getDefaultDomainByAxisType(type);
+
     // we didn't create the domain from user's props above, so we need to calculate it
     if (!domain || domain.length === 0) {
-      const childDomain = child.props.domain ?? getDefaultDomainByAxisType(type);
+      const childDomain = child.props.domain ?? defaultDomain;
 
       if (dataKey) {
         // has dataKey in <Axis />
@@ -436,7 +439,7 @@ const getAxisMapByAxes = (
         domain,
         categoricalDomain,
         duplicateDomain,
-        originalDomain: child.props.domain,
+        originalDomain: child.props.domain ?? defaultDomain,
         isCategorical,
         layout,
       },

--- a/test/chart/generateCategoricalChart.test.ts
+++ b/test/chart/generateCategoricalChart.test.ts
@@ -1,0 +1,213 @@
+import { getAxisMapByAxes, CategoricalChartProps } from '../../src/chart/generateCategoricalChart';
+
+const data = [
+  {
+    name: 'Page A',
+    uv: 590,
+    pv: 800,
+    amt: 1400,
+  },
+  {
+    name: 'Page B',
+    uv: 868,
+    pv: 967,
+    amt: 1506,
+  },
+  {
+    name: 'Page C',
+    uv: 1397,
+    pv: 1098,
+    amt: 989,
+  },
+  {
+    name: 'Page D',
+    uv: 1480,
+    pv: 1200,
+    amt: 1228,
+  },
+  {
+    name: 'Page E',
+    uv: 1520,
+    pv: 1108,
+    amt: 1100,
+  },
+  {
+    name: 'Page F',
+    uv: 1400,
+    pv: 680,
+    amt: 1700,
+  },
+];
+
+describe('generateCategoricalChart', () => {
+  const graphicalItems = [
+    {
+      props: {
+        type: 'monotone',
+        dataKey: 'uv',
+        stroke: '#8884d8',
+        fill: '#8884d8',
+        fillOpacity: 0.6,
+        xAxisId: 0,
+        yAxisId: 0,
+        legendType: 'line',
+        connectNulls: false,
+        points: [] as any[],
+        dot: false,
+        activeDot: true,
+        hide: false,
+        isAnimationActive: true,
+        animationBegin: 0,
+        animationDuration: 1500,
+        animationEasing: 'ease',
+      },
+    },
+  ];
+
+  const axisProps = {
+    allowDecimals: true,
+    hide: false,
+    orientation: 'bottom',
+    width: 0,
+    height: 30,
+    mirror: false,
+    tickCount: 2,
+    type: 'category',
+    padding: { left: 0, right: 0 },
+    allowDataOverflow: false,
+    scale: 'auto',
+    reversed: false,
+    allowDuplicatedCategory: true,
+  };
+
+  const xAxes = [
+    {
+      props: { ...axisProps, xAxisId: 0, dataKey: 'name' },
+    },
+  ];
+
+  const yAxes = [
+    {
+      props: {
+        ...axisProps,
+        orientation: 'left',
+        width: 0,
+        height: 30,
+        mirror: false,
+        yAxisId: 0,
+        tickCount: 2,
+        type: 'number',
+        dataKey: 'uv',
+      },
+    },
+  ];
+
+  describe('getAxisMapByAxes', () => {
+    const props: CategoricalChartProps = {
+      data,
+      margin: { top: 10, right: 30, left: 0, bottom: 0 },
+      layout: 'horizontal',
+      stackOffset: 'none',
+      barCategoryGap: '10%',
+      barGap: 4,
+      reverseStackOrder: false,
+      syncMethod: 'index',
+      width: 415,
+      height: 500,
+    };
+
+    const stackGroups = [
+      { hasStack: false, stackGroups: { _stackId_49: { cateAxisId: 'xAxisId', items: graphicalItems } } },
+    ];
+
+    const input = {
+      axes: xAxes,
+      graphicalItems,
+      stackGroups,
+      axisType: 'xAxis',
+      axisIdKey: 'xAxisId',
+      dataStartIndex: 0,
+      dataEndIndex: 5,
+    };
+
+    test('xAxis categorical - should have domain of the categorical data sent', () => {
+      const res = getAxisMapByAxes(props, {
+        axes: xAxes,
+        graphicalItems,
+        stackGroups,
+        axisType: 'xAxis',
+        axisIdKey: 'xAxisId',
+        dataStartIndex: 0,
+        dataEndIndex: 5,
+      });
+
+      expect(res).toEqual(
+        expect.objectContaining({
+          '0': {
+            dataKey: 'name',
+            allowDecimals: true,
+            hide: false,
+            orientation: 'bottom',
+            width: 0,
+            height: 30,
+            mirror: false,
+            xAxisId: 0,
+            tickCount: 2,
+            type: 'category',
+            padding: { left: 0, right: 0 },
+            allowDataOverflow: false,
+            scale: 'auto',
+            reversed: false,
+            allowDuplicatedCategory: true,
+            axisType: 'xAxis',
+            domain: ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F'],
+            categoricalDomain: undefined,
+            duplicateDomain: undefined,
+            originalDomain: undefined,
+            isCategorical: true,
+            layout: 'horizontal',
+          },
+        }),
+      );
+    });
+
+    test('yAxis numerical - should have originalDomain of [0, `auto`] and auto domain data sent', () => {
+      // override data to represent yAxis domain generation
+      // eslint-disable-next-line no-underscore-dangle
+      stackGroups[0].stackGroups._stackId_49.cateAxisId = 'yAxisId';
+
+      const yAxisInput = { ...input, axisIdKey: 'yAxisId', axisType: 'yAxis', axes: yAxes };
+
+      const res = getAxisMapByAxes(props, yAxisInput);
+
+      expect(res).toEqual(
+        expect.objectContaining({
+          '0': {
+            dataKey: 'uv',
+            allowDecimals: true,
+            hide: false,
+            orientation: 'left',
+            width: 0,
+            height: 30,
+            mirror: false,
+            yAxisId: 0,
+            tickCount: 2,
+            type: 'number',
+            padding: { left: 0, right: 0 },
+            allowDataOverflow: false,
+            scale: 'auto',
+            reversed: false,
+            allowDuplicatedCategory: true,
+            axisType: 'yAxis',
+            domain: [0, 1520],
+            categoricalDomain: undefined,
+            duplicateDomain: undefined,
+            originalDomain: [0, 'auto'],
+            isCategorical: false,
+            layout: 'horizontal',
+          },
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Domain `[0, 'auto']` default broke because `originalDomain` was no longer set correctly - this was used by other functions of `generateCategoricalChart` especially when calculating `ticks` using `tickCount`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/3377

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Axis default broken in 2.4.0+

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* add some basic unit tests for generateCategoricalChart that would've prevented this breaking change

## Screenshots (if appropriate):

Pre-Change (bug):
![image](https://user-images.githubusercontent.com/25180830/219494771-403a8cab-0f68-4eff-a166-3ee39229862e.png)


Post-Change (fixed):
![image](https://user-images.githubusercontent.com/25180830/219494628-6d700adb-65be-45cd-ad60-b75f614cb2ab.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
