### PR TITLE
RadialBarChart support to custom class names

### DIFF
--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -292,7 +292,7 @@ export class RadialBar extends PureComponent<Props, State> {
         ...entry,
         ...adaptEventsOfChild(this.props, entry, i),
         key: `sector-${i}`,
-        className: 'recharts-radial-bar-sector',
+        className: `recharts-radial-bar-sector ${entry.className}`,
         forceCornerRadius: others.forceCornerRadius,
         cornerIsExternal: others.cornerIsExternal,
       };

--- a/test/chart/RadialBarChart.spec.tsx
+++ b/test/chart/RadialBarChart.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { RadialBarChart, RadialBar, Legend, Sector, Tooltip } from '../../src';
+import { RadialBarChart, RadialBar, Legend, Sector, Tooltip, Cell } from '../../src';
 
 describe('<RadialBarChart />', () => {
   const data = [
@@ -172,5 +172,27 @@ describe('<RadialBarChart />', () => {
 
     expect(container.querySelectorAll('.recharts-tooltip-wrapper')).toHaveLength(1);
     expect(container.querySelectorAll('.recharts-default-tooltip')).toHaveLength(1);
+  });
+
+  test('Renders Cell children component className prop', () => {
+    const { container } = render(
+      <RadialBarChart
+        width={500}
+        height={300}
+        cx={150}
+        cy={150}
+        innerRadius={20}
+        outerRadius={140}
+        barSize={10}
+        data={data}
+      >
+        <RadialBar background dataKey="uv" isAnimationActive={false}>
+          {data.map((_, index) => (
+            <Cell key={`cell-${index}`} className="unit-test-class" />
+          ))}
+        </RadialBar>
+      </RadialBarChart>,
+    );
+    expect(container.querySelectorAll('.unit-test-class')).toHaveLength(data.length);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added support in `RadialBarChart` to add custom class names for `Cell`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3653 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
`RadialBarChart` support `Cell` as child component, but doesn't support custom class names

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with the current unit tests and the new provided with the changes

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
