### PR TITLE
Add category area chart storybook, and tests and types for parseDomainOfCategoryAxis

### DIFF
--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1216,18 +1216,17 @@ export const getBandSizeOfAxis = (axis?: any, ticks?: Array<TickItem>, isBar?: b
  * parse the domain of a category axis when a domain is specified
  * @param   {Array}        specifiedDomain  The domain specified by users
  * @param   {Array}        calculatedDomain The domain calculated by dateKey
- * @param   {ReactElement} axisChild        The axis element
+ * @param   {ReactElement} axisChild        The axis ReactElement
  * @returns {Array}        domains
  */
-export const parseDomainOfCategoryAxis = (
-  specifiedDomain: Array<any>,
-  calculatedDomain: Array<any>,
+export const parseDomainOfCategoryAxis = <T>(
+  specifiedDomain: ReadonlyArray<T> | undefined,
+  calculatedDomain: ReadonlyArray<T>,
   axisChild: ReactElement,
-) => {
+): ReadonlyArray<T> => {
   if (!specifiedDomain || !specifiedDomain.length) {
     return calculatedDomain;
   }
-
   if (_.isEqual(specifiedDomain, _.get(axisChild, 'type.defaultProps.domain'))) {
     return calculatedDomain;
   }

--- a/storybook/stories/API/chart/AreaChart.stories.tsx
+++ b/storybook/stories/API/chart/AreaChart.stories.tsx
@@ -55,12 +55,7 @@ export const CategoricalAreaChart = {
       <ResponsiveContainer width="100%" height={400}>
         <AreaChart {...args}>
           <Area dataKey="A" stroke="green" fill="green" fillOpacity={0.5} />
-          <XAxis
-            dataKey="subject"
-            type="category"
-            allowDuplicatedCategory={false}
-            domain={['Math', 'Physics', 'Geography']}
-          />
+          <XAxis dataKey="subject" type="category" allowDuplicatedCategory={false} />
           <Tooltip />
         </AreaChart>
       </ResponsiveContainer>

--- a/storybook/stories/API/chart/AreaChart.stories.tsx
+++ b/storybook/stories/API/chart/AreaChart.stories.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { curveCardinal } from 'victory-vendor/d3-shape';
-import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip } from '../../../../src';
-import { pageData } from '../../data';
+import { Args } from '@storybook/react';
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis } from '../../../../src';
+import { pageData, subjectData } from '../../data';
 import { CategoricalChartProps } from '../props/ChartProps';
+import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 
 export default {
   argTypes: {
@@ -13,11 +15,10 @@ export default {
 
 export const Simple = {
   render: (args: Record<string, any>) => {
-    const { data } = args;
     return (
       <ResponsiveContainer width="100%" height={400}>
-        <AreaChart data={data}>
-          <Area dataKey="pv" stroke="#2451B7" fill="url(#color)" />
+        <AreaChart {...args}>
+          <Area dataKey="pv" strokeWidth={3} stroke="#2451B7" fill="#5376C4" />
           <Tooltip />
           <CartesianGrid opacity={0.1} vertical={false} />
         </AreaChart>
@@ -25,6 +26,7 @@ export const Simple = {
     );
   },
   args: {
+    ...getStoryArgsFromArgsTypesObject(CategoricalChartProps),
     data: pageData,
   },
 };
@@ -33,16 +35,40 @@ const stepAround = curveCardinal.tension(0.5);
 
 export const CustomType = {
   render: (args: Record<string, any>) => {
-    const { data } = args;
     return (
       <ResponsiveContainer width="100%" height={400}>
-        <AreaChart data={data}>
+        <AreaChart {...args}>
           <Area type={stepAround} dataKey="pv" stroke="#ff7300" fill="#ff7300" fillOpacity={0.9} />
         </AreaChart>
       </ResponsiveContainer>
     );
   },
   args: {
+    ...getStoryArgsFromArgsTypesObject(CategoricalChartProps),
     data: pageData,
+  },
+};
+
+export const CategoricalAreaChart = {
+  render(args: Args) {
+    return (
+      <ResponsiveContainer width="100%" height={400}>
+        <AreaChart {...args}>
+          <Area dataKey="A" stroke="green" fill="green" fillOpacity={0.5} />
+          <XAxis
+            dataKey="subject"
+            type="category"
+            allowDuplicatedCategory={false}
+            domain={['Math', 'Physics', 'Geography']}
+          />
+          <Tooltip />
+        </AreaChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(CategoricalChartProps),
+    data: subjectData,
+    layout: 'horizontal',
   },
 };

--- a/test/util/ChartUtils/parseDomainOfCategoryAxis.spec.ts
+++ b/test/util/ChartUtils/parseDomainOfCategoryAxis.spec.ts
@@ -1,0 +1,74 @@
+import { ReactElement } from 'react';
+import { parseDomainOfCategoryAxis } from '../../../src/util/ChartUtils';
+
+function getChild(domain?: Array<unknown>): ReactElement {
+  return {
+    type: {
+      // @ts-expect-error this is not the correct shape of ReactElement but I do not want to mock the whole thing
+      defaultProps: {
+        domain,
+      },
+    },
+  };
+}
+
+describe('parseDomainOfCategoryAxis', () => {
+  it('should not modify the domains', () => {
+    const specifiedDomain = [7];
+    const calculatedDomain = [1, 2, 3];
+    const axisElement = getChild();
+    parseDomainOfCategoryAxis(specifiedDomain, calculatedDomain, axisElement);
+    expect(specifiedDomain).toEqual([7]);
+    expect(calculatedDomain).toEqual([1, 2, 3]);
+  });
+
+  it('should return calculatedDomain if specifiedDomain is undefined', () => {
+    const specifiedDomain: Array<number> | undefined = undefined;
+    const calculatedDomain = [1, 2, 3];
+    const axisElement = getChild();
+    const result = parseDomainOfCategoryAxis(specifiedDomain, calculatedDomain, axisElement);
+    expect(result).toBe(calculatedDomain);
+  });
+
+  it('should return calculatedDomain if specifiedDomain is empty', () => {
+    const specifiedDomain: Array<number> = [];
+    const calculatedDomain = [1, 2, 3];
+    const axisElement = getChild();
+    const result = parseDomainOfCategoryAxis(specifiedDomain, calculatedDomain, axisElement);
+    expect(result).toBe(calculatedDomain);
+  });
+
+  it('should return specified domain if it has at least one element', () => {
+    const specifiedDomain = [7];
+    const calculatedDomain = [1, 2, 3];
+    const axisElement = getChild();
+    expect(parseDomainOfCategoryAxis(specifiedDomain, calculatedDomain, axisElement)).toBe(specifiedDomain);
+  });
+
+  it('should return specified domain if it has at least one element, even if it is unhappy element', () => {
+    const specifiedDomain = [NaN];
+    const calculatedDomain = [1, 2, 3];
+    const axisElement = getChild();
+    const result = parseDomainOfCategoryAxis(specifiedDomain, calculatedDomain, axisElement);
+    expect(result).toBe(specifiedDomain);
+  });
+
+  /**
+   * This is a weird case. This code path is checking for defaultProps of an Axis.
+   * There are two big problems with this:
+   * 1. It always assumes that React will expose the defaultProps on property `type.defaultProps.x`, and
+   * 2. It assumes that we never switch from defaultProps to, say, hooks, or default argument values.
+   *
+   * And third, smaller problem:
+   * 3. No axis in recharts actually has a default domain defined, and AFAIK users cannot set defaultProps.
+   *
+   * So, can we remove the check for `type.defaultProps.domain` completely?
+   */
+  test('if the specified domain is same as a default of an axis, then return calculated domain', () => {
+    const specifiedDomain = [NaN];
+    const calculatedDomain = [1, 2, 3];
+    const axisElement = getChild(specifiedDomain);
+    const result = parseDomainOfCategoryAxis(specifiedDomain, calculatedDomain, axisElement);
+    expect(result).toBe(calculatedDomain);
+  });
+});


### PR DESCRIPTION
## Description

I am bamboozled by this function. The original commit says it fixes a bug: https://github.com/PavelVanecek/recharts/commit/c415cab33b103790867460ae4972dd17b2ee7f5c but doesn't say which bug. There are no tests or storybooks or linked issue.

I tried to replicate the bug so I wrote a storybook (and left it there for others to use) but couldn't - none of the Axes I found have domain in default props.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Confidence refactoring

## How Has This Been Tested?

TS, Jest, storybook

## Screenshots (if appropriate):

<img width="1680" alt="image" src="https://github.com/recharts/recharts/assets/1100170/19f87b24-813a-41e6-b795-594f302d6718">

Note that the XAxis does not render the left-most label, I don't know why.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
