### PR TITLE
add: default tabIndex and accept it as prop

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -133,7 +133,7 @@ export class Pie extends PureComponent<Props, State> {
 
   static displayName = 'Pie';
 
-  static defaultProps = {
+  static defaultProps: Partial<Props> = {
     stroke: '#fff',
     fill: '#808080',
     legendType: 'rect',
@@ -153,6 +153,7 @@ export class Pie extends PureComponent<Props, State> {
     animationEasing: 'ease',
     nameKey: 'name',
     blendStroke: false,
+    tabIndex: 0,
   };
 
   static parseDeltaAngle = (startAngle: number, endAngle: number) => {
@@ -636,7 +637,7 @@ export class Pie extends PureComponent<Props, State> {
 
     return (
       <Layer
-        tabIndex={0}
+        tabIndex={this.props.tabIndex}
         className={layerClass}
         ref={(ref: HTMLElement) => {
           this.pieRef = ref;

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -102,6 +102,7 @@ interface PieProps extends PieDef {
   onMouseEnter?: (data: any, index: number, e: React.MouseEvent) => void;
   onMouseLeave?: (data: any, index: number, e: React.MouseEvent) => void;
   onClick?: (data: any, index: number, e: React.MouseEvent) => void;
+  rootTabIndex?: number;
 }
 
 export interface PieLabelRenderProps extends PieDef {
@@ -133,7 +134,7 @@ export class Pie extends PureComponent<Props, State> {
 
   static displayName = 'Pie';
 
-  static defaultProps: Partial<Props> = {
+  static defaultProps = {
     stroke: '#fff',
     fill: '#808080',
     legendType: 'rect',
@@ -153,7 +154,7 @@ export class Pie extends PureComponent<Props, State> {
     animationEasing: 'ease',
     nameKey: 'name',
     blendStroke: false,
-    tabIndex: 0,
+    rootTabIndex: 0,
   };
 
   static parseDeltaAngle = (startAngle: number, endAngle: number) => {
@@ -637,7 +638,7 @@ export class Pie extends PureComponent<Props, State> {
 
     return (
       <Layer
-        tabIndex={this.props.tabIndex}
+        tabIndex={this.props.rootTabIndex}
         className={layerClass}
         ref={(ref: HTMLElement) => {
           this.pieRef = ref;

--- a/storybook/stories/API/polar/Pie.stories.tsx
+++ b/storybook/stories/API/polar/Pie.stories.tsx
@@ -124,6 +124,13 @@ const GeneralProps: Args = {
     description: 'The shape of inactive sector.',
     table: { type: { summary: 'Object | ReactElement | Function' }, category: 'General' },
   },
+  rootTabIndex: {
+    description: 'The tabIndex of the root layer of the Pie component.',
+    table: {
+      type: { summary: 'number', defaultValue: 0 },
+      category: 'General',
+    },
+  },
 };
 
 export default {
@@ -147,7 +154,7 @@ export const Simple = {
   render: (args: Record<string, any>) => {
     const [surfaceWidth, surfaceHeight] = [500, 500];
 
-    const { data, sectors } = args;
+    const { data, sectors, rootTabIndex } = args;
 
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
@@ -174,6 +181,7 @@ export const Simple = {
             dataKey="value"
             fill="#fff"
             stroke="#000"
+            rootTabIndex={rootTabIndex}
           />
           <line x1={0} y1={250} x2={500} y2={250} stroke="black" />
         </Surface>

--- a/test/polar/Pie.spec.tsx
+++ b/test/polar/Pie.spec.tsx
@@ -448,6 +448,56 @@ describe('<Pie />', () => {
     );
   });
 
+  test('Handles keyboard interaction: Tab can not focus in and out of the pie chart', async () => {
+    expect.assertions(3);
+    const timeout = 2000;
+    const { container } = render(
+      <div role="button" tabIndex={0} className="container">
+        <Surface width={500} height={500}>
+          <Pie
+            isAnimationActive={false}
+            cx={250}
+            cy={250}
+            label
+            innerRadius={0}
+            outerRadius={200}
+            sectors={sectors}
+            dataKey="cy"
+            rootTabIndex={-1}
+          />
+        </Surface>
+      </div>,
+    );
+    const pie = container.getElementsByClassName('recharts-pie')[0];
+    const pieContainer = document.getElementsByClassName('container')[0] as HTMLElement;
+
+    pieContainer.focus();
+    await waitFor(
+      () => {
+        expect(document.activeElement).toBe(pieContainer);
+      },
+      { timeout },
+    );
+
+    // Testing that pressing tab goes into pie chart
+    await userEvent.tab();
+    await waitFor(
+      () => {
+        expect(document.activeElement).not.toBe(pie);
+      },
+      { timeout },
+    );
+
+    // Testing that pressing tab goes out of pie chart
+    await userEvent.tab();
+    await waitFor(
+      () => {
+        expect(document.activeElement).not.toBe(document.body);
+      },
+      { timeout },
+    );
+  });
+
   test('Handles keyboard interaction: arrow keys can move focus into sectors', async () => {
     expect.assertions(2);
     const timeout = 2000;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make `<Pie />` component accept `rootTabIndex` as a prop and use it in the root
`Layer` in the render function.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Previously the root layer of `Pie` was always keyboard focus-able which
means it wasn't possible to control its behavior. This changes that to
accept an optional `rootTabIndex` prop which by default is `0` the old value
to make sure not introduce a breaking change, except now users can
control this via a prop.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
