### PR TITLE
fix(default-params): Sector to use default params

### DIFF
--- a/src/shape/Sector.tsx
+++ b/src/shape/Sector.tsx
@@ -195,7 +195,20 @@ interface SectorProps extends GeometrySector {
 
 export type Props = SVGProps<SVGPathElement> & SectorProps;
 
-export const Sector: React.FC<Props> = props => {
+const defaultProps = {
+  cx: 0,
+  cy: 0,
+  innerRadius: 0,
+  outerRadius: 0,
+  startAngle: 0,
+  endAngle: 0,
+  cornerRadius: 0,
+  forceCornerRadius: false,
+  cornerIsExternal: false,
+};
+
+export const Sector: React.FC<Props> = sectorProps => {
+  const props = { ...defaultProps, ...sectorProps };
   const {
     cx,
     cy,
@@ -235,16 +248,4 @@ export const Sector: React.FC<Props> = props => {
   }
 
   return <path {...filterProps(props, true)} className={layerClass} d={path} role="img" />;
-};
-
-Sector.defaultProps = {
-  cx: 0,
-  cy: 0,
-  innerRadius: 0,
-  outerRadius: 0,
-  startAngle: 0,
-  endAngle: 0,
-  cornerRadius: 0,
-  forceCornerRadius: false,
-  cornerIsExternal: false,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix latest React throwing error due to using defaultParams in function component within Sector. This is not at risk of breaking like other elements referenced in calls to the findAllByType, etc. functions in ReactUtils - the list of risky elements is in linked issue #3615 (comment)

## Related Issue

# 3615

## Motivation and Context

Continues to address a highly trafficked issue

## How Has This Been Tested?

- ran manual visual difference between defaultProps and default params
- checked through findAllByType to see if Sector was referenced, it wasn't
- ensure that default params and user provided params get merged correctly

## Screenshots (if appropriate)

- N/A - no visual diff

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
