### PR TITLE
feat(Sankey): add prop to control sankey sorting

### DIFF
--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -147,13 +147,15 @@ const updateYOfTree = (depthTree: any, height: number, nodePadding: number, link
   return links.map((link: any) => ({ ...link, dy: getValue(link) * yRatio }));
 };
 
-const resolveCollisions = (depthTree: any[], height: number, nodePadding: number) => {
+const resolveCollisions = (depthTree: any[], height: number, nodePadding: number, sort = true) => {
   for (let i = 0, len = depthTree.length; i < len; i++) {
     const nodes = depthTree[i];
     const n = nodes.length;
 
     // Sort by the value of y
-    nodes.sort(ascendingY);
+    if (sort) {
+      nodes.sort(ascendingY);
+    }
 
     let y0 = 0;
     for (let j = 0; j < n; j++) {
@@ -252,6 +254,7 @@ const computeData = ({
   iterations,
   nodeWidth,
   nodePadding,
+  sort
 }: {
   data: SankeyData;
   width: number;
@@ -268,17 +271,17 @@ const computeData = ({
   const depthTree = getDepthTree(tree);
   const newLinks = updateYOfTree(depthTree, height, nodePadding, links);
 
-  resolveCollisions(depthTree, height, nodePadding);
+  resolveCollisions(depthTree, height, nodePadding, sort);
 
   let alpha = 1;
   for (let i = 1; i <= iterations; i++) {
     relaxRightToLeft(tree, depthTree, newLinks, (alpha *= 0.99));
 
-    resolveCollisions(depthTree, height, nodePadding);
+    resolveCollisions(depthTree, height, nodePadding, sort);
 
     relaxLeftToRight(tree, depthTree, newLinks, alpha);
 
-    resolveCollisions(depthTree, height, nodePadding);
+    resolveCollisions(depthTree, height, nodePadding, sort);
   }
 
   updateYOfLinks(tree, newLinks);
@@ -379,6 +382,8 @@ interface SankeyProps {
   onMouseEnter?: any;
 
   onMouseLeave?: any;
+
+  sort?: boolean
 }
 
 type Props = SVGProps<SVGElement> & SankeyProps;
@@ -410,6 +415,7 @@ export class Sankey extends PureComponent<Props, State> {
     linkCurvature: 0.5,
     iterations: 32,
     margin: { top: 5, right: 5, bottom: 5, left: 5 },
+    sort: true
   };
 
   state = {
@@ -421,7 +427,7 @@ export class Sankey extends PureComponent<Props, State> {
   };
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
-    const { data, width, height, margin, iterations, nodeWidth, nodePadding } = nextProps;
+    const { data, width, height, margin, iterations, nodeWidth, nodePadding, sort } = nextProps;
 
     if (
       data !== prevState.prevData ||
@@ -430,7 +436,8 @@ export class Sankey extends PureComponent<Props, State> {
       !shallowEqual(margin, prevState.prevMargin) ||
       iterations !== prevState.prevIterations ||
       nodeWidth !== prevState.prevNodeWidth ||
-      nodePadding !== prevState.prevNodePadding
+      nodePadding !== prevState.prevNodePadding ||
+      sort !== prevState.sort
     ) {
       const contentWidth = width - ((margin && margin.left) || 0) - ((margin && margin.right) || 0);
       const contentHeight = height - ((margin && margin.top) || 0) - ((margin && margin.bottom) || 0);
@@ -441,6 +448,7 @@ export class Sankey extends PureComponent<Props, State> {
         iterations,
         nodeWidth,
         nodePadding,
+        sort
       });
 
       return {
@@ -455,6 +463,7 @@ export class Sankey extends PureComponent<Props, State> {
         prevNodePadding: nodePadding,
         prevNodeWidth: nodeWidth,
         prevIterations: iterations,
+        prevSort: sort
       };
     }
 

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -254,7 +254,7 @@ const computeData = ({
   iterations,
   nodeWidth,
   nodePadding,
-  sort
+  sort,
 }: {
   data: SankeyData;
   width: number;
@@ -262,6 +262,7 @@ const computeData = ({
   iterations: any;
   nodeWidth: number;
   nodePadding: number;
+  sort: boolean;
 }): {
   nodes: SankeyNode[];
   links: SankeyLink[];
@@ -383,7 +384,7 @@ interface SankeyProps {
 
   onMouseLeave?: any;
 
-  sort?: boolean
+  sort?: boolean;
 }
 
 type Props = SVGProps<SVGElement> & SankeyProps;
@@ -394,6 +395,7 @@ interface State {
   isTooltipActive: boolean;
   nodes: SankeyNode[];
   links: SankeyLink[];
+  sort?: boolean;
 
   prevData?: SankeyData;
   prevWidth?: number;
@@ -402,6 +404,7 @@ interface State {
   prevIterations?: number;
   prevNodeWidth?: number;
   prevNodePadding?: number;
+  prevSort?: boolean;
 }
 
 export class Sankey extends PureComponent<Props, State> {
@@ -415,7 +418,7 @@ export class Sankey extends PureComponent<Props, State> {
     linkCurvature: 0.5,
     iterations: 32,
     margin: { top: 5, right: 5, bottom: 5, left: 5 },
-    sort: true
+    sort: true,
   };
 
   state = {
@@ -448,7 +451,7 @@ export class Sankey extends PureComponent<Props, State> {
         iterations,
         nodeWidth,
         nodePadding,
-        sort
+        sort,
       });
 
       return {
@@ -463,7 +466,7 @@ export class Sankey extends PureComponent<Props, State> {
         prevNodePadding: nodePadding,
         prevNodeWidth: nodeWidth,
         prevIterations: iterations,
-        prevSort: sort
+        prevSort: sort,
       };
     }
 

--- a/storybook/stories/API/chart/Sankey.stories.tsx
+++ b/storybook/stories/API/chart/Sankey.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { nodeLinkData } from '../../data';
+import { complexNodeLinkData, nodeLinkData } from '../../data';
 import { ResponsiveContainer, Sankey } from '../../../../src';
 import { data, margin } from '../props/ChartProps';
 import { dataKey } from '../props/CartesianComponentShared';
+import { SankeyNode } from '../../../../src/util/types';
 
 export default {
   argTypes: {
@@ -16,7 +17,7 @@ export default {
     dataKey,
     margin,
     data,
-    sort: { description: 'Whether to sort the data or not (default to true)' },
+    sort: { description: 'Whether to sort the data or not' },
   },
   component: Sankey,
 };
@@ -48,5 +49,131 @@ export const Customized = {
     nodePadding: 60,
     height: 500,
     width: 960,
+  },
+};
+
+export const CustomNodeAndLink = {
+  render: (args: Record<string, any>) => {
+    const colors = ['#3C898E', '#486DF0', '#6F50E5'];
+
+    type CustomNodePayload = {
+      name: string;
+      sourceNodes: number[];
+      sourceLinks: number[];
+      targetLinks: number[];
+      targetNodes: number[];
+      value: number;
+      depth: number;
+      x: number;
+      dx: number;
+      y: number;
+      dy: number;
+    };
+
+    const CustomNode = (
+      props: SankeyNode & { width: number; height: number; payload: CustomNodePayload },
+    ): React.ReactElement => {
+      return (
+        <rect
+          x={props.x + 4}
+          y={props.y - 2}
+          width={props.width - 8}
+          height={props.height + 4}
+          fill={colors[props.payload.depth % colors.length]}
+          rx={2.5}
+        />
+      );
+    };
+
+    type CustomLinkPayload = {
+      source: CustomNodePayload;
+      target: CustomNodePayload;
+      value: number;
+      dy: number;
+      sy: number;
+      ty: number;
+    };
+
+    const CustomLink = (props: {
+      sourceX: number;
+      targetX: number;
+      sourceY: number;
+      targetY: number;
+      sourceControlX: number;
+      targetControlX: number;
+      sourceRelativeY: number;
+      targetRelativeY: number;
+      linkWidth: number;
+      index: number;
+      payload: CustomLinkPayload;
+    }) => {
+      return (
+        <g>
+          <path
+            d={`
+  M${props.sourceX},${props.sourceY}
+  C${props.sourceControlX},${props.sourceY} ${props.targetControlX},${props.targetY} ${props.targetX},${props.targetY}`}
+            fill="none"
+            stroke={colors[props.payload.source.depth % colors.length]}
+            strokeOpacity={0.4}
+            strokeWidth={props.linkWidth}
+            strokeLinecap="butt"
+          />
+          <foreignObject
+            x={props.sourceX}
+            y={props.targetY - props.linkWidth / 2}
+            width={Math.max(props.targetX, props.sourceX) - Math.min(props.targetX, props.sourceX)}
+            height={props.linkWidth}
+            style={{ overflow: 'visible' }}
+          >
+            <div
+              style={{
+                boxSizing: 'border-box',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                width: '100%',
+                height: '100%',
+                overflow: 'visible',
+                padding: '0.5em',
+                gap: 8,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 10,
+                  fontFamily: 'sans-serif',
+                  textAlign: 'center',
+                  backgroundColor: '#f1f5fe80',
+                  padding: '0.25em 0.5em',
+                  borderRadius: 4,
+                  position: 'relative',
+                  zIndex: 1,
+                }}
+              >
+                {props.payload.target.name ? `${props.payload.target.name}: ` : ''}
+                {props.payload.value}
+                &nbsp;€
+              </div>
+            </div>
+          </foreignObject>
+        </g>
+      );
+    };
+
+    return (
+      <ResponsiveContainer width="100%" height={400}>
+        <Sankey data={complexNodeLinkData} node={CustomNode} link={CustomLink} {...args} />
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    data: complexNodeLinkData,
+    nodeWidth: 16,
+    nodePadding: 14,
+    height: 500,
+    width: 960,
+    sort: false,
+    margin: { top: 20, left: 20, right: 20, bottom: 20 },
   },
 };

--- a/storybook/stories/API/chart/Sankey.stories.tsx
+++ b/storybook/stories/API/chart/Sankey.stories.tsx
@@ -16,6 +16,7 @@ export default {
     dataKey,
     margin,
     data,
+    sort: { description: 'Whether to sort the data or not (default to true)' },
   },
   component: Sankey,
 };

--- a/storybook/stories/data/NodeAndLink.ts
+++ b/storybook/stories/data/NodeAndLink.ts
@@ -9,8 +9,8 @@ const nodeLinkData = {
   links: [
     { source: 0, target: 1, value: 3728.3 },
     { source: 0, target: 2, value: 354170 },
-    { source: 2, target: 3, value: 62429 },
-    { source: 2, target: 4, value: 291741 },
+    { source: 2, target: 3, value: 291741 },
+    { source: 2, target: 4, value: 62429 },
   ],
 };
 

--- a/storybook/stories/data/NodeAndLink.ts
+++ b/storybook/stories/data/NodeAndLink.ts
@@ -16,63 +16,25 @@ const nodeLinkData = {
 
 const complexNodeLinkData = {
   nodes: [
-    {
-      name: 'Income',
-    },
-    {
-      name: 'Budget',
-    },
-    {
-      name: 'Investment',
-    },
-    {
-      name: 'Real Estate',
-    },
-    {
-      name: 'Crypto',
-    },
-    {
-      name: 'Stocks & Funds',
-    },
-    {
-      name: 'Saving',
-    },
-    {
-      name: 'Scpi',
-    },
-    {
-      name: 'BTC',
-    },
-    {
-      name: 'ETH',
-    },
-    {
-      name: 'SOL',
-    },
-    {
-      name: 'Housing',
-    },
-    {
-      name: 'Food',
-    },
-    {
-      name: 'Rent',
-    },
-    {
-      name: 'Utility',
-    },
-    {
-      name: 'Mortgage',
-    },
-    {
-      name: 'Groceries',
-    },
-    {
-      name: 'Delivery',
-    },
-    {
-      name: 'Restaurant',
-    },
+    { name: 'Income' },
+    { name: 'Budget' },
+    { name: 'Investment' },
+    { name: 'Real Estate' },
+    { name: 'Crypto' },
+    { name: 'Stocks & Funds' },
+    { name: 'Saving' },
+    { name: 'Scpi' },
+    { name: 'BTC' },
+    { name: 'ETH' },
+    { name: 'SOL' },
+    { name: 'Housing' },
+    { name: 'Food' },
+    { name: 'Rent' },
+    { name: 'Utility' },
+    { name: 'Mortgage' },
+    { name: 'Groceries' },
+    { name: 'Delivery' },
+    { name: 'Restaurant' },
   ],
   links: [
     {

--- a/storybook/stories/data/NodeAndLink.ts
+++ b/storybook/stories/data/NodeAndLink.ts
@@ -14,4 +14,158 @@ const nodeLinkData = {
   ],
 };
 
-export { nodeLinkData };
+const complexNodeLinkData = {
+  nodes: [
+    {
+      name: 'Income',
+    },
+    {
+      name: 'Budget',
+    },
+    {
+      name: 'Investment',
+    },
+    {
+      name: 'Real Estate',
+    },
+    {
+      name: 'Crypto',
+    },
+    {
+      name: 'Stocks & Funds',
+    },
+    {
+      name: 'Saving',
+    },
+    {
+      name: 'Scpi',
+    },
+    {
+      name: 'BTC',
+    },
+    {
+      name: 'ETH',
+    },
+    {
+      name: 'SOL',
+    },
+    {
+      name: 'Housing',
+    },
+    {
+      name: 'Food',
+    },
+    {
+      name: 'Rent',
+    },
+    {
+      name: 'Utility',
+    },
+    {
+      name: 'Mortgage',
+    },
+    {
+      name: 'Groceries',
+    },
+    {
+      name: 'Delivery',
+    },
+    {
+      name: 'Restaurant',
+    },
+  ],
+  links: [
+    {
+      source: 0,
+      target: 1,
+      value: 8500,
+    },
+    {
+      source: 1,
+      target: 2,
+      value: 2300,
+    },
+    {
+      source: 1,
+      target: 3,
+      value: 400,
+    },
+    {
+      source: 1,
+      target: 4,
+      value: 1250,
+    },
+    {
+      source: 2,
+      target: 5,
+      value: 1800,
+    },
+    {
+      source: 2,
+      target: 6,
+      value: 500,
+    },
+    {
+      source: 3,
+      target: 7,
+      value: 400,
+    },
+    {
+      source: 4,
+      target: 8,
+      value: 500,
+    },
+    {
+      source: 4,
+      target: 9,
+      value: 500,
+    },
+    {
+      source: 4,
+      target: 10,
+      value: 250,
+    },
+    {
+      source: 1,
+      target: 11,
+      value: 3384,
+    },
+    {
+      source: 1,
+      target: 12,
+      value: 800,
+    },
+    {
+      source: 11,
+      target: 13,
+      value: 1234,
+    },
+    {
+      source: 11,
+      target: 14,
+      value: 150,
+    },
+    {
+      source: 11,
+      target: 15,
+      value: 2000,
+    },
+    {
+      source: 12,
+      target: 16,
+      value: 450,
+    },
+    {
+      source: 12,
+      target: 17,
+      value: 200,
+    },
+    {
+      source: 12,
+      target: 18,
+      value: 150,
+    },
+  ],
+};
+
+export { nodeLinkData, complexNodeLinkData };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds a prop to the Sankey component to allow disabling the y sorting

## Description

The Sankey component sorts nodes by y value and doesn't expose a way to control this behavior. This PR adds a boolean prop that allow to disable that sorting behavior. This prop default to true so that existing implementation keep rendering the same.

Here's a visual to showcase the current behavior and the new one with the prop set to false:

With sorting | Without sorting
--|--
<img width="813" alt="image" src="https://github.com/recharts/recharts/assets/1694893/db511197-d045-4252-b83a-f093afd1bc3e"> | <img width="810" alt="image" src="https://github.com/recharts/recharts/assets/1694893/5941b06a-d2ec-460e-9bcd-47a20ccf4cc2">
<!--- Describe your changes in detail -->

The storybook has been updated to reflect the new prop

## Related Issue

#3683
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

When using Sankey charts to create cashflow charts, we want to group expenses or income by category. The automatic sorting makes chart links overlap and cross each other, when we want to actually group things by topic to keep the cashflow analysis legible. The fact that one expense in one category is smaller than others in other categories shouldn't move the link around and mix it with other categories, as it makes the chart more complicated to read. The goal is to give control to the user on the grouping of the branches, while still providing with the option to sort data by default for backward compatibility

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- [x] used the prop on a existing implementation
- [x] manually tested through storybook
- [x] ran the jest test suites
- [x] ran the storybook tests  

## Screenshots (if appropriate):

See description

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- ~[ ] Bug fix (non-breaking change which fixes an issue)~
- [x] New feature (non-breaking change which adds functionality)
- ~[ ] Breaking change (fix or feature that would cause existing functionality to change)~

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (https://github.com/recharts/recharts.org/pull/275)
- ~[ ] I have added tests to cover my changes.~ (I don't see how I can automatically test this since no data-attributes are present on the nodes / links and the existing Sankey test are just counting nodes)
- [x] All new and existing tests passed.
