### PR TITLE
fix: linechart storybook, add storybook types

### DIFF
--- a/storybook/stories/API/cartesian/Line.stories.tsx
+++ b/storybook/stories/API/cartesian/Line.stories.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
+import { Args, StoryObj } from '@storybook/react';
 import { Surface, Line, ResponsiveContainer, ComposedChart, Legend, Tooltip, XAxis, YAxis } from '../../../../src';
 import { coordinateData, pageData } from '../../data';
 import { EventHandlers } from '../props/EventHandlers';
@@ -9,17 +10,17 @@ import { AnimationProps } from '../props/AnimationProps';
 import { legendType } from '../props/Legend';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 
-const GeneralProps = {
+const GeneralProps: Args = {
   id: {
-    description:
-      'The unique id of this component, which will be used to generate unique clip path id internally. This props is suggested to be set in SSR.',
+    description: `The unique id of this component, which will be used to generate unique clip path id internally.
+      This props is suggested to be set in SSR.`,
     type: { name: 'string' },
     table: { category: 'General' },
   },
   name: {
     type: { name: 'string | number' },
-    description:
-      'The name of data. This option will be used in tooltip and legend to represent a line. If no value was set to this option, the value of dataKey will be used alternatively.',
+    description: `The name of data. This option will be used in tooltip and legend to represent a line.
+      If no value was set to this option, the value of dataKey will be used alternatively.`,
     table: { category: 'General' },
   },
   unit: {
@@ -37,18 +38,23 @@ const GeneralProps = {
     table: { type: { summary: 'string | number' }, category: 'General' },
   },
   dataKey: {
-    description:
-      'The key or getter of a group of data which should be unique in a LineChart. It could be an accessor function such as (row)=>value',
+    description: `The key or getter of a group of data which should be unique in a LineChart.
+      It could be an accessor function such as (row)=>value`,
     table: {
       type: { summary: 'string | number | function' },
       category: 'General',
     },
   },
 };
-const ResponsiveProps = {
+
+const ResponsiveProps: Args = {
   activeDot: {
-    description:
-      'The active dot is shown when a user enters a line chart and this chart has tooltip. If set to false, no active dot will be drawn. If set to true, active dot will be drawn with the props calculated internally. If passed an object, active dot will be drawn, and the internally calculated props will be merged with the key value pairs of the passed object. If passed a ReactElement, the option can be the custom active dot element. If passed a function, the function will be called to render a customized active dot.',
+    description: `The active dot is shown when a user enters a line chart and this chart has tooltip.
+      If set to false, no active dot will be drawn. If set to true, active dot will be drawn with the
+      props calculated internally. If passed an object, active dot will be drawn, and the internally
+      calculated props will be merged with the key value pairs of the passed object. If passed a ReactElement,
+      the option can be the custom active dot element. If passed a function, the function will be called to
+      render a customized active dot.`,
     table: {
       type: {
         summary: 'Boolean | Object | ReactElement | Function',
@@ -64,7 +70,8 @@ const ResponsiveProps = {
   },
   tooltipType: { table: { category: 'Responsive' }, control: { type: 'select' }, options: ['responsive', 'none'] },
 };
-const StyleProps = {
+
+const StyleProps: Args = {
   connectNulls: {
     description: 'Whether to connect a graph line across null points.',
     table: {
@@ -76,8 +83,10 @@ const StyleProps = {
     defaultValue: false,
   },
   dot: {
-    description:
-      'If false set, dots will not be drawn. If true set, dots will be drawn which have the props calculated internally. If object set, dots will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom dot element.If set a function, the function will be called to render customized dot.',
+    description: `If false set, dots will not be drawn. If true set, dots will be drawn which have the props
+      calculated internally. If object set, dots will be drawn which have the props mergered by the internal
+      calculated props and the option. If ReactElement set, the option can be the custom dot element.If set
+      a function, the function will be called to render customized dot.`,
     table: {
       type: {
         summary: 'Boolean | Object | ReactElement | Function',
@@ -102,8 +111,10 @@ const StyleProps = {
     table: { category: 'Style' },
   },
   label: {
-    description:
-      'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
+    description: `If false set, labels will not be drawn. If true set, labels will be drawn which have
+      the props calculated internally. If object set, labels will be drawn which have the props mergered
+      by the internal calculated props and the option. If ReactElement set, the option can be the custom
+      label element. If set a function, the function will be called to render customized label.`,
     table: {
       type: {
         summary: 'Boolean | Object | ReactElement | Function',
@@ -122,8 +133,8 @@ const StyleProps = {
     table: { category: 'Style' },
   },
   strokeDasharray: {
-    description:
-      'The pattern of dashes and gaps used to paint the line. https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray',
+    description: `The pattern of dashes and gaps used to paint the line.
+      https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray`,
     table: {
       type: {
         summary: 'string',
@@ -142,8 +153,8 @@ const StyleProps = {
     defaultValue: 1,
   },
   type: {
-    description:
-      "The interpolation type of line. It's the same as type in Area. And customized interpolation function can be set to type. https://github.com/d3/d3-shape#curves",
+    description: `The interpolation type of line. It's the same as type in Area.
+      And customized interpolation function can be set to type. https://github.com/d3/d3-shape#curves`,
     options: [
       'basis',
       'basisClosed',
@@ -210,7 +221,7 @@ export default {
   component: Line,
 };
 
-export const General = {
+export const General: StoryObj = {
   render: (args: Record<string, any>) => {
     return (
       <ResponsiveContainer width="100%" height={300}>
@@ -234,8 +245,7 @@ export const General = {
     );
   },
   args: {
-    ...
-    (GeneralProps),
+    ...getStoryArgsFromArgsTypesObject(GeneralProps),
   },
   parameters: {
     controls: { include: Object.keys(GeneralProps) },
@@ -247,7 +257,7 @@ export const General = {
   },
 };
 
-export const Style = {
+export const Style: StoryObj = {
   ...General,
   args: {
     ...getStoryArgsFromArgsTypesObject(StyleProps),
@@ -271,7 +281,7 @@ export const Style = {
   },
 };
 
-export const Responsive = {
+export const Responsive: StoryObj = {
   ...General,
   args: {
     ...getStoryArgsFromArgsTypesObject(ResponsiveProps),
@@ -293,7 +303,7 @@ export const Responsive = {
   },
 };
 
-export const Animation = {
+export const Animation: StoryObj = {
   ...General,
   args: {
     ...getStoryArgsFromArgsTypesObject(AnimationProps),
@@ -343,7 +353,7 @@ const renderLabel = (props: { index: number; x: number; y: number }) => {
   );
 };
 
-export const CustomizedLabel = {
+export const CustomizedLabel: StoryObj = {
   ...General,
   args: {
     isAnimationActive: false,
@@ -365,7 +375,7 @@ export const CustomizedLabel = {
   },
 };
 
-export const Points = {
+export const Points: StoryObj = {
   render: (args: Record<string, any>) => {
     const { points } = args;
 

--- a/storybook/stories/API/props/AnimationProps.ts
+++ b/storybook/stories/API/props/AnimationProps.ts
@@ -2,6 +2,7 @@
  * This file both exports the documentation of shared props separately, to be reused in places where only single props
  * are documented, as well as grouped in case a whole group is needed.
  */
+import { Args } from '@storybook/react';
 
 export const animateNewValues = { table: { category: 'Animation' } };
 export const animationBegin = {
@@ -29,9 +30,12 @@ export const isAnimationActive = {
   defaultValue: 'true in CSR, and false in SSR',
 };
 
-// Caveat: If any prop is added here, it would falsely be add to the documentation of the component where this group is used.
-// If the group is to be extended, then only single props should be imported by each component that does not use all of them.
-export const AnimationProps = {
+/**
+ * Caveat: If any prop is added here, it would falsely be add to the documentation of the component where this group
+ * is used. If the group is to be extended, then only single props should be imported by each component that does not
+ * use all of them.
+ * */
+export const AnimationProps: Args = {
   animateNewValues,
   animationBegin,
   animationEasing,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- fix accidental merge conflict issue 
-  add types to storybook args/stories
- fix linter issues with `max-len`

We should do this (add types) for all  SB components

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Line story currently failing to run

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- ran locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
