### PR TITLE
Bugfix/b(#2778) tooltip position when container uses transform scale

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1255,7 +1255,9 @@ export const generateCategoricalChart = ({
       const e = calculateChartCoordinate(event, containerOffset);
 
       const element = this.container;
-      const scale = element.getBoundingClientRect().width / element.offsetWidth;
+      const boundingRectWidth = element?.getBoundingClientRect()?.width;
+      const { offsetWidth } = element;
+      const scale = boundingRectWidth / offsetWidth || 1;
 
       const rangeObj = this.inRange(e.chartX, e.chartY, scale);
       if (!rangeObj) {

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1253,7 +1253,11 @@ export const generateCategoricalChart = ({
 
       const containerOffset = getOffset(this.container);
       const e = calculateChartCoordinate(event, containerOffset);
-      const rangeObj = this.inRange(e.chartX, e.chartY);
+
+      const element = this.container;
+      const scale = element.getBoundingClientRect().width / element.offsetWidth;
+
+      const rangeObj = this.inRange(e.chartX, e.chartY, scale);
       if (!rangeObj) {
         return null;
       }
@@ -1343,23 +1347,28 @@ export const generateCategoricalChart = ({
       ];
     }
 
-    inRange(x: number, y: number): any {
+    inRange(x: number, y: number, scale = 1): any {
       const { layout } = this.props;
+
+      const [scaledX, scaledY] = [x / scale, y / scale];
 
       if (layout === 'horizontal' || layout === 'vertical') {
         const { offset } = this.state;
-        const isInRange =
-          x >= offset.left && x <= offset.left + offset.width && y >= offset.top && y <= offset.top + offset.height;
 
-        return isInRange ? { x, y } : null;
+        const isInRange =
+          scaledX >= offset.left &&
+          scaledX <= offset.left + offset.width &&
+          scaledY >= offset.top &&
+          scaledY <= offset.top + offset.height;
+
+        return isInRange ? { x: scaledX, y: scaledY } : null;
       }
 
       const { angleAxisMap, radiusAxisMap } = this.state;
 
       if (angleAxisMap && radiusAxisMap) {
         const angleAxis = getAnyElementOfObject(angleAxisMap);
-
-        return inRangeOfSector({ x, y }, angleAxis);
+        return inRangeOfSector({ x: scaledX, y: scaledY }, angleAxis);
       }
 
       return null;

--- a/storybook/stories/Examples/Tooltip.stories.tsx
+++ b/storybook/stories/Examples/Tooltip.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-shadow */
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { pageData } from '../data';
 import { Bar, ComposedChart, Line, ResponsiveContainer, Tooltip } from '../../../src';
 import { DefaultTooltipContent } from '../../../src/component/DefaultTooltipContent';
@@ -56,4 +56,47 @@ export const LockedByClick = {
   controls: {},
   description:
     'This example shows how to lock the tooltip to a specific position. Click on the chart to show fix the Tooltip.',
+};
+
+export const CssScaledParent = {
+  render: () => {
+    const [scale, setScale] = useState(1.2);
+    const handleZoomIn = useCallback(() => setScale(s => s + 0.1), []);
+    const handleZoomOut = useCallback(() => setScale(s => s - 0.1), []);
+    return (
+      <div style={{ width: '100%' }}>
+        <h2>No transform: scale</h2>
+        <div style={{ display: 'flex' }}>
+          <ResponsiveContainer width="100%" height={200}>
+            <ComposedChart data={pageData}>
+              <Line dataKey="uv" />
+              <Bar dataKey="pv" />
+              <Tooltip />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+
+        <h2>
+          Parent container
+          {`<div style={{transform: scale(${scale})}}> ...`}
+        </h2>
+        <button type="button" onClick={handleZoomIn}>
+          Zoom In
+        </button>
+        <button type="button" onClick={handleZoomOut}>
+          Zoom Out
+        </button>
+        <div style={{ transform: `scale(${scale})`, transformOrigin: '50% 0' }}>
+          <ResponsiveContainer width="100%" height={200}>
+            <ComposedChart data={pageData}>
+              <Line dataKey="uv" />
+              <Bar dataKey="pv" />
+              <Tooltip />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    );
+  },
+  description: 'This example shows if Tooltip is shown correctly when parent component use transform:scale styling',
 };


### PR DESCRIPTION
Fixes detection of a tooltip mouse event

## Description

When a parent container used transform: scale(Number) Css - the tooltip mouse event was fired up in the incorrect mouse position 

## Related Issue

https://github.com/recharts/recharts/issues/2778

## Motivation and Context

This changes allows user to style parent container with transform style css property without affecting tooltip behaviour

## How Has This Been Tested?

npm run test, npm run storybook and did some manual testing. I also created a dedicated story.
The changes should not affect other parts of the code - it was a change within 1 function, that already had tests around it. It introduces new parameter to a "inRange" function that have default value if wasn't passed. The API of that function was not changed, only extended. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a story to the storybook
- [x] All new and existing tests passed.
