### PR TITLE
fix: release workflow on release publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,7 +5,7 @@ name: npm publish
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   test:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

tldr; release on `created` does not trigger when a draft release is made. use `published` instead

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
