### PR TITLE
Add value property to legend Formatter type

### DIFF
--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -28,6 +28,7 @@ export type Formatter = (
     color?: string;
     payload?: {
       strokeDasharray: ReactText;
+      value?: any;
     };
   },
   index: number,
@@ -40,6 +41,7 @@ export interface Payload {
   color?: string;
   payload?: {
     strokeDasharray: ReactText;
+    value?: any;
   };
   formatter?: Formatter;
   inactive?: boolean;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a property to `DefaultLegendContent` type `Formatter` - `value?: any;`. This will provide type safety when using legend formatter with a pie chart.

## Related Issue
https://github.com/recharts/recharts/issues/3666
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This solves a TS issue where when passing a formatter function to a legend inside a pie chart, `entry.payload` will not include the payload value.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
`npm run test`, `npm run lint` & `npm run build-types` all passed.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
