### PR TITLE
RadialBar: activeShape should work with Tooltip

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -5,7 +5,7 @@ import React, { Key, PureComponent, ReactElement } from 'react';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
 import _ from 'lodash';
-import { Rectangle, Props as RectangleProps } from '../shape/Rectangle';
+import { Props as RectangleProps } from '../shape/Rectangle';
 import { Layer } from '../container/Layer';
 import { ErrorBar, Props as ErrorBarProps, ErrorBarDataPointFormatter } from './ErrorBar';
 import { Cell } from '../component/Cell';
@@ -37,6 +37,7 @@ import {
   ActiveShape,
 } from '../util/types';
 import { ImplicitLabelType } from '../component/Label';
+import { BarRectangle } from '../util/BarUtils';
 
 export interface BarRectangleItem extends RectangleProps {
   value?: number | [number, number];
@@ -59,15 +60,10 @@ interface InternalBarProps {
   height?: number;
 }
 
-type RectangleShapeType =
-  | ReactElement<SVGElement>
-  | ((props: any) => ReactElement<SVGElement>)
-  | RectangleProps
-  | boolean;
-
 export interface BarProps extends InternalBarProps {
   className?: string;
   index?: Key;
+  activeIndex?: number;
   layout?: 'horizontal' | 'vertical';
   xAxisId?: string | number;
   yAxisId?: string | number;
@@ -81,9 +77,9 @@ export interface BarProps extends InternalBarProps {
   minPointSize?: number;
   maxBarSize?: number;
   hide?: boolean;
-  shape?: ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>);
-  activeBar?: ActiveShape<BarProps>;
-  background?: RectangleShapeType;
+  shape?: ActiveShape<BarProps, SVGPathElement>;
+  activeBar?: ActiveShape<BarProps, SVGPathElement>;
+  background?: ActiveShape<BarProps, SVGPathElement>;
   radius?: number | [number, number, number, number];
 
   onAnimationStart?: () => void;
@@ -287,36 +283,32 @@ export class Bar extends PureComponent<Props, State> {
     }
   };
 
-  static renderRectangle(option: RectangleShapeType, props: any) {
-    let rectangle;
-
-    if (React.isValidElement(option)) {
-      rectangle = React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
-      rectangle = option(props);
-    } else {
-      rectangle = <Rectangle {...props} />;
-    }
-
-    return rectangle;
-  }
-
   renderRectanglesStatically(data: BarRectangleItem[]) {
-    const { shape } = this.props;
+    const { shape, dataKey, activeIndex, activeBar } = this.props;
     const baseProps = filterProps(this.props);
 
     return (
       data &&
       data.map((entry, i) => {
-        const props = { ...baseProps, ...entry, index: i };
-
+        const isActive = i === activeIndex;
+        const option = isActive ? activeBar : shape;
+        const props = {
+          ...baseProps,
+          ...entry,
+          isActive,
+          option,
+          index: i,
+          dataKey,
+          onAnimationStart: this.handleAnimationStart,
+          onAnimationEnd: this.handleAnimationEnd,
+        };
         return (
           <Layer
             className="recharts-bar-rectangle"
             {...adaptEventsOfChild(this.props, entry, i)}
             key={`rectangle-${i}`} // eslint-disable-line react/no-array-index-key
           >
-            {Bar.renderRectangle(shape, props)}
+            <BarRectangle {...props} />
           </Layer>
         );
       })
@@ -394,7 +386,7 @@ export class Bar extends PureComponent<Props, State> {
   }
 
   renderBackground() {
-    const { data } = this.props;
+    const { data, dataKey, activeIndex } = this.props;
     const backgroundProps = filterProps(this.props.background);
 
     return data.map((entry, i) => {
@@ -410,12 +402,15 @@ export class Bar extends PureComponent<Props, State> {
         ...background,
         ...backgroundProps,
         ...adaptEventsOfChild(this.props, entry, i),
+        onAnimationStart: this.handleAnimationStart,
+        onAnimationEnd: this.handleAnimationEnd,
+        dataKey,
         index: i,
         key: `background-bar-${i}`,
         className: 'recharts-bar-background-rectangle',
       };
 
-      return Bar.renderRectangle(this.props.background, props);
+      return <BarRectangle option={this.props.background} isActive={i === activeIndex} {...props} />;
     });
   }
 

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -2151,6 +2151,12 @@ export const generateCategoricalChart = ({
             return [graphicalItem, this.renderActiveBar({ item, childIndex: activeTooltipIndex })];
           }
 
+          if (activeShape) {
+            const activeIndex =
+              element.props.activeIndex !== undefined ? element.props.activeIndex : activeTooltipIndex;
+            return [cloneElement(element, { ...item.props, ...itemEvents, activeIndex }), null, null];
+          }
+
           if (!_.isNil(activePoint)) {
             return [
               graphicalItem,
@@ -2172,8 +2178,8 @@ export const generateCategoricalChart = ({
            * An example usage case is a FunnelChart
            */
           const {
-            graphicalItem: { item: xyItem, childIndex },
-          } = this.getItemByXY(this.state.activeCoordinate);
+            graphicalItem: { item: xyItem = element, childIndex },
+          } = this.getItemByXY(this.state.activeCoordinate) ?? { graphicalItem };
 
           const elementProps = { ...item.props, ...itemEvents, activeIndex: childIndex };
 

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1,11 +1,10 @@
-import React, { Component, cloneElement, isValidElement, createElement, ComponentProps, ReactElement } from 'react';
+import React, { Component, cloneElement, isValidElement, createElement, ReactElement } from 'react';
 import classNames from 'classnames';
 import _, { isArray, isBoolean, isNil } from 'lodash';
 import invariant from 'tiny-invariant';
 import { getTicks } from '../cartesian/getTicks';
 import { Surface } from '../container/Surface';
 import { Layer } from '../container/Layer';
-import { Bar } from '../cartesian/Bar';
 import { Tooltip } from '../component/Tooltip';
 import { Legend } from '../component/Legend';
 import { Curve } from '../shape/Curve';
@@ -52,7 +51,6 @@ import {
   parseDomainOfCategoryAxis,
   getTooltipItem,
 } from '../util/ChartUtils';
-import { ActiveBar } from '../util/BarUtils';
 import { detectReferenceElementsDomain } from '../util/DetectReferenceElementsDomain';
 import { inRangeOfSector, polarToCartesian } from '../util/PolarUtils';
 import { shallowEqual } from '../util/ShallowEqual';
@@ -2065,39 +2063,6 @@ export const generateCategoricalChart = ({
       return result;
     };
 
-    renderActiveBar = ({
-      item,
-      childIndex,
-    }: {
-      item: GraphicalItem<ComponentProps<typeof Bar>>;
-      childIndex: number;
-    }) => {
-      const { key } = item.props;
-      const { activeBar, dataKey } = item.item.props;
-
-      /**
-       * Default to inheriting props from the parent bar
-       */
-      const inheritedProps = {
-        ...item.item.props,
-        ...item.props.data[childIndex],
-      };
-
-      const barProps = {
-        index: childIndex,
-        dataKey,
-        fill: getMainColorOfGraphicItem(item.item),
-        strokeWidth: 2,
-        stroke: '#fff',
-        key: `${key}-activeBar-${childIndex}`,
-        ...inheritedProps,
-        ...filterProps(activeBar),
-        ...adaptEventHandlers(activeBar),
-      } as ComponentProps<typeof Bar>;
-
-      return <ActiveBar option={activeBar} {...barProps} />;
-    };
-
     renderGraphicChild = (element: React.ReactElement, displayName: string, index: number): any[] => {
       const item = this.filterFormatItem(element, displayName, index);
       if (!item) {
@@ -2147,11 +2112,7 @@ export const generateCategoricalChart = ({
             basePoint = isRange && baseLine && baseLine[activeTooltipIndex];
           }
 
-          if (activeBar) {
-            return [graphicalItem, this.renderActiveBar({ item, childIndex: activeTooltipIndex })];
-          }
-
-          if (activeShape) {
+          if (activeShape || activeBar) {
             const activeIndex =
               element.props.activeIndex !== undefined ? element.props.activeIndex : activeTooltipIndex;
             return [cloneElement(element, { ...item.props, ...itemEvents, activeIndex }), null, null];

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export type { Props as PieProps, PieLabel, PieLabelRenderProps } from './polar/P
 export { Radar } from './polar/Radar';
 export type { Props as RadarProps } from './polar/Radar';
 export { RadialBar } from './polar/RadialBar';
-export type { Props as RadialBarProps } from './polar/RadialBar';
+export type { RadialBarProps } from './polar/RadialBar';
 
 export { Brush } from './cartesian/Brush';
 export type { Props as BrushProps } from './cartesian/Brush';

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -5,7 +5,7 @@ import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
 import _ from 'lodash';
-import { RadialBarSector, RadialBarSectorProps } from '../util/RadialBarUtils';
+import { parseCornerRadius, RadialBarSector, RadialBarSectorProps } from '../util/RadialBarUtils';
 import { Props as SectorProps } from '../shape/Sector';
 import { Layer } from '../container/Layer';
 import { findAllByType, filterProps } from '../util/ReactUtils';
@@ -277,7 +277,7 @@ export class RadialBar extends PureComponent<RadialBarProps, State> {
       const isActive = i === activeIndex;
       const props: RadialBarSectorProps = {
         ...baseProps,
-        cornerRadius: typeof cornerRadius === 'string' ? parseInt(cornerRadius, 10) : cornerRadius,
+        cornerRadius: parseCornerRadius(cornerRadius),
         ...entry,
         ...adaptEventsOfChild(this.props, entry, i),
         key: `sector-${i}`,
@@ -357,7 +357,7 @@ export class RadialBar extends PureComponent<RadialBarProps, State> {
       }
 
       const props: RadialBarSectorProps = {
-        cornerRadius: typeof cornerRadius === 'string' ? parseInt(cornerRadius, 10) : cornerRadius,
+        cornerRadius: parseCornerRadius(cornerRadius),
         ...rest,
         fill: '#eee',
         ...background,

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -1,11 +1,12 @@
 /**
  * @fileOverview Render a group of radial bar
  */
-import React, { PureComponent, ReactElement, ReactNode } from 'react';
+import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
 import _ from 'lodash';
-import { Sector, Props as SectorProps } from '../shape/Sector';
+import { RadialBarSector, RadialBarSectorProps } from '../util/RadialBarUtils';
+import { Props as SectorProps } from '../shape/Sector';
 import { Layer } from '../container/Layer';
 import { findAllByType, filterProps } from '../util/ReactUtils';
 import { Global } from '../util/Global';
@@ -28,6 +29,7 @@ import {
   adaptEventsOfChild,
   PresentationAttributesAdaptChildEvent,
   AnimationDuration,
+  ActiveShape,
 } from '../util/types';
 import { polarToCartesian } from '../util/PolarUtils';
 // TODO: Cause of circular dependency. Needs refactoring of functions that need them.
@@ -39,18 +41,17 @@ type RadialBarDataItem = SectorProps & {
   background?: SectorProps;
 };
 
-type RadialBarShape = ReactElement | ((props: Props) => ReactNode);
-type RadialBarBackground = ReactElement | ((props: Props) => ReactNode) | SectorProps | boolean;
+type RadialBarBackground = ActiveShape<SectorProps>;
 
-interface RadialBarProps {
+interface InternalRadialBarProps {
   animationId?: string | number;
   className?: string;
   angleAxisId?: string | number;
   radiusAxisId?: string | number;
   startAngle?: number;
   endAngle?: number;
-  shape?: RadialBarShape;
-  activeShape?: RadialBarShape;
+  shape?: ActiveShape<SectorProps, SVGPathElement>;
+  activeShape?: ActiveShape<SectorProps, SVGPathElement>;
   activeIndex?: number;
   dataKey: string | number | ((obj: any) => any);
   cornerRadius?: string | number;
@@ -73,7 +74,7 @@ interface RadialBarProps {
   animationEasing?: AnimationTiming;
 }
 
-export type Props = PresentationAttributesAdaptChildEvent<any, SVGElement> & RadialBarProps;
+export type RadialBarProps = PresentationAttributesAdaptChildEvent<any, SVGElement> & InternalRadialBarProps;
 
 interface State {
   readonly isAnimationFinished?: boolean;
@@ -82,7 +83,7 @@ interface State {
   readonly prevAnimationId?: string | number;
 }
 
-export class RadialBar extends PureComponent<Props, State> {
+export class RadialBar extends PureComponent<RadialBarProps, State> {
   static displayName = 'RadialBar';
 
   static defaultProps = {
@@ -121,7 +122,7 @@ export class RadialBar extends PureComponent<Props, State> {
     angleAxis: any; // AngleAxisProps;
     angleAxisTicks: Array<TickItem>;
     displayedData: any[];
-    dataKey: Props['dataKey'];
+    dataKey: RadialBarProps['dataKey'];
     stackedData?: any[];
     barPosition?: any[];
     bandSize?: number;
@@ -224,7 +225,7 @@ export class RadialBar extends PureComponent<Props, State> {
     isAnimationFinished: false,
   };
 
-  static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
+  static getDerivedStateFromProps(nextProps: RadialBarProps, prevState: State): State {
     if (nextProps.animationId !== prevState.prevAnimationId) {
       return {
         prevAnimationId: nextProps.animationId,
@@ -268,37 +269,26 @@ export class RadialBar extends PureComponent<Props, State> {
     }
   };
 
-  static renderSectorShape(shape: RadialBarBackground, props: any) {
-    let sectorShape;
-
-    if (React.isValidElement(shape)) {
-      sectorShape = React.cloneElement(shape, props);
-    } else if (_.isFunction(shape)) {
-      sectorShape = shape(props);
-    } else {
-      sectorShape = React.createElement(Sector, props);
-    }
-
-    return sectorShape;
-  }
-
   renderSectorsStatically(sectors: SectorProps[]) {
     const { shape, activeShape, activeIndex, cornerRadius, ...others } = this.props;
     const baseProps = filterProps(others);
 
     return sectors.map((entry, i) => {
-      const props = {
+      const isActive = i === activeIndex;
+      const props: RadialBarSectorProps = {
         ...baseProps,
-        cornerRadius,
+        cornerRadius: typeof cornerRadius === 'string' ? parseInt(cornerRadius, 10) : cornerRadius,
         ...entry,
         ...adaptEventsOfChild(this.props, entry, i),
         key: `sector-${i}`,
         className: `recharts-radial-bar-sector ${entry.className}`,
         forceCornerRadius: others.forceCornerRadius,
         cornerIsExternal: others.cornerIsExternal,
+        isActive,
+        option: isActive ? activeShape : shape,
       };
 
-      return RadialBar.renderSectorShape(i === activeIndex ? activeShape : shape, props);
+      return <RadialBarSector {...props} />;
     });
   }
 
@@ -366,8 +356,8 @@ export class RadialBar extends PureComponent<Props, State> {
         return null;
       }
 
-      const props = {
-        cornerRadius,
+      const props: RadialBarSectorProps = {
+        cornerRadius: typeof cornerRadius === 'string' ? parseInt(cornerRadius, 10) : cornerRadius,
         ...rest,
         fill: '#eee',
         ...background,
@@ -376,9 +366,11 @@ export class RadialBar extends PureComponent<Props, State> {
         index: i,
         key: `sector-${i}`,
         className: 'recharts-radial-bar-background-sector',
+        option: background,
+        isActive: false,
       };
 
-      return RadialBar.renderSectorShape(background, props);
+      return <RadialBarSector {...props} />;
     });
   }
 

--- a/src/util/ActiveShapeUtils.tsx
+++ b/src/util/ActiveShapeUtils.tsx
@@ -37,7 +37,7 @@ function ShapeSelector<ShapePropsType>({
 export function Shape<OptionType, ExtraProps, ShapePropsType>({
   option,
   shapeType,
-  propTransformer = () => ({} as ShapePropsType),
+  propTransformer = (arg1, arg2) => ({ ...arg1, ...arg2 } as unknown as ShapePropsType),
   activeClassName = 'recharts-active-shape',
   isActive,
   ...props

--- a/src/util/ActiveShapeUtils.tsx
+++ b/src/util/ActiveShapeUtils.tsx
@@ -1,0 +1,65 @@
+import React, { isValidElement, cloneElement } from 'react';
+import _ from 'lodash';
+import { Rectangle } from '../shape/Rectangle';
+import { Trapezoid } from '../shape/Trapezoid';
+import { Sector } from '../shape/Sector';
+import { Layer } from '../container/Layer';
+
+type ShapeType = 'trapezoid' | 'rectangle' | 'sector';
+
+export type ShapeProps<OptionType, ExtraProps, ShapePropsType> = {
+  shapeType: ShapeType;
+  option: OptionType;
+  propTransformer: (option: OptionType, props: ExtraProps) => ShapePropsType;
+  isActive: boolean;
+  activeClassName?: string;
+} & ExtraProps;
+
+function ShapeSelector<ShapePropsType>({
+  shapeType,
+  elementProps,
+}: {
+  shapeType: ShapeType;
+  elementProps: ShapePropsType;
+}) {
+  switch (shapeType) {
+    case 'rectangle':
+      return <Rectangle {...elementProps} />;
+    case 'trapezoid':
+      return <Trapezoid {...elementProps} />;
+    case 'sector':
+      return <Sector {...elementProps} />;
+    default:
+      return null;
+  }
+}
+
+export function Shape<OptionType, ExtraProps, ShapePropsType>({
+  option,
+  shapeType,
+  propTransformer = () => ({} as ShapePropsType),
+  activeClassName = 'recharts-active-shape',
+  isActive,
+  ...props
+}: ShapeProps<OptionType, ExtraProps, ShapePropsType>) {
+  let shape: React.JSX.Element;
+
+  if (isValidElement(option)) {
+    shape = cloneElement(option, props);
+  } else if (_.isFunction(option)) {
+    shape = option(props);
+  } else if (_.isPlainObject(option) && !_.isBoolean(option)) {
+    const shapeProps = props as unknown as ExtraProps;
+    const elementProps = propTransformer(option, shapeProps);
+    shape = <ShapeSelector<ShapePropsType> shapeType={shapeType} elementProps={elementProps} />;
+  } else {
+    const elementProps = props as unknown as ShapePropsType;
+    shape = <ShapeSelector<ShapePropsType> shapeType={shapeType} elementProps={elementProps} />;
+  }
+
+  if (isActive) {
+    return <Layer className={activeClassName}>{shape}</Layer>;
+  }
+
+  return shape;
+}

--- a/src/util/BarUtils.tsx
+++ b/src/util/BarUtils.tsx
@@ -1,9 +1,8 @@
-import _ from 'lodash';
-import React, { SVGProps, isValidElement, cloneElement, ReactElement } from 'react';
-import { Layer } from '../container/Layer';
+import React, { SVGProps } from 'react';
 import { ActiveShape } from './types';
-import { Rectangle } from '../shape/Rectangle';
+import { Props as RectangleProps } from '../shape/Rectangle';
 import { BarProps } from '../cartesian/Bar';
+import { Shape } from './ActiveShapeUtils';
 
 // Rectangle props is expecting x, y, height, width as numbers, name as a string, and radius as a custom type
 // When props are being spread in from a user defined component in Bar,
@@ -38,27 +37,13 @@ export function BarRectangle({
   option: ActiveShape<BarProps, SVGPathElement>;
   isActive: boolean;
 } & BarProps) {
-  let rectangle;
-
-  if (isValidElement(option)) {
-    const { props: optionProps } = option as ReactElement;
-    const elementProps = {
-      ...props,
-      ...(optionProps ?? {}),
-    };
-    rectangle = cloneElement(option, elementProps);
-  } else if (_.isFunction(option)) {
-    rectangle = option(props);
-  } else if (_.isPlainObject(option) && !_.isBoolean(option)) {
-    const rectangleProps = typeguardBarRectangleProps(option, props);
-    rectangle = <Rectangle {...rectangleProps} />;
-  } else {
-    rectangle = <Rectangle {...props} name={props.name as string} />;
-  }
-
-  if (props.isActive) {
-    return <Layer className="recharts-active-bar">{rectangle}</Layer>;
-  }
-
-  return rectangle;
+  return (
+    <Shape<ActiveShape<BarProps, SVGPathElement>, BarProps, RectangleProps>
+      option={option}
+      shapeType="rectangle"
+      propTransformer={typeguardBarRectangleProps}
+      activeClassName="recharts-active-bar"
+      {...props}
+    />
+  );
 }

--- a/src/util/BarUtils.tsx
+++ b/src/util/BarUtils.tsx
@@ -9,7 +9,10 @@ import { Shape } from './ActiveShapeUtils';
 // the prop types of an SVGElement have these typed as something else.
 // This function will return the passed in props
 // along with x, y, height as numbers, name as a string, and radius as number | [number, numbe, number, number]
-function typeguardBarRectangleProps({ x: xProp, y: yProp, ...option }: SVGProps<SVGPathElement>, props: BarProps) {
+function typeguardBarRectangleProps(
+  { x: xProp, y: yProp, ...option }: SVGProps<SVGPathElement>,
+  props: BarProps,
+): RectangleProps {
   const xValue = `${xProp}`;
   const x = parseInt(xValue, 10);
   const yValue = `${yProp}`;
@@ -30,16 +33,14 @@ function typeguardBarRectangleProps({ x: xProp, y: yProp, ...option }: SVGProps<
   };
 }
 
-export function BarRectangle({
-  option,
-  ...props
-}: {
+type BarRectangleProps = {
   option: ActiveShape<BarProps, SVGPathElement>;
   isActive: boolean;
-} & BarProps) {
+} & BarProps;
+
+export function BarRectangle(props: BarRectangleProps) {
   return (
-    <Shape<ActiveShape<BarProps, SVGPathElement>, BarProps, RectangleProps>
-      option={option}
+    <Shape
       shapeType="rectangle"
       propTransformer={typeguardBarRectangleProps}
       activeClassName="recharts-active-bar"

--- a/src/util/FunnelUtils.tsx
+++ b/src/util/FunnelUtils.tsx
@@ -1,8 +1,7 @@
-import React, { SVGProps, isValidElement, cloneElement } from 'react';
-import _ from 'lodash';
+import React, { SVGProps } from 'react';
 import { FunnelProps, FunnelTrapezoidItem } from '../numberAxis/Funnel';
-import { Trapezoid } from '../shape/Trapezoid';
-import { Layer } from '../container/Layer';
+import { Props as TrapezoidProps } from '../shape/Trapezoid';
+import { Shape } from './ActiveShapeUtils';
 
 // Trapezoid props is expecting x, y, height as numbers.
 // When props are being spread in from a user defined component in Funnel,
@@ -13,7 +12,7 @@ export function typeGuardTrapezoidProps(option: SVGProps<SVGPathElement>, props:
   const x = parseInt(xValue, 10);
   const yValue = `${props.y || option.y}`;
   const y = parseInt(yValue, 10);
-  const heightValue = `${props.height || option.height}`;
+  const heightValue = `${props?.height || option?.height}`;
   const height = parseInt(heightValue, 10);
   return {
     ...props,
@@ -25,26 +24,12 @@ export function typeGuardTrapezoidProps(option: SVGProps<SVGPathElement>, props:
 }
 
 export function FunnelTrapezoid({ option, ...props }: { option: FunnelProps['activeShape'] } & FunnelTrapezoidItem) {
-  let trapezoid;
-
-  if (isValidElement(option)) {
-    const elementProps = {
-      ...props,
-      ...(option.props ?? {}),
-    };
-    trapezoid = cloneElement(option, elementProps);
-  } else if (_.isFunction(option)) {
-    trapezoid = option(props);
-  } else if (_.isPlainObject(option) && !_.isBoolean(option)) {
-    const trapezoidProps = typeGuardTrapezoidProps(option, props);
-    trapezoid = <Trapezoid {...trapezoidProps} />;
-  } else {
-    trapezoid = <Trapezoid {...props} />;
-  }
-
-  if (props.isActive) {
-    return <Layer className="recharts-active-shape">{trapezoid}</Layer>;
-  }
-
-  return trapezoid;
+  return (
+    <Shape<FunnelProps['activeShape'], FunnelTrapezoidItem, TrapezoidProps>
+      option={option}
+      shapeType="trapezoid"
+      propTransformer={typeGuardTrapezoidProps}
+      {...props}
+    />
+  );
 }

--- a/src/util/FunnelUtils.tsx
+++ b/src/util/FunnelUtils.tsx
@@ -7,7 +7,7 @@ import { Shape } from './ActiveShapeUtils';
 // When props are being spread in from a user defined component in Funnel,
 // the prop types of an SVGElement have these typed as string | number.
 // This function will return the passed in props along with x, y, height as numbers.
-export function typeGuardTrapezoidProps(option: SVGProps<SVGPathElement>, props: FunnelTrapezoidItem) {
+export function typeGuardTrapezoidProps(option: SVGProps<SVGPathElement>, props: FunnelTrapezoidItem): TrapezoidProps {
   const xValue = `${props.x || option.x}`;
   const x = parseInt(xValue, 10);
   const yValue = `${props.y || option.y}`;
@@ -23,13 +23,8 @@ export function typeGuardTrapezoidProps(option: SVGProps<SVGPathElement>, props:
   };
 }
 
-export function FunnelTrapezoid({ option, ...props }: { option: FunnelProps['activeShape'] } & FunnelTrapezoidItem) {
-  return (
-    <Shape<FunnelProps['activeShape'], FunnelTrapezoidItem, TrapezoidProps>
-      option={option}
-      shapeType="trapezoid"
-      propTransformer={typeGuardTrapezoidProps}
-      {...props}
-    />
-  );
+type FunnelTrapezoidProps = { option: FunnelProps['activeShape'] } & FunnelTrapezoidItem;
+
+export function FunnelTrapezoid(props: FunnelTrapezoidProps) {
+  return <Shape shapeType="trapezoid" propTransformer={typeGuardTrapezoidProps} {...props} />;
 }

--- a/src/util/RadialBarUtils.tsx
+++ b/src/util/RadialBarUtils.tsx
@@ -1,8 +1,7 @@
-import React, { isValidElement, cloneElement, SVGProps } from 'react';
-import _ from 'lodash';
+import React, { SVGProps } from 'react';
 import { RadialBarProps } from '../polar/RadialBar';
-import { Sector, Props as SectorProps } from '../shape/Sector';
-import { Layer } from '../container/Layer';
+import { Props as SectorProps } from '../shape/Sector';
+import { Shape } from './ActiveShapeUtils';
 
 export function parseCornerRadius(cornerRadius: string | number): number {
   if (typeof cornerRadius === 'string') {
@@ -36,22 +35,12 @@ export interface RadialBarSectorProps extends SectorProps {
 }
 
 export function RadialBarSector({ option, ...props }: RadialBarSectorProps) {
-  let sectorShape: React.JSX.Element;
-
-  if (isValidElement(option)) {
-    sectorShape = cloneElement(option, props);
-  } else if (_.isFunction(option)) {
-    sectorShape = option(props);
-  } else if (_.isPlainObject(option) && !_.isBoolean(option)) {
-    const elementProps = typeGuardSectorProps(option, props);
-    sectorShape = <Sector {...elementProps} />;
-  } else {
-    sectorShape = <Sector {...props} />;
-  }
-
-  if (props.isActive) {
-    return <Layer className="recharts-active-shape">{sectorShape}</Layer>;
-  }
-
-  return sectorShape;
+  return (
+    <Shape<RadialBarProps['activeShape'], SectorProps, SectorProps>
+      option={option}
+      shapeType="sector"
+      propTransformer={typeGuardSectorProps}
+      {...props}
+    />
+  );
 }

--- a/src/util/RadialBarUtils.tsx
+++ b/src/util/RadialBarUtils.tsx
@@ -4,6 +4,14 @@ import { RadialBarProps } from '../polar/RadialBar';
 import { Sector, Props as SectorProps } from '../shape/Sector';
 import { Layer } from '../container/Layer';
 
+export function parseCornerRadius(cornerRadius: string | number): number {
+  if (typeof cornerRadius === 'string') {
+    return parseInt(cornerRadius, 10);
+  }
+
+  return cornerRadius;
+}
+
 // Sector props is expecting cx, cy as numbers.
 // When props are being spread in from a user defined component in RadialBar,
 // the prop types of an SVGElement have these typed as string | number.

--- a/src/util/RadialBarUtils.tsx
+++ b/src/util/RadialBarUtils.tsx
@@ -1,0 +1,49 @@
+import React, { isValidElement, cloneElement, SVGProps } from 'react';
+import _ from 'lodash';
+import { RadialBarProps } from '../polar/RadialBar';
+import { Sector, Props as SectorProps } from '../shape/Sector';
+import { Layer } from '../container/Layer';
+
+// Sector props is expecting cx, cy as numbers.
+// When props are being spread in from a user defined component in RadialBar,
+// the prop types of an SVGElement have these typed as string | number.
+// This function will return the passed in props along with cx, cy as numbers.
+export function typeGuardSectorProps(option: SVGProps<SVGPathElement>, props: SectorProps) {
+  const cxValue = `${props.cx || option.cx}`;
+  const cx = parseInt(cxValue, 10);
+  const cyValue = `${props.cy || option.cy}`;
+  const cy = parseInt(cyValue, 10);
+  return {
+    ...props,
+    ...option,
+    cx,
+    cy,
+  };
+}
+
+export interface RadialBarSectorProps extends SectorProps {
+  index?: number;
+  option: RadialBarProps['activeShape'];
+  isActive: boolean;
+}
+
+export function RadialBarSector({ option, ...props }: RadialBarSectorProps) {
+  let sectorShape: React.JSX.Element;
+
+  if (isValidElement(option)) {
+    sectorShape = cloneElement(option, props);
+  } else if (_.isFunction(option)) {
+    sectorShape = option(props);
+  } else if (_.isPlainObject(option) && !_.isBoolean(option)) {
+    const elementProps = typeGuardSectorProps(option, props);
+    sectorShape = <Sector {...elementProps} />;
+  } else {
+    sectorShape = <Sector {...props} />;
+  }
+
+  if (props.isActive) {
+    return <Layer className="recharts-active-shape">{sectorShape}</Layer>;
+  }
+
+  return sectorShape;
+}

--- a/src/util/RadialBarUtils.tsx
+++ b/src/util/RadialBarUtils.tsx
@@ -15,7 +15,7 @@ export function parseCornerRadius(cornerRadius: string | number): number {
 // When props are being spread in from a user defined component in RadialBar,
 // the prop types of an SVGElement have these typed as string | number.
 // This function will return the passed in props along with cx, cy as numbers.
-export function typeGuardSectorProps(option: SVGProps<SVGPathElement>, props: SectorProps) {
+export function typeGuardSectorProps(option: SVGProps<SVGPathElement>, props: SectorProps): SectorProps {
   const cxValue = `${props.cx || option.cx}`;
   const cx = parseInt(cxValue, 10);
   const cyValue = `${props.cy || option.cy}`;
@@ -34,13 +34,6 @@ export interface RadialBarSectorProps extends SectorProps {
   isActive: boolean;
 }
 
-export function RadialBarSector({ option, ...props }: RadialBarSectorProps) {
-  return (
-    <Shape<RadialBarProps['activeShape'], SectorProps, SectorProps>
-      option={option}
-      shapeType="sector"
-      propTransformer={typeGuardSectorProps}
-      {...props}
-    />
-  );
+export function RadialBarSector(props: RadialBarSectorProps) {
+  return <Shape shapeType="sector" propTransformer={typeGuardSectorProps} {...props} />;
 }

--- a/storybook/stories/API/chart/FunnelChart.stories.tsx
+++ b/storybook/stories/API/chart/FunnelChart.stories.tsx
@@ -8,7 +8,7 @@ export default {
     ...CategoricalChartProps,
     activeIndex: {
       description:
-        'The index of the individual shapes that make up the Funnel to be marked as active, and render props.activeShape as a result',
+        'The index of the individual shapes of Funnel to be marked as active, and render props.activeShape as a result',
       table: {
         type: {
           summary: 'number',

--- a/storybook/stories/API/chart/RadialBarChart.stories.tsx
+++ b/storybook/stories/API/chart/RadialBarChart.stories.tsx
@@ -1,30 +1,55 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
+import { Meta } from '@storybook/react';
 import React, { useState } from 'react';
 import { pageData, pageDataWithFillColor } from '../../data';
-import { RadialBar, RadialBarChart, ResponsiveContainer, Cell, Legend } from '../../../../src';
+import { Tooltip, RadialBar, RadialBarChart, ResponsiveContainer, Cell, Legend, RadialBarProps } from '../../../../src';
 import { CategoricalChartProps } from '../props/ChartProps';
 
 export default {
   argTypes: {
     ...CategoricalChartProps,
+    activeIndex: {
+      description:
+        'The index of the individual shapes that make up the Funnel to be marked as active, and render props.activeShape as a result',
+      table: {
+        type: {
+          summary: 'number | undefined',
+        },
+        defaultValue: undefined,
+        category: 'General',
+      },
+    },
+    activeShape: {
+      description: 'The customized shape to be rendered if activeIndex or activeTooltipIndex match',
+      table: {
+        type: {
+          summary: 'Function | boolean | ReactElement | object',
+        },
+        defaultValue: undefined,
+        category: 'General',
+      },
+    },
   },
   component: RadialBarChart,
 };
 
-export const Simple = {
+export const Simple: Meta<RadialBarProps> = {
   render: (args: Record<string, any>) => {
     const { data } = args;
     return (
       <ResponsiveContainer width="100%" height={400}>
         <RadialBarChart data={data}>
-          <RadialBar dataKey="uv" />
+          <RadialBar dataKey="uv" activeShape={args.activeShape} activeIndex={args.activeIndex} />
+          <Tooltip />
         </RadialBarChart>
       </ResponsiveContainer>
     );
   },
   args: {
     data: pageData,
+    activeShape: { fill: 'red' },
+    activeIndex: undefined,
   },
 };
 

--- a/storybook/stories/API/chart/RadialBarChart.stories.tsx
+++ b/storybook/stories/API/chart/RadialBarChart.stories.tsx
@@ -11,7 +11,7 @@ export default {
     ...CategoricalChartProps,
     activeIndex: {
       description:
-        'The index of the individual shapes that make up the Funnel to be marked as active, and render props.activeShape as a result',
+        'The index of the individual shapes of RadialBar to be marked as active, and render props.activeShape',
       table: {
         category: 'General',
       },

--- a/storybook/stories/API/chart/RadialBarChart.stories.tsx
+++ b/storybook/stories/API/chart/RadialBarChart.stories.tsx
@@ -13,20 +13,12 @@ export default {
       description:
         'The index of the individual shapes that make up the Funnel to be marked as active, and render props.activeShape as a result',
       table: {
-        type: {
-          summary: 'number | undefined',
-        },
-        defaultValue: undefined,
         category: 'General',
       },
     },
     activeShape: {
       description: 'The customized shape to be rendered if activeIndex or activeTooltipIndex match',
       table: {
-        type: {
-          summary: 'Function | boolean | ReactElement | object',
-        },
-        defaultValue: undefined,
         category: 'General',
       },
     },

--- a/test/chart/RadialBarChart.spec.tsx
+++ b/test/chart/RadialBarChart.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { RadialBarChart, RadialBar, Legend, Sector, Tooltip, Cell } from '../../src';
+import { mockMouseEvent } from '../helper/mockMouseEvent';
 
 describe('<RadialBarChart />', () => {
   const data = [
@@ -194,5 +195,145 @@ describe('<RadialBarChart />', () => {
       </RadialBarChart>,
     );
     expect(container.querySelectorAll('.unit-test-class')).toHaveLength(data.length);
+  });
+
+  test('Renders customized active shape when activeShape set to be a function', () => {
+    const { container } = render(
+      <RadialBarChart
+        width={500}
+        height={300}
+        cx={150}
+        cy={150}
+        innerRadius={20}
+        outerRadius={140}
+        barSize={10}
+        data={data}
+      >
+        <RadialBar
+          background
+          dataKey="uv"
+          isAnimationActive={false}
+          activeShape={props => <Sector {...props} fill="red" />}
+        />
+        <Tooltip />
+      </RadialBarChart>,
+    );
+
+    const sectorNodes = container.querySelectorAll('.recharts-sector');
+    const [sector] = Array.from(sectorNodes);
+    const mouseOverEvent = mockMouseEvent('mouseover', sector, { pageX: 200, pageY: 200 });
+
+    mouseOverEvent.fire();
+
+    const activeSector = container.querySelectorAll('.recharts-active-shape');
+    expect(activeSector).toHaveLength(1);
+  });
+
+  test('Renders customized active bar when activeBar set to be a ReactElement', () => {
+    const { container } = render(
+      <RadialBarChart
+        width={500}
+        height={300}
+        cx={150}
+        cy={150}
+        innerRadius={20}
+        outerRadius={140}
+        barSize={10}
+        data={data}
+      >
+        <RadialBar background dataKey="uv" isAnimationActive={false} activeShape={<Sector fill="red" />} />
+        <Tooltip />
+      </RadialBarChart>,
+    );
+
+    const sectorNodes = container.querySelectorAll('.recharts-sector');
+    const [sector] = Array.from(sectorNodes);
+    const mouseOverEvent = mockMouseEvent('mouseover', sector, { pageX: 200, pageY: 200 });
+
+    mouseOverEvent.fire();
+
+    const activeSector = container.querySelectorAll('.recharts-active-shape');
+    expect(activeSector).toHaveLength(1);
+  });
+
+  test('Renders customized active bar when activeBar is set to be a truthy boolean', () => {
+    const { container } = render(
+      <RadialBarChart
+        width={500}
+        height={300}
+        cx={150}
+        cy={150}
+        innerRadius={20}
+        outerRadius={140}
+        barSize={10}
+        data={data}
+      >
+        <RadialBar background dataKey="uv" isAnimationActive={false} activeShape />
+        <Tooltip />
+      </RadialBarChart>,
+    );
+
+    const sectorNodes = container.querySelectorAll('.recharts-sector');
+    const [sector] = Array.from(sectorNodes);
+    const mouseOverEvent = mockMouseEvent('mouseover', sector, { pageX: 200, pageY: 200 });
+
+    mouseOverEvent.fire();
+
+    const activeSector = container.querySelectorAll('.recharts-active-shape');
+    expect(activeSector).toHaveLength(1);
+  });
+
+  test('Does not render customized active bar when activeBar set to be a falsy boolean', () => {
+    const { container } = render(
+      <RadialBarChart
+        width={500}
+        height={300}
+        cx={150}
+        cy={150}
+        innerRadius={20}
+        outerRadius={140}
+        barSize={10}
+        data={data}
+      >
+        <RadialBar background dataKey="uv" isAnimationActive={false} activeShape={false} />
+        <Tooltip />
+      </RadialBarChart>,
+    );
+
+    const sectorNodes = container.querySelectorAll('.recharts-sector');
+    const [sector] = Array.from(sectorNodes);
+    const mouseOverEvent = mockMouseEvent('mouseover', sector, { pageX: 200, pageY: 200 });
+
+    mouseOverEvent.fire();
+
+    const activeSector = container.querySelectorAll('.recharts-active-shape');
+    expect(activeSector).toHaveLength(0);
+  });
+
+  test('Renders customized active bar when activeBar set to be an object', () => {
+    const { container } = render(
+      <RadialBarChart
+        width={500}
+        height={300}
+        cx={150}
+        cy={150}
+        innerRadius={20}
+        outerRadius={140}
+        barSize={10}
+        data={data}
+      >
+        <RadialBar background dataKey="uv" isAnimationActive={false} activeShape={{ fill: 'red' }} />
+        <Tooltip />
+      </RadialBarChart>,
+    );
+
+    const sectorNodes = container.querySelectorAll('.recharts-sector');
+    const [sector] = Array.from(sectorNodes);
+    const mouseOverEvent = mockMouseEvent('mouseover', sector, { pageX: 200, pageY: 200 });
+
+    mouseOverEvent.fire();
+
+    const activeSector = container.querySelectorAll('.recharts-active-shape');
+    expect(activeSector).toHaveLength(1);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The existing activeShape prop on `<RadialBar />` should work with the `<Tooltip />` in the same manner as `<Line />`, `<Bar />`, `<Funnel/>` do.
## Description

<!--- Describe your changes in detail -->
- #### src/chart/generateCategoricalChart.tsx
  - Added another if block to render the graphical item when `activeShape` is truthy.
Inside the new if block, render the graphical item and pass in `activeIndex` which defaults to user defined `activeIndex` and falls back to `activeTooltipIndex` when undefined.

- #### src/polar/RadialBar.tsx
  - Renamed the generically exported type named Props to RadialBarProps
  - Refactored static render method out to RadialBarUtils
  - Updated type of `RadialBar.activeShape` to match the signature of activeLine/activeBar/activeShape in Line/Bar/Funnel components

## Related Issue
#3792 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To provide a consistent interface between Line / Bar / Funnel / RadialBar and their respective props of activeDot / activeBar / activeShape

## How Has This Been Tested?
Unit tests and storybook

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="342" alt="Screenshot 2023-09-29 at 5 23 19 PM" src="https://github.com/recharts/recharts/assets/24420033/bc25c31b-1e9a-4538-9441-0161b3045cc4">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
