### PR TITLE
fix: refactor Text to use default params

### DIFF
--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -188,48 +188,39 @@ const getWordsByLines = ({ width, scaleToFit, children, style, breakAll, maxLine
   return getWordsWithoutCalculate(children);
 };
 
-const textDefaultProps = {
-  x: 0,
-  y: 0,
-  lineHeight: '1em',
-  capHeight: '0.71em', // Magic number from d3
-  scaleToFit: false,
-  textAnchor: 'start',
-  verticalAnchor: 'end', // Maintain compat with existing charts / default SVG behavior
-  fill: '#808080',
-};
+const DEFAULT_FILL = '#808080';
 
-export const Text = (props: Props) => {
+export const Text = ({
+  x: propsX = 0,
+  y: propsY = 0,
+  lineHeight = '1em',
+  // Magic number from d3
+  capHeight = '0.71em',
+  scaleToFit = false,
+  textAnchor = 'start',
+  // Maintain compat with existing charts / default SVG behavior
+  verticalAnchor = 'end',
+  fill = DEFAULT_FILL,
+  ...props
+}: Props) => {
   const wordsByLines: Array<Words> = useMemo(() => {
     return getWordsByLines({
       breakAll: props.breakAll,
       children: props.children,
       maxLines: props.maxLines,
-      scaleToFit: props.scaleToFit,
+      scaleToFit,
       style: props.style,
       width: props.width,
     });
-  }, [props.breakAll, props.children, props.maxLines, props.scaleToFit, props.style, props.width]);
+  }, [props.breakAll, props.children, props.maxLines, scaleToFit, props.style, props.width]);
 
-  const {
-    dx,
-    dy,
-    textAnchor,
-    verticalAnchor,
-    scaleToFit,
-    angle,
-    lineHeight,
-    capHeight,
-    className,
-    breakAll,
-    ...textProps
-  } = props;
+  const { dx, dy, angle, className, breakAll, ...textProps } = props;
 
-  if (!isNumOrStr(textProps.x) || !isNumOrStr(textProps.y)) {
+  if (!isNumOrStr(propsX) || !isNumOrStr(propsY)) {
     return null;
   }
-  const x = (textProps.x as number) + (isNumber(dx as number) ? (dx as number) : 0);
-  const y = (textProps.y as number) + (isNumber(dy as number) ? (dy as number) : 0);
+  const x = (propsX as number) + (isNumber(dx as number) ? (dx as number) : 0);
+  const y = (propsY as number) + (isNumber(dy as number) ? (dy as number) : 0);
 
   let startDy: number;
   switch (verticalAnchor) {
@@ -264,7 +255,7 @@ export const Text = (props: Props) => {
       y={y}
       className={classNames('recharts-text', className)}
       textAnchor={textAnchor}
-      fill={textProps.fill.includes('url') ? textDefaultProps.fill : textProps.fill}
+      fill={fill.includes('url') ? DEFAULT_FILL : fill}
     >
       {wordsByLines.map((line, index) => (
         // eslint-disable-next-line react/no-array-index-key
@@ -275,5 +266,3 @@ export const Text = (props: Props) => {
     </text>
   );
 };
-
-Text.defaultProps = textDefaultProps;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix latest React throwing error due to using defaultParams in function component within `Text`. This is not at risk of breaking like other elements referenced in calls to the `findAllByType`, etc. functions in `ReactUtils` - the list of risky elements is in linked issue https://github.com/recharts/recharts/issues/3615#issuecomment-1651094565

## Related Issue
https://github.com/recharts/recharts/issues/3615

Fixes one of a few occurrences of this error being logged

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Starts to address a highly trafficked issue

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- ran manual visual difference between defaultProps and default params
- checked through `findAllByType` to see if Text was referenced, it wasn't - see comment https://github.com/recharts/recharts/issues/3615#issuecomment-1651094565

## Screenshots (if appropriate):

- N/A - no visual diff

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
