### PR TITLE
Revert "Refactored: added default values in params for ReferenceAreaand ReferenceLine since default props is deprecated 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -51,15 +51,7 @@
     "import/no-extraneous-dependencies": [
       "error",
       {
-        "devDependencies": [
-          "demo/**",
-          "test/**",
-          "test-jest/**",
-          "*.config.js",
-          "scripts/**",
-          "**/Spec.js",
-          "storybook/**"
-        ]
+        "devDependencies": true
       }
     ],
     "max-len": ["warn", 120],

--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -67,32 +67,7 @@ const getRect = (hasX1: boolean, hasX2: boolean, hasY1: boolean, hasY2: boolean,
   return rectWithPoints(p1, p2);
 };
 
-export function ReferenceArea({
-  isFront = false,
-  ifOverflow = 'discard',
-  xAxisId = 0,
-  yAxisId = 0,
-  r = 10,
-  fill = '#ccc',
-  fillOpacity = 0.5,
-  stroke = 'none',
-  strokeWidth = 1,
-  ...restProps
-}: Props) {
-  // Props with default values added.
-  const props: Props = {
-    isFront,
-    ifOverflow,
-    xAxisId,
-    yAxisId,
-    r,
-    fill,
-    fillOpacity,
-    stroke,
-    strokeWidth,
-    ...restProps,
-  };
-
+export function ReferenceArea(props: Props) {
   const { x1, x2, y1, y2, className, alwaysShow, clipPathId } = props;
 
   warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
@@ -125,6 +100,17 @@ export function ReferenceArea({
 }
 
 ReferenceArea.displayName = 'ReferenceArea';
+ReferenceArea.defaultProps = {
+  isFront: false,
+  ifOverflow: 'discard',
+  xAxisId: 0,
+  yAxisId: 0,
+  r: 10,
+  fill: '#ccc',
+  fillOpacity: 0.5,
+  stroke: 'none',
+  strokeWidth: 1,
+};
 
 ReferenceArea.renderRect = (option: ReferenceAreaProps['shape'], props: any) => {
   let rect;

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -117,32 +117,7 @@ const getEndPoints = (scales: any, isFixedX: boolean, isFixedY: boolean, isSegme
   return null;
 };
 
-export function ReferenceLine({
-  isFront = false,
-  ifOverflow = 'discard',
-  xAxisId = 0,
-  yAxisId = 0,
-  position = 'middle',
-  fill = 'none',
-  fillOpacity = 1,
-  stroke = '#ccc',
-  strokeWidth = 1,
-  ...restProps
-}: Props) {
-  // Props with default values added.
-  const props: Props = {
-    isFront,
-    ifOverflow,
-    xAxisId,
-    yAxisId,
-    fill,
-    stroke,
-    fillOpacity,
-    strokeWidth,
-    position,
-    ...restProps,
-  };
-
+export function ReferenceLine(props: Props) {
   const { x: fixedX, y: fixedY, segment, xAxis, yAxis, shape, className, alwaysShow, clipPathId } = props;
 
   warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
@@ -180,3 +155,14 @@ export function ReferenceLine({
 }
 
 ReferenceLine.displayName = 'ReferenceLine';
+ReferenceLine.defaultProps = {
+  isFront: false,
+  ifOverflow: 'discard',
+  xAxisId: 0,
+  yAxisId: 0,
+  fill: 'none',
+  stroke: '#ccc',
+  fillOpacity: 1,
+  strokeWidth: 1,
+  position: 'middle',
+};

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1923,8 +1923,8 @@ export const generateCategoricalChart = ({
 
       return cloneElement(element, {
         key: element.key || `${displayName}-${index}`,
-        xAxis: xAxisMap[xAxisId ?? 0],
-        yAxis: yAxisMap[yAxisId ?? 0],
+        xAxis: xAxisMap[xAxisId],
+        yAxis: yAxisMap[yAxisId],
         viewBox: {
           x: offset.left,
           y: offset.top,

--- a/storybook/stories/API/cartesian/Line.stories.tsx
+++ b/storybook/stories/API/cartesian/Line.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';

--- a/storybook/stories/API/cartesian/ReferenceArea.stories.tsx
+++ b/storybook/stories/API/cartesian/ReferenceArea.stories.tsx
@@ -1,3 +1,5 @@
+import { expect } from '@storybook/jest';
+import { within } from '@storybook/testing-library';
 import React from 'react';
 import { Line, LineChart, ReferenceArea, CartesianGrid, XAxis, YAxis, ResponsiveContainer } from '../../../../src';
 import { pageData } from '../../data';
@@ -50,6 +52,17 @@ export const IfOverflow = {
     data: pageData,
     y1: 1890,
     y2: -1000,
+    ifOverflow: 'extendDomain',
   },
   parameters: { controls: { include: ['ifOverflow'] } },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const { findByText } = within(canvasElement);
+    /**
+     * assert that when ifOverflow="extendDomain" 1900 becomes the new domain y-max.
+     * this test will fail when the user changes the ifOverflow arg, but it will give us confidence
+     * that 'extendDomain' behavior remains the same.
+     */
+    expect(await findByText('1900')).toBeInTheDocument();
+    expect(await findByText('-950')).toBeInTheDocument();
+  },
 };


### PR DESCRIPTION
…(#3283)"

This reverts commit ea138056765d5a0b50ed652d9b49f3355a236e3b.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

See comment here https://github.com/recharts/recharts/issues/3438#issuecomment-1467419256

Basically recharts breaks down without defaultProps because it references props set by defaultProps _outside_ of said component (antipattern alert 🚫) before the components are initialized/invoked. Default parameters do not get set until the component is run - before that function components only have reference to the props sent by the user.

This will be a huge undertaking to fix. For now revert the change.

Two other small changes with this revert:
* fixed annoying eslint issue
* added storybook test 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/3438

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
bug introduced in 2.4.x

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* existing tests pass
* run on storybook
   * settings are now set correctly
   * add storybook test

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25180830/224912521-7a73da23-87ec-434a-9236-f8a739705b90.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
