### PR TITLE
fix: unify line stories data

### DIFF
--- a/storybook/stories/API/cartesian/Line.stories.tsx
+++ b/storybook/stories/API/cartesian/Line.stories.tsx
@@ -170,7 +170,7 @@ export const CustomizedLabel = {
     // to make getAllByText works
     await new Promise(r => setTimeout(r, 0));
 
-    await expect(getAllByText(/Customized Label/)).toHaveLength(5);
+    await expect(getAllByText(/Customized Label/)).toHaveLength(4);
   },
 };
 

--- a/storybook/stories/API/cartesian/Line.stories.tsx
+++ b/storybook/stories/API/cartesian/Line.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 import { Surface, Line, ResponsiveContainer, ComposedChart } from '../../../../src';
-import { coordinateWithNullY, coordinateData, coordinateWithValueData } from '../../data';
+import { coordinateWithNullY, coordinateData } from '../../data';
 
 export default {
   component: Line,
@@ -68,7 +68,7 @@ export const Simple = {
     );
   },
   args: {
-    data: coordinateWithValueData,
+    data: coordinateData,
     dataKey: 'y',
   },
   parameters: {
@@ -103,7 +103,7 @@ export const LineFromData = {
 export const Style = {
   ...Simple,
   args: {
-    data: coordinateWithValueData,
+    data: coordinateData,
     stroke: 'red',
     fill: 'teal',
     dot: { r: 10 },
@@ -133,7 +133,7 @@ const renderDot = (props: { cx: number; cy: number }) => {
 export const CustomizedDot = {
   ...Simple,
   args: {
-    data: coordinateWithValueData,
+    data: coordinateData,
     isAnimationActive: true,
     dot: renderDot,
   },
@@ -160,7 +160,7 @@ const renderLabel = (props: { index: number; x: number; y: number }) => {
 export const CustomizedLabel = {
   ...Simple,
   args: {
-    data: coordinateWithValueData,
+    data: coordinateData,
     isAnimationActive: false,
     label: renderLabel,
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Unified the data used in the line stories API.
LineFromData using coordinateWithNullY is a story to show the edgecase, so I left it as is.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
