### PR TITLE
feat: add onDragEnd event to Brush component

### DIFF
--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -298,10 +298,10 @@ export class Brush extends PureComponent<Props, State> {
       },
       () => {
         const { endIndex, onDragEnd, startIndex } = this.props;
-          onDragEnd?.({
-            endIndex,
-            startIndex,
-          });
+        onDragEnd?.({
+          endIndex,
+          startIndex,
+        });
       },
     );
     this.detachDragEndListener();

--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -44,6 +44,7 @@ interface BrushProps extends InternalBrushProps {
   children?: ReactElement;
 
   onChange?: (newIndex: BrushStartEndIndex) => void;
+  onDragEnd?: (newIndex: BrushStartEndIndex) => void;
   leaveTimeOut?: number;
   alwaysShowText?: boolean;
 }
@@ -290,10 +291,21 @@ export class Brush extends PureComponent<Props, State> {
   }
 
   handleDragEnd = () => {
-    this.setState({
-      isTravellerMoving: false,
-      isSlideMoving: false,
-    });
+    this.setState(
+      {
+        isTravellerMoving: false,
+        isSlideMoving: false,
+      },
+      () => {
+        const { endIndex, onDragEnd, startIndex } = this.props;
+        if (onDragEnd) {
+          onDragEnd({
+            endIndex,
+            startIndex,
+          });
+        }
+      },
+    );
     this.detachDragEndListener();
   };
 

--- a/storybook/stories/API/cartesian/Brush.stories.tsx
+++ b/storybook/stories/API/cartesian/Brush.stories.tsx
@@ -58,6 +58,10 @@ const GeneralProps: Args = {
     description: 'The handler of changing the active scope of brush.',
     table: { type: { summary: 'Function' }, category: 'General' },
   },
+  onDragEnd: {
+    description: 'The handler of ending the brush drag.',
+    table: { type: { summary: 'Function' }, category: 'General' },
+  },
   alwaysShowText: {
     control: { type: 'boolean' },
     table: { type: { summary: 'boolean' }, category: 'General' },

--- a/storybook/stories/API/cartesian/Brush.stories.tsx
+++ b/storybook/stories/API/cartesian/Brush.stories.tsx
@@ -56,11 +56,11 @@ const GeneralProps: Args = {
   },
   onChange: {
     description: 'The handler of changing the active scope of brush.',
-    table: { type: { summary: 'Function' }, category: 'General' },
+    table: { type: { summary: 'Function' }, category: 'Event handlers' },
   },
   onDragEnd: {
     description: 'The handler of ending the brush drag.',
-    table: { type: { summary: 'Function' }, category: 'General' },
+    table: { type: { summary: 'Function' }, category: 'Event handlers' },
   },
   alwaysShowText: {
     control: { type: 'boolean' },

--- a/storybook/stories/Examples/cartesian/Bar/WithBrushAndOnDragEnd.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Bar/WithBrushAndOnDragEnd.stories.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Brush, ResponsiveContainer, Bar, BarChart, XAxis, YAxis } from '../../../../../src';
+import { dateWithValueData } from '../../../data';
+
+export default {
+  title: 'Examples/cartesian/Bar/With Brush and onDragEnd',
+};
+
+interface BrushStartEndIndex {
+  startIndex?: number;
+  endIndex?: number;
+}
+
+export const WithBrushAndOnDragEnd = {
+  render: () => {
+    const [dragIndexes, setDragIndexes] = React.useState<BrushStartEndIndex>({
+      startIndex: 0,
+      endIndex: dateWithValueData.length - 1,
+    });
+    return (
+      <div style={{ width: '100%', height: 'calc(100% - 84px)' }}>
+        <div>
+          Start index:
+          {dragIndexes.startIndex}
+        </div>
+        <div>
+          End index:
+          {dragIndexes.endIndex}
+        </div>
+        <ResponsiveContainer>
+          <BarChart data={dateWithValueData}>
+            <XAxis dataKey="value" />
+            <YAxis />
+            <Brush
+              dataKey="name"
+              height={30}
+              stroke="#8884d8"
+              onDragEnd={indexes => {
+                setDragIndexes(indexes as BrushStartEndIndex);
+              }}
+            />
+            <Bar dataKey="value" fill="#8884d8" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    );
+  },
+};

--- a/storybook/stories/Examples/cartesian/Bar/WithBrushAndOnDragEnd.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Bar/WithBrushAndOnDragEnd.stories.tsx
@@ -18,6 +18,7 @@ export const WithBrushAndOnDragEnd = {
       endIndex: dateWithValueData.length - 1,
     });
     return (
+      // Calc compensates for the text above the chart
       <div style={{ width: '100%', height: 'calc(100% - 84px)' }}>
         <div>
           Start index:
@@ -34,12 +35,11 @@ export const WithBrushAndOnDragEnd = {
             <Brush
               dataKey="name"
               height={30}
-              stroke="#8884d8"
               onDragEnd={indexes => {
                 setDragIndexes(indexes as BrushStartEndIndex);
               }}
             />
-            <Bar dataKey="value" fill="#8884d8" />
+            <Bar dataKey="value" />
           </BarChart>
         </ResponsiveContainer>
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Currently the only way to access event data from `Brush` is through `onChange` event handler which is fired whenever the brush is changed. This is not ideal as it fires whenever the brush moves and when the chart needs to load data from an API for an example this might become slow. As mentioned in linked issues, workaround might be to debounce whatever is needed to be done after dragging the brush is done but it is still just a workaround.

## Description

<!--- Describe your changes in detail -->
This change is adding `onDragEnd` function to the `Brush` component and exposed start and end indexes through it.

## Related Issue

https://github.com/recharts/recharts/issues/2534
https://github.com/recharts/recharts/issues/859

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
I have created a new storybook example that utilises the existing Brush and newly added onDragEvent. In the example i've added text component that keeps track of currently active brush indexes. After the brush has been updated and dragging has ended the indexes updated to the latest ones.

## Screenshots (if appropriate):
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
