### PR TITLE
Add SVGProps to PieLabel type

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -55,7 +55,7 @@ type PieLabelLine =
 export type PieLabel<P = any> =
   | ReactElement<SVGElement>
   | ((props: P) => ReactNode | ReactElement<SVGElement>)
-  | { offsetRadius: number }
+  | SVGProps<SVGTextElement> & { offsetRadius?: number }
   | boolean;
 type PieSectorDataItem = SectorProps & {
   percent?: number;

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -55,7 +55,7 @@ type PieLabelLine =
 export type PieLabel<P = any> =
   | ReactElement<SVGElement>
   | ((props: P) => ReactNode | ReactElement<SVGElement>)
-  | SVGProps<SVGTextElement> & { offsetRadius?: number }
+  | (SVGProps<SVGTextElement> & { offsetRadius?: number })
   | boolean;
 type PieSectorDataItem = SectorProps & {
   percent?: number;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `Pie` element [merges custom label props](https://github.com/recharts/recharts/blob/758205a48837219bd403b7e8e3309bc441c17fef/src/polar/Pie.tsx#L436) into the label, which are forwarded to an SVG [text element](https://github.com/recharts/recharts/blob/758205a48837219bd403b7e8e3309bc441c17fef/src/polar/Pie.tsx#L411). This allows supplying custom SVG props for the label, such a custom `fill`:

```jsx
<Pie
  data={data}
  dataKey="value"
  label={{ fill: 'green' }}
>
```

This works in reality, but TypeScript complains since LabelLine [allows SVG props](https://github.com/recharts/recharts/blob/master/src/polar/Pie.tsx#L53) but Label does not. This adds the `SVGProps` option for Label as well. The [documentation](https://recharts.org/en-US/api/Pie#label) implies this is the expected behavior already.

## Related Issue

https://github.com/recharts/recharts/issues/3593

## Motivation and Context

Type errors when supplying custom SVG props to PieLabel

## How Has This Been Tested?

Tested by modifying the dist types output locally.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
