### PR TITLE
fix: update type for equidistantPreserveStart axis interval

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -14,6 +14,7 @@ import {
   adaptEventsOfChild,
   PresentationAttributesAdaptChildEvent,
   CartesianTickItem,
+  AxisInterval,
 } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { getTicks } from './getTicks';
@@ -42,7 +43,7 @@ export interface CartesianAxisProps {
   /** The formatter function of tick */
   tickFormatter?: (value: any, index: number) => string;
   ticksGenerator?: (props?: CartesianAxisProps) => CartesianTickItem[];
-  interval?: number | 'preserveStart' | 'preserveEnd' | 'preserveStartEnd' | 'equidistantPreserveStart';
+  interval?: AxisInterval;
 }
 
 interface IState {

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1110,7 +1110,7 @@ export interface BaseAxisProps {
   label?: string | number | ReactElement | object;
 }
 
-export type AxisInterval = number | 'preserveStart' | 'preserveEnd' | 'preserveStartEnd';
+export type AxisInterval = number | 'preserveStart' | 'preserveEnd' | 'preserveStartEnd' | 'equidistantPreserveStart';
 
 export interface TickItem {
   value?: any;


### PR DESCRIPTION
fix: update type for equidistantPreserveStart axis interval

## Description

After https://github.com/recharts/recharts/pull/3392, the `AxisInterval` type definition was missing the new equidistantPreserveStart.

This updates it

## How Has This Been Tested?

`npm run test`, storybook

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
