### PR TITLE
fix: check for stacked data in barchart errorbar dataPointFormatter

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -7,7 +7,7 @@ import Animate from 'react-smooth';
 import _ from 'lodash';
 import { Rectangle, Props as RectangleProps } from '../shape/Rectangle';
 import { Layer } from '../container/Layer';
-import { ErrorBar, Props as ErrorBarProps } from './ErrorBar';
+import { ErrorBar, Props as ErrorBarProps, ErrorBarDataPointFormatter } from './ErrorBar';
 import { Cell } from '../component/Cell';
 import { LabelList } from '../component/LabelList';
 import { uniqueId, mathSign, interpolateNumber } from '../util/DataUtils';
@@ -36,8 +36,8 @@ import {
 } from '../util/types';
 import { ImplicitLabelType } from '../component/Label';
 
-interface BarRectangleItem extends RectangleProps {
-  value?: number;
+export interface BarRectangleItem extends RectangleProps {
+  value?: number | [number, number];
   /** the coordinate of background rectangle */
   background?: {
     x?: number;
@@ -430,14 +430,19 @@ export class Bar extends PureComponent<Props, State> {
 
     const offset = layout === 'vertical' ? data[0].height / 2 : data[0].width / 2;
 
-    function dataPointFormatter(dataPoint: BarRectangleItem, dataKey: Props['dataKey']) {
+    const dataPointFormatter: ErrorBarDataPointFormatter = (dataPoint: BarRectangleItem, dataKey) => {
+      /**
+       * if the value coming from `getComposedData` is an array then this is a stacked bar chart.
+       * arr[1] represents end value of the bar since the data is in the form of [startValue, endValue].
+       * */
+      const value = Array.isArray(dataPoint.value) ? dataPoint.value[1] : dataPoint.value;
       return {
         x: dataPoint.x,
         y: dataPoint.y,
-        value: dataPoint.value,
+        value,
         errorVal: getValueByDataKey(dataPoint, dataKey),
       };
-    }
+    };
 
     const errorBarProps = {
       clipPath: needClip ? `url(#clipPath-${clipPathId})` : null,

--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -7,20 +7,28 @@ import { Props as XAxisProps } from './XAxis';
 import { Props as YAxisProps } from './YAxis';
 import { D3Scale, DataKey } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
+import { BarRectangleItem } from './Bar';
+import { LinePointItem } from './Line';
+import { ScatterPointItem } from './Scatter';
 
-interface ErrorBarDataItem {
+export interface ErrorBarDataItem {
   x: number;
   y: number;
   value: number;
   errorVal?: number[] | number;
 }
 
+export type ErrorBarDataPointFormatter = (
+  entry: BarRectangleItem | LinePointItem | ScatterPointItem,
+  dataKey: DataKey<any>,
+) => ErrorBarDataItem;
+
 interface InternalErrorBarProps {
   xAxis?: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> };
   yAxis?: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> };
   data?: any[];
   layout?: 'horizontal' | 'vertical';
-  dataPointFormatter?: (entry: any, dataKey: DataKey<any>) => ErrorBarDataItem;
+  dataPointFormatter?: ErrorBarDataPointFormatter;
   /** The offset between central and the given coordinate, often set by <Bar/> */
   offset?: number;
 }

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -10,7 +10,7 @@ import { Dot, Props as DotProps } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelType } from '../component/Label';
 import { LabelList } from '../component/LabelList';
-import { ErrorBar, Props as ErrorBarProps } from './ErrorBar';
+import { ErrorBar, ErrorBarDataPointFormatter, Props as ErrorBarProps } from './ErrorBar';
 import { uniqueId, interpolateNumber } from '../util/DataUtils';
 import { findAllByType, filterProps } from '../util/ReactUtils';
 import { Global } from '../util/Global';
@@ -21,7 +21,7 @@ import { D3Scale, LegendType, TooltipType, AnimationTiming, ChartOffset, DataKey
 
 type LineDot = ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | DotProps | boolean;
 
-interface LinePointItem extends CurvePoint {
+export interface LinePointItem extends CurvePoint {
   value?: number;
   payload?: any;
 }
@@ -263,14 +263,14 @@ export class Line extends PureComponent<Props, State> {
       return null;
     }
 
-    function dataPointFormatter(dataPoint: LinePointItem, dataKey: Props['dataKey']) {
+    const dataPointFormatter: ErrorBarDataPointFormatter = (dataPoint: LinePointItem, dataKey) => {
       return {
         x: dataPoint.x,
         y: dataPoint.y,
         value: dataPoint.value,
         errorVal: getValueByDataKey(dataPoint.payload, dataKey),
       };
-    }
+    };
 
     const errorBarProps = {
       clipPath: needClip ? `url(#clipPath-${clipPathId})` : null,

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -37,7 +37,7 @@ interface ScattterPointNode {
   z?: number | string;
 }
 
-interface ScatterPointItem {
+export interface ScatterPointItem {
   cx?: number;
   cy?: number;
   size?: number;
@@ -359,24 +359,6 @@ export class Scatter extends PureComponent<Props, State> {
       return null;
     }
 
-    function dataPointFormatterY(dataPoint: ScatterPointItem, dataKey: Props['dataKey']) {
-      return {
-        x: dataPoint.cx,
-        y: dataPoint.cy,
-        value: +dataPoint.node.y,
-        errorVal: getValueByDataKey(dataPoint, dataKey),
-      };
-    }
-
-    function dataPointFormatterX(dataPoint: ScatterPointItem, dataKey: Props['dataKey']) {
-      return {
-        x: dataPoint.cx,
-        y: dataPoint.cy,
-        value: +dataPoint.node.x,
-        errorVal: getValueByDataKey(dataPoint, dataKey),
-      };
-    }
-
     return errorBarItems.map((item, i: number) => {
       const { direction } = item.props;
 
@@ -386,7 +368,14 @@ export class Scatter extends PureComponent<Props, State> {
         xAxis,
         yAxis,
         layout: direction === 'x' ? 'vertical' : 'horizontal',
-        dataPointFormatter: direction === 'x' ? dataPointFormatterX : dataPointFormatterY,
+        dataPointFormatter: (dataPoint: ScatterPointItem, dataKey: Props['dataKey']) => {
+          return {
+            x: dataPoint.cx,
+            y: dataPoint.cy,
+            value: direction === 'x' ? +dataPoint.node.x : +dataPoint.node.y,
+            errorVal: getValueByDataKey(dataPoint, dataKey),
+          };
+        },
       });
     });
   }

--- a/storybook/stories/Examples/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart.stories.tsx
@@ -15,6 +15,7 @@ import {
   ComposedChart,
   LabelList,
   Brush,
+  ErrorBar,
 } from '../../../src';
 
 export default {
@@ -86,6 +87,39 @@ export const Stacked = {
           <Legend />
           <Bar dataKey="pv" stackId="a" fill="#8884d8" />
           <Bar dataKey="uv" stackId="a" fill="#82ca9d" />
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  },
+};
+
+const pvErrorData = pageData.map(d => ({ ...d, pvError: [100, 200] }));
+
+export const StackedWithErrorBar = {
+  render: () => {
+    return (
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          width={500}
+          height={300}
+          data={pvErrorData}
+          margin={{
+            top: 20,
+            right: 30,
+            left: 20,
+            bottom: 5,
+          }}
+          layout="vertical"
+        >
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis type="number" />
+          <YAxis dataKey="name" type="category" />
+          <Tooltip />
+          <Legend />
+          <Bar dataKey="pv" stackId="a" fill="#8884d8" />
+          <Bar dataKey="uv" stackId="a" fill="#82ca9d">
+            <ErrorBar dataKey="pvError" width={5} stroke="red" direction="x" />
+          </Bar>
         </BarChart>
       </ResponsiveContainer>
     );

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -1,38 +1,74 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { Bar, BarChart, Line, LineChart, ErrorBar } from '../../src';
+import { Bar, BarChart, Line, LineChart, ErrorBar, XAxis, YAxis } from '../../src';
+
+// asserts an error bar has both a start and end position
+const assertErrorBars = (container: HTMLElement, barsExpected: number) => {
+  const errorBars = container.querySelectorAll('.recharts-errorBar');
+  expect(errorBars).toHaveLength(barsExpected);
+
+  errorBars.forEach(bar => {
+    const lineElements = bar.getElementsByTagName('line');
+
+    for (let i = 0; i < lineElements.length; i++) {
+      const line = lineElements[i];
+      expect(line.getAttribute('y1')).toEqual(expect.any(String));
+      expect(line.getAttribute('y2')).toEqual(expect.any(String));
+      expect(line.getAttribute('x1')).toEqual(expect.any(String));
+      expect(line.getAttribute('x2')).toEqual(expect.any(String));
+    }
+  });
+};
 
 describe('<ErrorBar />', () => {
   const barData = [
     { name: 'food', uv: 2000, pv: 2013, time: 1, uvError: [100, 50], pvError: [110, 20] },
-    { name: 'cosmetic', uv: 3300, pv: 2000, time: 2, uvError: 120, pvError: 50 },
+    { name: 'cosmetic', uv: 3300, pv: 2000, time: 2, uvError: [120, 140], pvError: 50 },
     { name: 'storage', uv: 3200, pv: 1398, time: 3, uvError: [120, 80], pvError: [200, 100] },
-    { name: 'digital', uv: 2800, pv: 2800, time: 4, uvError: 100, pvError: 30 },
+    { name: 'digital', uv: 2800, pv: 2800, time: 4, uvError: [100, 200], pvError: 30 },
   ];
 
   test('Renders Error Bars in Bar', () => {
     const { container } = render(
-      <BarChart data={barData} width={500} height={500} layout="vertical">
+      <BarChart data={barData} width={500} height={500}>
         <Bar isAnimationActive={false} dataKey="uv">
           <ErrorBar dataKey="uvError" />
         </Bar>
       </BarChart>,
     );
 
-    expect(container.querySelectorAll('.recharts-errorBar')).toHaveLength(4);
+    assertErrorBars(container, 4);
   });
 
   test('Renders Multiple Error Bars in Bar', () => {
     const { container } = render(
       <BarChart data={barData} width={500} height={500} layout="vertical">
         <Bar isAnimationActive={false} dataKey="uv">
+          <ErrorBar dataKey="uvError" direction="x" />
+          <ErrorBar dataKey="pvError" direction="x" />
+        </Bar>
+        {/* Axes are needed in order to actually render anything useful in a vertical chart */}
+        <XAxis dataKey="uv" type="number" />
+        <YAxis dataKey="name" type="category" />
+      </BarChart>,
+    );
+
+    assertErrorBars(container, 8);
+  });
+
+  test('Renders Error Bars in stacked Bar', () => {
+    const { container } = render(
+      <BarChart data={barData} width={500} height={500}>
+        <Bar isAnimationActive={false} dataKey="uv" stackId="1">
           <ErrorBar dataKey="uvError" />
-          <ErrorBar dataKey="pvError" />
+        </Bar>
+        <Bar isAnimationActive={false} dataKey="pv" stackId="1">
+          <ErrorBar dataKey="uvError" />
         </Bar>
       </BarChart>,
     );
 
-    expect(container.querySelectorAll('.recharts-errorBar')).toHaveLength(8);
+    assertErrorBars(container, 8);
   });
 
   const lineData = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
When using `ErrorBar` in a stacked bar chart, the error bars do no appear. Refactor types to correctly reflect what could happen. Fix bug in the `Bar` `dataPointFormatter`

This _might_ be considered a breaking change because of the type changes of `dataPointFormatter`? I don't really know though... I would have to create an example of how it would break someone to see how intrusive it might be. If it does break someone it will direct them to the correct way of using `dataPointFormatter`...

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/2585

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix a bug that has been around for a while. It is caused by this line of code https://github.com/recharts/recharts/blob/master/src/cartesian/Bar.tsx#L235 - this causes `value` to be a `[number, number]` when a chart is stacked.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Uncover the bug via failing unit test (no x values in rendered ErrorBar lines pre-change) and refactor until the test passes. 


## Screenshots (if appropriate):

Before (see left side):
<img width="1292" alt="image" src="https://github.com/recharts/recharts/assets/25180830/2717c26a-ae85-4be3-98b1-1acf6a29011e">


After:
<img width="1306" alt="image" src="https://github.com/recharts/recharts/assets/25180830/da727df6-7daf-42fb-babd-b0427c4ff3bc">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
