### PR TITLE
fix: default min-width to 0 to override default auto behavior that breaks flexbox layouts

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -37,7 +37,11 @@ export const ResponsiveContainer = forwardRef(
       aspect,
       width = '100%',
       height = '100%',
-      minWidth,
+      /*
+       * default min-width to 0 if not specified - 'auto' causes issues with flexbox
+       * https://github.com/recharts/recharts/issues/172
+       */
+      minWidth = 0,
       minHeight,
       maxHeight,
       children,

--- a/storybook/stories/Examples/ResponsiveContainer/style.css
+++ b/storybook/stories/Examples/ResponsiveContainer/style.css
@@ -2,9 +2,9 @@
   display: flex;
   flex-direction: row;
   height: 500px;
+  width: 100%;
 }
 
 .flex-child {
-  min-width: 0;
   flex: 1;
 }

--- a/test/component/ResponsiveContainer.spec.tsx
+++ b/test/component/ResponsiveContainer.spec.tsx
@@ -215,4 +215,32 @@ describe('<ResponsiveContainer />', () => {
 
     expect(onResize).toHaveBeenCalledTimes(2);
   });
+
+  it('should have a min-width of 0 when no minWidth is set', () => {
+    const onResize = jest.fn();
+
+    const { container } = render(
+      <ResponsiveContainer width="100%" height={200} onResize={onResize}>
+        <div data-testid="inside" />
+      </ResponsiveContainer>,
+    );
+
+    const element = container.querySelector('.recharts-responsive-container');
+
+    expect(element).toHaveStyle({ width: '100%', height: '200px', 'min-width': '0' });
+  });
+
+  it('should have a min-width of 200px when minWidth is 200', () => {
+    const onResize = jest.fn();
+
+    const { container } = render(
+      <ResponsiveContainer width="100%" height={200} minWidth={200} onResize={onResize}>
+        <div data-testid="inside" />
+      </ResponsiveContainer>,
+    );
+
+    const element = container.querySelector('.recharts-responsive-container');
+
+    expect(element).toHaveStyle({ width: '100%', height: '200px', 'min-width': '200px' });
+  });
 });


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
default `minWidth` to 0 so that flexbox works correctly when specifying `ResponsiveContainer` as a flex item. Otherwise responsive container does not shrink as described in below issue and in below SOF answer.

This replaces `auto` and allows the container to behave as it should when in flex layouts. Doesn't affect non-flex layouts.

See this SOF answer https://stackoverflow.com/a/36247448/8050147

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#172 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
See linked issue. Oldest current open issue

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Add unit tests

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25180830/220541090-42428711-e809-42fb-bcef-8bae7b7f6968.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
