### PR TITLE
Fix treemap tooltip crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recharts",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "recharts",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "React charts",
   "main": "lib/index",
   "module": "es6/index",

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -354,6 +354,7 @@ export class Treemap extends PureComponent<Props, State> {
   }
 
   handleMouseEnter(node: TreemapNode, e: any) {
+    e.persist();
     const { onMouseEnter, children } = this.props;
     const tooltipItem = findChildByType(children, Tooltip);
 
@@ -375,6 +376,7 @@ export class Treemap extends PureComponent<Props, State> {
   }
 
   handleMouseLeave(node: TreemapNode, e: any) {
+    e.persist();
     const { onMouseLeave, children } = this.props;
     const tooltipItem = findChildByType(children, Tooltip);
 

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -141,19 +141,19 @@ export const Tooltip = <TValue extends ValueType, TName extends NameType>(
         setDismissed(true);
         setDismissedAtCoordinate(prev => ({
           ...prev,
-          x: coordinate.x,
-          y: coordinate.y,
+          x: coordinate?.x,
+          y: coordinate?.y,
         }));
       }
     },
-    [coordinate.x, coordinate.y],
+    [coordinate?.x, coordinate?.y],
   );
 
   useEffect(() => {
     const updateBBox = () => {
       if (dismissed) {
         document.removeEventListener('keydown', handleKeyDown);
-        if (coordinate.x !== dismissedAtCoordinate.x || coordinate.y !== dismissedAtCoordinate.y) {
+        if (coordinate?.x !== dismissedAtCoordinate.x || coordinate?.y !== dismissedAtCoordinate.y) {
           setDismissed(false);
         }
       } else {
@@ -178,16 +178,7 @@ export const Tooltip = <TValue extends ValueType, TName extends NameType>(
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [
-    boxHeight,
-    boxWidth,
-    coordinate.x,
-    coordinate.y,
-    dismissed,
-    dismissedAtCoordinate.x,
-    dismissedAtCoordinate.y,
-    handleKeyDown,
-  ]);
+  }, [boxHeight, boxWidth, coordinate, dismissed, dismissedAtCoordinate.x, dismissedAtCoordinate.y, handleKeyDown]);
 
   const getTranslate = ({
     key,

--- a/storybook/stories/API/chart/Treemap.stories.tsx
+++ b/storybook/stories/API/chart/Treemap.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { sizeData } from '../../data';
-import { ResponsiveContainer, Treemap } from '../../../../src';
+import { ResponsiveContainer, Tooltip, Treemap } from '../../../../src';
 import { ChartSizeProps, data } from '../props/ChartProps';
 import {
   animationBegin,
@@ -80,6 +80,24 @@ export const Simple = {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <Treemap {...args} />
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    data: sizeData,
+    dataKey: 'size',
+    nameKey: 'name',
+    isAnimationActive: false,
+  },
+};
+
+export const WithTooltip = {
+  render: (args: Record<string, any>) => {
+    return (
+      <ResponsiveContainer width="100%" height={400}>
+        <Treemap {...args}>
+          <Tooltip />
+        </Treemap>
       </ResponsiveContainer>
     );
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Bug released in 2.6 with refactor of Tooltip to a function component. Add optionals to prevent crashing when `coordinate` is `null`. 

This resulted in other errors surrounding event pooling https://legacy.reactjs.org/docs/legacy-event-pooling.html

This isn't an issue in React 17+ but throws errors in react <17 so call e.persist() in the offending functions in `Treemap` - this resolves errors in React 16 and has no effect in React 17 (see https://legacy.reactjs.org/blog/2020/08/10/react-v17-rc.html#no-event-pooling)

## Related Issue
https://github.com/recharts/recharts/issues/3578
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix 2.6.0 bug https://github.com/recharts/recharts/issues/3578

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create new treemap story to reproduce bug from https://github.com/recharts/recharts/issues/3578
- Ensure bug has been fixed

## Screenshots (if appropriate):
<img width="553" alt="image" src="https://github.com/recharts/recharts/assets/25180830/c4dd313b-4214-4ff7-b152-262e3862a6cf">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
