### PR TITLE
Add Example for lockable Tooltip

### DIFF
--- a/storybook/stories/Examples/Tooltip.stories.tsx
+++ b/storybook/stories/Examples/Tooltip.stories.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable no-shadow */
+import React from 'react';
+import { pageData } from '../data';
+import { Bar, ComposedChart, Line, ResponsiveContainer, Tooltip } from '../../../src';
+import { DefaultTooltipContent } from '../../../src/component/DefaultTooltipContent';
+
+export default {
+  component: Tooltip,
+};
+
+export const LockedByClick = {
+  render: (_args: Record<string, any>) => {
+    const [isLocked, setIsLocked] = React.useState(false);
+    // The TooltipData contains the payload, the label and the x position of the tooltip.
+    // Their update is interrupted by the click event, so we need to store them in a state.
+    const [tooltipData, setTooltipData] = React.useState<{ payload?: unknown[]; label?: string; x?: number }>({});
+
+    // A custom Tooltip that updates the payload of the tooltip if the chart is locked, and either way always renders using the normal Tooltip.
+    const CustomTooltip = (props: any) => {
+      // If the chart is locked, and the payload is not empty, and the x position of the tooltip has changed, update the tooltipData.
+      if (!isLocked && props.payload && props.payload.length > 0 && props.coordinate.x !== tooltipData.x) {
+        setTooltipData({ payload: props.payload, x: props.coordinate.x, label: props.label });
+      }
+      return (
+        <DefaultTooltipContent
+          {...props}
+          payload={props.tooltipData.payload ?? props.payload}
+          label={props.tooltipData.label ?? props.label}
+        />
+      );
+    };
+
+    return (
+      <ResponsiveContainer width="100%" height={500}>
+        <ComposedChart
+          data={pageData}
+          // Clicking the chart locks the tooltip to the current position, and fixes its content.
+          onClick={() => {
+            setIsLocked(!isLocked);
+          }}
+        >
+          <Line dataKey="uv" />
+          <Bar dataKey="pv" />
+
+          <Tooltip
+            position={{ y: 0, x: tooltipData.x }} // The y position fixes the Tooltip to the top of the chart.
+            content={<CustomTooltip tooltipData={tooltipData} />}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {},
+  controls: {},
+  description:
+    'This example shows how to lock the tooltip to a specific position. Click on the chart to show fix the Tooltip.',
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Create a story that shows a Tooltip, where clicking on the chart fixes the Tooltip content and its position. Clicking it again, unlocks the Tooltip. 

I worked on this and wanted to share it :)

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
