### PR TITLE
Export default tooltip and legend content components

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,12 @@ export type { Props as LayerProps } from './container/Layer';
 
 export { Legend } from './component/Legend';
 export type { Props as LegendProps } from './component/Legend';
+export { DefaultLegendContent } from './component/DefaultLegendContent';
+export type { Props as DefaultLegendContentProps } from './component/DefaultLegendContent';
 export { Tooltip } from './component/Tooltip';
 export type { TooltipProps } from './component/Tooltip';
+export { DefaultTooltipContent } from './component/DefaultTooltipContent';
+export type { Props as DefaultTooltipContentProps } from './component/DefaultTooltipContent';
 export { ResponsiveContainer } from './component/ResponsiveContainer';
 export type { Props as ResponsiveContainerProps } from './component/ResponsiveContainer';
 export { Cell } from './component/Cell';


### PR DESCRIPTION
## Description

Export the default implementations of Tooltip and Legend content to make them re-usable.

## Related Issue

https://github.com/recharts/recharts/issues/3288

## Motivation and Context

By exposing those content components, it is possible to wrap them in custom elements without needing to re-implement all the logic that is provided by the default content components.

## How Has This Been Tested?

Within a private repository, the changes have been successfully used to add additional content on top of the legend.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
