### PR TITLE
feat: Expose verticalAnchor on XAxis (and CartesianAxis)

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -44,6 +44,7 @@ export interface CartesianAxisProps {
   ticksGenerator?: (props?: CartesianAxisProps) => CartesianTickItem[];
   interval?: number | 'preserveStart' | 'preserveEnd' | 'preserveStartEnd' | 'equidistantPreserveStart';
   angle?: number;
+  verticalAnchor?: 'start' | 'middle' | 'end';
 }
 
 interface IState {
@@ -177,7 +178,10 @@ export class CartesianAxis extends Component<Props, IState> {
   }
 
   getTickVerticalAnchor() {
-    const { orientation, mirror } = this.props;
+    const { orientation, mirror, verticalAnchor: verticalAnchorProp } = this.props;
+    if (verticalAnchorProp) {
+      return verticalAnchorProp;
+    }
     let verticalAnchor = 'end';
 
     switch (orientation) {

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -43,6 +43,7 @@ export interface CartesianAxisProps {
   tickFormatter?: (value: any, index: number) => string;
   ticksGenerator?: (props?: CartesianAxisProps) => CartesianTickItem[];
   interval?: number | 'preserveStart' | 'preserveEnd' | 'preserveStartEnd' | 'equidistantPreserveStart';
+  angle?: number;
 }
 
 interface IState {

--- a/storybook/stories/API/cartesian/CartesianAxis.stories.tsx
+++ b/storybook/stories/API/cartesian/CartesianAxis.stories.tsx
@@ -77,6 +77,78 @@ export const TickPositioning = {
   },
 };
 
+export const TickAlignment = {
+  render: (args: Record<string, any>) => {
+    return (
+      <ResponsiveContainer width="100%" height={surfaceHeight}>
+        <Surface
+          width={surfaceWidth}
+          height={surfaceHeight}
+          viewBox={{
+            x: -50,
+            y: -50,
+            width: surfaceWidth + 50,
+            height: surfaceHeight + 50,
+          }}
+        >
+          <CartesianAxis
+            width={surfaceHeight}
+            height={surfaceWidth}
+            viewBox={{
+              x: 0,
+              y: 0,
+              width: surfaceWidth,
+              height: surfaceHeight,
+            }}
+            ticks={args.data}
+            angle={args.angle}
+            textAnchor={args.textAnchor}
+            verticalAnchor={args.verticalAnchor}
+          />
+          <CartesianAxis
+            width={surfaceHeight}
+            height={surfaceWidth}
+            viewBox={{
+              x: 0,
+              y: 0,
+              width: surfaceWidth,
+              height: surfaceHeight,
+            }}
+            ticks={args.data}
+            orientation="left"
+            angle={args.angle}
+            textAnchor={args.textAnchor}
+            verticalAnchor={args.verticalAnchor}
+          />
+        </Surface>
+      </ResponsiveContainer>
+    );
+  },
+
+  args: {
+    data: ticks,
+    angle: -42,
+    textAnchor: 'end',
+    verticalAnchor: 'end',
+  },
+  argTypes: {
+    textAnchor: {
+      options: ['start', 'middle', 'end'],
+      control: { type: 'radio' },
+    },
+  },
+  parameters: {
+    controls: { include: ['angle', 'textAnchor', 'verticalAnchor'] },
+    docs: {
+      description: {
+        story:
+          'The tick labels on a cartesian axis can be rotated around a set vertical and horizontal anchor. These can ' +
+          'be controlled through the `anchor`, `verticalAnchor` and `textAnchor` props.',
+      },
+    },
+  },
+};
+
 export const Combined = {
   render: (args: Record<string, any>) => {
     return (

--- a/storybook/stories/API/cartesian/Line.stories.tsx
+++ b/storybook/stories/API/cartesian/Line.stories.tsx
@@ -8,7 +8,6 @@ import { EventHandlers } from '../props/EventHandlers';
 import { Animation } from '../props/Animation';
 import { legendType } from '../props/Legend';
 
-
 const GeneralProps = {
   id: {
     description:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds the option to manually override the _verticalAnchor_ prop in order to be able to define the rotation anchor without using a custom tick component.

## Related Issue
https://github.com/recharts/recharts/issues/3469

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The _XAxis_ component has the _angle_ prop, which lets the user add a rotation to the tick labels. The horizontal anchor point for this rotation can be set through the _textAnchor_ prop, but the vertical anchor is calculated in _CartesianAxis_ internally.
```typescript
  getTickVerticalAnchor() {
    const { orientation, mirror } = this.props;
    let verticalAnchor = 'end';

    switch (orientation) {
      case 'left':
      case 'right':
        verticalAnchor = 'middle';
        break;
      case 'top':
        verticalAnchor = mirror ? 'start' : 'end';
        break;
      default:
        verticalAnchor = mirror ? 'end' : 'start';
        break;
    }

    return verticalAnchor;
  }
```
Thus for the X axis, the vertical anchor can only be `start` or `end` which can result in some visual discrepancies:
code | result
--|--
`<XAxis dataKey="name" angle={90} textAnchor="start" />` | <img width="245" alt="Screenshot 2023-03-21 at 11 20 03" src="https://user-images.githubusercontent.com/2715418/226577647-25ba236a-0edd-416a-ba60-e043880bef9d.png">

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
code | result
--|--
`<XAxis dataKey="name" angle={90} textAnchor="start" verticalAnchor="middle" />` |  <img width="262" alt="Screenshot 2023-03-21 at 11 22 27" src="https://user-images.githubusercontent.com/2715418/226578199-4021a39f-ceb2-4e8b-93fd-c8ba3031a46d.png">


https://user-images.githubusercontent.com/2715418/226579948-9270987d-6358-42db-95c8-cb23fed8f056.mov



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
