### PR TITLE
Extract StorybookArgs type to separate file and use it in other stories too

### DIFF
--- a/storybook/StorybookArgs.ts
+++ b/storybook/StorybookArgs.ts
@@ -1,0 +1,113 @@
+import { Args } from '@storybook/react';
+
+/*
+ * This is the type as defined here: https://storybook.js.org/docs/react/api/arg-types#argtypes
+ * The actual library exports only `interface Args { [name: string]: any; }`.
+ * The "any" does not allow your editor to show autocomplete or documentation.
+ *
+ * This has been reported before: https://github.com/storybookjs/storybook/issues/11916
+ * If the official types get updated then we can remove this whole file
+ * and import directly Args from '@storybook/react'
+ */
+
+export type StorybookArg = {
+  description?: string;
+  /**
+   * This property is not defined in the Storybook Args
+   * - but our internal recharts `getStoryArgsFromArgsTypesObject` function reads it.
+   */
+  defaultValue?: unknown;
+  control?: ControlType | { type: ControlType };
+  options?: string[];
+  /**
+   * Specifies the semantic type of the argType.
+   * When an argType is inferred, the information from the various tools is summarized in this property,
+   * which is then used to infer other properties, like control and table.type.
+   *
+   * If you only need to specify the documented type, you should use `table.type`, instead.
+   */
+  type?: SBType | SBType['name'];
+  table?: {
+    defaultValue?: { summary: string; detail?: string } | unknown;
+    /**
+     * The documented type of the argType.
+     * summary is typically used for the type itself,
+     * while detail is used for additional information.
+     *
+     * If you need to specify the actual, semantic type, you should use `type`, instead.
+     */
+    type?: {
+      summary?: string;
+      detail?: string;
+    };
+    category?: 'Content' | 'Styles' | 'Position' | 'Internal' | string;
+  };
+};
+
+/**
+ * ArgTypes specify the behavior of args.
+ * By specifying the type of an arg, you constrain the values that it can accept
+ * and provide information about args that are not explicitly set (i.e., description).
+ * You can also use argTypes to “annotate” args with information used by addons that make use of those args.
+ * For instance, to instruct the controls addon to render a color picker, you could specify the 'color' control type.
+ *
+ * See: https://storybook.js.org/docs/react/api/arg-types
+ */
+export interface StorybookArgs extends Args {
+  [name: string]: StorybookArg;
+}
+
+/**
+ * See https://storybook.js.org/docs/react/api/arg-types#controltype
+ */
+type ControlType =
+  | 'object'
+  | 'boolean'
+  | 'check'
+  | 'inline-check'
+  | 'radio'
+  | 'inline-radio'
+  | 'select'
+  | 'multi-select'
+  | 'number'
+  | 'range'
+  | 'file'
+  | 'color'
+  | 'date'
+  | 'text';
+
+interface SBBaseType {
+  required?: boolean;
+  raw?: string;
+}
+
+type SBScalarType = SBBaseType & {
+  name: 'boolean' | 'string' | 'number' | 'function' | 'symbol';
+};
+
+type SBArrayType = SBBaseType & {
+  name: 'array';
+  value: SBType;
+};
+type SBObjectType = SBBaseType & {
+  name: 'object';
+  value: Record<string, SBType>;
+};
+type SBEnumType = SBBaseType & {
+  name: 'enum';
+  value: (string | number)[];
+};
+type SBIntersectionType = SBBaseType & {
+  name: 'intersection';
+  value: SBType[];
+};
+type SBUnionType = SBBaseType & {
+  name: 'union';
+  value: SBType[];
+};
+type SBOtherType = SBBaseType & {
+  name: 'other';
+  value: string;
+};
+
+type SBType = SBScalarType | SBEnumType | SBArrayType | SBObjectType | SBIntersectionType | SBUnionType | SBOtherType;

--- a/storybook/stories/API/component/Tooltip.stories.tsx
+++ b/storybook/stories/API/component/Tooltip.stories.tsx
@@ -2,22 +2,9 @@ import React from 'react';
 import { ResponsiveContainer, Tooltip, LineChart, Line } from '../../../../src';
 import { pageData } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
+import { StorybookArgs } from '../../../StorybookArgs';
 
-type MyArgType = {
-  [argName: string]: {
-    description: string;
-    defaultValue?: unknown;
-    table: {
-      type: {
-        summary: string;
-        detail?: string;
-      };
-      category: 'Content' | 'Styles' | 'Position' | 'Internal';
-    };
-  };
-};
-
-const TooltipProps: MyArgType = {
+const TooltipProps: StorybookArgs = {
   separator: {
     description: 'The separator between name and value.',
     defaultValue: ' : ',

--- a/storybook/stories/API/props/AnimationProps.ts
+++ b/storybook/stories/API/props/AnimationProps.ts
@@ -2,10 +2,10 @@
  * This file both exports the documentation of shared props separately, to be reused in places where only single props
  * are documented, as well as grouped in case a whole group is needed.
  */
-import { Args } from '@storybook/react';
+import { StorybookArg, StorybookArgs } from '../../../StorybookArgs';
 
-export const animateNewValues = { table: { category: 'Animation' } };
-export const animationBegin = {
+export const animateNewValues: StorybookArg = { table: { category: 'Animation' } };
+export const animationBegin: StorybookArg = {
   description: 'Specifies when the animation should begin, the unit of this option is ms.',
   type: { name: 'number' },
   defaultValue: 0,
@@ -14,18 +14,18 @@ export const animationBegin = {
     category: 'Animation',
   },
 };
-export const animationDuration = {
+export const animationDuration: StorybookArg = {
   table: {
     category: 'Animation',
   },
 };
-export const animationEasing = {
+export const animationEasing: StorybookArg = {
   table: {
     category: 'Animation',
   },
 };
-export const animationId = { table: { category: 'Animation' } };
-export const isAnimationActive = {
+export const animationId: StorybookArg = { table: { category: 'Animation' } };
+export const isAnimationActive: StorybookArg = {
   description: 'If set false, animation of component will be disabled.',
   table: {
     type: { summary: 'boolean' },
@@ -40,7 +40,7 @@ export const isAnimationActive = {
  * is used. If the group is to be extended, then only single props should be imported by each component that does not
  * use all of them.
  * */
-export const AnimationProps: Args = {
+export const AnimationProps: StorybookArgs = {
   animateNewValues,
   animationBegin,
   animationEasing,

--- a/storybook/stories/API/props/CartesianComponentShared.ts
+++ b/storybook/stories/API/props/CartesianComponentShared.ts
@@ -1,6 +1,6 @@
-import { Args } from '@storybook/react';
+import { StorybookArg, StorybookArgs } from '../../../StorybookArgs';
 
-export const dataKey = {
+export const dataKey: StorybookArg = {
   description: `The key or getter of a group of data.
       It could be an accessor function such as (row)=>value`,
   table: {
@@ -9,7 +9,7 @@ export const dataKey = {
   },
 };
 
-export const nameKey = {
+export const nameKey: StorybookArg = {
   description: "The key of each sector's name.",
   table: {
     type: { summary: 'String' },
@@ -17,7 +17,7 @@ export const nameKey = {
   },
 };
 
-export const activeShape = {
+export const activeShape: StorybookArg = {
   description: '',
   table: {
     type: {
@@ -27,7 +27,7 @@ export const activeShape = {
   },
 };
 
-export const trapezoids = {
+export const trapezoids: StorybookArg = {
   description: 'The coordinates of all trapezoids in the chart, usually calculated internally',
   table: {
     type: {
@@ -37,20 +37,20 @@ export const trapezoids = {
   },
 };
 
-export const xAxisId = {
+export const xAxisId: StorybookArg = {
   description: 'The id of x-axis which is corresponding to the data.',
   table: { type: { summary: 'string | number' }, category: 'General' },
 };
-export const yAxisId = {
+export const yAxisId: StorybookArg = {
   description: 'The id of y-axis which is corresponding to the data.',
   table: { type: { summary: 'string | number' }, category: 'General' },
 };
-export const zAxisId = {
+export const zAxisId: StorybookArg = {
   description: 'The id of z-axis which is corresponding to the data.',
   table: { type: { summary: 'string | number' }, category: 'General' },
 };
 
-export const General: Args = {
+export const General: StorybookArgs = {
   dataKey,
   id: {
     description: `The unique id of this component, which will be used to generate unique clip path id internally.
@@ -59,14 +59,16 @@ export const General: Args = {
     table: { category: 'General' },
   },
   name: {
-    type: { name: 'string | number' },
     description: `The name of data. This option will be used in tooltip and legend to represent a line.
-      If no value was set to this option, the value of dataKey will be used alternatively.`,
-    table: { category: 'General' },
+    If no value was set to this option, the value of dataKey will be used alternatively.`,
+    table: {
+      type: { summary: 'string | number' },
+      category: 'General',
+    },
   },
   unit: {
-    type: { name: 'string | number' },
     table: {
+      type: { summary: 'string | number' },
       category: 'General',
     },
   },
@@ -74,7 +76,7 @@ export const General: Args = {
   yAxisId,
 };
 
-export const points = {
+export const points: StorybookArg = {
   description:
     'The coordinates of points in the line, usually calculated internally. In most cases this should not be used.',
   table: {
@@ -86,8 +88,8 @@ export const points = {
   },
 };
 
-export const data = { table: { category: 'Internal' } };
-export const layout = {
+export const data: StorybookArg = { table: { category: 'Internal' } };
+export const layout: StorybookArg = {
   description: 'The layout of line, usually inherited from parent.',
   table: {
     type: {
@@ -96,7 +98,7 @@ export const layout = {
     category: 'Internal',
   },
 };
-export const Internal = {
+export const Internal: StorybookArgs = {
   points,
   data,
   layout,

--- a/storybook/stories/API/props/ChartProps.ts
+++ b/storybook/stories/API/props/ChartProps.ts
@@ -1,7 +1,7 @@
-import { Args } from '@storybook/react';
 import { onClick, onMouseDown, onMouseEnter, onMouseLeave, onMouseMove, onMouseUp } from './EventHandlers';
+import { StorybookArg, StorybookArgs } from '../../../StorybookArgs';
 
-export const data = {
+export const data: StorybookArg = {
   description: 'The source data, in which each element is an object.',
   table: {
     type: {
@@ -11,13 +11,12 @@ export const data = {
   },
 };
 
-export const ChartSizeProps: Args = {
+export const ChartSizeProps: StorybookArgs = {
   height: {
     description: 'The height of chart container.',
     table: {
       type: {
-        summary: 'Number',
-        defaultValue: null,
+        summary: 'number',
       },
       category: 'General',
     },
@@ -26,8 +25,7 @@ export const ChartSizeProps: Args = {
     description: 'The width of chart container.',
     table: {
       type: {
-        summary: 'Number',
-        defaultValue: null,
+        summary: 'number',
       },
       category: 'General',
     },
@@ -39,8 +37,8 @@ export const margin = {
   table: {
     type: {
       summary: 'Object',
-      defaultValue: { top: 0, right: 0, bottom: 0, left: 0 },
     },
+    defaultValue: { top: 0, right: 0, bottom: 0, left: 0 },
     category: 'General',
   },
 };
@@ -49,7 +47,7 @@ export const dataKey = {
   description: 'The key or getter of a group of data which should be unique in a chart.',
   table: {
     type: {
-      summary: 'String | Number | Function',
+      summary: 'string | number | Function',
     },
     category: 'General',
   },
@@ -65,7 +63,7 @@ export const dataKey = {
 // - RadialBarChart
 // - ScatterChart
 // - FunnelChart
-export const CategoricalChartProps: Args = {
+export const CategoricalChartProps: StorybookArgs = {
   ...ChartSizeProps,
   data,
   margin,
@@ -73,9 +71,9 @@ export const CategoricalChartProps: Args = {
     description: 'Turn on keyboard accessibility',
     table: {
       type: {
-        summary: 'Boolean',
-        defaultValue: 'false',
+        summary: 'boolean',
       },
+      defaultValue: false,
       category: 'General',
     },
   },
@@ -84,8 +82,8 @@ export const CategoricalChartProps: Args = {
     table: {
       type: {
         summary: 'String | undefined',
-        defaultValue: 'undefined',
       },
+      defaultValue: undefined,
       category: 'General',
     },
   },
@@ -93,9 +91,9 @@ export const CategoricalChartProps: Args = {
     description: 'If and where the chart should appear in the tab order',
     table: {
       type: {
-        summary: 'Number | undefined',
-        defaultValue: 'undefined',
+        summary: 'number | undefined',
       },
+      defaultValue: undefined,
       category: 'General',
     },
   },
@@ -103,9 +101,9 @@ export const CategoricalChartProps: Args = {
     description: 'The gap between two bar categories, which can be a percent value or a fixed value.',
     table: {
       type: {
-        summary: 'Percentage | Number',
-        defaultValue: '10%',
+        summary: 'Percentage | number',
       },
+      defaultValue: '10%',
       category: 'Bar',
     },
   },
@@ -131,9 +129,9 @@ export const CategoricalChartProps: Args = {
     description: 'The gap between two bars in the same category.',
     table: {
       type: {
-        summary: 'Number',
-        defaultValue: 4,
+        summary: 'number',
       },
+      defaultValue: 4,
       category: 'Bar',
     },
   },
@@ -142,7 +140,7 @@ export const CategoricalChartProps: Args = {
       will be calculated by the barCategoryGap, barGap and the quantity of bar groups.`,
     table: {
       type: {
-        summary: 'Number',
+        summary: 'number',
       },
       category: 'Bar',
     },
@@ -151,9 +149,9 @@ export const CategoricalChartProps: Args = {
     description: 'The base value of area.',
     table: {
       type: {
-        summary: "Number | 'dataMin' | 'dataMax' | 'auto'",
-        defaultValue: 'auto',
+        summary: "number | 'dataMin' | 'dataMax' | 'auto'",
       },
+      defaultValue: 'auto',
       category: 'Area',
     },
   },
@@ -166,9 +164,9 @@ export const CategoricalChartProps: Args = {
     description: 'If true set, the chart will be rendered in compact mode.',
     table: {
       type: {
-        summary: 'Boolean | undefined',
-        defaultValue: 'undefined',
+        summary: 'boolean | undefined',
       },
+      defaultValue: undefined,
       category: 'General',
     },
   },
@@ -176,7 +174,7 @@ export const CategoricalChartProps: Args = {
     description: 'The x-coordinate of the center of the circle.',
     table: {
       type: {
-        summary: 'Number',
+        summary: 'number',
       },
       category: 'Polar',
     },
@@ -185,7 +183,7 @@ export const CategoricalChartProps: Args = {
     description: 'The y-coordinate of the center of the circle.',
     table: {
       type: {
-        summary: 'Number',
+        summary: 'number',
       },
       category: 'Polar',
     },
@@ -194,7 +192,7 @@ export const CategoricalChartProps: Args = {
     description: 'If true set, the tooltip will be displayed when the chart is rendered.',
     table: {
       type: {
-        summary: 'Boolean',
+        summary: 'boolean',
       },
       category: 'General',
     },
@@ -224,8 +222,8 @@ export const CategoricalChartProps: Args = {
     table: {
       type: {
         summary: "'horizontal' | 'vertical'",
-        defaultValue: "'horizontal'",
       },
+      defaultValue: "'horizontal'",
       category: 'General',
     },
   },
@@ -233,7 +231,7 @@ export const CategoricalChartProps: Args = {
     description: 'The maximum size of bar.',
     table: {
       type: {
-        summary: 'Number',
+        summary: 'number',
       },
       category: 'Bar',
     },
@@ -258,9 +256,9 @@ export const CategoricalChartProps: Args = {
       will be rendered right to left. (Render direction affects SVG layering, not x position.)`,
     table: {
       type: {
-        summary: 'Boolean',
-        defaultValue: false,
+        summary: 'boolean',
       },
+      defaultValue: false,
       category: 'General',
     },
   },
@@ -270,8 +268,8 @@ export const CategoricalChartProps: Args = {
     table: {
       type: {
         summary: "'expand' | 'none' | 'wiggle' | 'silhouette' | 'sign'",
-        defaultValue: "'none'",
       },
+      defaultValue: "'none'",
       category: 'General',
     },
   },
@@ -298,8 +296,8 @@ export const CategoricalChartProps: Args = {
     table: {
       type: {
         summary: "'index' | 'value' | function",
-        defaultValue: "'index'",
       },
+      defaultValue: "'index'",
       category: 'General',
     },
   },

--- a/storybook/stories/API/props/DotProps.ts
+++ b/storybook/stories/API/props/DotProps.ts
@@ -2,9 +2,9 @@
  * This file both exports the documentation of shared props separately, to be reused in places where only single props
  * are documented, as well as grouped in case a whole group is needed.
  */
-import { Args } from '@storybook/react';
+import { StorybookArg, StorybookArgs } from '../../../StorybookArgs';
 
-export const r = {
+export const r: StorybookArg = {
   description: 'The radius of the dot.',
   control: { type: 'number' },
   table: {
@@ -15,7 +15,7 @@ export const r = {
   defaultValue: 10,
 };
 
-export const cx = {
+export const cx: StorybookArg = {
   description: 'The x-coordinate of the dots center.',
   table: {
     type: { summary: 'number' },
@@ -23,7 +23,7 @@ export const cx = {
   },
 };
 
-export const cy = {
+export const cy: StorybookArg = {
   description: 'The y-coordinate of the dots center.',
   table: {
     type: { summary: 'number' },
@@ -36,7 +36,7 @@ export const cy = {
  * is used. If the group is to be extended, then only single props should be imported by each component that does not
  * use all of them.
  * */
-export const DotProps: Args = {
+export const DotProps: StorybookArgs = {
   r,
   cx,
   cy,

--- a/storybook/stories/API/props/EventHandlers.ts
+++ b/storybook/stories/API/props/EventHandlers.ts
@@ -3,6 +3,8 @@
  * are documented, as well as grouped in case a whole group is needed.
  */
 
+import { StorybookArgs } from '../../../StorybookArgs';
+
 export const onAbort = { table: { category: 'EventHandlers' } };
 export const onAbortCapture = { table: { category: 'EventHandlers' } };
 export const onAnimationEnd = {
@@ -177,7 +179,7 @@ export const onWheelCapture = { table: { category: 'EventHandlers' } };
 // Caveat: If any prop is added here, it would falsely be add to the documentation of the component
 // where this group is used. If the group is to be extended, then only single props should be imported
 // by each component that does not use all of them.
-export const EventHandlers = {
+export const EventHandlers: StorybookArgs = {
   onAbort,
   onAbortCapture,
   onAnimationEnd,

--- a/storybook/stories/API/props/Legend.ts
+++ b/storybook/stories/API/props/Legend.ts
@@ -1,4 +1,6 @@
-export const legendType = {
+import { StorybookArg, StorybookArgs } from '../../../StorybookArgs';
+
+export const legendType: StorybookArg = {
   description: "The type of icon in legend. If set to 'none', no legend item will be rendered.",
   table: {
     type: {
@@ -14,6 +16,6 @@ export const legendType = {
 // Caveat: If any prop is added here, it would falsely be add to the documentation of the component
 // where this group is used. If the group is to be extended, then only single props should be imported
 // by each component that does not use all of them.
-export const Legend = {
+export const Legend: StorybookArgs = {
   legendType,
 };

--- a/storybook/stories/API/props/RectangleProps.ts
+++ b/storybook/stories/API/props/RectangleProps.ts
@@ -2,9 +2,10 @@
  * This file both exports the documentation of shared props separately, to be reused in places where only single props
  * are documented, as well as grouped in case a whole group is needed.
  */
-import { Args } from '@storybook/react';
 
-export const radius = {
+import { StorybookArg, StorybookArgs } from '../../../StorybookArgs';
+
+export const radius: StorybookArg = {
   description:
     'If set a value, the option is the radius of all the rounderd corners. If set a array, the option' +
     ' are in turn the radiuses of top-left corner, top-right corner, bottom-right corner, bottom-left' +
@@ -16,7 +17,7 @@ export const radius = {
   },
 };
 
-export const isUpdateAnimationActive = {
+export const isUpdateAnimationActive: StorybookArg = {
   description: 'If set false, animation of component updates will be disabled.',
   table: { category: 'Animation' },
 };
@@ -26,7 +27,7 @@ export const isUpdateAnimationActive = {
  * where this group is used. If the group is to be extended, then only single props should be imported
  * by each component that does not use all of them.
  * */
-export const RectangleProps: Args = {
+export const RectangleProps: StorybookArgs = {
   radius,
   isUpdateAnimationActive,
 };

--- a/storybook/stories/API/props/ReferenceComponentShared.ts
+++ b/storybook/stories/API/props/ReferenceComponentShared.ts
@@ -1,6 +1,6 @@
-import { Args } from '@storybook/react';
+import { StorybookArgs } from '../../../StorybookArgs';
 
-export const ReferenceComponentStyle: Args = {
+export const ReferenceComponentStyle: StorybookArgs = {
   isFront: {
     description: `If set true, the reference component will be rendered in front of bars in BarChart, etc.`,
     table: { category: 'Style' },
@@ -12,11 +12,11 @@ export const ReferenceComponentStyle: Args = {
     will be drawn completely. If set to 'extendDomain', the domain of the overflown axis will be 
     extended such that the reference component fits into the canvas.`,
     table: { type: { summary: "'discard' | 'hidden' | 'visible' | 'extendDomain'" }, category: 'Style' },
-    default: 'discard',
+    defaultValue: 'discard',
   },
 };
 
-export const ReferenceComponentGeneralArgs: Args = {
+export const ReferenceComponentGeneralArgs: StorybookArgs = {
   xAxisId: {
     description: 'The id of x-axis which is corresponding to the data.',
     table: { type: { summary: 'string | number' }, category: 'General' },
@@ -27,7 +27,7 @@ export const ReferenceComponentGeneralArgs: Args = {
   },
 };
 
-export const ReferenceComponentInternalArgs: Args = {
+export const ReferenceComponentInternalArgs: StorybookArgs = {
   xAxis: {
     description: 'The configuration of the corresponding x-axis, usually calculated internally.',
     table: { type: { summary: 'Object' }, category: 'Internal' },

--- a/storybook/stories/API/props/Styles.ts
+++ b/storybook/stories/API/props/Styles.ts
@@ -1,6 +1,7 @@
 // The Line props are shared between multiple components, such as the Line and the Area.
 
 import { Args } from '@storybook/react';
+import { StorybookArgs } from '../../../StorybookArgs';
 
 export const hide = {
   description: 'Hides the component when true, useful when toggling visibility state via legend',
@@ -9,7 +10,7 @@ export const hide = {
   table: { category: 'Style' },
 };
 
-export const GeneralStyle: Args = {
+export const GeneralStyle: StorybookArgs = {
   fill: {
     control: { type: 'color' },
     table: { category: 'Style' },

--- a/storybook/stories/API/props/TextProps.ts
+++ b/storybook/stories/API/props/TextProps.ts
@@ -1,40 +1,37 @@
-import { Args } from '@storybook/react';
+import { StorybookArgs } from '../../../StorybookArgs';
 
-export const TextProps: Args = {
+export const TextProps: StorybookArgs = {
   content: {
     description: 'The content of text.',
   },
   lineHeight: {
     description: 'The height of each line of text in pixels.',
     table: {
-      control: { type: 'string' },
+      type: { summary: 'string' },
     },
   },
   breakAll: {
     description: 'Break words if the text exceeds the width.',
-    table: {
-      control: { type: 'boolean' },
-      defaultValue: false,
-    },
+    defaultValue: true,
   },
   maxLines: {
     description: 'The max number of lines for text wrapping.',
     table: {
-      control: { type: 'number' },
+      type: { summary: 'number' },
     },
   },
   scaleToFit: {
     description: 'Scale the text to fit the width or not.',
     table: {
-      control: { type: 'boolean' },
-      defaultValue: false,
+      type: { summary: 'boolean' },
     },
+    defaultValue: false,
   },
 
   angle: {
     description: 'The rotate angle of Text. (Optional)',
     table: {
-      control: { type: 'number' },
+      type: { summary: 'number' },
     },
   },
 
@@ -43,23 +40,23 @@ export const TextProps: Args = {
       'The width of Text. When the width is specified to be a number,' +
       ' the text will warp auto by calculating the width of text. (Optional)',
     table: {
-      control: { type: 'number' },
+      type: { summary: 'number' },
     },
   },
 
   textAnchor: {
     table: {
-      summary: 'start | middle | end | inherit',
-      control: { type: 'number' },
-      defaultValue: 'start',
+      type: { summary: 'start | middle | end | inherit' },
     },
+    defaultValue: 'start',
   },
 
   verticalAnchor: {
     table: {
-      summary: 'start | middle | end ',
-      control: { type: 'number' },
-      defaultValue: 'end',
+      type: {
+        summary: 'start | middle | end ',
+      },
     },
+    defaultValue: 'end',
   },
 };

--- a/storybook/stories/API/props/Tooltip.ts
+++ b/storybook/stories/API/props/Tooltip.ts
@@ -1,12 +1,12 @@
-import { Args } from '@storybook/react';
+import { StorybookArg, StorybookArgs } from '../../../StorybookArgs';
 
-export const tooltipType = {
+export const tooltipType: StorybookArg = {
   table: { category: 'Tooltip' },
   control: { type: 'select' },
   options: ['responsive', 'none'],
 };
 
-export const activeDot = {
+export const activeDot: StorybookArg = {
   description: `The active dot is shown when a user enters a line chart and this chart has tooltip.
       If set to false, no active dot will be drawn. If set to true, active dot will be drawn with the
       props calculated internally. If passed an object, active dot will be drawn, and the internally
@@ -26,7 +26,7 @@ export const activeDot = {
   },
 };
 
-export const ResponsiveProps: Args = {
+export const ResponsiveProps: StorybookArgs = {
   activeDot,
   tooltipType,
 };

--- a/storybook/stories/API/props/utils.ts
+++ b/storybook/stories/API/props/utils.ts
@@ -1,10 +1,7 @@
+import { StorybookArgs } from '../../../StorybookArgs';
+
 // A helper function to generate Args for a story based on ArgsTypes objects
-export const getStoryArgsFromArgsTypesObject = (
-  argsTypes: Record<
-    string,
-    { defaultValue?: unknown; table?: { defaultValue?: unknown; [key: string]: unknown }; [key: string]: unknown }
-  >,
-): Record<string, unknown> => {
+export const getStoryArgsFromArgsTypesObject = (argsTypes: StorybookArgs): Record<string, unknown> => {
   const args: Record<string, unknown> = {};
   Object.keys(argsTypes).forEach((key: string) => {
     const defaultValue = argsTypes[key]?.defaultValue ?? argsTypes[key]?.table?.defaultValue;


### PR DESCRIPTION
followup from https://github.com/recharts/recharts/pull/3759#discussion_r1327816026

Adding the type helps to find out what the properties are and what shape is expected.

Storybook website has it documented, and provides typescript types, but for some reason that type is not exported in code.

## Description

Add type to storybooks

## Related Issue

https://github.com/recharts/recharts/pull/3759

## Motivation and Context

Helps to write storybooks.

## How Has This Been Tested?

lint, ts

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
