### PR TITLE
fix: remove invariant check for zAxisId for now

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -852,10 +852,11 @@ export const generateCategoricalChart = ({
 
         /**
          * tell the user in dev mode that their configuration is incorrect if we cannot find a match between
-         * axisId on the chart and axisId on the axis
+         * axisId on the chart and axisId on the axis. zAxis does not get passed in the map for ComposedChart,
+         * leave it out of the check for now.
          */
         invariant(
-          axisMap && axisMap[id],
+          (axisMap && axisMap[id]) || entry.axisType === 'zAxis',
           `Specifying a(n) ${entry.axisType}Id requires a corresponding ${
             entry.axisType
           }Id on the targeted graphical component ${item?.type?.displayName ?? ''}`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Storybook is failing to build and deploy due to this https://master--63da8268a0da9970db6992aa.chromatic.com/?path=/story/examples-composedchart-boxplot--box-plot-chart error in `BoxPlot` story.

This is because of PR https://github.com/recharts/recharts/pull/3720 which adds an invariant check if an axisId does not have a corresponding graph component.

Apparently `ComposedChart` doesn't pass in a ZAxis component in the axis map when there is a `Scatter` and `ZAxis` within it - this seems suspicious and is probably a bug. For now to stop the invalid error, remove `zAxis` from the invariant check

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A, failing build

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
failing build

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- run storybook
  - story is fixed
  - check for regressions with x and y axes

## Screenshots (if appropriate):
Box plot fixed
![image](https://github.com/recharts/recharts/assets/25180830/5d384acf-58c6-438f-8869-48b9330dc4f2)

Still throw error in X and Y axis case
![image](https://github.com/recharts/recharts/assets/25180830/82d153f7-d600-4a30-bdcf-736c8b7dab07)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
