### PR TITLE
Address React syntax error message on Storybook welcome page

### DIFF
--- a/storybook/stories/Welcome.mdx
+++ b/storybook/stories/Welcome.mdx
@@ -31,7 +31,7 @@ A composable charting library built on React components
   </LineChart>
 ```
 <iframe src="https://ghbtns.com/github-btn.html?user=recharts&repo=recharts&type=star&count=true&size=median"
-        frameborder="0"
+        frameBorder="0"
         scrolling="0"
         width="150"
         height="20"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In `master`, if you run `npm run storybook`, Storybook launches. The front "Welcome" page includes this React error message:
![image](https://user-images.githubusercontent.com/108109448/232609738-50863cfd-b730-4207-9a93-df7d70d67eac.png)

Indicating that the property `frameborder` should actually be `frameBorder`. This PR fixes the property syntax.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

I wanted to clean up error messages out of the console, so that they don't become red herrings when people try to debug things in the future.

## How Has This Been Tested?

After making the change, I refreshed storybook, and the error message was no longer present.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [NA] My change requires a change to the documentation.
- [NA] I have updated the documentation accordingly.
- [NA] I have added tests to cover my changes.
- [x] All new and existing tests passed.
