### PR TITLE
[a11y] Add basic keyboard accessibility support for the Brush component

### DIFF
--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -54,6 +54,7 @@ type BrushTravellerId = 'startX' | 'endX';
 
 interface State {
   isTravellerMoving?: boolean;
+  isTravellerFocused?: boolean;
   isSlideMoving?: boolean;
   startX?: number;
   endX?: number;
@@ -101,6 +102,7 @@ const createScale = ({
     isTextActive: false,
     isSlideMoving: false,
     isTravellerMoving: false,
+    isTravellerFocused: false,
     startX: scale(startIndex),
     endX: scale(endIndex),
     scale,
@@ -487,6 +489,7 @@ export class Brush extends PureComponent<Props, State> {
     return (
       <Layer
         tabIndex={0}
+        role="slider"
         className="recharts-brush-traveller"
         onMouseEnter={this.handleEnterSlideOrTraveller}
         onMouseLeave={this.handleLeaveSlideOrTraveller}
@@ -499,6 +502,12 @@ export class Brush extends PureComponent<Props, State> {
           e.preventDefault();
           e.stopPropagation();
           this.handleTravellerMoveKeyboard(e.key === 'ArrowRight' ? 1 : -1, id);
+        }}
+        onFocus={() => {
+          this.setState({ isTravellerFocused: true });
+        }}
+        onBlur={() => {
+          this.setState({ isTravellerFocused: false });
         }}
         style={{ cursor: 'col-resize' }}
       >
@@ -566,7 +575,7 @@ export class Brush extends PureComponent<Props, State> {
 
   render() {
     const { data, className, children, x, y, width, height, alwaysShowText } = this.props;
-    const { startX, endX, isTextActive, isSlideMoving, isTravellerMoving } = this.state;
+    const { startX, endX, isTextActive, isSlideMoving, isTravellerMoving, isTravellerFocused } = this.state;
 
     if (
       !data ||
@@ -597,7 +606,8 @@ export class Brush extends PureComponent<Props, State> {
         {this.renderSlide(startX, endX)}
         {this.renderTravellerLayer(startX, 'startX')}
         {this.renderTravellerLayer(endX, 'endX')}
-        {(isTextActive || isSlideMoving || isTravellerMoving || alwaysShowText) && this.renderText()}
+        {(isTextActive || isSlideMoving || isTravellerMoving || isTravellerFocused || alwaysShowText) &&
+          this.renderText()}
       </Layer>
     );
   }

--- a/storybook/stories/API/Accessibility.mdx
+++ b/storybook/stories/API/Accessibility.mdx
@@ -1,5 +1,5 @@
 import { curveCardinal } from 'victory-vendor/d3-shape';
-import { CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis, LineChart, Line } from '../../../src';
+import { CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis, LineChart, Line, Brush } from '../../../src';
 import { pageData } from '../data';
 import { CategoricalChartProps } from './props/ChartProps';
 
@@ -21,8 +21,11 @@ To see how this works, try the following chart, where the accessibility layer ha
         <XAxis dataKey="name" />
         <YAxis />
         <Tooltip />
+        <Brush />
     </LineChart>
 </ResponsiveContainer>
+
+This chart also contains a "brush", a range slider that lets you control what appears on the X-axis. You can tab to the "travellers" on the brush, and use the left/right arrow keys to adjust them.
 
 The code to generate this example is:
 ```jsx


### PR DESCRIPTION
## Description

- Provided support for keyboard-based interactions with the brush travellers of the `<Brush />` component. This includes being able to focus on the travelers, as well as using the left/right arrow keys to move between tick indeces.
- Added test cases for keyboard-based interactions
- Updated Accessibility documentation

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#3549 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Improves accessibility for keyboard-only users

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually and with automated tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
