### PR TITLE
Add missing 'data' type to Area component

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -51,6 +51,7 @@ interface InternalAreaProps {
 interface AreaProps extends InternalAreaProps {
   className?: string;
   dataKey: DataKey<any>;
+  data?: any[];
   type?: CurveType;
   unit?: string | number;
   name?: string | number;


### PR DESCRIPTION
## Description

Simple fix of typescript in Area component. The same works for Line. It is also documented here fo Line: https://recharts.org/en-US/examples/LineChartHasMultiSeries as Multi Series chart. It works the same for Areas.

## Related Issue

https://github.com/recharts/recharts/issues/2487

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've tested it locally and see typescript does not complain.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
