### PR TITLE
Add tests and types for getDomainOfDataByKey

### DIFF
--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1050,8 +1050,13 @@ export interface GeometrySector {
 export type D3Scale<T> = D3ScaleContinuousNumeric<T, number>;
 
 export type AxisDomainItem = string | number | Function | 'auto' | 'dataMin' | 'dataMax';
+
 /**
- * The domain of axis, always defined by an array of exactly two values, for the min and the max of the axis.
+ * The domain of axis.
+ * This is the definition
+ *
+ * Numeric domain is always defined by an array of exactly two values, for the min and the max of the axis.
+ * Categorical domain is defined as array of all possible values.
  *
  * Can be specified in many ways:
  * - array of numbers
@@ -1069,8 +1074,8 @@ export type AxisDomain =
   | (([dataMin, dataMax]: [number, number], allowDataOverflow: boolean) => [number, number]);
 
 /**
- * NumberDomain is an evaluated AxisDomain.
- * Unlike AxisDomain, it has no variety - it's a tuple of two number.
+ * NumberDomain is an evaluated {@link AxisDomain}.
+ * Unlike {@link AxisDomain}, it has no variety - it's a tuple of two number.
  * This is after all the keywords and functions were evaluated and what is left is [min, max].
  *
  * Know that the min, max values are not guaranteed to be nice numbers - values like -Infinity or NaN are possible.
@@ -1078,6 +1083,8 @@ export type AxisDomain =
  * There are also `category` axes that have different things than numbers in their domain.
  */
 export type NumberDomain = [min: number, max: number];
+
+export type CategoricalDomain = (number | string | Date)[];
 
 /** The props definition of base axis */
 export interface BaseAxisProps {

--- a/test/util/ChartUtils/getDomainOfDataByKey.spec.tsx
+++ b/test/util/ChartUtils/getDomainOfDataByKey.spec.tsx
@@ -1,0 +1,169 @@
+import { getDomainOfDataByKey } from '../../../src/util/ChartUtils';
+
+describe('getDomainOfDataByKey', () => {
+  describe('number axis', () => {
+    it('should return [Infinity, -Infinity] if data is empty array', () => {
+      const result = getDomainOfDataByKey([], '', 'number');
+      expect(result).toEqual([Infinity, -Infinity]);
+    });
+
+    it('should return [min,max] from dataKey array', () => {
+      const data = [{ x: 4 }, { x: 2 }, { x: 8 }];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      expect(result).toEqual([2, 8]);
+    });
+
+    it('should understand infinities', () => {
+      const data = [{ x: 4 }, { x: -Infinity }, { x: 8 }, { x: Infinity }];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      expect(result).toEqual([-Infinity, Infinity]);
+    });
+
+    it('should understand scientific notation', () => {
+      const data = [{ x: 9 }, { x: 1e3 }, { x: 8e2 }];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      expect(result).toEqual([9, 1000]);
+    });
+
+    it('when given positive and negative zeroes, should use the first one from the array as both min and max', () => {
+      const data = [{ x: -0 }, { x: 0 }];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      expect(result).toEqual([-0, -0]);
+
+      const data2 = [{ x: 0 }, { x: -0 }];
+      const result2 = getDomainOfDataByKey(data2, 'x', 'number');
+      expect(result2).toEqual([0, 0]);
+    });
+
+    it('should flatten arrays of numbers', () => {
+      const data = [{ x: [4, 1] }, { x: [2, 16] }, { x: [8, 3] }];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      expect(result).toEqual([1, 16]);
+    });
+
+    it('should treat stringified numbers as strings', () => {
+      const data = [{ x: '4' }, { x: '2' }, { x: '8' }, { x: '12' }];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      /*
+       * Even though 2 is smaller number than 12, '12' is smaller string than '2'.
+       * This is 100% a bug but before we fix it let's talk about backwards compatibility
+       */
+      expect(result).toEqual(['12', '8']);
+    });
+
+    it('should ignore non-number values', () => {
+      const data = [{ x: 'twelve' }, { x: 4 }, { x: 8 }, { x: '0' }];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      expect(result).toEqual([4, 8]);
+    });
+
+    it('should return [Infinity, -Infinity] if none of the data points is a number', () => {
+      const data = [{ x: 'yesterday' }, { x: 'today' }, { x: 'tomorrow' }];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      expect(result).toEqual([Infinity, -Infinity]);
+    });
+
+    it('should return 0 if it is specified as a number', () => {
+      const data = [{ x: 0 }, { x: 100 }, { x: 200 }];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      expect(result).toEqual([0, 200]);
+    });
+
+    it('should ignore filterNil parameter', () => {
+      const data = [{ x: 0 }, { x: 100 }, { x: 200 }];
+      const resultWithTrue = getDomainOfDataByKey(data, 'x', 'number', true);
+      const resultWithFalse = getDomainOfDataByKey(data, 'x', 'number', false);
+      expect(resultWithTrue).toEqual(resultWithFalse);
+    });
+
+    it('should ignore 0 if it is specified as a string', () => {
+      const data = [{ x: '0' }, { x: '100' }, { x: '200' }];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      expect(result).toEqual(['100', '200']);
+    });
+
+    it('should use the same number as both min and max if there is only one data point', () => {
+      const data = [{ x: 7 }];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      expect(result).toEqual([7, 7]);
+    });
+
+    it('should ignore NaN', () => {
+      const data = [{ x: NaN }];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      expect(result).toEqual([Infinity, -Infinity]);
+    });
+
+    it('should remove other non-numeric and Date values', () => {
+      const data: unknown[] = [
+        { x: NaN },
+        { x: {} },
+        { x: [] },
+        {
+          x() {
+            return 1;
+          },
+        },
+        { x: false },
+        { x: null },
+        { x: undefined },
+        { x: new Date(0) },
+      ];
+      const result = getDomainOfDataByKey(data, 'x', 'number');
+      expect(result).toEqual([Infinity, -Infinity]);
+    });
+  });
+
+  describe('category axis', () => {
+    it('should return empty array if data is empty array', () => {
+      const result = getDomainOfDataByKey([], '', 'category');
+      expect(result).toEqual([]);
+    });
+
+    it('should filter away nulls and undefineds if filterNil is true', () => {
+      const data: unknown[] = [{ x: null }, { x: undefined }];
+      const result = getDomainOfDataByKey(data, 'x', 'category', true);
+      expect(result).toEqual([]);
+    });
+
+    it('should flatten arrays', () => {
+      const data: unknown[] = [{ x: [1, 2] }, { x: [3, 4] }, { x: [] }];
+      const result = getDomainOfDataByKey(data, 'x', 'category', true);
+      expect(result).toEqual([1, 2, 3, 4]);
+    });
+
+    test.each([
+      NaN,
+      {},
+      function anon() {
+        return 1;
+      },
+      true,
+      false,
+      null,
+      undefined,
+    ])('should turn %s into emptystring if filterNil is false', v => {
+      const result = getDomainOfDataByKey([{ v }], 'v', 'category', false);
+      expect(result).toEqual(['']);
+    });
+
+    test.each([
+      NaN,
+      {},
+      function anon() {
+        return 1;
+      },
+      true,
+      false,
+    ])('should turn %s into emptystring if filterNil is true', v => {
+      const result = getDomainOfDataByKey([{ v }], 'v', 'category', true);
+      expect(result).toEqual(['']);
+    });
+
+    it('should include strings, numbers, and Dates in the domain', () => {
+      const data: unknown[] = [{ x: 1 }, { x: 'my string' }, { x: new Date(100) }];
+      const result = getDomainOfDataByKey(data, 'x', 'category', false);
+      expect(result).toEqual([1, 'my string', new Date(100)]);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Tests and types only.

I don't think that all of the behaviour of `getDomainOfDataByKey` function is intentional :-X it appears to me like a product of a developer that doesn't have the habit of writing unit tests. I'm not certain if it's worth fixing some of these and what the release strategy should be.

Some of the behaviour is obviously wrong (sorting strings) and deserves a fix, on the other hand perhaps we should wait and see how it interacts with rest of the system?

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Observing how the library works

## How Has This Been Tested?

Jest, TS

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
