### PR TITLE
To resolve Issue 3721

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -167,7 +167,7 @@ export const ResponsiveContainer = forwardRef(
       }
     }, [getContainerSize]);
 
-    const styles: React.CSSProperties = style ?? { width, height, minWidth, minHeight, maxHeight };
+    const styles: React.CSSProperties = { ...style, width, height, minWidth, minHeight, maxHeight };
 
     return (
       <ReactResizeDetector

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -32,6 +32,7 @@ export interface Props {
   debounce?: number;
   id?: string | number;
   className?: string | number;
+  style?: React.CSSProperties;
   onResize?: (width: number, height: number) => void;
 }
 
@@ -57,6 +58,7 @@ export const ResponsiveContainer = forwardRef(
       id,
       className,
       onResize,
+      style,
     }: Props,
     ref,
   ) => {
@@ -165,7 +167,7 @@ export const ResponsiveContainer = forwardRef(
       }
     }, [getContainerSize]);
 
-    const style: React.CSSProperties = { width, height, minWidth, minHeight, maxHeight };
+    const styles: React.CSSProperties = style ?? { width, height, minWidth, minHeight, maxHeight };
 
     return (
       <ReactResizeDetector
@@ -179,7 +181,7 @@ export const ResponsiveContainer = forwardRef(
         <div
           {...(id != null ? { id: `${id}` } : {})}
           className={classNames('recharts-responsive-container', className)}
-          style={style}
+          style={styles}
           ref={containerRef}
         >
           {chartContent}

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -58,7 +58,7 @@ export const ResponsiveContainer = forwardRef(
       id,
       className,
       onResize,
-      style,
+      style = {},
     }: Props,
     ref,
   ) => {

--- a/test/component/ResponsiveContainer.spec.tsx
+++ b/test/component/ResponsiveContainer.spec.tsx
@@ -230,6 +230,19 @@ describe('<ResponsiveContainer />', () => {
     expect(element).toHaveStyle({ width: '100%', height: '200px', 'min-width': '0' });
   });
 
+  it('should accept and render the style prop if it is set', () => {
+    const { container } = render(
+      <ResponsiveContainer style={{ color: 'red', width: '100px' }}>
+        <div data-testid="inside" />
+      </ResponsiveContainer>,
+    );
+
+    expect(container.querySelector('.recharts-responsive-container')).toHaveStyle({
+      color: 'red',
+      width: '100px',
+    });
+  });
+
   it('should have a min-width of 200px when minWidth is 200', () => {
     const onResize = jest.fn();
 

--- a/test/component/ResponsiveContainer.spec.tsx
+++ b/test/component/ResponsiveContainer.spec.tsx
@@ -232,14 +232,29 @@ describe('<ResponsiveContainer />', () => {
 
   it('should accept and render the style prop if it is set', () => {
     const { container } = render(
-      <ResponsiveContainer style={{ color: 'red', width: '100px' }}>
+      <ResponsiveContainer style={{ color: 'red', backgroundColor: '#FF00FF' }}>
         <div data-testid="inside" />
       </ResponsiveContainer>,
     );
 
     expect(container.querySelector('.recharts-responsive-container')).toHaveStyle({
       color: 'red',
+      backgroundColor: '#FF00FF',
+    });
+  });
+
+  it('should accept and render the style prop and any other specified outside of it', () => {
+    const { container } = render(
+      <ResponsiveContainer style={{ backgroundColor: 'red', color: 'red' }} width={100} height={100}>
+        <div data-testid="inside" />
+      </ResponsiveContainer>,
+    );
+
+    expect(container.querySelector('.recharts-responsive-container')).toHaveStyle({
       width: '100px',
+      height: '100px',
+      backgroundColor: 'red',
+      color: 'red',
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Per [issue 3721](https://github.com/recharts/recharts/issues/3721), this adds the ability to pass the `style` prop without it being ignored.

## Related Issue

[Issue #3721](https://github.com/recharts/recharts/issues/3721)

## Motivation and Context

It allows the user to pass their own styles and have them rendered with the `ResponsiveContainer` component.

## How Has This Been Tested?

Unit tests have been added and have confirmed `style` being rendered.



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
