### PR TITLE
fix(storybook): use correct xAxis type in d3 time series story

### DIFF
--- a/storybook/stories/Examples/TimeSeries.stories.tsx
+++ b/storybook/stories/Examples/TimeSeries.stories.tsx
@@ -5,14 +5,19 @@ import { scaleTime } from 'd3-scale';
 import { timeFormat } from 'd3-time-format';
 import { timeDay, timeHour, timeMinute, timeMonth, timeSecond, timeWeek, timeYear } from 'd3-time';
 import { timeData } from '../data';
-import { ComposedChart, Line, ResponsiveContainer, XAxis } from '../../../src';
+import { ComposedChart, Line, ResponsiveContainer, XAxis, Tooltip } from '../../../src';
+import { Props as XAxisProps } from '../../../src/cartesian/XAxis';
 
 export default {
   component: XAxis,
 };
 
+interface Args {
+  data: { x: Date; y: number }[];
+}
+
 const StoryTemplate = {
-  render: (args: Record<string, any>) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <ComposedChart
@@ -82,7 +87,7 @@ function multiFormat(date: Date) {
 
 export const WithD3Scale = {
   ...StoryTemplate,
-  render: args => {
+  render: (args: Args) => {
     const timeValues = args.data.map(row => row.x);
     // The d3 scaleTime domain requires numeric values
     const numericValues = timeValues.map(time => time.valueOf());
@@ -91,11 +96,11 @@ export const WithD3Scale = {
       .domain([Math.min(...numericValues), Math.max(...numericValues)])
       .nice();
 
-    const xAxisArgs = {
+    const xAxisArgs: XAxisProps = {
       domain: timeScale.domain().map(date => date.valueOf()),
       scale: timeScale,
-      xAxisType: 'number' as const,
-      ticks: timeScale.ticks(5) as any,
+      type: 'number',
+      ticks: timeScale.ticks(5).map(date => date.valueOf()),
       tickFormatter: multiFormat,
     };
 
@@ -112,6 +117,7 @@ export const WithD3Scale = {
         >
           <XAxis dataKey="x" {...args} {...xAxisArgs} />
           <Line dataKey="y" />
+          <Tooltip />
         </ComposedChart>
       </ResponsiveContainer>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the D3 time series story to have the correct x axis type, allowing for the data to align to the axis correctly.

## Related Issue
https://github.com/recharts/recharts/issues/956
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This story is very useful as it allows users to display time series data using recharts. The current story has a small bug which this addresses.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran storybook locally
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
