### PR TITLE
fix: refactor curve to defaultParams

### DIFF
--- a/src/shape/Curve.tsx
+++ b/src/shape/Curve.tsx
@@ -105,7 +105,7 @@ type GetPathProps = Pick<Props, 'type' | 'points' | 'baseLine' | 'layout' | 'con
  * Calculate the path of curve
  * @return {String} path
  */
-const getPath = ({ type, points, baseLine, layout, connectNulls }: GetPathProps): string => {
+const getPath = ({ type = 'linear', points = [], baseLine, layout, connectNulls = false }: GetPathProps): string => {
   const curveFactory = getCurveFactory(type, layout);
   const formatPoints = connectNulls ? points.filter(entry => defined(entry)) : points;
   let lineFunction;
@@ -160,5 +160,3 @@ export const Curve: React.FC<Props> = props => {
     />
   );
 };
-
-Curve.defaultProps = { type: 'linear', points: [], connectNulls: false };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix latest React throwing error due to using defaultParams in function component within `Curve`. This is not at risk of breaking like other elements referenced in calls to the `findAllByType`, etc. functions in `ReactUtils` - the list of risky elements is in linked issue https://github.com/recharts/recharts/issues/3615#issuecomment-1651094565

## Related Issue
https://github.com/recharts/recharts/issues/3615

Fixes one of a few occurrences of this error being logged

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Continues to address a highly trafficked issue

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- ran manual visual difference between defaultProps and default params
- checked through `findAllByType` to see if Curve was referenced, it wasn't - see comment https://github.com/recharts/recharts/issues/3615#issuecomment-1651094565

## Screenshots (if appropriate):

- N/A - no visual diff

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
