### PR TITLE
Switches useLayoutEffect to useEffect

### DIFF
--- a/src/shape/Rectangle.tsx
+++ b/src/shape/Rectangle.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Rectangle
  */
-import React, { SVGProps, useLayoutEffect, useRef, useState } from 'react';
+import React, { SVGProps, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
 import { AnimationTiming } from '../util/types';
@@ -106,7 +106,7 @@ export const Rectangle: React.FC<Props> = props => {
   const pathRef = useRef<SVGPathElement>();
   const [totalLength, setTotalLength] = useState(-1);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (pathRef.current && pathRef.current.getTotalLength) {
       try {
         const pathTotalLength = pathRef.current.getTotalLength();

--- a/src/shape/Trapezoid.tsx
+++ b/src/shape/Trapezoid.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Rectangle
  */
-import React, { SVGProps, useLayoutEffect, useRef, useState } from 'react';
+import React, { SVGProps, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
 import { AnimationTiming } from '../util/types';
@@ -38,7 +38,7 @@ export const Trapezoid: React.FC<Props> = props => {
   const pathRef = useRef<SVGPathElement>();
   const [totalLength, setTotalLength] = useState(-1);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (pathRef.current && pathRef.current.getTotalLength) {
       try {
         const pathTotalLength = pathRef.current.getTotalLength();


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->

When rendering a chart on server side we get this warning:

Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
    at Rectangle (app/node_modules/recharts/lib/shape/Rectangle.js:81:35)

Switching to useEffect seems to solve the problem and the chart renders well without any warnings.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/3656

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change is required when rendering on server side with `ReactDOMServer.renderToString`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change was tested by server side rendering a chart that used the rectangle shape.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
