### PR TITLE
getTicks: Refactor to simplify and reuse functionality between the implementation of getTicksStart and getTicksEnd

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -25,7 +25,7 @@ export type Orientation = 'top' | 'bottom' | 'left' | 'right';
 export type Unit = string | number;
 /** The formatter function of tick */
 export type TickFormatter = (value: any, index: number) => string;
-
+/** The minimum gap between two adjacent labels. */
 export type TickGap = number;
 
 export interface CartesianAxisProps {

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -25,8 +25,6 @@ export type Orientation = 'top' | 'bottom' | 'left' | 'right';
 export type Unit = string | number;
 /** The formatter function of tick */
 export type TickFormatter = (value: any, index: number) => string;
-/** The minimum gap between two adjacent labels. */
-export type TickGap = number;
 
 export interface CartesianAxisProps {
   className?: string;
@@ -46,7 +44,7 @@ export interface CartesianAxisProps {
   hide?: boolean;
   label?: any;
 
-  minTickGap?: TickGap;
+  minTickGap?: number;
   ticks?: CartesianTickItem[];
   tickSize?: number;
   tickFormatter?: TickFormatter;

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -19,14 +19,23 @@ import {
 import { filterProps } from '../util/ReactUtils';
 import { getTicks } from './getTicks';
 
+/** The orientation of the axis in correspondence to the chart */
+export type Orientation = 'top' | 'bottom' | 'left' | 'right';
+/** A unit to be appended to a value */
+export type Unit = string | number;
+/** The formatter function of tick */
+export type TickFormatter = (value: any, index: number) => string;
+
+export type TickGap = number;
+
 export interface CartesianAxisProps {
   className?: string;
   x?: number;
   y?: number;
   width?: number;
   height?: number;
-  unit?: string | number;
-  orientation?: 'top' | 'bottom' | 'left' | 'right';
+  unit?: Unit;
+  orientation?: Orientation;
   // The viewBox of svg
   viewBox?: CartesianViewBox;
   tick?: SVGProps<SVGTextElement> | ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | boolean;
@@ -37,11 +46,10 @@ export interface CartesianAxisProps {
   hide?: boolean;
   label?: any;
 
-  minTickGap?: number;
+  minTickGap?: TickGap;
   ticks?: CartesianTickItem[];
   tickSize?: number;
-  /** The formatter function of tick */
-  tickFormatter?: (value: any, index: number) => string;
+  tickFormatter?: TickFormatter;
   ticksGenerator?: (props?: CartesianAxisProps) => CartesianTickItem[];
   interval?: AxisInterval;
   /** Angle in which ticks will be rendered. */

--- a/src/cartesian/getTicks.ts
+++ b/src/cartesian/getTicks.ts
@@ -6,7 +6,7 @@ import { Global } from '../util/Global';
 import {
   doesTickFitInBetweenStartAndEnd,
   getEveryNThTick,
-  getInitialStartAndEnd,
+  getTickBoundaries,
   getNumberIntervalTicks,
   getSizeOfTick,
 } from '../util/TickUtils';
@@ -129,7 +129,7 @@ export function getTicks(props: CartesianAxisProps, fontSize?: string, letterSpa
   };
 
   const sign = ticks.length >= 2 ? mathSign(ticks[1].coordinate - ticks[0].coordinate) : 1;
-  const boundaries = getInitialStartAndEnd(viewBox, sign, sizeKey);
+  const boundaries = getTickBoundaries(viewBox, sign, sizeKey);
 
   if (interval === 'equidistantPreserveStart') {
     candidates = getTicksStart(sign, boundaries, getTickSize, ticks, minTickGap);

--- a/src/cartesian/getTicks.ts
+++ b/src/cartesian/getTicks.ts
@@ -18,7 +18,7 @@ function getTicksEnd(
   boundaries: { start: number; end: number },
   getTickSize: (tick: CartesianTickItem, index: number) => number,
   ticks: CartesianTickItem[],
-  minTickGap: CartesianAxisProps['minTickGap'],
+  minTickGap: number,
 ): CartesianTickItem[] {
   const result = (ticks || []).slice();
   const len = result.length;
@@ -55,7 +55,7 @@ function getTicksStart(
   boundaries: { start: number; end: number },
   getTickSize: (tick: CartesianTickItem, index: number) => number,
   ticks: CartesianTickItem[],
-  minTickGap: CartesianAxisProps['minTickGap'],
+  minTickGap: number,
   preserveEnd?: boolean,
 ): CartesianTickItem[] {
   const result = (ticks || []).slice();

--- a/src/cartesian/getTicks.ts
+++ b/src/cartesian/getTicks.ts
@@ -4,7 +4,7 @@ import { getStringSize } from '../util/DOMUtils';
 import { Props as CartesianAxisProps } from './CartesianAxis';
 import { Global } from '../util/Global';
 import {
-  doesTickFitInBetweenStartAndEnd,
+  isVisible,
   getEveryNThTick,
   getTickBoundaries,
   getNumberIntervalTicks,
@@ -39,7 +39,7 @@ function getTicksEnd(
       result[i] = entry = { ...entry, tickCoord: entry.coordinate };
     }
 
-    const isShow = doesTickFitInBetweenStartAndEnd(sign, entry.tickCoord, size, start, end);
+    const isShow = isVisible(sign, entry.tickCoord, size, start, end);
 
     if (isShow) {
       end = entry.tickCoord - sign * (size / 2 + minTickGap);
@@ -73,7 +73,7 @@ function getTicksStart(
       tickCoord: tailGap > 0 ? tail.coordinate - tailGap * sign : tail.coordinate,
     };
 
-    const isTailShow = doesTickFitInBetweenStartAndEnd(sign, tail.tickCoord, tailSize, start, end);
+    const isTailShow = isVisible(sign, tail.tickCoord, tailSize, start, end);
 
     if (isTailShow) {
       end = tail.tickCoord - sign * (tailSize / 2 + minTickGap);
@@ -96,7 +96,7 @@ function getTicksStart(
       result[i] = entry = { ...entry, tickCoord: entry.coordinate };
     }
 
-    const isShow = doesTickFitInBetweenStartAndEnd(sign, entry.tickCoord, size, start, end);
+    const isShow = isVisible(sign, entry.tickCoord, size, start, end);
 
     if (isShow) {
       start = entry.tickCoord + sign * (size / 2 + minTickGap);

--- a/src/cartesian/getTicks.ts
+++ b/src/cartesian/getTicks.ts
@@ -1,81 +1,32 @@
-import _ from 'lodash';
 import { CartesianTickItem, Size } from '../util/types';
 import { mathSign, isNumber } from '../util/DataUtils';
 import { getStringSize } from '../util/DOMUtils';
 import { Props as CartesianAxisProps } from './CartesianAxis';
 import { Global } from '../util/Global';
-import { getEveryNthWithCondition } from '../util/getEveryNthWithCondition';
-import { getAngledRectangleWidth } from '../util/CartesianUtils';
+import {
+  doesTickFitInBetweenStartAndEnd,
+  getEveryNThTick,
+  getInitialStartAndEnd,
+  getNumberIntervalTicks,
+  getSizeOfTick,
+} from '../util/TickUtils';
 
-/**
- * Given an array of ticks, find N, the lowest possible number for which every
- * nTH tick in the ticks array isShow == true and return the array of every nTh tick.
- * @param {CartesianTickItem[]} ticks An array of CartesianTickItem with the
- * information whether they can be shown without overlapping with their neighbour isShow.
- * @returns {CartesianTickItem[]} Every nTh tick in an array.
- */
-export function getEveryNThTick(ticks: CartesianTickItem[]) {
-  let N = 1;
-  let previous = getEveryNthWithCondition(ticks, N, tickItem => tickItem.isShow);
-  while (N <= ticks.length) {
-    if (previous !== undefined) {
-      return previous;
-    }
-    N++;
-    previous = getEveryNthWithCondition(ticks, N, tickItem => tickItem.isShow);
-  }
-
-  return ticks.slice(0, 1);
-}
-
-export function getNumberIntervalTicks(ticks: CartesianTickItem[], interval: number) {
-  return getEveryNthWithCondition(ticks, interval + 1);
-}
-
-function getAngledTickWidth(contentSize: Size, unitSize: Size, angle: number) {
-  const size = { width: contentSize.width + unitSize.width, height: contentSize.height + unitSize.height };
-
-  return getAngledRectangleWidth(size, angle);
-}
-
-function getTicksEnd({
-  angle,
-  ticks,
-  tickFormatter,
-  viewBox,
-  orientation,
-  minTickGap,
-  unit,
-  fontSize,
-  letterSpacing,
-}: Omit<CartesianAxisProps, 'tickMargin'>): CartesianTickItem[] {
-  const { x, y, width, height } = viewBox;
-  const sizeKey = orientation === 'top' || orientation === 'bottom' ? 'width' : 'height';
-  // we need add the width of 'unit' only when sizeKey === 'width'
-  const unitSize: Size =
-    unit && sizeKey === 'width' ? getStringSize(unit, { fontSize, letterSpacing }) : { width: 0, height: 0 };
+function getTicksEnd(
+  unitSize: Size,
+  sizeKey: 'width' | 'height',
+  { angle, ticks, tickFormatter, viewBox, minTickGap, fontSize, letterSpacing }: Omit<CartesianAxisProps, 'tickMargin'>,
+): CartesianTickItem[] {
   const result = (ticks || []).slice();
   const len = result.length;
   const sign = len >= 2 ? mathSign(result[1].coordinate - result[0].coordinate) : 1;
 
-  let start, end;
-
-  if (sign === 1) {
-    start = sizeKey === 'width' ? x : y;
-    end = sizeKey === 'width' ? x + width : y + height;
-  } else {
-    start = sizeKey === 'width' ? x + width : y + height;
-    end = sizeKey === 'width' ? x : y;
-  }
+  const boundaries = getInitialStartAndEnd(viewBox, sign, sizeKey);
+  const { start } = boundaries;
+  let { end } = boundaries;
 
   for (let i = len - 1; i >= 0; i--) {
     let entry = result[i];
-    const content = _.isFunction(tickFormatter) ? tickFormatter(entry.value, len - i - 1) : entry.value;
-    // Recharts only supports angles when sizeKey === 'width'
-    const size =
-      sizeKey === 'width'
-        ? getAngledTickWidth(getStringSize(content, { fontSize, letterSpacing }), unitSize, angle)
-        : getStringSize(content, { fontSize, letterSpacing })[sizeKey];
+    const size = getSizeOfTick(tickFormatter, entry, len - i - 1, sizeKey, fontSize, letterSpacing, unitSize, angle);
     if (i === len - 1) {
       const gap = sign * (entry.coordinate + (sign * size) / 2 - end);
       result[i] = entry = {
@@ -86,9 +37,7 @@ function getTicksEnd({
       result[i] = entry = { ...entry, tickCoord: entry.coordinate };
     }
 
-    const isShow =
-      sign * (entry.tickCoord - (sign * size) / 2 - start) >= 0 &&
-      sign * (entry.tickCoord + (sign * size) / 2 - end) <= 0;
+    const isShow = doesTickFitInBetweenStartAndEnd(sign, entry.tickCoord, size, start, end);
 
     if (isShow) {
       end = entry.tickCoord - sign * (size / 2 + minTickGap);
@@ -100,56 +49,28 @@ function getTicksEnd({
 }
 
 function getTicksStart(
-  {
-    angle,
-    ticks,
-    tickFormatter,
-    viewBox,
-    orientation,
-    minTickGap,
-    unit,
-    fontSize,
-    letterSpacing,
-  }: Omit<CartesianAxisProps, 'tickMargin'>,
+  unitSize: Size,
+  sizeKey: 'width' | 'height',
+  { angle, ticks, tickFormatter, viewBox, minTickGap, fontSize, letterSpacing }: Omit<CartesianAxisProps, 'tickMargin'>,
   preserveEnd?: boolean,
 ): CartesianTickItem[] {
-  const { x, y, width, height } = viewBox;
-  const sizeKey = orientation === 'top' || orientation === 'bottom' ? 'width' : 'height';
   const result = (ticks || []).slice();
-  // we need add the width of 'unit' only when sizeKey === 'width'
-  const unitSize: Size =
-    unit && sizeKey === 'width' ? getStringSize(unit, { fontSize, letterSpacing }) : { width: 0, height: 0 };
   const len = result.length;
   const sign = len >= 2 ? mathSign(result[1].coordinate - result[0].coordinate) : 1;
 
-  let start, end;
-
-  if (sign === 1) {
-    start = sizeKey === 'width' ? x : y;
-    end = sizeKey === 'width' ? x + width : y + height;
-  } else {
-    start = sizeKey === 'width' ? x + width : y + height;
-    end = sizeKey === 'width' ? x : y;
-  }
+  let { start, end } = getInitialStartAndEnd(viewBox, sign, sizeKey);
 
   if (preserveEnd) {
     // Try to guarantee the tail to be displayed
     let tail = ticks[len - 1];
-    const tailContent = _.isFunction(tickFormatter) ? tickFormatter(tail.value, len - 1) : tail.value;
-    // Recharts only supports angles when sizeKey === 'width'
-    const tailSize =
-      sizeKey === 'width'
-        ? getAngledTickWidth(getStringSize(tailContent, { fontSize, letterSpacing }), unitSize, angle)
-        : getStringSize(tailContent, { fontSize, letterSpacing })[sizeKey];
+    const tailSize = getSizeOfTick(tickFormatter, tail, len - 1, sizeKey, fontSize, letterSpacing, unitSize, angle);
     const tailGap = sign * (tail.coordinate + (sign * tailSize) / 2 - end);
     result[len - 1] = tail = {
       ...tail,
       tickCoord: tailGap > 0 ? tail.coordinate - tailGap * sign : tail.coordinate,
     };
 
-    const isTailShow =
-      sign * (tail.tickCoord - (sign * tailSize) / 2 - start) >= 0 &&
-      sign * (tail.tickCoord + (sign * tailSize) / 2 - end) <= 0;
+    const isTailShow = doesTickFitInBetweenStartAndEnd(sign, tail.tickCoord, tailSize, start, end);
 
     if (isTailShow) {
       end = tail.tickCoord - sign * (tailSize / 2 + minTickGap);
@@ -160,11 +81,7 @@ function getTicksStart(
   const count = preserveEnd ? len - 1 : len;
   for (let i = 0; i < count; i++) {
     let entry = result[i];
-    const content = _.isFunction(tickFormatter) ? tickFormatter(entry.value, i) : entry.value;
-    const size =
-      sizeKey === 'width'
-        ? getAngledTickWidth(getStringSize(content, { fontSize, letterSpacing }), unitSize, angle)
-        : getStringSize(content, { fontSize, letterSpacing })[sizeKey];
+    const size = getSizeOfTick(tickFormatter, entry, i, sizeKey, fontSize, letterSpacing, unitSize, angle);
 
     if (i === 0) {
       const gap = sign * (entry.coordinate - (sign * size) / 2 - start);
@@ -176,9 +93,7 @@ function getTicksStart(
       result[i] = entry = { ...entry, tickCoord: entry.coordinate };
     }
 
-    const isShow =
-      sign * (entry.tickCoord - (sign * size) / 2 - start) >= 0 &&
-      sign * (entry.tickCoord + (sign * size) / 2 - end) <= 0;
+    const isShow = doesTickFitInBetweenStartAndEnd(sign, entry.tickCoord, size, start, end);
 
     if (isShow) {
       start = entry.tickCoord + sign * (size / 2 + minTickGap);
@@ -202,8 +117,12 @@ export function getTicks(props: CartesianAxisProps, fontSize?: string, letterSpa
 
   let candidates: CartesianTickItem[] = [];
 
+  const sizeKey = orientation === 'top' || orientation === 'bottom' ? 'width' : 'height';
+  const unitSize: Size =
+    unit && sizeKey === 'width' ? getStringSize(unit, { fontSize, letterSpacing }) : { width: 0, height: 0 };
+
   if (interval === 'equidistantPreserveStart') {
-    candidates = getTicksStart({
+    candidates = getTicksStart(unitSize, sizeKey, {
       angle,
       ticks,
       tickFormatter,
@@ -220,6 +139,8 @@ export function getTicks(props: CartesianAxisProps, fontSize?: string, letterSpa
 
   if (interval === 'preserveStart' || interval === 'preserveStartEnd') {
     candidates = getTicksStart(
+      unitSize,
+      sizeKey,
       {
         angle,
         ticks,
@@ -227,21 +148,19 @@ export function getTicks(props: CartesianAxisProps, fontSize?: string, letterSpa
         viewBox,
         orientation,
         minTickGap,
-        unit,
         fontSize,
         letterSpacing,
       },
       interval === 'preserveStartEnd',
     );
   } else {
-    candidates = getTicksEnd({
+    candidates = getTicksEnd(unitSize, sizeKey, {
       angle,
       ticks,
       tickFormatter,
       viewBox,
       orientation,
       minTickGap,
-      unit,
       fontSize,
       letterSpacing,
     });

--- a/src/cartesian/getTicks.ts
+++ b/src/cartesian/getTicks.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { CartesianTickItem, Size } from '../util/types';
 import { mathSign, isNumber } from '../util/DataUtils';
 import { getStringSize } from '../util/DOMUtils';
@@ -8,7 +9,7 @@ import {
   getEveryNThTick,
   getTickBoundaries,
   getNumberIntervalTicks,
-  getSizeOfTick,
+  getAngledTickWidth,
 } from '../util/TickUtils';
 
 type Sign = 0 | 1 | -1;
@@ -125,7 +126,11 @@ export function getTicks(props: CartesianAxisProps, fontSize?: string, letterSpa
     unit && sizeKey === 'width' ? getStringSize(unit, { fontSize, letterSpacing }) : { width: 0, height: 0 };
 
   const getTickSize = (content: CartesianTickItem, index: number) => {
-    return getSizeOfTick(tickFormatter, content, index, sizeKey, fontSize, letterSpacing, unitSize, angle);
+    const value = _.isFunction(tickFormatter) ? tickFormatter(content.value, index) : content.value;
+    // Recharts only supports angles when sizeKey === 'width'
+    return sizeKey === 'width'
+      ? getAngledTickWidth(getStringSize(value, { fontSize, letterSpacing }), unitSize, angle)
+      : getStringSize(value, { fontSize, letterSpacing })[sizeKey];
   };
 
   const sign = ticks.length >= 2 ? mathSign(ticks[1].coordinate - ticks[0].coordinate) : 1;

--- a/src/util/TickUtils.ts
+++ b/src/util/TickUtils.ts
@@ -1,8 +1,4 @@
-import _ from 'lodash';
-
-import { TickFormatter } from '../cartesian/CartesianAxis';
 import { getAngledRectangleWidth } from './CartesianUtils';
-import { getStringSize } from './DOMUtils';
 import { getEveryNthWithCondition } from './getEveryNthWithCondition';
 import { Size, CartesianViewBox, CartesianTickItem } from './types';
 
@@ -25,23 +21,6 @@ export function getTickBoundaries(viewBox: CartesianViewBox, sign: number, sizeK
     start: isWidth ? x + width : y + height,
     end: isWidth ? x : y,
   };
-}
-
-export function getSizeOfTick(
-  tickFormatter: TickFormatter,
-  entry: CartesianTickItem,
-  index: number,
-  sizeKey: 'width' | 'height',
-  fontSize: string | number,
-  letterSpacing: string | number,
-  unitSize: Size,
-  angle: number,
-) {
-  const content = _.isFunction(tickFormatter) ? tickFormatter(entry.value, index) : entry.value;
-  // Recharts only supports angles when sizeKey === 'width'
-  return sizeKey === 'width'
-    ? getAngledTickWidth(getStringSize(content, { fontSize, letterSpacing }), unitSize, angle)
-    : getStringSize(content, { fontSize, letterSpacing })[sizeKey];
 }
 
 export function isVisible(sign: number, tickPosition: number, size: number, start: number, end: number): boolean {

--- a/src/util/TickUtils.ts
+++ b/src/util/TickUtils.ts
@@ -12,19 +12,21 @@ export function getAngledTickWidth(contentSize: Size, unitSize: Size, angle: num
   return getAngledRectangleWidth(size, angle);
 }
 
-export function getInitialStartAndEnd(viewBox: CartesianViewBox, sign: number, sizeKey: string) {
-  let start, end;
-
+export function getTickBoundaries(viewBox: CartesianViewBox, sign: number, sizeKey: string) {
+  const isWidth = sizeKey === 'width';
   const { x, y, width, height } = viewBox;
   if (sign === 1) {
-    start = sizeKey === 'width' ? x : y;
-    end = sizeKey === 'width' ? x + width : y + height;
-  } else {
-    start = sizeKey === 'width' ? x + width : y + height;
-    end = sizeKey === 'width' ? x : y;
+    return {
+      start: isWidth ? x : y,
+      end: isWidth ? x + width : y + height,
+    };
   }
-  return { end, start };
+  return {
+    start: isWidth ? x + width : y + height,
+    end: isWidth ? x : y,
+  };
 }
+
 export function getSizeOfTick(
   tickFormatter: TickFormatter,
   entry: CartesianTickItem,

--- a/src/util/TickUtils.ts
+++ b/src/util/TickUtils.ts
@@ -1,0 +1,78 @@
+import _ from 'lodash';
+
+import { TickFormatter } from '../cartesian/CartesianAxis';
+import { getAngledRectangleWidth } from './CartesianUtils';
+import { getStringSize } from './DOMUtils';
+import { getEveryNthWithCondition } from './getEveryNthWithCondition';
+import { Size, CartesianViewBox, CartesianTickItem } from './types';
+
+export function getAngledTickWidth(contentSize: Size, unitSize: Size, angle: number) {
+  const size = { width: contentSize.width + unitSize.width, height: contentSize.height + unitSize.height };
+
+  return getAngledRectangleWidth(size, angle);
+}
+
+export function getInitialStartAndEnd(viewBox: CartesianViewBox, sign: number, sizeKey: string) {
+  let start, end;
+
+  const { x, y, width, height } = viewBox;
+  if (sign === 1) {
+    start = sizeKey === 'width' ? x : y;
+    end = sizeKey === 'width' ? x + width : y + height;
+  } else {
+    start = sizeKey === 'width' ? x + width : y + height;
+    end = sizeKey === 'width' ? x : y;
+  }
+  return { end, start };
+}
+export function getSizeOfTick(
+  tickFormatter: TickFormatter,
+  entry: CartesianTickItem,
+  index: number,
+  sizeKey: 'width' | 'height',
+  fontSize: string | number,
+  letterSpacing: string | number,
+  unitSize: Size,
+  angle: number,
+) {
+  const content = _.isFunction(tickFormatter) ? tickFormatter(entry.value, index) : entry.value;
+  // Recharts only supports angles when sizeKey === 'width'
+  return sizeKey === 'width'
+    ? getAngledTickWidth(getStringSize(content, { fontSize, letterSpacing }), unitSize, angle)
+    : getStringSize(content, { fontSize, letterSpacing })[sizeKey];
+}
+
+export function doesTickFitInBetweenStartAndEnd(
+  sign: number,
+  tickPosition: number,
+  size: number,
+  start: number,
+  end: number,
+): boolean {
+  return sign * (tickPosition - (sign * size) / 2 - start) >= 0 && sign * (tickPosition + (sign * size) / 2 - end) <= 0;
+}
+
+/**
+ * Given an array of ticks, find N, the lowest possible number for which every
+ * nTH tick in the ticks array isShow == true and return the array of every nTh tick.
+ * @param {CartesianTickItem[]} ticks An array of CartesianTickItem with the
+ * information whether they can be shown without overlapping with their neighbour isShow.
+ * @returns {CartesianTickItem[]} Every nTh tick in an array.
+ */
+export function getEveryNThTick(ticks: CartesianTickItem[]) {
+  let N = 1;
+  let previous = getEveryNthWithCondition(ticks, N, tickItem => tickItem.isShow);
+  while (N <= ticks.length) {
+    if (previous !== undefined) {
+      return previous;
+    }
+    N++;
+    previous = getEveryNthWithCondition(ticks, N, tickItem => tickItem.isShow);
+  }
+
+  return ticks.slice(0, 1);
+}
+
+export function getNumberIntervalTicks(ticks: CartesianTickItem[], interval: number) {
+  return getEveryNthWithCondition(ticks, interval + 1);
+}

--- a/src/util/TickUtils.ts
+++ b/src/util/TickUtils.ts
@@ -44,13 +44,7 @@ export function getSizeOfTick(
     : getStringSize(content, { fontSize, letterSpacing })[sizeKey];
 }
 
-export function doesTickFitInBetweenStartAndEnd(
-  sign: number,
-  tickPosition: number,
-  size: number,
-  start: number,
-  end: number,
-): boolean {
+export function isVisible(sign: number, tickPosition: number, size: number, start: number, end: number): boolean {
   return sign * (tickPosition - (sign * size) / 2 - start) >= 0 && sign * (tickPosition + (sign * size) / 2 - end) <= 0;
 }
 

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1114,6 +1114,13 @@ export interface BaseAxisProps {
   className?: string;
 }
 
+/** Defines how ticks are places and whether / how tick collisions are handled.
+ * 'preserveStart' keeps the left tick on collision and ensures that the first tick is always shown.
+ * 'preserveEnd' keeps the right tick on collision and ensures that the last tick is always shown.
+ * 'preserveStartEnd' keeps the left tick on collision and ensures that the first and last ticks are always shown.
+ * 'equidistantPreserveStart' computes which ticks are shown according to the 'preserveStart' strategy and
+ *  then selects a number N such that every nTh tick will be shown.
+ */
 export type AxisInterval = number | 'preserveStart' | 'preserveEnd' | 'preserveStartEnd' | 'equidistantPreserveStart';
 
 export interface TickItem {

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1114,7 +1114,7 @@ export interface BaseAxisProps {
   className?: string;
 }
 
-/** Defines how ticks are places and whether / how tick collisions are handled.
+/** Defines how ticks are placed and whether / how tick collisions are handled.
  * 'preserveStart' keeps the left tick on collision and ensures that the first tick is always shown.
  * 'preserveEnd' keeps the right tick on collision and ensures that the last tick is always shown.
  * 'preserveStartEnd' keeps the left tick on collision and ensures that the first and last ticks are always shown.

--- a/storybook/stories/Examples/cartesian/CartesianAxis/TickPositioning.stories.tsx
+++ b/storybook/stories/Examples/cartesian/CartesianAxis/TickPositioning.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CartesianAxis, ResponsiveContainer, Surface } from '../../../../../src';
+import { Line, LineChart, ResponsiveContainer, XAxis } from '../../../../../src';
 import { ticks } from '../../../data';
 
 export default {
@@ -8,38 +8,23 @@ export default {
 
 export const TickPositioning = {
   render: () => {
-    const intervalOptions = ['preserveStart', 'preserveEnd', 'preserveStartEnd', 'equidistantPreserveStart', 0, 1, 2];
+    const intervalOptions = ['preserveStart', 'preserveEnd', 'preserveStartEnd', 'equidistantPreserveStart', 0];
 
-    const [surfaceWidth, surfaceHeight] = [600, 300];
     return (
-      <ResponsiveContainer width={500} height={surfaceHeight}>
-        <Surface
-          width={surfaceWidth}
-          height={surfaceHeight}
-          viewBox={{
-            x: 0,
-            y: 0,
-            width: surfaceWidth,
-            height: surfaceHeight,
-          }}
-        >
+      <ResponsiveContainer>
+        <LineChart data={ticks}>
+          <Line dataKey="coordinate" />
           {intervalOptions.map((intervalOption, index) => (
-            <CartesianAxis
+            <XAxis
+              dataKey="value"
               key={intervalOption}
-              width={surfaceWidth}
-              height={surfaceHeight}
-              viewBox={{
-                x: 0,
-                y: 0,
-                width: surfaceWidth,
-                height: surfaceHeight,
-              }}
-              ticks={ticks}
               interval={intervalOption as any}
-              y={index * 50}
+              xAxisId={index}
+              label={intervalOption}
+              height={70}
             />
           ))}
-        </Surface>
+        </LineChart>
       </ResponsiveContainer>
     );
   },

--- a/test/cartesian/getTicks.spec.ts
+++ b/test/cartesian/getTicks.spec.ts
@@ -1,4 +1,4 @@
-import { getEveryNThTick, getTicks } from '../../src/cartesian/getTicks';
+import { getTicks } from '../../src/cartesian/getTicks';
 import { CartesianTickItem } from '../../src/util/types';
 import { CartesianAxisProps } from '../../src';
 
@@ -288,46 +288,5 @@ describe('getTicks', () => {
         expect(resultingTickValues).toEqual(expectedResult);
       },
     );
-  });
-});
-
-describe('getEveryNThTick', () => {
-  test.each([
-    // Ever tick can be shown
-    [[true], [0]],
-    [
-      [true, true],
-      [0, 1],
-    ],
-    [
-      [true, true, true],
-      [0, 1, 2],
-    ],
-    // Every 2nd tick
-    [
-      [true, false, true],
-      [0, 2],
-    ],
-    [
-      [true, false, true, false],
-      [0, 2],
-    ],
-
-    [
-      [true, false, true, true],
-      [0, 2],
-    ],
-    // Only the first tick can be shown.
-    [[true], [0]],
-    [[true, false], [0]],
-    [[true, true, false], [0]],
-    // The first tick is returned, even if it is isShow=false
-    [[false], [0]],
-  ])(`getEveryNThTick for visibility %s returns the ticks at index %s`, (tickVisibility, result) => {
-    const ticks = tickVisibility.map((isShow, index) => ({ isShow, coordinate: index }));
-
-    const resultingTickValues = (getEveryNThTick(ticks) ?? []).map(tick => tick.coordinate);
-
-    expect(resultingTickValues).toEqual(result);
   });
 });

--- a/test/util/TickUtils.spec.ts
+++ b/test/util/TickUtils.spec.ts
@@ -1,0 +1,42 @@
+import { getEveryNThTick } from '../../src/util/TickUtils';
+
+describe('getEveryNThTick', () => {
+  test.each([
+    // Ever tick can be shown
+    [[true], [0]],
+    [
+      [true, true],
+      [0, 1],
+    ],
+    [
+      [true, true, true],
+      [0, 1, 2],
+    ],
+    // Every 2nd tick
+    [
+      [true, false, true],
+      [0, 2],
+    ],
+    [
+      [true, false, true, false],
+      [0, 2],
+    ],
+
+    [
+      [true, false, true, true],
+      [0, 2],
+    ],
+    // Only the first tick can be shown.
+    [[true], [0]],
+    [[true, false], [0]],
+    [[true, true, false], [0]],
+    // The first tick is returned, even if it is isShow=false
+    [[false], [0]],
+  ])(`getEveryNThTick for visibility %s returns the ticks at index %s`, (tickVisibility, result) => {
+    const ticks = tickVisibility.map((isShow, index) => ({ isShow, coordinate: index }));
+
+    const resultingTickValues = (getEveryNThTick(ticks) ?? []).map(tick => tick.coordinate);
+
+    expect(resultingTickValues).toEqual(result);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Refactors getTicks.ts to reuse logic which is shared between getTicksStart and getTicksEnd. The goal of this refatoring is to make it easier to add new methods to compute the ticks, i.e. equidistant ticks. 

Improvements to TickPositioning story:
- Resize (important to test how different interval options lead to ticks disappearing) 
- Add the interval option under the axis as a title

Additionally comments and new types wherever useful. 


<!--- Describe your changes in detail -->

## Related Issue
https://github.com/recharts/recharts/issues/3305

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
