### PR TITLE
fix(default-params): symbol and trapezoid to default params

### DIFF
--- a/src/shape/Symbols.tsx
+++ b/src/shape/Symbols.tsx
@@ -78,30 +78,25 @@ interface SymbolsProp {
 
 export type Props = SVGProps<SVGPathElement> & SymbolsProp;
 
-const symbolsDefaultProps = {
-  type: 'circle',
-  size: 64,
-  sizeType: 'area',
-};
-
 const registerSymbol = (key: string, factory: D3SymbolType) => {
   symbolFactories[`symbol${_.upperFirst(key)}`] = factory;
 };
 
-export const Symbols = (props: Props) => {
+export const Symbols = ({ type = 'circle', size = 64, sizeType = 'area', ...rest }: Props) => {
+  const props = { ...rest, type, size, sizeType };
+
   /**
    * Calculate the path of curve
    * @return {String} path
    */
   const getPath = () => {
-    const { size, sizeType, type } = props;
     const symbolFactory = getSymbolFactory(type);
     const symbol = shapeSymbol().type(symbolFactory).size(calculateAreaSize(size, sizeType, type));
 
     return symbol();
   };
 
-  const { className, cx, cy, size } = props;
+  const { className, cx, cy } = props;
   const filteredProps = filterProps(props, true);
 
   if (cx === +cx && cy === +cy && size === +size) {
@@ -118,5 +113,4 @@ export const Symbols = (props: Props) => {
   return null;
 };
 
-Symbols.defaultProps = symbolsDefaultProps;
 Symbols.registerSymbol = registerSymbol;

--- a/src/shape/Trapezoid.tsx
+++ b/src/shape/Trapezoid.tsx
@@ -34,7 +34,21 @@ interface TrapezoidProps {
 
 export type Props = SVGProps<SVGPathElement> & TrapezoidProps;
 
+const defaultProps: Props = {
+  x: 0,
+  y: 0,
+  upperWidth: 0,
+  lowerWidth: 0,
+  height: 0,
+  isUpdateAnimationActive: false,
+  animationBegin: 0,
+  animationDuration: 1500,
+  animationEasing: 'ease',
+};
+
 export const Trapezoid: React.FC<Props> = props => {
+  const trapezoidProps: Props = { ...defaultProps, ...props };
+
   const pathRef = useRef<SVGPathElement>();
   const [totalLength, setTotalLength] = useState(-1);
 
@@ -52,8 +66,8 @@ export const Trapezoid: React.FC<Props> = props => {
     }
   }, []);
 
-  const { x, y, upperWidth, lowerWidth, height, className } = props;
-  const { animationEasing, animationDuration, animationBegin, isUpdateAnimationActive } = props;
+  const { x, y, upperWidth, lowerWidth, height, className } = trapezoidProps;
+  const { animationEasing, animationDuration, animationBegin, isUpdateAnimationActive } = trapezoidProps;
 
   if (
     x !== +x ||
@@ -73,7 +87,7 @@ export const Trapezoid: React.FC<Props> = props => {
     return (
       <g>
         <path
-          {...filterProps(props, true)}
+          {...filterProps(trapezoidProps, true)}
           className={layerClass}
           d={getTrapezoidPath(x, y, upperWidth, lowerWidth, height)}
         />
@@ -112,7 +126,7 @@ export const Trapezoid: React.FC<Props> = props => {
           easing={animationEasing}
         >
           <path
-            {...filterProps(props, true)}
+            {...filterProps(trapezoidProps, true)}
             className={layerClass}
             d={getTrapezoidPath(currX, currY, currUpperWidth, currLowerWidth, currHeight)}
             ref={pathRef}
@@ -121,16 +135,4 @@ export const Trapezoid: React.FC<Props> = props => {
       )}
     </Animate>
   );
-};
-
-Trapezoid.defaultProps = {
-  x: 0,
-  y: 0,
-  upperWidth: 0,
-  lowerWidth: 0,
-  height: 0,
-  isUpdateAnimationActive: false,
-  animationBegin: 0,
-  animationDuration: 1500,
-  animationEasing: 'ease',
 };

--- a/test/shape/Symbols.spec.tsx
+++ b/test/shape/Symbols.spec.tsx
@@ -16,6 +16,8 @@ describe('<Symbols />', () => {
   test('Render 1 symbol when type is wrong', () => {
     const { container } = render(
       <Surface width={400} height={400}>
+        {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+        {/* @ts-ignore */}
         <Symbols cx={100} cy={100} type={undefined} />
       </Surface>,
     );

--- a/test/shape/Trapezoid.spec.tsx
+++ b/test/shape/Trapezoid.spec.tsx
@@ -25,7 +25,7 @@ describe('<Trapezoid />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test("Don't render any Trapezoid when props is invalid", () => {
+  test("Don't render any Trapezoid when props are invalid", () => {
     const { container } = render(
       <Surface width={500} height={500}>
         <Trapezoid fill="#f00" x={300} y={100} upperWidth={0} lowerWidth={0} height={50} />

--- a/test/shape/__snapshots__/Trapezoid.spec.tsx.snap
+++ b/test/shape/__snapshots__/Trapezoid.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Trapezoid /> Don't render any Trapezoid when props is invalid 1`] = `
+exports[`<Trapezoid /> Don't render any Trapezoid when props are invalid 1`] = `
 <div>
   <svg
     class="recharts-surface"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix latest React throwing error due to using defaultParams in function component within `Trapezoid` and `Symbol`. This is not at risk of breaking like other elements referenced in calls to the `findAllByType`, etc. functions in `ReactUtils` - the list of risky elements is in linked issue https://github.com/recharts/recharts/issues/3615#issuecomment-1651094565

## Related Issue
https://github.com/recharts/recharts/issues/3615

Fixes two of a few occurrences of this error being logged

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Continues to address a highly trafficked issue

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- ran manual visual difference between defaultProps and default params
- checked through `findAllByType` to see if Trapezoid/Symbol was referenced, it wasn't
- ensure that default params and user provided params get merged correctly

## Screenshots (if appropriate):

- N/A - no visual diff

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
