### PR TITLE
fix: stop focusing on tooltip when displayed

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -130,14 +130,31 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
     this.updateBBox();
   }
 
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.handleKeyDown);
+  }
+
   componentDidUpdate() {
     this.updateBBox();
   }
 
+  handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      this.setState({
+        dismissed: true,
+        dismissedAtCoordinate: {
+          ...this.state.dismissedAtCoordinate,
+          x: this.props.coordinate.x,
+          y: this.props.coordinate.y,
+        },
+      });
+    }
+  };
+
   updateBBox() {
     const { boxWidth, boxHeight, dismissed } = this.state;
     if (dismissed) {
-      this.wrapperNode.blur();
+      document.removeEventListener('keydown', this.handleKeyDown);
       if (
         this.props.coordinate.x !== this.state.dismissedAtCoordinate.x ||
         this.props.coordinate.y !== this.state.dismissedAtCoordinate.y
@@ -145,7 +162,7 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
         this.setState({ dismissed: false });
       }
     } else {
-      this.wrapperNode.focus({ preventScroll: true });
+      document.addEventListener('keydown', this.handleKeyDown);
     }
 
     if (this.wrapperNode && this.wrapperNode.getBoundingClientRect) {
@@ -277,18 +294,6 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
       <div
         tabIndex={-1}
         role="dialog"
-        onKeyDown={event => {
-          if (event.key === 'Escape') {
-            this.setState({
-              dismissed: true,
-              dismissedAtCoordinate: {
-                ...this.state.dismissedAtCoordinate,
-                x: this.props.coordinate.x,
-                y: this.props.coordinate.y,
-              },
-            });
-          }
-        }}
         className={cls}
         style={outerStyle}
         ref={node => {


### PR DESCRIPTION
## Description
When the tooltip is displayed it becomes focused so it can be dismissed by pressing the _escape_ key. However, by focusing the tooltip, several issues occur on the apps using this lib. 
In this pr, based on this [comment](https://github.com/recharts/recharts/pull/2914#issuecomment-1284703302), I replaced the dismissing handling from the `onKeyDrown` prop for a event listener 

## Related Issue
[Issues/#3063](https://github.com/recharts/recharts/issues/3063)

## Motivation and Context
This issue was afecting our product since when mousing over a chart, we can no longer edit a pre focused input. Other users have complained about similar issues like closing of modals (which close on blur event)

## How Has This Been Tested?
I tested the behaviour manualy using the storybook. I didn't add any test since I didn't add a new feature.

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
