### PR TITLE
Address issue where tooltips and AccessibilityManager can get misaligned

### DIFF
--- a/src/chart/AccessibilityManager.ts
+++ b/src/chart/AccessibilityManager.ts
@@ -39,9 +39,8 @@ export class AccessibilityManager {
     this.offset = offset ?? this.offset;
     this.mouseHandlerCallback = mouseHandlerCallback ?? this.mouseHandlerCallback;
 
-    if (this.activeIndex >= this.coordinateList.length) {
-      this.activeIndex = this.coordinateList.length - 1;
-    }
+    // Keep activeIndex in the bounds between 0 and the last coordinate index
+    this.activeIndex = Math.min(Math.max(this.activeIndex, 0), this.coordinateList.length - 1);
   }
 
   public focus() {
@@ -49,6 +48,13 @@ export class AccessibilityManager {
   }
 
   public keyboardEvent(e: any) {
+    // The AccessibilityManager relies on the Tooltip component. When tooltips suddenly stop existing,
+    // it can cause errors. We use this function to check. We don't want arrow keys to be processed
+    // if there are no tooltips, since that will cause unexpected behavior of users.
+    if (this.coordinateList.length === 0) {
+      return;
+    }
+
     switch (e.key) {
       case 'ArrowRight': {
         if (this.layout !== 'horizontal') {
@@ -74,6 +80,12 @@ export class AccessibilityManager {
 
   private spoofMouse() {
     if (this.layout !== 'horizontal') {
+      return;
+    }
+
+    // This can happen when the tooltips suddenly stop existing as children of the component
+    // That update doesn't otherwise fire events, so we have to double check here.
+    if (this.coordinateList.length === 0) {
       return;
     }
 


### PR DESCRIPTION
Addresses bug with AccessibilityManager where, when the user interacts with the AccessibilityManager and *then* the `<Tooltip/>` component changes, there is a javascript runtime error. (Note that I could only reproduce this if the container chart used the `margin` prop.)

## Description

- I added error handling to prevent the javascript runtime error from throwing.
- TDD test

## Related Issue

@ckifer - Was the issue filed? 

For reference, the issue can be reproduced using this sandbox:
https://codesandbox.io/s/stacked-area-chart-forked-8ipx36?file=/src/App.tsx:951-1010

## Motivation and Context

Solves a javascript runtime error

## How Has This Been Tested?

I generated a reproducible example within the jest testing framework and in Storybook. Once I added in defensive checks for the error condition, I confirmed that this solved the error in both a browser and jest.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [NA] My change requires a change to the documentation.
- [NA] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
