### PR TITLE
fix: dont throw when dot is null, use typeguard in line and improve in area

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -24,9 +24,9 @@ import {
   DataKey,
   TickItem,
 } from '../util/types';
-import { filterProps } from '../util/ReactUtils';
+import { filterProps, isDotProps } from '../util/ReactUtils';
 
-type AreaDot =
+export type AreaDot =
   | ReactElement<SVGElement>
   | ((props: any) => ReactElement<SVGElement>)
   | ((props: any) => ReactElement<SVGElement>)
@@ -95,9 +95,6 @@ interface State {
   isAnimationFinished?: boolean;
   totalLength?: number;
 }
-
-const isDotProps = (dot: AreaDot): dot is DotProps =>
-  typeof dot === 'object' && 'cx' in dot && 'cy' in dot && 'r' in dot;
 
 export class Area extends PureComponent<Props, State> {
   static displayName = 'Area';

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -12,14 +12,14 @@ import { ImplicitLabelType } from '../component/Label';
 import { LabelList } from '../component/LabelList';
 import { ErrorBar, ErrorBarDataPointFormatter, Props as ErrorBarProps } from './ErrorBar';
 import { uniqueId, interpolateNumber } from '../util/DataUtils';
-import { findAllByType, filterProps } from '../util/ReactUtils';
+import { findAllByType, filterProps, isDotProps } from '../util/ReactUtils';
 import { Global } from '../util/Global';
 import { getCateCoordinateOfLine, getValueByDataKey } from '../util/ChartUtils';
 import { Props as XAxisProps } from './XAxis';
 import { Props as YAxisProps } from './YAxis';
 import { D3Scale, LegendType, TooltipType, AnimationTiming, ChartOffset, DataKey, TickItem } from '../util/types';
 
-type LineDot = ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | DotProps | boolean;
+export type LineDot = ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | DotProps | boolean;
 
 export interface LinePointItem extends CurvePoint {
   value?: number;
@@ -466,7 +466,7 @@ export class Line extends PureComponent<Props, State> {
     const needClip = needClipX || needClipY;
     const clipPathId = _.isNil(id) ? this.id : id;
     const { r = 3, strokeWidth = 2 } = filterProps(dot) ?? { r: 3, strokeWidth: 2 };
-    const { clipDot = true } = dot as DotProps;
+    const { clipDot = true } = isDotProps(dot) ? dot : {};
     const dotSize = r * 2 + strokeWidth;
 
     return (

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -1,10 +1,12 @@
 import _ from 'lodash';
 import React, { Children, Component, FunctionComponent, isValidElement, ReactNode } from 'react';
 import { isFragment } from 'react-is';
-
+import { DotProps } from '..';
 import { isNumber } from './DataUtils';
 import { shallowEqual } from './ShallowEqual';
 import { FilteredSvgElementType, FilteredElementKeyMap, SVGElementPropKeys, EventKeys } from './types';
+import { AreaDot } from '../cartesian/Area';
+import { LineDot } from '../cartesian/Line';
 
 const REACT_BROWSER_EVENT_MAP: Record<string, string> = {
   click: 'onClick',
@@ -259,6 +261,9 @@ const SVG_TAGS: string[] = [
 ];
 
 const isSvgElement = (child: any) => child && child.type && _.isString(child.type) && SVG_TAGS.indexOf(child.type) >= 0;
+
+export const isDotProps = (dot: LineDot | AreaDot): dot is DotProps =>
+  dot && typeof dot === 'object' && 'cx' in dot && 'cy' in dot && 'r' in dot;
 
 /**
  * Checks if the property is valid to spread onto an SVG element or onto a specific component

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -93,6 +93,21 @@ describe('<Area />', () => {
     expect(screen.getAllByRole('cell')).toHaveLength(data.length);
   });
 
+  test('Does not throw when dot is null', () => {
+    const { container } = render(
+      <Surface width={500} height={500}>
+        {/* Test that the error Cannot read properties of null (reading 'clipDot') does not appear in JS projects */}
+        {/* eslint-disable-next-line */}
+        {/* @ts-ignore */}
+        <Area dataKey="value" points={data} dot={null} />
+      </Surface>,
+    );
+
+    expect(container.querySelectorAll('.recharts-area-area')).toHaveLength(1);
+    expect(container.querySelectorAll('.recharts-area-curve')).toHaveLength(1);
+    expect(container.querySelectorAll('.recharts-area-dot')).toHaveLength(0);
+  });
+
   test("Don't render any path when data is empty", () => {
     const { container } = render(
       <Surface width={500} height={500}>

--- a/test/cartesian/Line.spec.tsx
+++ b/test/cartesian/Line.spec.tsx
@@ -21,6 +21,19 @@ describe('<Line />', () => {
     expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
   });
 
+  it('Does not throw when dot is null', () => {
+    const { container } = render(
+      <Surface width={500} height={500}>
+        {/* Test that the error Cannot read properties of null (reading 'clipDot') does not appear in JS projects */}
+        {/* eslint-disable-next-line */}
+        {/* @ts-ignore */}
+        <Line isAnimationActive={false} points={data} dot={null} />
+      </Surface>,
+    );
+
+    expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
+  });
+
   it("Don't render any path when data is empty", () => {
     const { container } = render(
       <Surface width={500} height={500}>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

When the `clipDots` PR was merged I added a typeguard to `Area` but I did not see to do the same for `Line`. If `dot` was something other than `DotProps` this cast is incorrect and wrong. 

Linked issue is caused when passing `null` to `dot`.  `null` is not an acceptable type to `dot` and therefore this wasn't a breaking change, but it still uncovered a need for this check.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

fixes https://github.com/recharts/recharts/issues/3635

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

See issue, removes need to cast to `DotProps`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit tests that reproduce the issue and are green after fixing it

## Screenshots (if appropriate):

N/A no visual changes

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [Y] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [Y] My code follows the code style of this project.
- [N] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [Y] I have added tests to cover my changes.
- [Y] All new and existing tests passed.
