### PR TITLE
fix(default-props): polar grid to default params

### DIFF
--- a/src/polar/PolarGrid.tsx
+++ b/src/polar/PolarGrid.tsx
@@ -14,7 +14,7 @@ interface PolarGridProps {
   polarAngles?: number[];
   polarRadius?: number[];
   gridType?: 'polygon' | 'circle';
-  radialLines: boolean;
+  radialLines?: boolean;
 }
 export type Props = SVGProps<SVGPathElement> & PolarGridProps;
 
@@ -23,15 +23,6 @@ type ConcentricProps = Props & {
   radius: number;
   // The index of circle
   index: number;
-};
-
-const polarGridDefaultProps = {
-  cx: 0,
-  cy: 0,
-  innerRadius: 0,
-  outerRadius: 0,
-  gridType: 'polygon',
-  radialLines: true,
 };
 
 const getPolygonPath = (radius: number, cx: number, cy: number, polarAngles: number[]) => {
@@ -144,20 +135,41 @@ const ConcentricPath: React.FC<Props> = props => {
   );
 };
 
-export const PolarGrid = (props: Props) => {
-  const { outerRadius } = props;
-
+export const PolarGrid = ({
+  cx = 0,
+  cy = 0,
+  innerRadius = 0,
+  outerRadius = 0,
+  gridType = 'polygon',
+  radialLines = true,
+  ...props
+}: Props) => {
   if (outerRadius <= 0) {
     return null;
   }
 
   return (
     <g className="recharts-polar-grid">
-      <PolarAngles {...props} />
-      <ConcentricPath {...props} />
+      <PolarAngles
+        cx={cx}
+        cy={cy}
+        innerRadius={innerRadius}
+        outerRadius={outerRadius}
+        gridType={gridType}
+        radialLines={radialLines}
+        {...props}
+      />
+      <ConcentricPath
+        cx={cx}
+        cy={cy}
+        innerRadius={innerRadius}
+        outerRadius={outerRadius}
+        gridType={gridType}
+        radialLines={radialLines}
+        {...props}
+      />
     </g>
   );
 };
 
 PolarGrid.displayName = 'PolarGrid';
-PolarGrid.defaultProps = polarGridDefaultProps;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix default props of PolarGrid - this is the last remaining easy refactor to defaultParams

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/3615

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
error logged for users on render about defaultProps deprecation

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
