### PR TITLE
Storybook API: Add a docs page to the Area component and reusing prop types and descriptions from the Line

### DIFF
--- a/storybook/stories/API/cartesian/Area.mdx
+++ b/storybook/stories/API/cartesian/Area.mdx
@@ -1,0 +1,19 @@
+import { ArgTypes  } from '@storybook/blocks';
+import  * as AreaStories from './Area.stories';
+
+# Area
+
+## Parent Component
+The Line can be used within a `<ComposedChart/>` or a `<AreaChart/>`.
+
+## Child component
+The Line can be used with the following child components: `<LabelList/>`
+
+## Properties
+Properties in the groups Other and Internal are not recommended to be used.
+
+<ArgTypes of={AreaStories} sort={'requiredFirst'}/>
+
+
+
+

--- a/storybook/stories/API/cartesian/Area.mdx
+++ b/storybook/stories/API/cartesian/Area.mdx
@@ -4,7 +4,7 @@ import  * as AreaStories from './Area.stories';
 # Area
 
 ## Parent Component
-The Line can be used within a `<ComposedChart/>` or a `<AreaChart/>`.
+The Area can be used within a `<ComposedChart/>` or a `<AreaChart/>`.
 
 ## Child component
 The Area can be used with the following child components: `<LabelList/>`

--- a/storybook/stories/API/cartesian/Area.mdx
+++ b/storybook/stories/API/cartesian/Area.mdx
@@ -13,7 +13,3 @@ The Line can be used with the following child components: `<LabelList/>`
 Properties in the groups Other and Internal are not recommended to be used.
 
 <ArgTypes of={AreaStories} sort={'requiredFirst'}/>
-
-
-
-

--- a/storybook/stories/API/cartesian/Area.mdx
+++ b/storybook/stories/API/cartesian/Area.mdx
@@ -7,7 +7,7 @@ import  * as AreaStories from './Area.stories';
 The Line can be used within a `<ComposedChart/>` or a `<AreaChart/>`.
 
 ## Child component
-The Line can be used with the following child components: `<LabelList/>`
+The Area can be used with the following child components: `<LabelList/>`
 
 ## Properties
 Properties in the groups Other and Internal are not recommended to be used.

--- a/storybook/stories/API/cartesian/Area.stories.tsx
+++ b/storybook/stories/API/cartesian/Area.stories.tsx
@@ -98,7 +98,7 @@ export const General: StoryObj = {
     controls: { include: Object.keys(GeneralProps) },
     docs: {
       description: {
-        story: 'The dataKey defines the y-Values of a Line. Without an xAxis, the index is used for x.',
+        story: 'The dataKey defines the y-Values of a Area. Without an xAxis, the index is used for x.',
       },
     },
   },

--- a/storybook/stories/API/cartesian/Area.stories.tsx
+++ b/storybook/stories/API/cartesian/Area.stories.tsx
@@ -1,53 +1,132 @@
 import React from 'react';
-import { ComposedChart, Area, ResponsiveContainer, Surface } from '../../../../src';
-import { coordinateWithValueData } from '../../data';
+import { StoryObj } from '@storybook/react';
+import { ComposedChart, Area, ResponsiveContainer, Surface, Legend, Tooltip, XAxis, YAxis } from '../../../../src';
+import { coordinateData, coordinateWithValueData, pageData } from '../../data';
+import { LineStyle } from '../props/LineStyle';
+import { AnimationProps } from '../props/AnimationProps';
+import { legendType } from '../props/Legend';
+import { General as GeneralProps, Internal } from '../props/CartesianComponentShared';
+import { ResponsiveProps } from '../props/Responsive';
+import { getStoryArgsFromArgsTypesObject } from '../props/utils';
+
+const AreaSpecificProps = {
+  // These two props are not documented on the website. Further investigation is required to document them.
+  baseValue: { table: { category: 'Other' } },
+  isRange: { table: { category: 'Other' } },
+  stackId: {
+    description: `The id of group which this area should be stacked into. If no id is specified, the area will not be stacked.
+       When two components have the same value axis and same stackId, then they are stacked in order.`,
+    table: {
+      type: {
+        summary: 'string | number',
+      },
+      category: 'General',
+    },
+  },
+};
 
 export default {
-  tags: ['autodocs'],
   component: Area,
   argTypes: {
-    connectNulls: {
-      control: {
-        type: 'boolean',
-      },
-    },
-    stroke: {
-      control: { type: 'color' },
-    },
-    fill: {
-      control: { type: 'color' },
-    },
-    type: {
-      // TODO: These options should be generated from the type directly instead of duplicating the type information here. Will iterate.
-      options: [
-        'basis',
-        'basisClosed',
-        'basisOpen',
-        'linear',
-        'linearClosed',
-        'natural',
-        'monotoneX',
-        'monotoneY',
-        'monotone',
-        'step',
-        'stepBefore',
-        'stepAfter',
-      ],
-      control: {
-        type: 'select',
-      },
-    },
-    animationEasing: {
-      // TODO: These options should be generated from the animationEasing directly instead of duplicating the animationEasing information here. Will iterate.
-      options: ['ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear'],
-      control: {
-        type: 'select',
+    ...AreaSpecificProps,
+    ...LineStyle,
+    ...AnimationProps,
+    legendType,
+    ...GeneralProps,
+    ...Internal,
+    ...ResponsiveProps,
+    // Other
+    baseLine: { table: { category: 'Other' } },
+    left: { table: { category: 'Other' } },
+    top: { table: { category: 'Other' } },
+    xAxis: { table: { category: 'Other' } },
+    yAxis: { table: { category: 'Other' } },
+  },
+};
+
+const [surfaceWidth, surfaceHeight] = [600, 300];
+
+export const AllProps = {
+  render: (args: Record<string, any>) => {
+    return (
+      <ResponsiveContainer width="100%" height={surfaceHeight}>
+        <ComposedChart
+          width={surfaceWidth}
+          height={surfaceHeight}
+          margin={{
+            top: 20,
+            right: 20,
+            bottom: 20,
+            left: 20,
+          }}
+          data={pageData}
+        >
+          <Area dataKey="uv" isAnimationActive={false} {...args} />
+        </ComposedChart>
+      </ResponsiveContainer>
+    );
+  },
+};
+
+export const General: StoryObj = {
+  render: (args: Record<string, any>) => {
+    return (
+      <ResponsiveContainer width="100%" height={300}>
+        <ComposedChart
+          margin={{
+            top: 20,
+            right: 20,
+            bottom: 20,
+            left: 20,
+          }}
+          data={pageData}
+        >
+          <Area isAnimationActive={false} dataKey="uv" {...args} />
+          {/* All further components are added to show the interaction with the Area properties */}
+          <Legend />
+          <Tooltip />
+          <XAxis dataKey="name" />
+          <YAxis />
+        </ComposedChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(GeneralProps),
+  },
+  parameters: {
+    controls: { include: Object.keys(GeneralProps) },
+    docs: {
+      description: {
+        story: 'The dataKey defines the y-Values of a Line. Without an xAxis, the index is used for x.',
       },
     },
   },
 };
 
-const [surfaceWidth, surfaceHeight] = [600, 300];
+export const Style: StoryObj = {
+  ...General,
+  args: {
+    ...getStoryArgsFromArgsTypesObject(LineStyle),
+    type: 'linear',
+    connectNulls: true,
+    stroke: 'red',
+    fill: 'teal',
+    strokeDasharray: '4 1',
+    label: { fill: 'red', fontSize: 20 },
+    dot: { stroke: 'green', strokeWidth: 2 },
+  },
+  parameters: {
+    controls: { include: Object.keys(LineStyle) },
+    docs: {
+      description: {
+        story:
+          'The Area is generated from the data by connecting the dots. ' +
+          'The type and connectNulls define how the dots are used.',
+      },
+    },
+  },
+};
 
 const Basic = {
   render: (args: Record<string, any>) => {
@@ -79,37 +158,42 @@ const Basic = {
   parameters: { controls: { include: ['data'] } },
 };
 
-export const Simple = {
-  ...Basic,
-  parameters: { controls: { include: ['data', 'dataKey'] } },
-  docs: {
-    description: {
-      story: 'The dataKey defines the y-Values of a Line. Without an xAxis, the index is used for x.',
+export const Responsive: StoryObj = {
+  ...General,
+  args: {
+    ...getStoryArgsFromArgsTypesObject(ResponsiveProps),
+    activeDot: { stroke: 'green', strokeWidth: 2 },
+    tooltipType: 'responsive',
+  },
+  parameters: {
+    controls: {
+      include: Object.keys(ResponsiveProps),
+      tooltipType: { type: 'select', options: ['responsive', 'none'] },
+    },
+    docs: {
+      description: {
+        story: '', // TODO
+      },
     },
   },
 };
 
-export const Style = {
-  ...Basic,
+export const Animation: StoryObj = {
+  ...General,
   args: {
-    data: coordinateWithValueData,
-    stroke: 'red',
-    fill: 'teal',
-    type: 'linear',
-    baseline: 200,
-    connectNulls: false,
-    strokeWidth: 2,
+    ...getStoryArgsFromArgsTypesObject(AnimationProps),
     isAnimationActive: true,
   },
   parameters: {
-    controls: { include: ['stroke', 'fill', 'type', 'baseline', 'connectNulls', 'strokeWidth', 'isAnimationActive'] },
+    controls: { include: Object.keys(AnimationProps) },
+    docs: {
+      description: { story: 'Reloading the story triggers the animation.' },
+    },
   },
 };
 
 export const Stacked = {
   render: (args: Record<string, any>) => {
-    const { data, dataKey1, dataKey2, areaColor1, areaColor2, ...areaArgs } = args;
-
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
         <ComposedChart
@@ -121,34 +205,20 @@ export const Stacked = {
             bottom: 20,
             left: 20,
           }}
-          data={data}
+          data={pageData}
         >
-          <Area stackId="pv-uv" dataKey={dataKey1} stroke={areaColor1} fill={areaColor1} {...areaArgs} />
-          <Area stackId="pv-uv" dataKey={dataKey2} stroke={areaColor2} fill={areaColor2} {...areaArgs} />
+          <Area fill="red" isAnimationActive={false} stackId={args.stackId1} dataKey="uv" />
+          <Area fill="green" isAnimationActive={false} stackId={args.stackId2} dataKey="pv" />
         </ComposedChart>
       </ResponsiveContainer>
     );
   },
   args: {
-    data: coordinateWithValueData,
-    dataKey1: 'x',
-    dataKey2: 'y',
-    areaColor1: 'lightblue',
-    areaColor2: 'lightgreen',
-    isAnimationActive: false,
-  },
-  argTypes: {
-    areaColor1: {
-      control: { type: 'color' },
-    },
-    areaColor2: {
-      control: { type: 'color' },
-    },
+    stackId1: '1',
+    stackId2: '1',
   },
   parameters: {
-    controls: {
-      include: ['data', 'dataKey1', 'dataKey2', 'areaColor1', 'areaColor2'],
-    },
+    controls: { include: ['stackId1', 'stackId2'] },
   },
 };
 
@@ -251,20 +321,6 @@ export const FillGradient = {
   },
 };
 
-export const Animation = {
-  ...Basic,
-  args: {
-    data: coordinateWithValueData,
-    isAnimationActive: true,
-    animationEasing: 'linear',
-    animationBegin: 0,
-    animationDuration: 1500,
-  },
-  parameters: {
-    controls: { include: ['animationEasing', 'isAnimationActive', 'animationBegin', 'animationDuration'] },
-  },
-};
-
 export const Points = {
   render: (args: Record<string, any>) => {
     const { points } = args;
@@ -281,13 +337,13 @@ export const Points = {
             height: surfaceHeight,
           }}
         >
-          <Area dataKey="" isAnimationActive={false} points={points} />
+          <Area dataKey={undefined} isAnimationActive={false} points={points} />
         </Surface>
       </ResponsiveContainer>
     );
   },
   args: {
-    points: coordinateWithValueData,
+    points: coordinateData,
   },
   parameters: {
     controls: { include: ['points'] },

--- a/storybook/stories/API/cartesian/Line.mdx
+++ b/storybook/stories/API/cartesian/Line.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Meta, ArgTypes  } from '@storybook/blocks';
+import { ArgTypes  } from '@storybook/blocks';
 import * as LineStories from './Line.stories';
 
 # Line

--- a/storybook/stories/API/cartesian/Line.stories.tsx
+++ b/storybook/stories/API/cartesian/Line.stories.tsx
@@ -1,182 +1,16 @@
 import React from 'react';
 import { within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
-import { Args, StoryObj } from '@storybook/react';
+import { StoryObj } from '@storybook/react';
 import { Surface, Line, ResponsiveContainer, ComposedChart, Legend, Tooltip, XAxis, YAxis } from '../../../../src';
 import { coordinateData, pageData } from '../../data';
 import { EventHandlers } from '../props/EventHandlers';
 import { AnimationProps } from '../props/AnimationProps';
 import { legendType } from '../props/Legend';
+import { LineStyle } from '../props/LineStyle';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
-
-const GeneralProps: Args = {
-  id: {
-    description: `The unique id of this component, which will be used to generate unique clip path id internally.
-      This props is suggested to be set in SSR.`,
-    type: { name: 'string' },
-    table: { category: 'General' },
-  },
-  name: {
-    type: { name: 'string | number' },
-    description: `The name of data. This option will be used in tooltip and legend to represent a line.
-      If no value was set to this option, the value of dataKey will be used alternatively.`,
-    table: { category: 'General' },
-  },
-  unit: {
-    type: { name: 'string | number' },
-    table: {
-      category: 'General',
-    },
-  },
-  xAxisId: {
-    description: 'The id of x-axis which is corresponding to the data.',
-    table: { type: { summary: 'string | number' }, category: 'General' },
-  },
-  yAxisId: {
-    description: 'The id of y-axis which is corresponding to the data.',
-    table: { type: { summary: 'string | number' }, category: 'General' },
-  },
-  dataKey: {
-    description: `The key or getter of a group of data which should be unique in a LineChart.
-      It could be an accessor function such as (row)=>value`,
-    table: {
-      type: { summary: 'string | number | function' },
-      category: 'General',
-    },
-  },
-};
-
-const ResponsiveProps: Args = {
-  activeDot: {
-    description: `The active dot is shown when a user enters a line chart and this chart has tooltip.
-      If set to false, no active dot will be drawn. If set to true, active dot will be drawn with the
-      props calculated internally. If passed an object, active dot will be drawn, and the internally
-      calculated props will be merged with the key value pairs of the passed object. If passed a ReactElement,
-      the option can be the custom active dot element. If passed a function, the function will be called to
-      render a customized active dot.`,
-    table: {
-      type: {
-        summary: 'Boolean | Object | ReactElement | Function',
-        detail:
-          '<Line dataKey="value" activeDot={false} />\n' +
-          '<Line dataKey="value" activeDot={{ stroke: \'red\', strokeWidth: 2 }} />\n' +
-          '<Line dataKey="value" activeDot={<CustomizedDot />} />\n' +
-          '<Line dataKey="value" activeDot={renderDot} />',
-      },
-      defaultValue: true,
-      category: 'Responsive',
-    },
-  },
-  tooltipType: { table: { category: 'Responsive' }, control: { type: 'select' }, options: ['responsive', 'none'] },
-};
-
-const StyleProps: Args = {
-  connectNulls: {
-    description: 'Whether to connect a graph line across null points.',
-    table: {
-      type: {
-        summary: 'boolean',
-      },
-      category: 'Style',
-    },
-    defaultValue: false,
-  },
-  dot: {
-    description: `If false set, dots will not be drawn. If true set, dots will be drawn which have the props
-      calculated internally. If object set, dots will be drawn which have the props mergered by the internal
-      calculated props and the option. If ReactElement set, the option can be the custom dot element.If set
-      a function, the function will be called to render customized dot.`,
-    table: {
-      type: {
-        summary: 'Boolean | Object | ReactElement | Function',
-        detail:
-          '<Line dataKey="value" dot={false} />\n' +
-          '<Line dataKey="value" dot={{ stroke: \'red\', strokeWidth: 2 }} />\n' +
-          '<Line dataKey="value" dot={<CustomizedDot />} />\n' +
-          '<Line dataKey="value" dot={renderDot} />',
-      },
-      category: 'Style',
-      defaultValue: true,
-    },
-  },
-  fill: {
-    control: { type: 'color' },
-    table: { category: 'Style' },
-  },
-  hide: {
-    description: 'Hides the line when true, useful when toggling visibility state via legend',
-    type: { name: 'boolean' },
-    defaultValue: false,
-    table: { category: 'Style' },
-  },
-  label: {
-    description: `If false set, labels will not be drawn. If true set, labels will be drawn which have
-      the props calculated internally. If object set, labels will be drawn which have the props mergered
-      by the internal calculated props and the option. If ReactElement set, the option can be the custom
-      label element. If set a function, the function will be called to render customized label.`,
-    table: {
-      type: {
-        summary: 'Boolean | Object | ReactElement | Function',
-        detail:
-          '<Line dataKey="value" label />\n' +
-          '<Line dataKey="value" label={{ fill: \'red\', fontSize: 20 }} />\n' +
-          '<Line dataKey="value" label={<CustomizedLabel />} />\n' +
-          '<Line dataKey="value" label={renderLabel} />',
-      },
-      defaultValue: false,
-      category: 'Style',
-    },
-  },
-  stroke: {
-    control: { type: 'color' },
-    table: { category: 'Style' },
-  },
-  strokeDasharray: {
-    description: `The pattern of dashes and gaps used to paint the line.
-      https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray`,
-    table: {
-      type: {
-        summary: 'string',
-      },
-      category: 'Style',
-    },
-  },
-  strokeWidth: {
-    description: 'The width of the stroke.',
-    table: {
-      type: {
-        summary: 'String | Number',
-      },
-      category: 'Style',
-    },
-    defaultValue: 1,
-  },
-  type: {
-    description: `The interpolation type of line. It's the same as type in Area.
-      And customized interpolation function can be set to type. https://github.com/d3/d3-shape#curves`,
-    options: [
-      'basis',
-      'basisClosed',
-      'basisOpen',
-      'linear',
-      'linearClosed',
-      'natural',
-      'monotoneX',
-      'monotoneY',
-      'monotone',
-      'step',
-      'stepBefore',
-      'stepAfter',
-    ],
-    default: 'linear',
-    control: {
-      type: 'select',
-    },
-    table: {
-      category: 'Style',
-    },
-  },
-};
+import { General as GeneralProps, Internal } from '../props/CartesianComponentShared';
+import { ResponsiveProps } from '../props/Responsive';
 
 export default {
   argTypes: {
@@ -184,8 +18,9 @@ export default {
     ...AnimationProps,
     legendType,
     ...GeneralProps,
+    ...Internal,
     ...ResponsiveProps,
-    ...StyleProps,
+    ...LineStyle,
     // Deprecated
     dangerouslySetInnerHTML: { table: { category: 'Deprecated' }, hide: true, disable: true },
     // Other
@@ -194,30 +29,28 @@ export default {
     top: { table: { category: 'Other' } },
     xAxis: { table: { category: 'Other' } },
     yAxis: { table: { category: 'Other' } },
-    // Internal
-    points: {
-      description:
-        'The coordinates of points in the line, usually calculated internally. In most cases this should not be used.',
-      table: {
-        type: {
-          summary: 'array',
-          detail: '[{x: 12, y: 12, value: 240}]',
-        },
-        category: 'Internal',
-      },
-    },
-    data: { table: { category: 'Internal' } },
-    layout: {
-      description: 'The layout of line, usually inherited from parent.',
-      table: {
-        type: {
-          summary: 'horizontal | vertical',
-        },
-        category: 'Internal',
-      },
-    },
   },
   component: Line,
+};
+
+export const AllProps = {
+  render: (args: Record<string, any>) => {
+    return (
+      <ResponsiveContainer width="100%" height={300}>
+        <ComposedChart
+          margin={{
+            top: 20,
+            right: 20,
+            bottom: 20,
+            left: 20,
+          }}
+          data={pageData}
+        >
+          <Line isAnimationActive={false} dataKey="uv" {...args} />
+        </ComposedChart>
+      </ResponsiveContainer>
+    );
+  },
 };
 
 export const General: StoryObj = {
@@ -259,7 +92,7 @@ export const General: StoryObj = {
 export const Style: StoryObj = {
   ...General,
   args: {
-    ...getStoryArgsFromArgsTypesObject(StyleProps),
+    ...getStoryArgsFromArgsTypesObject(LineStyle),
     type: 'linear',
     connectNulls: true,
     stroke: 'red',
@@ -269,7 +102,7 @@ export const Style: StoryObj = {
     dot: { stroke: 'green', strokeWidth: 2 },
   },
   parameters: {
-    controls: { include: Object.keys(StyleProps) },
+    controls: { include: Object.keys(LineStyle) },
     docs: {
       description: {
         story:
@@ -294,9 +127,7 @@ export const Responsive: StoryObj = {
     },
     docs: {
       description: {
-        story:
-          'The line is generated from the data by connecting the dots. ' +
-          'The type and connectNulls define how the dots are used.',
+        story: '', // TODO
       },
     },
   },

--- a/storybook/stories/API/props/CartesianComponentShared.ts
+++ b/storybook/stories/API/props/CartesianComponentShared.ts
@@ -1,0 +1,62 @@
+import { Args } from '@storybook/react';
+
+export const General: Args = {
+  id: {
+    description: `The unique id of this component, which will be used to generate unique clip path id internally.
+      This props is suggested to be set in SSR.`,
+    type: { name: 'string' },
+    table: { category: 'General' },
+  },
+  name: {
+    type: { name: 'string | number' },
+    description: `The name of data. This option will be used in tooltip and legend to represent a line.
+      If no value was set to this option, the value of dataKey will be used alternatively.`,
+    table: { category: 'General' },
+  },
+  unit: {
+    type: { name: 'string | number' },
+    table: {
+      category: 'General',
+    },
+  },
+  xAxisId: {
+    description: 'The id of x-axis which is corresponding to the data.',
+    table: { type: { summary: 'string | number' }, category: 'General' },
+  },
+  yAxisId: {
+    description: 'The id of y-axis which is corresponding to the data.',
+    table: { type: { summary: 'string | number' }, category: 'General' },
+  },
+  dataKey: {
+    description: `The key or getter of a group of data which should be unique in a LineChart.
+      It could be an accessor function such as (row)=>value`,
+    table: {
+      type: { summary: 'string | number | function' },
+      category: 'General',
+    },
+  },
+};
+
+export const Internal = {
+  points: {
+    description:
+      'The coordinates of points in the line, usually calculated internally. In most cases this should not be used.',
+    table: {
+      type: {
+        summary: 'array',
+        detail: '[{x: 12, y: 12, value: 240}]',
+      },
+      category: 'Internal',
+    },
+  },
+  data: { table: { category: 'Internal' } },
+  layout: {
+    description: 'The layout of line, usually inherited from parent.',
+    table: {
+      type: {
+        summary: 'horizontal | vertical',
+      },
+      category: 'Internal',
+    },
+  },
+};

--- a/storybook/stories/API/props/LineStyle.ts
+++ b/storybook/stories/API/props/LineStyle.ts
@@ -1,0 +1,111 @@
+// The Line props are shared between multiple components, such as the Line and the Area.
+
+import { Args } from '@storybook/react';
+
+export const LineStyle: Args = {
+  connectNulls: {
+    description: 'Whether to connect a graph line across null points.',
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      category: 'Style',
+    },
+    defaultValue: false,
+  },
+  dot: {
+    description: `If false set, dots will not be drawn. If true set, dots will be drawn which have the props
+      calculated internally. If object set, dots will be drawn which have the props mergered by the internal
+      calculated props and the option. If ReactElement set, the option can be the custom dot element.If set
+      a function, the function will be called to render customized dot.`,
+    table: {
+      type: {
+        summary: 'Boolean | Object | ReactElement | Function',
+        detail:
+          '<Line dataKey="value" dot={false} />\n' +
+          '<Line dataKey="value" dot={{ stroke: \'red\', strokeWidth: 2 }} />\n' +
+          '<Line dataKey="value" dot={<CustomizedDot />} />\n' +
+          '<Line dataKey="value" dot={renderDot} />',
+      },
+      category: 'Style',
+      defaultValue: true,
+    },
+  },
+  fill: {
+    control: { type: 'color' },
+    table: { category: 'Style' },
+  },
+  hide: {
+    description: 'Hides the line when true, useful when toggling visibility state via legend',
+    type: { name: 'boolean' },
+    defaultValue: false,
+    table: { category: 'Style' },
+  },
+  label: {
+    description: `If false set, labels will not be drawn. If true set, labels will be drawn which have
+      the props calculated internally. If object set, labels will be drawn which have the props mergered
+      by the internal calculated props and the option. If ReactElement set, the option can be the custom
+      label element. If set a function, the function will be called to render customized label.`,
+    table: {
+      type: {
+        summary: 'Boolean | Object | ReactElement | Function',
+        detail:
+          '<Line dataKey="value" label />\n' +
+          '<Line dataKey="value" label={{ fill: \'red\', fontSize: 20 }} />\n' +
+          '<Line dataKey="value" label={<CustomizedLabel />} />\n' +
+          '<Line dataKey="value" label={renderLabel} />',
+      },
+      defaultValue: false,
+      category: 'Style',
+    },
+  },
+  stroke: {
+    control: { type: 'color' },
+    table: { category: 'Style' },
+  },
+  strokeDasharray: {
+    description: `The pattern of dashes and gaps used to paint the line.
+      https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray`,
+    table: {
+      type: {
+        summary: 'string',
+      },
+      category: 'Style',
+    },
+  },
+  strokeWidth: {
+    description: 'The width of the stroke.',
+    table: {
+      type: {
+        summary: 'String | Number',
+      },
+      category: 'Style',
+    },
+    defaultValue: 1,
+  },
+  type: {
+    description: `The interpolation type of line. It's the same as type in Area.
+      And customized interpolation function can be set to type. https://github.com/d3/d3-shape#curves`,
+    options: [
+      'basis',
+      'basisClosed',
+      'basisOpen',
+      'linear',
+      'linearClosed',
+      'natural',
+      'monotoneX',
+      'monotoneY',
+      'monotone',
+      'step',
+      'stepBefore',
+      'stepAfter',
+    ],
+    default: 'linear',
+    control: {
+      type: 'select',
+    },
+    table: {
+      category: 'Style',
+    },
+  },
+};

--- a/storybook/stories/API/props/Responsive.ts
+++ b/storybook/stories/API/props/Responsive.ts
@@ -1,0 +1,25 @@
+import { Args } from '@storybook/react';
+
+export const ResponsiveProps: Args = {
+  activeDot: {
+    description: `The active dot is shown when a user enters a line chart and this chart has tooltip.
+      If set to false, no active dot will be drawn. If set to true, active dot will be drawn with the
+      props calculated internally. If passed an object, active dot will be drawn, and the internally
+      calculated props will be merged with the key value pairs of the passed object. If passed a ReactElement,
+      the option can be the custom active dot element. If passed a function, the function will be called to
+      render a customized active dot.`,
+    table: {
+      type: {
+        summary: 'Boolean | Object | ReactElement | Function',
+        detail:
+          '<Line dataKey="value" activeDot={false} />\n' +
+          '<Line dataKey="value" activeDot={{ stroke: \'red\', strokeWidth: 2 }} />\n' +
+          '<Line dataKey="value" activeDot={<CustomizedDot />} />\n' +
+          '<Line dataKey="value" activeDot={renderDot} />',
+      },
+      defaultValue: true,
+      category: 'Responsive',
+    },
+  },
+  tooltipType: { table: { category: 'Responsive' }, control: { type: 'select' }, options: ['responsive', 'none'] },
+};


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add the missing doc page with ArgsTable to the Area component. 
Structure stories in alignment with the Line component. 
Reuse prop types and stories as much as possible, creating a unified experience. 

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/recharts/recharts/issues/3422
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
