### PR TITLE
getStackedData - add tests, types, and storybook, and update docs

### DIFF
--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -7,7 +7,6 @@ import {
   stackOffsetSilhouette,
   stackOffsetWiggle,
   stackOrderNone,
-  stackOffsetDiverging,
 } from 'victory-vendor/d3-shape';
 import _ from 'lodash';
 import { ReactElement, ReactNode } from 'react';
@@ -909,8 +908,6 @@ type OffsetAccessor = (series: Array<Series<Record<string, unknown>, string>>, o
 
 const STACK_OFFSET_MAP: Record<string, OffsetAccessor> = {
   sign: offsetSign,
-  // @ts-expect-error definitelytyped types are incorrect
-  d: stackOffsetDiverging,
   // @ts-expect-error definitelytyped types are incorrect
   expand: stackOffsetExpand,
   // @ts-expect-error definitelytyped types are incorrect

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1,11 +1,13 @@
 import * as d3Scales from 'victory-vendor/d3-scale';
 import {
+  Series,
   stack as shapeStack,
   stackOffsetExpand,
   stackOffsetNone,
   stackOffsetSilhouette,
   stackOffsetWiggle,
   stackOrderNone,
+  stackOffsetDiverging,
 } from 'victory-vendor/d3-shape';
 import _ from 'lodash';
 import { ReactElement, ReactNode } from 'react';
@@ -27,6 +29,7 @@ import {
   NumberDomain,
   TickItem,
   CategoricalDomain,
+  StackOffsetType,
 } from './types';
 import { Payload as LegendPayload } from '../component/DefaultLegendContent';
 
@@ -818,8 +821,15 @@ export const truncateByDomain = (value: any[], domain: any[]) => {
   return result;
 };
 
-/* eslint no-param-reassign: 0 */
-export const offsetSign = (series: any) => {
+/**
+ * Stacks all positive numbers above zero and all negative numbers below zero.
+ *
+ * If all values in the series are positive then this behaves the same as 'none' stacker.
+ *
+ * @param {Array} series from d3-shape Stack
+ * @return {Array} series with applied offset
+ */
+export const offsetSign: OffsetAccessor = series => {
   const n = series.length;
   if (n <= 0) {
     return;
@@ -832,7 +842,7 @@ export const offsetSign = (series: any) => {
     for (let i = 0; i < n; ++i) {
       const value = _.isNaN(series[i][j][1]) ? series[i][j][0] : series[i][j][1];
 
-      /* eslint-disable prefer-destructuring */
+      /* eslint-disable prefer-destructuring, no-param-reassign */
       if (value >= 0) {
         series[i][j][0] = positive;
         series[i][j][1] = positive + value;
@@ -842,12 +852,20 @@ export const offsetSign = (series: any) => {
         series[i][j][1] = negative + value;
         negative = series[i][j][1];
       }
-      /* eslint-enable prefer-destructuring */
+      /* eslint-enable prefer-destructuring, no-param-reassign */
     }
   }
 };
 
-export const offsetPositive = (series: any) => {
+/**
+ * Replaces all negative values with zero when stacking data.
+ *
+ * If all values in the series are positive then this behaves the same as 'none' stacker.
+ *
+ * @param {Array} series from d3-shape Stack
+ * @return {Array} series with applied offset
+ */
+export const offsetPositive: OffsetAccessor = series => {
   const n = series.length;
   if (n <= 0) {
     return;
@@ -859,7 +877,7 @@ export const offsetPositive = (series: any) => {
     for (let i = 0; i < n; ++i) {
       const value = _.isNaN(series[i][j][1]) ? series[i][j][0] : series[i][j][1];
 
-      /* eslint-disable prefer-destructuring */
+      /* eslint-disable prefer-destructuring, no-param-reassign */
       if (value >= 0) {
         series[i][j][0] = positive;
         series[i][j][1] = positive + value;
@@ -868,27 +886,56 @@ export const offsetPositive = (series: any) => {
         series[i][j][0] = 0;
         series[i][j][1] = 0;
       }
-      /* eslint-enable prefer-destructuring */
+      /* eslint-enable prefer-destructuring, no-param-reassign */
     }
   }
 };
 
-const STACK_OFFSET_MAP: Record<string, any> = {
+/**
+ * Function type to compute offset for stacked data.
+ *
+ * d3-shape has something fishy going on with its types.
+ * In @definitelytyped/d3-shape, this function (the offset accessor) is typed as Series<> => void.
+ * However! When I actually open the storybook I can see that the offset accessor actually receives Array<Series<>>.
+ * The same I can see in the source code itself:
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/66042
+ * That one unfortunately has no types but we can tell it passes three-dimensional array.
+ *
+ * Which leads me to believe that definitelytyped is wrong on this one.
+ * There's open discussion on this topic without much attention:
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/66042
+ */
+type OffsetAccessor = (series: Array<Series<Record<string, unknown>, string>>, order: number[]) => void;
+
+const STACK_OFFSET_MAP: Record<string, OffsetAccessor> = {
   sign: offsetSign,
+  // @ts-expect-error definitelytyped types are incorrect
+  d: stackOffsetDiverging,
+  // @ts-expect-error definitelytyped types are incorrect
   expand: stackOffsetExpand,
+  // @ts-expect-error definitelytyped types are incorrect
   none: stackOffsetNone,
+  // @ts-expect-error definitelytyped types are incorrect
   silhouette: stackOffsetSilhouette,
+  // @ts-expect-error definitelytyped types are incorrect
   wiggle: stackOffsetWiggle,
   positive: offsetPositive,
 };
 
-export const getStackedData = (data: any, stackItems: any, offsetType: string) => {
-  const dataKeys = stackItems.map((item: any) => item.props.dataKey);
-  const stack = shapeStack()
+export const getStackedData = (
+  data: ReadonlyArray<Record<string, unknown>>,
+  stackItems: ReadonlyArray<{ props: { dataKey?: DataKey<any> } }>,
+  offsetType: StackOffsetType,
+): ReadonlyArray<Series<Record<string, unknown>, string>> => {
+  const dataKeys = stackItems.map(item => item.props.dataKey);
+  const offsetAccessor: OffsetAccessor = STACK_OFFSET_MAP[offsetType];
+  const stack = shapeStack<Record<string, unknown>>()
+    // @ts-expect-error stack.keys type wants an array of strings, but we provide array of DataKeys
     .keys(dataKeys)
     .value((d, key) => +getValueByDataKey(d, key, 0))
     .order(stackOrderNone)
-    .offset(STACK_OFFSET_MAP[offsetType]);
+    // @ts-expect-error definitelytyped types are incorrect
+    .offset(offsetAccessor);
 
   return stack(data);
 };

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -24,6 +24,18 @@ import {
 import _ from 'lodash';
 import { ScaleContinuousNumeric as D3ScaleContinuousNumeric } from 'victory-vendor/d3-scale';
 
+/**
+ * Determines how values are stacked:
+ *
+ * - `none` is the default, it adds values on top of each other. No smarts. Negative values will overlap.
+ * - `expand` make it so that the values always add up to 1 - so the chart will look like a rectangle.
+ * - `wiggle` and `silhouette` tries to keep the chart centered.
+ * - `sign` stacks positive values above zero and negative values below zero. Similar to `none` but handles negatives.
+ * - `positive` ignores all negative values, and then behaves like \`none\`.
+ *
+ * Also see https://d3js.org/d3-shape/stack#stack-offsets
+ * (note that the `diverging` offset in d3 is named `sign` in recharts)
+ */
 export type StackOffsetType = 'sign' | 'expand' | 'none' | 'wiggle' | 'silhouette' | 'positive';
 export type LayoutType = 'horizontal' | 'vertical' | 'centric' | 'radial';
 export type PolarLayoutType = 'radial' | 'centric';

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -24,7 +24,7 @@ import {
 import _ from 'lodash';
 import { ScaleContinuousNumeric as D3ScaleContinuousNumeric } from 'victory-vendor/d3-scale';
 
-export type StackOffsetType = 'sign' | 'expand' | 'none' | 'wiggle' | 'silhouette';
+export type StackOffsetType = 'sign' | 'expand' | 'none' | 'wiggle' | 'silhouette' | 'positive';
 export type LayoutType = 'horizontal' | 'vertical' | 'centric' | 'radial';
 export type PolarLayoutType = 'radial' | 'centric';
 export type AxisType = 'xAxis' | 'yAxis' | 'zAxis' | 'angleAxis' | 'radiusAxis';

--- a/storybook/stories/API/chart/BarChart.stories.tsx
+++ b/storybook/stories/API/chart/BarChart.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Bar, BarChart, ResponsiveContainer, XAxis } from '../../../../src';
-import { pageData } from '../../data';
+import { Args } from '@storybook/react';
+import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from '../../../../src';
+import { pageData, pageDataWithNegativeNumbers } from '../../data';
 import { CategoricalChartProps } from '../props/ChartProps';
 
 export default {
@@ -41,5 +42,27 @@ export const BarInBar = {
   },
   args: {
     data: pageData,
+  },
+};
+
+export const Stacked = {
+  render: (args: Args) => {
+    return (
+      <ResponsiveContainer width="100%" height={400}>
+        <BarChart {...args}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          <Bar dataKey="uv" stackId="a" fill="green" barSize={50} />
+          <Bar dataKey="pv" stackId="a" fill="red" barSize={30} />
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    data: pageDataWithNegativeNumbers,
+    stackOffset: 'none',
   },
 };

--- a/storybook/stories/API/props/ChartProps.ts
+++ b/storybook/stories/API/props/ChartProps.ts
@@ -263,11 +263,20 @@ export const CategoricalChartProps: StorybookArgs = {
     },
   },
   stackOffset: {
-    description: `The type of offset function used to generate the lower and upper
-      values in the series array. The four types are built-in offsets in d3-shape.`,
+    description: `Determines how values are stacked:
+    
+- \`none\` is the default, it adds values on top of each other. No smarts. Negative values will overlap.
+- \`expand\` make it so that the values always add up to 1 - so the chart will look like a rectangle.
+- \`wiggle\` and \`silhouette\` tries to keep the chart centered.
+- \`sign\` stacks positive values above zero and negative values below zero. Similar to \`none\` but handles negatives.
+- \`positive\` ignores all negative values, and then behaves like \`none\`.
+
+Also see https://d3js.org/d3-shape/stack#stack-offsets
+(note that the \`diverging\` offset in d3 is named \`sign\` in recharts)
+`,
     table: {
       type: {
-        summary: "'expand' | 'none' | 'wiggle' | 'silhouette' | 'sign'",
+        summary: "'expand' | 'none' | 'wiggle' | 'silhouette' | 'sign' | 'positive'",
       },
       defaultValue: "'none'",
       category: 'General',

--- a/storybook/stories/data/Page.ts
+++ b/storybook/stories/data/Page.ts
@@ -44,6 +44,51 @@ const pageData: PageDataType[] = [
   },
 ];
 
+export const pageDataWithNegativeNumbers: PageDataType[] = [
+  {
+    name: 'Page A',
+    uv: 4000,
+    pv: 2400,
+    amt: 2400,
+  },
+  {
+    name: 'Page B',
+    uv: -3000,
+    pv: 1398,
+    amt: 2210,
+  },
+  {
+    name: 'Page C',
+    uv: -2000,
+    pv: -9800,
+    amt: 2290,
+  },
+  {
+    name: 'Page D',
+    uv: 2780,
+    pv: 3908,
+    amt: 2000,
+  },
+  {
+    name: 'Page E',
+    uv: -1890,
+    pv: 4800,
+    amt: 2181,
+  },
+  {
+    name: 'Page F',
+    uv: 2390,
+    pv: -3800,
+    amt: 2500,
+  },
+  {
+    name: 'Page G',
+    uv: 3490,
+    pv: 4300,
+    amt: 2100,
+  },
+];
+
 const numberData = [
   { name: '1', uv: 300, pv: 456 },
   { name: '2', uv: -145, pv: 230 },

--- a/test/util/ChartUtils.spec.tsx
+++ b/test/util/ChartUtils.spec.tsx
@@ -12,7 +12,6 @@ import {
   getValueByDataKey,
   MAX_VALUE_REG,
   MIN_VALUE_REG,
-  offsetSign,
   parseSpecifiedDomain,
   getTicksOfAxis,
 } from '../../src/util/ChartUtils';
@@ -317,40 +316,6 @@ describe('getValueByDataKey', () => {
     },
   ])('should return result of function getter if data object is %s', d => {
     expect(getValueByDataKey(d, () => 1, 7)).toEqual(1);
-  });
-});
-
-describe('offsetSign', () => {
-  describe('of data', () => {
-    const data = [
-      [
-        [0, 1],
-        [0, 2],
-        [0, -5],
-      ],
-      [
-        [0, -1],
-        [0, 2],
-        [0, -5],
-      ],
-    ];
-
-    offsetSign(data);
-
-    it('should change', () => {
-      expect(data).toEqual([
-        [
-          [0, 1],
-          [0, 2],
-          [0, -5],
-        ],
-        [
-          [0, -1],
-          [2, 4],
-          [-5, -10],
-        ],
-      ]);
-    });
   });
 });
 

--- a/test/util/ChartUtils/getStackedData.spec.ts
+++ b/test/util/ChartUtils/getStackedData.spec.ts
@@ -2,7 +2,7 @@ import { Series, SeriesPoint } from 'victory-vendor/d3-shape';
 import { getStackedData, offsetSign } from '../../../src/util/ChartUtils';
 import { DataKey, StackOffsetType } from '../../../src/util/types';
 
-function dk(dataKey: DataKey<any>) {
+function createDataKeyProps(dataKey: DataKey<any>) {
   return { props: { dataKey } };
 }
 
@@ -104,13 +104,21 @@ describe('getStackedData', () => {
   });
 
   it('should return one empty array for each dataKey even if it is not part of the data', () => {
-    const result = getStackedData([], [dk('x'), dk('y'), dk('z')], 'none');
+    const result = getStackedData(
+      [],
+      [createDataKeyProps('x'), createDataKeyProps('y'), createDataKeyProps('z')],
+      'none',
+    );
     const expected = [createSeries('x', 0), createSeries('y', 1), createSeries('z', 2)];
     expect(result).toEqual(expected);
   });
 
   it('should return one empty array for each data key even if it is not part of the data', () => {
-    const result = getStackedData([], [dk('x'), dk('y'), dk('z')], 'none');
+    const result = getStackedData(
+      [],
+      [createDataKeyProps('x'), createDataKeyProps('y'), createDataKeyProps('z')],
+      'none',
+    );
     const expected = [createSeries('x', 0), createSeries('y', 1), createSeries('z', 2)];
     expect(result).toEqual(expected);
   });
@@ -118,7 +126,7 @@ describe('getStackedData', () => {
   const allOffsets: StackOffsetType[] = ['expand', 'none', 'positive', 'sign', 'silhouette', 'wiggle'];
   describe.each(allOffsets)('with offset %s', offset => {
     it('should stack numerical data', () => {
-      const dataKeys = [dk('uv'), dk('pv')];
+      const dataKeys = [createDataKeyProps('uv'), createDataKeyProps('pv')];
       const result = getStackedData(mockData, dataKeys, offset);
       expect(result).toHaveLength(dataKeys.length);
       result.forEach(series => {
@@ -133,7 +141,7 @@ describe('getStackedData', () => {
     });
 
     it('should stack data when dataKey is a function', () => {
-      const dataKeys = [dk(o => o.uv + 100), dk(o => o.pv - 100)];
+      const dataKeys = [createDataKeyProps(o => o.uv + 100), createDataKeyProps(o => o.pv - 100)];
       const result = getStackedData(mockData, dataKeys, offset);
       expect(result).toHaveLength(dataKeys.length);
       result.forEach(series => {
@@ -149,7 +157,7 @@ describe('getStackedData', () => {
   });
 
   it('should stack numerical data with offset: none', () => {
-    const result = getStackedData(mockData, [dk('uv'), dk('pv')], 'none');
+    const result = getStackedData(mockData, [createDataKeyProps('uv'), createDataKeyProps('pv')], 'none');
     const firstSeries = createSeries('uv', 0, [
       createSeriesPoint(0, 590, mockData[0]),
       createSeriesPoint(0, 868, mockData[1]),
@@ -163,7 +171,11 @@ describe('getStackedData', () => {
   });
 
   it('should stack numerical data with offset: sign', () => {
-    const result = getStackedData(dataWithNegativeNumbers, [dk('uv'), dk('pv')], 'sign');
+    const result = getStackedData(
+      dataWithNegativeNumbers,
+      [createDataKeyProps('uv'), createDataKeyProps('pv')],
+      'sign',
+    );
     const uvSeries = createSeries('uv', 0, [
       createSeriesPoint(0, 4000, dataWithNegativeNumbers[0]),
       createSeriesPoint(0, -3000, dataWithNegativeNumbers[1]),
@@ -187,7 +199,7 @@ describe('getStackedData', () => {
   });
 
   it('with offset: positive should ignore all negative data points', () => {
-    const dataKeys = [dk('uv'), dk('pv')];
+    const dataKeys = [createDataKeyProps('uv'), createDataKeyProps('pv')];
     const result = getStackedData(dataWithNegativeNumbers, dataKeys, 'positive');
     const uvSeries = createSeries('uv', 0, [
       createSeriesPoint(0, 4000, dataWithNegativeNumbers[0]),
@@ -212,7 +224,11 @@ describe('getStackedData', () => {
   });
 
   it('should stack data when dataKey is a function with offset: none', () => {
-    const result = getStackedData(mockData, [dk(o => o.uv + 100), dk(o => o.pv - 100)], 'none');
+    const result = getStackedData(
+      mockData,
+      [createDataKeyProps(o => o.uv + 100), createDataKeyProps(o => o.pv - 100)],
+      'none',
+    );
     const firstSeries = createSeries('uv', 0, [
       createSeriesPoint(0, 690, mockData[0]),
       createSeriesPoint(0, 968, mockData[1]),
@@ -249,7 +265,7 @@ describe('getStackedData', () => {
         name: 'z',
       },
     ];
-    const result = getStackedData(mockCategoryData, [dk('x')], 'positive');
+    const result = getStackedData(mockCategoryData, [createDataKeyProps('x')], 'positive');
     const expected = [
       createSeries('x', 0, [
         createSeriesPoint(0, 0, mockCategoryData[0]),
@@ -277,7 +293,7 @@ describe('getStackedData', () => {
         },
       },
     ];
-    const result = getStackedData(mockCategoryData, [dk('x')], 'sign');
+    const result = getStackedData(mockCategoryData, [createDataKeyProps('x')], 'sign');
     const expected = [
       createSeries('x', 0, [
         createSeriesPoint(0, 0, mockCategoryData[0]),

--- a/test/util/ChartUtils/getStackedData.spec.ts
+++ b/test/util/ChartUtils/getStackedData.spec.ts
@@ -1,0 +1,284 @@
+import { Series, SeriesPoint } from 'victory-vendor/d3-shape';
+import { getStackedData, offsetSign } from '../../../src/util/ChartUtils';
+import { DataKey, StackOffsetType } from '../../../src/util/types';
+
+function dk(dataKey: DataKey<any>) {
+  return { props: { dataKey } };
+}
+
+function s(
+  key: string,
+  index: number,
+  data: Array<SeriesPoint<Record<string, unknown>>> = [],
+): Series<Record<string, unknown>, string> {
+  return Object.assign(data, { key, index });
+}
+
+function sp(first: number, second: number, data: Record<string, unknown>): SeriesPoint<Record<string, unknown>> {
+  return Object.assign([], { data, 0: first, 1: second });
+}
+
+const mockData = [
+  {
+    name: 'Page A',
+    uv: 590,
+    pv: 800,
+    amt: 1400,
+  },
+  {
+    name: 'Page B',
+    uv: 868,
+    pv: 967,
+    amt: 1506,
+  },
+];
+
+const dataWithNegativeNumbers = [
+  {
+    name: 'Page A',
+    uv: 4000,
+    pv: 2400,
+    amt: 2400,
+  },
+  {
+    name: 'Page B',
+    uv: -3000,
+    pv: 1398,
+    amt: 2210,
+  },
+  {
+    name: 'Page C',
+    uv: -2000,
+    pv: -9800,
+    amt: 2290,
+  },
+  {
+    name: 'Page D',
+    uv: 2780,
+    pv: 3908,
+    amt: 2000,
+  },
+  {
+    name: 'Page E',
+    uv: -1890,
+    pv: 4800,
+    amt: 2181,
+  },
+  {
+    name: 'Page F',
+    uv: 2390,
+    pv: -3800,
+    amt: 2500,
+  },
+  {
+    name: 'Page G',
+    uv: 3490,
+    pv: 4300,
+    amt: 2100,
+  },
+];
+
+/**
+ * If you see one of these tests failing with a message "serializes to the same string",
+ * that is because the d3-shape library assigns abitrary property keys to an array.
+ *
+ * Jest doesn't like that. When it compares the two arrays it can see that it has extra property,
+ * and if that extra property is different then it fails.
+ * But when printing the array, it only prints the usual array elements, and ignores the extra properties.
+ * Therefore the "serializes to the same string" problem.
+ *
+ * So when you see that error, try to compare the other properties, like `Series.key` and `SeriesPoint.data`.
+ * Or print them with console.log, that will show the difference.
+ */
+describe('getStackedData', () => {
+  it('should return empty array if there is no data', () => {
+    expect(getStackedData([], [], 'none')).toEqual([]);
+  });
+
+  it('should return empty array if there is some data but no data keys', () => {
+    expect(getStackedData([{ x: 1 }], [], 'none')).toEqual([]);
+  });
+
+  it('should return one empty array for each dataKey even if it is not part of the data', () => {
+    const result = getStackedData([], [dk('x'), dk('y'), dk('z')], 'none');
+    const expected = [s('x', 0), s('y', 1), s('z', 2)];
+    expect(result).toEqual(expected);
+  });
+
+  it('should return one empty array for each data key even if it is not part of the data', () => {
+    const result = getStackedData([], [dk('x'), dk('y'), dk('z')], 'none');
+    const expected = [s('x', 0), s('y', 1), s('z', 2)];
+    expect(result).toEqual(expected);
+  });
+
+  const allOffsets: StackOffsetType[] = ['expand', 'none', 'positive', 'sign', 'silhouette', 'wiggle'];
+  describe.each(allOffsets)('with offset %s', offset => {
+    it('should stack numerical data', () => {
+      const dataKeys = [dk('uv'), dk('pv')];
+      const result = getStackedData(mockData, dataKeys, offset);
+      expect(result).toHaveLength(dataKeys.length);
+      result.forEach(series => {
+        expect(series).toHaveLength(mockData.length);
+        series.forEach(point => {
+          expect(point[0]).toEqual(expect.any(Number));
+          expect(point[1]).toEqual(expect.any(Number));
+          expect(point[0]).not.toBeNaN();
+          expect(point[1]).not.toBeNaN();
+        });
+      });
+    });
+
+    it('should stack data when dataKey is a function', () => {
+      const dataKeys = [dk(o => o.uv + 100), dk(o => o.pv - 100)];
+      const result = getStackedData(mockData, dataKeys, offset);
+      expect(result).toHaveLength(dataKeys.length);
+      result.forEach(series => {
+        expect(series).toHaveLength(mockData.length);
+        series.forEach(point => {
+          expect(point[0]).toEqual(expect.any(Number));
+          expect(point[1]).toEqual(expect.any(Number));
+          expect(point[0]).not.toBeNaN();
+          expect(point[1]).not.toBeNaN();
+        });
+      });
+    });
+  });
+
+  it('should stack numerical data with offset: none', () => {
+    const result = getStackedData(mockData, [dk('uv'), dk('pv')], 'none');
+    const firstSeries = s('uv', 0, [sp(0, 590, mockData[0]), sp(0, 868, mockData[1])]);
+    const secondSeries = s('pv', 1, [sp(590, 1390, mockData[0]), sp(868, 1835, mockData[1])]);
+    const expected = [firstSeries, secondSeries];
+    expect(result).toEqual(expected);
+  });
+
+  it('should stack numerical data with offset: sign', () => {
+    const result = getStackedData(dataWithNegativeNumbers, [dk('uv'), dk('pv')], 'sign');
+    const uvSeries = s('uv', 0, [
+      sp(0, 4000, dataWithNegativeNumbers[0]),
+      sp(0, -3000, dataWithNegativeNumbers[1]),
+      sp(0, -2000, dataWithNegativeNumbers[2]),
+      sp(0, 2780, dataWithNegativeNumbers[3]),
+      sp(0, -1890, dataWithNegativeNumbers[4]),
+      sp(0, 2390, dataWithNegativeNumbers[5]),
+      sp(0, 3490, dataWithNegativeNumbers[6]),
+    ]);
+    const pvSeries = s('pv', 1, [
+      sp(4000, 6400, dataWithNegativeNumbers[0]),
+      sp(0, 1398, dataWithNegativeNumbers[1]),
+      sp(-2000, -11800, dataWithNegativeNumbers[2]),
+      sp(2780, 6688, dataWithNegativeNumbers[3]),
+      sp(0, 4800, dataWithNegativeNumbers[4]),
+      sp(0, -3800, dataWithNegativeNumbers[5]),
+      sp(3490, 7790, dataWithNegativeNumbers[6]),
+    ]);
+    const expected = [uvSeries, pvSeries];
+    expect(result).toEqual(expected);
+  });
+
+  it('with offset: positive should ignore all negative data points', () => {
+    const dataKeys = [dk('uv'), dk('pv')];
+    const result = getStackedData(dataWithNegativeNumbers, dataKeys, 'positive');
+    const uvSeries = s('uv', 0, [
+      sp(0, 4000, dataWithNegativeNumbers[0]),
+      sp(0, 0, dataWithNegativeNumbers[1]),
+      sp(0, 0, dataWithNegativeNumbers[2]),
+      sp(0, 2780, dataWithNegativeNumbers[3]),
+      sp(0, 0, dataWithNegativeNumbers[4]),
+      sp(0, 2390, dataWithNegativeNumbers[5]),
+      sp(0, 3490, dataWithNegativeNumbers[6]),
+    ]);
+    const pvSeries = s('pv', 1, [
+      sp(4000, 6400, dataWithNegativeNumbers[0]),
+      sp(0, 1398, dataWithNegativeNumbers[1]),
+      sp(0, 0, dataWithNegativeNumbers[2]),
+      sp(2780, 6688, dataWithNegativeNumbers[3]),
+      sp(0, 4800, dataWithNegativeNumbers[4]),
+      sp(0, 0, dataWithNegativeNumbers[5]),
+      sp(3490, 7790, dataWithNegativeNumbers[6]),
+    ]);
+    const expected = [uvSeries, pvSeries];
+    expect(result).toEqual(expected);
+  });
+
+  it('should stack data when dataKey is a function with offset: none', () => {
+    const result = getStackedData(mockData, [dk(o => o.uv + 100), dk(o => o.pv - 100)], 'none');
+    const firstSeries = s('uv', 0, [sp(0, 690, mockData[0]), sp(0, 968, mockData[1])]);
+    const secondSeries = s('pv', 1, [sp(690, 1390, mockData[0]), sp(968, 1835, mockData[1])]);
+    const expected = [firstSeries, secondSeries];
+    /*
+     * Direct comparison with .toEqual doesn't work because the `key` property is a function
+     * and jest always rejects when comparing functions.
+     */
+    expect(result).toHaveLength(expected.length);
+    expect(result[0]).toHaveLength(firstSeries.length);
+    expect(result[1]).toHaveLength(secondSeries.length);
+    result[0].forEach((point, index) => {
+      expect(point).toEqual(firstSeries[index]);
+    });
+    result[1].forEach((point, index) => {
+      expect(point).toEqual(secondSeries[index]);
+    });
+  });
+
+  test('offset: positive should turn data that are not numbers to zero', () => {
+    const mockCategoryData = [
+      {
+        name: 'x',
+      },
+      {
+        name: 'y',
+      },
+      {
+        name: 'z',
+      },
+    ];
+    const result = getStackedData(mockCategoryData, [dk('x')], 'positive');
+    const expected = [
+      s('x', 0, [sp(0, 0, mockCategoryData[0]), sp(0, 0, mockCategoryData[1]), sp(0, 0, mockCategoryData[2])]),
+    ];
+    expect(result).toEqual(expected);
+  });
+
+  test('offset: sign should turn data that are not numbers to zero', () => {
+    const mockCategoryData = [
+      {
+        name: 'x',
+      },
+      {
+        name: '',
+      },
+      {
+        name: NaN,
+      },
+      {
+        name: function anon() {
+          return 0;
+        },
+      },
+    ];
+    const result = getStackedData(mockCategoryData, [dk('x')], 'sign');
+    const expected = [
+      s('x', 0, [
+        sp(0, 0, mockCategoryData[0]),
+        sp(0, 0, mockCategoryData[1]),
+        sp(0, 0, mockCategoryData[2]),
+        sp(0, 0, mockCategoryData[3]),
+      ]),
+    ];
+    expect(result).toEqual(expected);
+  });
+
+  test('offsetSign should mutate data in place', () => {
+    const data = [
+      s('', 0, [sp(0, 1, {}), sp(0, 2, {}), sp(0, -5, {})]),
+      s('', 1, [sp(0, -1, {}), sp(0, 2, {}), sp(0, -5, {})]),
+    ];
+    const expected = [
+      s('', 0, [sp(0, 1, {}), sp(0, 2, {}), sp(0, -5, {})]),
+      s('', 1, [sp(0, -1, {}), sp(2, 4, {}), sp(-5, -10, {})]),
+    ];
+    offsetSign(data, []);
+    expect(data).toEqual(expected);
+  });
+});

--- a/test/util/ChartUtils/getStackedData.spec.ts
+++ b/test/util/ChartUtils/getStackedData.spec.ts
@@ -6,7 +6,7 @@ function dk(dataKey: DataKey<any>) {
   return { props: { dataKey } };
 }
 
-function s(
+function createSeries(
   key: string,
   index: number,
   data: Array<SeriesPoint<Record<string, unknown>>> = [],
@@ -14,7 +14,11 @@ function s(
   return Object.assign(data, { key, index });
 }
 
-function sp(first: number, second: number, data: Record<string, unknown>): SeriesPoint<Record<string, unknown>> {
+function createSeriesPoint(
+  first: number,
+  second: number,
+  data: Record<string, unknown>,
+): SeriesPoint<Record<string, unknown>> {
   return Object.assign([], { data, 0: first, 1: second });
 }
 
@@ -101,13 +105,13 @@ describe('getStackedData', () => {
 
   it('should return one empty array for each dataKey even if it is not part of the data', () => {
     const result = getStackedData([], [dk('x'), dk('y'), dk('z')], 'none');
-    const expected = [s('x', 0), s('y', 1), s('z', 2)];
+    const expected = [createSeries('x', 0), createSeries('y', 1), createSeries('z', 2)];
     expect(result).toEqual(expected);
   });
 
   it('should return one empty array for each data key even if it is not part of the data', () => {
     const result = getStackedData([], [dk('x'), dk('y'), dk('z')], 'none');
-    const expected = [s('x', 0), s('y', 1), s('z', 2)];
+    const expected = [createSeries('x', 0), createSeries('y', 1), createSeries('z', 2)];
     expect(result).toEqual(expected);
   });
 
@@ -146,31 +150,37 @@ describe('getStackedData', () => {
 
   it('should stack numerical data with offset: none', () => {
     const result = getStackedData(mockData, [dk('uv'), dk('pv')], 'none');
-    const firstSeries = s('uv', 0, [sp(0, 590, mockData[0]), sp(0, 868, mockData[1])]);
-    const secondSeries = s('pv', 1, [sp(590, 1390, mockData[0]), sp(868, 1835, mockData[1])]);
+    const firstSeries = createSeries('uv', 0, [
+      createSeriesPoint(0, 590, mockData[0]),
+      createSeriesPoint(0, 868, mockData[1]),
+    ]);
+    const secondSeries = createSeries('pv', 1, [
+      createSeriesPoint(590, 1390, mockData[0]),
+      createSeriesPoint(868, 1835, mockData[1]),
+    ]);
     const expected = [firstSeries, secondSeries];
     expect(result).toEqual(expected);
   });
 
   it('should stack numerical data with offset: sign', () => {
     const result = getStackedData(dataWithNegativeNumbers, [dk('uv'), dk('pv')], 'sign');
-    const uvSeries = s('uv', 0, [
-      sp(0, 4000, dataWithNegativeNumbers[0]),
-      sp(0, -3000, dataWithNegativeNumbers[1]),
-      sp(0, -2000, dataWithNegativeNumbers[2]),
-      sp(0, 2780, dataWithNegativeNumbers[3]),
-      sp(0, -1890, dataWithNegativeNumbers[4]),
-      sp(0, 2390, dataWithNegativeNumbers[5]),
-      sp(0, 3490, dataWithNegativeNumbers[6]),
+    const uvSeries = createSeries('uv', 0, [
+      createSeriesPoint(0, 4000, dataWithNegativeNumbers[0]),
+      createSeriesPoint(0, -3000, dataWithNegativeNumbers[1]),
+      createSeriesPoint(0, -2000, dataWithNegativeNumbers[2]),
+      createSeriesPoint(0, 2780, dataWithNegativeNumbers[3]),
+      createSeriesPoint(0, -1890, dataWithNegativeNumbers[4]),
+      createSeriesPoint(0, 2390, dataWithNegativeNumbers[5]),
+      createSeriesPoint(0, 3490, dataWithNegativeNumbers[6]),
     ]);
-    const pvSeries = s('pv', 1, [
-      sp(4000, 6400, dataWithNegativeNumbers[0]),
-      sp(0, 1398, dataWithNegativeNumbers[1]),
-      sp(-2000, -11800, dataWithNegativeNumbers[2]),
-      sp(2780, 6688, dataWithNegativeNumbers[3]),
-      sp(0, 4800, dataWithNegativeNumbers[4]),
-      sp(0, -3800, dataWithNegativeNumbers[5]),
-      sp(3490, 7790, dataWithNegativeNumbers[6]),
+    const pvSeries = createSeries('pv', 1, [
+      createSeriesPoint(4000, 6400, dataWithNegativeNumbers[0]),
+      createSeriesPoint(0, 1398, dataWithNegativeNumbers[1]),
+      createSeriesPoint(-2000, -11800, dataWithNegativeNumbers[2]),
+      createSeriesPoint(2780, 6688, dataWithNegativeNumbers[3]),
+      createSeriesPoint(0, 4800, dataWithNegativeNumbers[4]),
+      createSeriesPoint(0, -3800, dataWithNegativeNumbers[5]),
+      createSeriesPoint(3490, 7790, dataWithNegativeNumbers[6]),
     ]);
     const expected = [uvSeries, pvSeries];
     expect(result).toEqual(expected);
@@ -179,23 +189,23 @@ describe('getStackedData', () => {
   it('with offset: positive should ignore all negative data points', () => {
     const dataKeys = [dk('uv'), dk('pv')];
     const result = getStackedData(dataWithNegativeNumbers, dataKeys, 'positive');
-    const uvSeries = s('uv', 0, [
-      sp(0, 4000, dataWithNegativeNumbers[0]),
-      sp(0, 0, dataWithNegativeNumbers[1]),
-      sp(0, 0, dataWithNegativeNumbers[2]),
-      sp(0, 2780, dataWithNegativeNumbers[3]),
-      sp(0, 0, dataWithNegativeNumbers[4]),
-      sp(0, 2390, dataWithNegativeNumbers[5]),
-      sp(0, 3490, dataWithNegativeNumbers[6]),
+    const uvSeries = createSeries('uv', 0, [
+      createSeriesPoint(0, 4000, dataWithNegativeNumbers[0]),
+      createSeriesPoint(0, 0, dataWithNegativeNumbers[1]),
+      createSeriesPoint(0, 0, dataWithNegativeNumbers[2]),
+      createSeriesPoint(0, 2780, dataWithNegativeNumbers[3]),
+      createSeriesPoint(0, 0, dataWithNegativeNumbers[4]),
+      createSeriesPoint(0, 2390, dataWithNegativeNumbers[5]),
+      createSeriesPoint(0, 3490, dataWithNegativeNumbers[6]),
     ]);
-    const pvSeries = s('pv', 1, [
-      sp(4000, 6400, dataWithNegativeNumbers[0]),
-      sp(0, 1398, dataWithNegativeNumbers[1]),
-      sp(0, 0, dataWithNegativeNumbers[2]),
-      sp(2780, 6688, dataWithNegativeNumbers[3]),
-      sp(0, 4800, dataWithNegativeNumbers[4]),
-      sp(0, 0, dataWithNegativeNumbers[5]),
-      sp(3490, 7790, dataWithNegativeNumbers[6]),
+    const pvSeries = createSeries('pv', 1, [
+      createSeriesPoint(4000, 6400, dataWithNegativeNumbers[0]),
+      createSeriesPoint(0, 1398, dataWithNegativeNumbers[1]),
+      createSeriesPoint(0, 0, dataWithNegativeNumbers[2]),
+      createSeriesPoint(2780, 6688, dataWithNegativeNumbers[3]),
+      createSeriesPoint(0, 4800, dataWithNegativeNumbers[4]),
+      createSeriesPoint(0, 0, dataWithNegativeNumbers[5]),
+      createSeriesPoint(3490, 7790, dataWithNegativeNumbers[6]),
     ]);
     const expected = [uvSeries, pvSeries];
     expect(result).toEqual(expected);
@@ -203,8 +213,14 @@ describe('getStackedData', () => {
 
   it('should stack data when dataKey is a function with offset: none', () => {
     const result = getStackedData(mockData, [dk(o => o.uv + 100), dk(o => o.pv - 100)], 'none');
-    const firstSeries = s('uv', 0, [sp(0, 690, mockData[0]), sp(0, 968, mockData[1])]);
-    const secondSeries = s('pv', 1, [sp(690, 1390, mockData[0]), sp(968, 1835, mockData[1])]);
+    const firstSeries = createSeries('uv', 0, [
+      createSeriesPoint(0, 690, mockData[0]),
+      createSeriesPoint(0, 968, mockData[1]),
+    ]);
+    const secondSeries = createSeries('pv', 1, [
+      createSeriesPoint(690, 1390, mockData[0]),
+      createSeriesPoint(968, 1835, mockData[1]),
+    ]);
     const expected = [firstSeries, secondSeries];
     /*
      * Direct comparison with .toEqual doesn't work because the `key` property is a function
@@ -235,7 +251,11 @@ describe('getStackedData', () => {
     ];
     const result = getStackedData(mockCategoryData, [dk('x')], 'positive');
     const expected = [
-      s('x', 0, [sp(0, 0, mockCategoryData[0]), sp(0, 0, mockCategoryData[1]), sp(0, 0, mockCategoryData[2])]),
+      createSeries('x', 0, [
+        createSeriesPoint(0, 0, mockCategoryData[0]),
+        createSeriesPoint(0, 0, mockCategoryData[1]),
+        createSeriesPoint(0, 0, mockCategoryData[2]),
+      ]),
     ];
     expect(result).toEqual(expected);
   });
@@ -259,11 +279,11 @@ describe('getStackedData', () => {
     ];
     const result = getStackedData(mockCategoryData, [dk('x')], 'sign');
     const expected = [
-      s('x', 0, [
-        sp(0, 0, mockCategoryData[0]),
-        sp(0, 0, mockCategoryData[1]),
-        sp(0, 0, mockCategoryData[2]),
-        sp(0, 0, mockCategoryData[3]),
+      createSeries('x', 0, [
+        createSeriesPoint(0, 0, mockCategoryData[0]),
+        createSeriesPoint(0, 0, mockCategoryData[1]),
+        createSeriesPoint(0, 0, mockCategoryData[2]),
+        createSeriesPoint(0, 0, mockCategoryData[3]),
       ]),
     ];
     expect(result).toEqual(expected);
@@ -271,12 +291,12 @@ describe('getStackedData', () => {
 
   test('offsetSign should mutate data in place', () => {
     const data = [
-      s('', 0, [sp(0, 1, {}), sp(0, 2, {}), sp(0, -5, {})]),
-      s('', 1, [sp(0, -1, {}), sp(0, 2, {}), sp(0, -5, {})]),
+      createSeries('', 0, [createSeriesPoint(0, 1, {}), createSeriesPoint(0, 2, {}), createSeriesPoint(0, -5, {})]),
+      createSeries('', 1, [createSeriesPoint(0, -1, {}), createSeriesPoint(0, 2, {}), createSeriesPoint(0, -5, {})]),
     ];
     const expected = [
-      s('', 0, [sp(0, 1, {}), sp(0, 2, {}), sp(0, -5, {})]),
-      s('', 1, [sp(0, -1, {}), sp(2, 4, {}), sp(-5, -10, {})]),
+      createSeries('', 0, [createSeriesPoint(0, 1, {}), createSeriesPoint(0, 2, {}), createSeriesPoint(0, -5, {})]),
+      createSeries('', 1, [createSeriesPoint(0, -1, {}), createSeriesPoint(2, 4, {}), createSeriesPoint(-5, -10, {})]),
     ];
     offsetSign(data, []);
     expect(data).toEqual(expected);


### PR DESCRIPTION
## Description

I dig a bit into getStackedData and discovered how it works and wrote some tests and a storybook.

It looks to me that `sign` is identical to `diverging` from d3 and we could remove it in favour of d3 - let me know if you think it's a good idea.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Documentation and tests

## How Has This Been Tested?

Jest and TS and storybook

## Screenshots (if appropriate):

<img width="775" alt="image" src="https://github.com/recharts/recharts/assets/1100170/7028e134-93cf-400c-90e9-c3d1a89ae319">

<img width="1476" alt="image" src="https://github.com/recharts/recharts/assets/1100170/6ec37540-d49f-4a15-ab52-f5626d4cee15">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
