### PR TITLE
fix(default-params): Rectangle to use default params

### DIFF
--- a/src/shape/Rectangle.tsx
+++ b/src/shape/Rectangle.tsx
@@ -102,7 +102,24 @@ export const isInRectangle = (
 
 export type Props = Omit<SVGProps<SVGPathElement>, 'radius'> & RectangleProps;
 
-export const Rectangle: React.FC<Props> = props => {
+const defaultProps = {
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+  // The radius of border
+  // The radius of four corners when radius is a number
+  // The radius of left-top, right-top, right-bottom, left-bottom when radius is an array
+  radius: 0,
+  isAnimationActive: false,
+  isUpdateAnimationActive: false,
+  animationBegin: 0,
+  animationDuration: 1500,
+  animationEasing: 'ease',
+};
+
+export const Rectangle: React.FC<Props> = rectangleProps => {
+  const props = { ...defaultProps, ...rectangleProps };
   const pathRef = useRef<SVGPathElement>();
   const [totalLength, setTotalLength] = useState(-1);
 
@@ -164,20 +181,4 @@ export const Rectangle: React.FC<Props> = props => {
       )}
     </Animate>
   );
-};
-
-Rectangle.defaultProps = {
-  x: 0,
-  y: 0,
-  width: 0,
-  height: 0,
-  // The radius of border
-  // The radius of four corners when radius is a number
-  // The radius of left-top, right-top, right-bottom, left-bottom when radius is an array
-  radius: 0,
-  isAnimationActive: false,
-  isUpdateAnimationActive: false,
-  animationBegin: 0,
-  animationDuration: 1500,
-  animationEasing: 'ease',
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix latest React throwing error due to using defaultParams in function component within Rectangle. This is not at risk of breaking like other elements referenced in calls to the findAllByType, etc. functions in ReactUtils - the list of risky elements is in linked issue #3615 (comment)

## Related Issue

# 3615

## Motivation and Context

Continues to address a highly trafficked issue

## How Has This Been Tested?

- ran manual visual difference between defaultProps and default params
- checked through findAllByType to see if Rectangle was referenced, it wasn't
- ensure that default params and user provided params get merged correctly

## Screenshots (if appropriate)

- N/A - no visual diff

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
