### PR TITLE
feat: Implement activeBar for Bar component

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -73,7 +73,7 @@ export interface BarProps extends InternalBarProps {
   stackId?: string | number;
   barSize?: number;
   unit?: string | number;
-  name?: string;
+  name?: string | number;
   dataKey: DataKey<any>;
   tooltipType?: TooltipType;
   legendType?: LegendType;

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Render a group of bar
  */
-import React, { PureComponent, ReactElement, SVGProps } from 'react';
+import React, { Key, PureComponent, ReactElement, SVGProps } from 'react';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
 import _ from 'lodash';
@@ -64,15 +64,16 @@ type RectangleShapeType =
   | RectangleProps
   | boolean;
 
-interface BarProps extends InternalBarProps {
+export interface BarProps extends InternalBarProps {
   className?: string;
+  index?: Key;
   layout?: 'horizontal' | 'vertical';
   xAxisId?: string | number;
   yAxisId?: string | number;
   stackId?: string | number;
   barSize?: number;
   unit?: string | number;
-  name?: string | number;
+  name?: string;
   dataKey: DataKey<any>;
   tooltipType?: TooltipType;
   legendType?: LegendType;
@@ -80,7 +81,11 @@ interface BarProps extends InternalBarProps {
   maxBarSize?: number;
   hide?: boolean;
   shape?: ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>);
-  activeBar?: ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | boolean | SVGProps<SVGElement>;
+  activeBar?:
+    | ReactElement<SVGProps<SVGElement>>
+    | ((props: BarProps) => ReactElement<SVGProps<SVGElement>>)
+    | boolean
+    | SVGProps<SVGElement>;
   background?: RectangleShapeType;
   radius?: number | [number, number, number, number];
 

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Render a group of bar
  */
-import React, { PureComponent, ReactElement } from 'react';
+import React, { PureComponent, ReactElement, SVGProps } from 'react';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
 import _ from 'lodash';
@@ -80,6 +80,7 @@ interface BarProps extends InternalBarProps {
   maxBarSize?: number;
   hide?: boolean;
   shape?: ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>);
+  activeBar?: ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | boolean | SVGProps<SVGElement>;
   background?: RectangleShapeType;
   radius?: number | [number, number, number, number];
 
@@ -115,6 +116,7 @@ export class Bar extends PureComponent<Props, State> {
     hide: false,
     data: [] as BarRectangleItem[],
     layout: 'vertical',
+    activeBar: true,
     isAnimationActive: !Global.isSsr,
     animationBegin: 0,
     animationDuration: 400,

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -5,6 +5,7 @@ import invariant from 'tiny-invariant';
 import { getTicks } from '../cartesian/getTicks';
 import { Surface } from '../container/Surface';
 import { Layer } from '../container/Layer';
+import { Bar } from '../cartesian/Bar';
 import { Tooltip } from '../component/Tooltip';
 import { Legend } from '../component/Legend';
 import { Curve } from '../shape/Curve';
@@ -2040,6 +2041,24 @@ export const generateCategoricalChart = ({
       );
     };
 
+    static renderActiveBar = (option: any, props: any): React.ReactElement => {
+      let bar;
+
+      if (isValidElement(option)) {
+        bar = cloneElement(option, props);
+      } else if (_.isFunction(option)) {
+        bar = option(props);
+      } else {
+        bar = Bar.renderRectangle(props.shape, props);
+      }
+
+      return (
+        <Layer className="recharts-active-bar" key={props.key}>
+          {bar}
+        </Layer>
+      );
+    };
+
     renderActivePoints = ({ item, activePoint, basePoint, childIndex, isRange }: any) => {
       const result = [];
       const { key } = item.props;
@@ -2078,19 +2097,48 @@ export const generateCategoricalChart = ({
       return result;
     };
 
+    renderActiveBar = ({ item, childIndex }: any) => {
+      const result = [];
+      const { key } = item.props;
+      const { activeBar, dataKey } = item.item.props;
+
+      /**
+       * Default to inheriting props from the parent bar
+       */
+      const inheritedProps = {
+        ...item.item.props,
+        ...item.props.data[childIndex],
+      };
+
+      const barProps = {
+        index: childIndex,
+        dataKey,
+        fill: getMainColorOfGraphicItem(item.item),
+        strokeWidth: 2,
+        stroke: '#fff',
+        key: `${key}-activeBar-${childIndex}`,
+        ...inheritedProps,
+        ...filterProps(activeBar),
+        ...adaptEventHandlers(activeBar),
+      };
+
+      result.push(CategoricalChartWrapper.renderActiveBar(activeBar, barProps));
+
+      return result;
+    };
+
     renderGraphicChild = (element: React.ReactElement, displayName: string, index: number): any[] => {
       const item = this.filterFormatItem(element, displayName, index);
       if (!item) {
         return null;
       }
-
       const tooltipEventType = this.getTooltipEventType();
       const { isTooltipActive, tooltipAxis, activeTooltipIndex, activeLabel } = this.state;
       const { children } = this.props;
       const tooltipItem = findChildByType(children, Tooltip);
       const { points, isRange, baseLine } = item.props;
-      const { activeDot, hide } = item.item.props;
-      const hasActive = !hide && isTooltipActive && tooltipItem && activeDot && activeTooltipIndex >= 0;
+      const { activeDot, hide, activeBar } = item.item.props;
+      const hasActive = !hide && isTooltipActive && tooltipItem && (activeDot || activeBar) && activeTooltipIndex >= 0;
       let itemEvents = {};
 
       if (tooltipEventType !== 'axis' && tooltipItem && tooltipItem.props.trigger === 'click') {
@@ -2123,8 +2171,12 @@ export const generateCategoricalChart = ({
           activePoint = findEntryInArray(points, specifiedKey, activeLabel);
           basePoint = isRange && baseLine && findEntryInArray(baseLine, specifiedKey, activeLabel);
         } else {
-          activePoint = points[activeTooltipIndex];
+          activePoint = points?.[activeTooltipIndex];
           basePoint = isRange && baseLine && baseLine[activeTooltipIndex];
+        }
+
+        if (activeBar) {
+          return [graphicalItem, ...this.renderActiveBar({ item, childIndex: activeTooltipIndex })];
         }
 
         if (!_.isNil(activePoint)) {

--- a/src/util/BarUtils.tsx
+++ b/src/util/BarUtils.tsx
@@ -1,0 +1,27 @@
+import _ from 'lodash';
+import React, { ComponentProps, isValidElement, cloneElement } from 'react';
+import { Bar, BarProps } from '../cartesian/Bar';
+import { Layer } from '../container/Layer';
+
+export const ActiveBar = ({
+  option,
+  ...props
+}: {
+  option: BarProps['activeBar'];
+} & ComponentProps<typeof Bar>) => {
+  let bar;
+
+  if (isValidElement(option)) {
+    bar = cloneElement<BarProps['activeBar']>(option, props);
+  } else if (_.isFunction(option)) {
+    bar = option(props);
+  } else {
+    bar = Bar.renderRectangle(props.shape, props);
+  }
+
+  return (
+    <Layer className="recharts-active-bar" key={props.key}>
+      {bar}
+    </Layer>
+  );
+};

--- a/storybook/stories/API/cartesian/Bar.stories.tsx
+++ b/storybook/stories/API/cartesian/Bar.stories.tsx
@@ -344,6 +344,12 @@ const EventHandlersForBar = {
   onWheelCapture,
 };
 
+// declaring this here so that it displays evenly spaced in storybook.
+const activeBarDetailString = `<Bar dataKey="value" activeBar={false} />\n
+<Bar dataKey="value" activeBar={{ stroke: 'red', strokeWidth: 2 }} />\n
+<Bar dataKey="value" activeBar={<CustomizedBar />} />\n
+<Bar dataKey="value" activeBar={renderBar} />`;
+
 const StyleProps: Args = {
   strokeDasharray: GeneralStyle.strokeDasharray,
   stroke: GeneralStyle.stroke,
@@ -373,6 +379,22 @@ const StyleProps: Args = {
   },
   shape: {
     table: { category: 'Style' },
+  },
+  activeBar: {
+    description: `The active bar is shown when a user enters a bar chart and this chart has tooltip.
+    If set to false, no active bar will be drawn.
+    If set to true, active bar will be drawn with the props calculated internally.
+    If passed an object, active bar will be drawn,
+    and the internally calculated props will be merged with the key value pairs of the passed object.
+    If passed a ReactElement, the option can be the custom active bar element.
+    If passed a function, the function will be called to render a customized active bar.`,
+    table: {
+      type: {
+        summary: 'Boolean | Object | ReactElement | Function',
+        detail: activeBarDetailString,
+      },
+      category: 'Tooltip',
+    },
   },
   label: {
     description: `If set a string or a number, default label will be drawn, and the option is content.
@@ -469,6 +491,12 @@ export const API = {
     ...getStoryArgsFromArgsTypesObject(AnimationProps),
     isAnimationActive: true,
     label: { fill: 'red', fontSize: 20 },
+    activeBar: {
+      strokeWidth: 4,
+      stroke: 'blue',
+      fill: 'red',
+      radius: 10,
+    },
     dataKey: 'uv',
     unit: ' Visitors',
     stackId: 1,

--- a/storybook/stories/Examples/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart.stories.tsx
@@ -16,6 +16,7 @@ import {
   LabelList,
   Brush,
   ErrorBar,
+  Rectangle,
 } from '../../../src';
 
 export default {
@@ -57,8 +58,8 @@ export const Simple = {
           <YAxis />
           <Tooltip />
           <Legend />
-          <Bar dataKey="pv" fill="#8884d8" />
-          <Bar dataKey="uv" fill="#82ca9d" />
+          <Bar dataKey="pv" fill="#8884d8" activeBar={<Rectangle fill="pink" stroke="blue" />} />
+          <Bar dataKey="uv" fill="#82ca9d" activeBar={<Rectangle fill="gold" stroke="purple" />} />
         </BarChart>
       </ResponsiveContainer>
     );

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -1,7 +1,8 @@
 import { render } from '@testing-library/react';
-import React from 'react';
+import React, { ComponentProps } from 'react';
 
-import { Bar, BarChart, Tooltip, XAxis, YAxis } from '../../src';
+import { Bar, BarChart, Rectangle, Tooltip, XAxis, YAxis } from '../../src';
+import { mockMouseEvent } from '../helper/mockMouseEvent';
 
 describe('<BarChart />', () => {
   const data = [
@@ -108,6 +109,147 @@ describe('<BarChart />', () => {
     // Both the default Tooltip as well as the Tooltip wrapper are rendered even if not visible
     expect(container.querySelectorAll('.recharts-default-tooltip')).toHaveLength(1);
     expect(container.querySelectorAll('.recharts-tooltip-wrapper')).toHaveLength(1);
+  });
+
+  test('Renders customized active bar by default', () => {
+    jest.useFakeTimers();
+
+    const { container } = render(
+      <div style={{ height: 200, width: 700 }}>
+        <BarChart width={700} height={200} data={data}>
+          <Bar dataKey="uv" stackId="test" fill="#ff7300" />
+          <Tooltip />
+        </BarChart>
+        ,
+      </div>,
+    );
+
+    const chart = container.querySelector('.recharts-wrapper');
+    const mouseOverEvent = mockMouseEvent('mouseover', chart!, { pageX: 100, pageY: 100 });
+
+    mouseOverEvent.fire();
+
+    jest.runAllTimers();
+    const bar = container.querySelectorAll('.recharts-active-bar');
+    expect(bar).toHaveLength(1);
+  });
+
+  test('Renders customized active bar when activeBar set to be a function', () => {
+    jest.useFakeTimers();
+
+    const activeBarRenderer: ComponentProps<typeof Bar>['activeBar'] = props => {
+      return <Rectangle {...props} />;
+    };
+
+    const { container } = render(
+      <div style={{ height: 200, width: 700 }}>
+        <BarChart width={700} height={200} data={data}>
+          <Bar dataKey="uv" stackId="test" fill="#ff7300" activeBar={activeBarRenderer} />
+          <Tooltip />
+        </BarChart>
+        ,
+      </div>,
+    );
+
+    const chart = container.querySelector('.recharts-wrapper');
+    const mouseOverEvent = mockMouseEvent('mouseover', chart!, { pageX: 100, pageY: 100 });
+
+    mouseOverEvent.fire();
+
+    jest.runAllTimers();
+    const bar = container.querySelectorAll('.recharts-active-bar');
+    expect(bar).toHaveLength(1);
+  });
+
+  test('Renders customized active bar when activeBar set to be a ReactElement', () => {
+    jest.useFakeTimers();
+
+    const { container } = render(
+      <div style={{ height: 200, width: 700 }}>
+        <BarChart width={700} height={200} data={data}>
+          <Bar dataKey="uv" stackId="test" fill="#ff7300" activeBar={<Rectangle />} />
+          <Tooltip />
+        </BarChart>
+        ,
+      </div>,
+    );
+
+    const chart = container.querySelector('.recharts-wrapper');
+    const mouseOverEvent = mockMouseEvent('mouseover', chart!, { pageX: 100, pageY: 100 });
+
+    mouseOverEvent.fire();
+
+    jest.runAllTimers();
+    const bar = container.querySelectorAll('.recharts-active-bar');
+    expect(bar).toHaveLength(1);
+  });
+
+  test('Renders customized active bar when activeBar is set to be a truthy boolean', () => {
+    jest.useFakeTimers();
+
+    const { container } = render(
+      <div style={{ height: 200, width: 700 }}>
+        <BarChart width={700} height={200} data={data}>
+          <Bar dataKey="uv" stackId="test" fill="#ff7300" activeBar />
+          <Tooltip />
+        </BarChart>
+        ,
+      </div>,
+    );
+
+    const chart = container.querySelector('.recharts-wrapper');
+    const mouseOverEvent = mockMouseEvent('mouseover', chart!, { pageX: 100, pageY: 100 });
+
+    mouseOverEvent.fire();
+
+    jest.runAllTimers();
+    const bar = container.querySelectorAll('.recharts-active-bar');
+    expect(bar).toHaveLength(1);
+  });
+
+  test('Does not render customized active bar when activeBar set to be a falsy boolean', () => {
+    jest.useFakeTimers();
+
+    const { container } = render(
+      <div style={{ height: 200, width: 700 }}>
+        <BarChart width={700} height={200} data={data}>
+          <Bar dataKey="uv" stackId="test" fill="#ff7300" activeBar={false} />
+          <Tooltip />
+        </BarChart>
+      </div>,
+    );
+
+    const chart = container.querySelector('.recharts-wrapper');
+    const mouseOverEvent = mockMouseEvent('mouseover', chart!, { pageX: 100, pageY: 100 });
+
+    mouseOverEvent.fire();
+
+    jest.runAllTimers();
+    const bar = container.querySelectorAll('.recharts-active-bar');
+    expect(bar).toHaveLength(0);
+  });
+
+  test('Renders customized active bar when activeBar set to be an object', () => {
+    jest.useFakeTimers();
+
+    const { container } = render(
+      <div style={{ height: 200, width: 700 }}>
+        <BarChart width={700} height={200} data={data}>
+          <Bar dataKey="uv" stackId="test" fill="#ff7300" activeBar={{ strokeWidth: 4, fill: 'green' }} />
+          <Tooltip />
+        </BarChart>
+        ,
+      </div>,
+    );
+
+    const chart = container.querySelector('.recharts-wrapper');
+    const mouseOverEvent = mockMouseEvent('mouseover', chart!, { pageX: 100, pageY: 100 });
+
+    mouseOverEvent.fire();
+
+    jest.runAllTimers();
+    const bar = container.querySelectorAll('.recharts-active-bar');
+    expect(bar).toHaveLength(1);
   });
 
   test('Render empty when data is empty', () => {

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -145,7 +145,7 @@ describe('<BarChart />', () => {
             stackId="test"
             fill="#ff7300"
             activeBar={props => {
-              return <Rectangle {...props} />;
+              return <Rectangle {...props} name={props.name as string} />;
             }}
           />
           <Tooltip />

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import React, { ComponentProps } from 'react';
+import React from 'react';
 
 import { Bar, BarChart, Rectangle, Tooltip, XAxis, YAxis } from '../../src';
 import { mockMouseEvent } from '../helper/mockMouseEvent';
@@ -137,14 +137,17 @@ describe('<BarChart />', () => {
   test('Renders customized active bar when activeBar set to be a function', () => {
     jest.useFakeTimers();
 
-    const activeBarRenderer: ComponentProps<typeof Bar>['activeBar'] = props => {
-      return <Rectangle {...props} />;
-    };
-
     const { container } = render(
       <div style={{ height: 200, width: 700 }}>
         <BarChart width={700} height={200} data={data}>
-          <Bar dataKey="uv" stackId="test" fill="#ff7300" activeBar={activeBarRenderer} />
+          <Bar
+            dataKey="uv"
+            stackId="test"
+            fill="#ff7300"
+            activeBar={props => {
+              return <Rectangle {...props} />;
+            }}
+          />
           <Tooltip />
         </BarChart>
         ,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Implementing support for `activeBar` prop on Bar component. I attempted to follow the same behavior of activeDot for a Line. 

<!--- Describe your changes in detail -->

## Related Issue
#3723 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Feature request for a consistent interface between Line/Bar for customizing the active element that renders via the Tooltip
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tests and storybook
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="964" alt="Screenshot 2023-09-13 at 9 19 29 AM" src="https://github.com/recharts/recharts/assets/24420033/582fd859-edae-43f5-a346-ae5c358e7515">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
