### PR TITLE
fix(default-params): Cross to use default params

### DIFF
--- a/src/shape/Cross.tsx
+++ b/src/shape/Cross.tsx
@@ -22,8 +22,17 @@ const getPath = (x: number, y: number, width: number, height: number, top: numbe
   return `M${x},${top}v${height}M${left},${y}h${width}`;
 };
 
-export const Cross: React.FC<Props> = props => {
-  const { x, y, width, height, top, left, className } = props;
+export const Cross: React.FC<Props> = ({
+  x = 0,
+  y = 0,
+  top = 0,
+  left = 0,
+  width = 0,
+  height = 0,
+  className,
+  ...rest
+}) => {
+  const props = { x, y, top, left, width, height, ...rest };
 
   if (!isNumber(x) || !isNumber(y) || !isNumber(width) || !isNumber(height) || !isNumber(top) || !isNumber(left)) {
     return null;
@@ -36,13 +45,4 @@ export const Cross: React.FC<Props> = props => {
       d={getPath(x, y, width, height, top, left)}
     />
   );
-};
-
-Cross.defaultProps = {
-  x: 0,
-  y: 0,
-  top: 0,
-  left: 0,
-  width: 0,
-  height: 0,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix latest React throwing error due to using defaultParams in function component within Cross. This is not at risk of breaking like other elements referenced in calls to the findAllByType, etc. functions in ReactUtils - the list of risky elements is in linked issue #3615 (comment)

## Related Issue

# 3615

## Motivation and Context

Continues to address a highly trafficked issue

## How Has This Been Tested?

- ran manual visual difference between defaultProps and default params
- checked through findAllByType to see if Cross was referenced, it wasn't
- ensure that default params and user provided params get merged correctly

## Screenshots (if appropriate)

- N/A - no visual diff

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
