### PR TITLE
Scatter: activeShape should work with Tooltip

### DIFF
--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -11,14 +11,12 @@ import { findAllByType, filterProps } from '../util/ReactUtils';
 import { Global } from '../util/Global';
 import { ZAxis, Props as ZAxisProps } from './ZAxis';
 import { Curve, Props as CurveProps, CurveType } from '../shape/Curve';
-import { Symbols, Props as SymbolsProps } from '../shape/Symbols';
 import { ErrorBar } from './ErrorBar';
 import { Cell } from '../component/Cell';
 import { uniqueId, interpolateNumber, getLinearRegression } from '../util/DataUtils';
 import { getValueByDataKey, getCateCoordinateOfLine } from '../util/ChartUtils';
 import {
   LegendType,
-  SymbolType,
   AnimationTiming,
   D3Scale,
   ChartOffset,
@@ -27,10 +25,13 @@ import {
   adaptEventsOfChild,
   PresentationAttributesAdaptChildEvent,
   AnimationDuration,
+  ActiveShape,
+  SymbolType,
 } from '../util/types';
 import { TooltipType } from '../component/DefaultTooltipContent';
 import { Props as XAxisProps } from './XAxis';
 import { Props as YAxisProps } from './YAxis';
+import { ScatterSymbol } from '../util/ScatterUtils';
 
 interface ScattterPointNode {
   x?: number | string;
@@ -72,8 +73,8 @@ interface ScatterProps {
   name?: string | number;
 
   activeIndex?: number;
-  activeShape?: ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | SymbolsProps;
-  shape?: SymbolType | ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>);
+  activeShape?: ActiveShape<ScatterPointItem> | SymbolType;
+  shape?: ActiveShape<ScatterPointItem> | SymbolType;
   points?: ScatterPointItem[];
   hide?: boolean;
   label?: ImplicitLabelListType<any>;
@@ -258,25 +259,13 @@ export class Scatter extends PureComponent<Props, State> {
 
   id = uniqueId('recharts-scatter-');
 
-  static renderSymbolItem(option: Props['activeShape'] | Props['shape'], props: any) {
-    let symbol;
-
-    if (React.isValidElement(option)) {
-      symbol = React.cloneElement(option, props);
-    } else if (_.isFunction(option)) {
-      symbol = option(props);
-    } else if (typeof option === 'string') {
-      symbol = <Symbols {...props} type={option} />;
-    }
-
-    return symbol;
-  }
-
   renderSymbolsStatically(points: ScatterPointItem[]) {
     const { shape, activeShape, activeIndex } = this.props;
     const baseProps = filterProps(this.props);
 
     return points.map((entry, i) => {
+      const isActive = activeIndex === i;
+      const option = isActive ? activeShape : shape;
       const props = { key: `symbol-${i}`, ...baseProps, ...entry };
 
       return (
@@ -286,7 +275,7 @@ export class Scatter extends PureComponent<Props, State> {
           key={`symbol-${i}`} // eslint-disable-line react/no-array-index-key
           role="img"
         >
-          {Scatter.renderSymbolItem(activeIndex === i ? activeShape : shape, props)}
+          <ScatterSymbol option={option} isActive={isActive} {...props} />
         </Layer>
       );
     });

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -32,6 +32,7 @@ import { TooltipType } from '../component/DefaultTooltipContent';
 import { Props as XAxisProps } from './XAxis';
 import { Props as YAxisProps } from './YAxis';
 import { ScatterSymbol } from '../util/ScatterUtils';
+import { InnerSymbolsProp } from '../shape/Symbols';
 
 interface ScattterPointNode {
   x?: number | string;
@@ -46,6 +47,8 @@ export interface ScatterPointItem {
   node?: ScattterPointNode;
   payload?: any;
 }
+
+export type ScatterCustomizedShape = ActiveShape<ScatterPointItem, SVGPathElement & InnerSymbolsProp> | SymbolType;
 
 interface ScatterProps {
   data?: any[];
@@ -73,8 +76,8 @@ interface ScatterProps {
   name?: string | number;
 
   activeIndex?: number;
-  activeShape?: ActiveShape<ScatterPointItem> | SymbolType;
-  shape?: ActiveShape<ScatterPointItem> | SymbolType;
+  activeShape?: ScatterCustomizedShape;
+  shape?: ScatterCustomizedShape;
   points?: ScatterPointItem[];
   hide?: boolean;
   label?: ImplicitLabelListType<any>;

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -2280,6 +2280,17 @@ export const generateCategoricalChart = ({
               graphicalItem: { ...graphicalItem, childIndex },
               payload: graphicalItem.props.data[activeIndex],
             };
+          } else if (itemDisplayName === 'Scatter') {
+            const activeScatterIndex = item.props.data.findIndex((datum: typeof activeItem.payload) => {
+              return _.isEqual(activeItem.payload, datum);
+            });
+
+            const childIndex = item.props.activeIndex === undefined ? activeScatterIndex : item.props.activeIndex;
+
+            return {
+              graphicalItem: { ...graphicalItem, childIndex },
+              payload: item.props.data[activeScatterIndex],
+            };
           }
         }
       }

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -73,6 +73,7 @@ import {
 import { AccessibilityManager } from './AccessibilityManager';
 import { isDomainSpecifiedByUser } from '../util/isDomainSpecifiedByUser';
 import { deferer, CancelFunction } from '../util/deferer';
+import { getActiveShapeIndexForTooltip } from '../util/ActiveShapeUtils';
 
 export type GraphicalItem<Props = Record<string, any>> = ReactElement<
   Props,
@@ -2251,45 +2252,20 @@ export const generateCategoricalChart = ({
             if (activeBarItem) {
               return { graphicalItem, payload: activeBarItem };
             }
-          } else if (itemDisplayName === 'Funnel') {
-            /*
-             * To handle possible duplicates in the data set,
-             * match both the data value of the active item to a data value on a graph item,
-             * and match the mouse coordinates of the active item to the coordinates of a trapezoid.
-             * This assumes equal lengths of trapezoids on a funnel to data items.
-             */
-            const activeIndex = item.props.data.findIndex((funnelData: { value: string }, dataIndex: number) => {
-              const valuesMatch = funnelData.value === activeItem.payload.value;
-
-              const indexOfMouseCoordinates = graphicalItem.props.trapezoids.findIndex(
-                (trapezoid: { x: number; y: number }) => {
-                  const xMatches = trapezoid.x === activeItem.labelViewBox.x || trapezoid.x === activeItem.x;
-                  const yMatches = trapezoid.y === activeItem.labelViewBox.y || trapezoid.y === activeItem.y;
-                  return xMatches && yMatches;
-                },
-              );
-
-              const coordinatesMatch = dataIndex === indexOfMouseCoordinates;
-
-              return valuesMatch && coordinatesMatch;
+          } else if (itemDisplayName === 'Funnel' || itemDisplayName === 'Pie' || itemDisplayName === 'Scatter') {
+            const activeIndex = getActiveShapeIndexForTooltip({
+              itemDisplayName,
+              graphicalItem,
+              activeTooltipItem: activeItem,
+              itemData: item.props.data,
             });
 
             const childIndex = item.props.activeIndex === undefined ? activeIndex : item.props.activeIndex;
 
             return {
               graphicalItem: { ...graphicalItem, childIndex },
-              payload: graphicalItem.props.data[activeIndex],
-            };
-          } else if (itemDisplayName === 'Scatter') {
-            const activeScatterIndex = item.props.data.findIndex((datum: typeof activeItem.payload) => {
-              return _.isEqual(activeItem.payload, datum);
-            });
-
-            const childIndex = item.props.activeIndex === undefined ? activeScatterIndex : item.props.activeIndex;
-
-            return {
-              graphicalItem: { ...graphicalItem, childIndex },
-              payload: item.props.data[activeScatterIndex],
+              payload:
+                itemDisplayName === 'Scatter' ? item.props.data[activeIndex] : graphicalItem.props.data[activeIndex],
             };
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export type { Props as DotProps } from './shape/Dot';
 export { Cross } from './shape/Cross';
 export type { Props as CrossProps } from './shape/Cross';
 export { Symbols } from './shape/Symbols';
-export type { Props as SymbolsProps } from './shape/Symbols';
+export type { SymbolsProps } from './shape/Symbols';
 
 export { PolarGrid } from './polar/PolarGrid';
 export type { Props as PolarGridProps } from './polar/PolarGrid';

--- a/src/shape/Symbols.tsx
+++ b/src/shape/Symbols.tsx
@@ -67,7 +67,7 @@ const calculateAreaSize = (size: number, sizeType: SizeType, type: SymbolType) =
   }
 };
 
-interface SymbolsProp {
+export interface InnerSymbolsProp {
   className?: string;
   type: SymbolType;
   cx?: number;
@@ -76,13 +76,13 @@ interface SymbolsProp {
   sizeType?: SizeType;
 }
 
-export type Props = SVGProps<SVGPathElement> & SymbolsProp;
+export type SymbolsProps = SVGProps<SVGPathElement> & InnerSymbolsProp;
 
 const registerSymbol = (key: string, factory: D3SymbolType) => {
   symbolFactories[`symbol${_.upperFirst(key)}`] = factory;
 };
 
-export const Symbols = ({ type = 'circle', size = 64, sizeType = 'area', ...rest }: Props) => {
+export const Symbols = ({ type = 'circle', size = 64, sizeType = 'area', ...rest }: SymbolsProps) => {
   const props = { ...rest, type, size, sizeType };
 
   /**

--- a/src/util/ActiveShapeUtils.tsx
+++ b/src/util/ActiveShapeUtils.tsx
@@ -4,7 +4,7 @@ import { Rectangle } from '../shape/Rectangle';
 import { Trapezoid } from '../shape/Trapezoid';
 import { Sector } from '../shape/Sector';
 import { Layer } from '../container/Layer';
-import { Symbols, Props as SymbolsProps } from '../shape/Symbols';
+import { Symbols, SymbolsProps } from '../shape/Symbols';
 
 type ShapeType = 'trapezoid' | 'rectangle' | 'sector' | 'symbols';
 

--- a/src/util/ActiveShapeUtils.tsx
+++ b/src/util/ActiveShapeUtils.tsx
@@ -4,16 +4,24 @@ import { Rectangle } from '../shape/Rectangle';
 import { Trapezoid } from '../shape/Trapezoid';
 import { Sector } from '../shape/Sector';
 import { Layer } from '../container/Layer';
+import { Symbols, Props as SymbolsProps } from '../shape/Symbols';
 
-type ShapeType = 'trapezoid' | 'rectangle' | 'sector';
+type ShapeType = 'trapezoid' | 'rectangle' | 'sector' | 'symbols';
 
 export type ShapeProps<OptionType, ExtraProps, ShapePropsType> = {
   shapeType: ShapeType;
   option: OptionType;
-  propTransformer: (option: OptionType, props: ExtraProps) => ShapePropsType;
   isActive: boolean;
   activeClassName?: string;
+  propTransformer?: (option: OptionType, props: ExtraProps) => ShapePropsType;
 } & ExtraProps;
+
+function defaultPropTransformer<OptionType, ExtraProps, ShapePropsType>(option: OptionType, props: ExtraProps) {
+  return {
+    ...props,
+    ...option,
+  } as unknown as ShapePropsType;
+}
 
 function ShapeSelector<ShapePropsType>({
   shapeType,
@@ -29,6 +37,8 @@ function ShapeSelector<ShapePropsType>({
       return <Trapezoid {...elementProps} />;
     case 'sector':
       return <Sector {...elementProps} />;
+    case 'symbols':
+      return <Symbols {...(elementProps as unknown as SymbolsProps)} />;
     default:
       return null;
   }
@@ -37,7 +47,7 @@ function ShapeSelector<ShapePropsType>({
 export function Shape<OptionType, ExtraProps, ShapePropsType>({
   option,
   shapeType,
-  propTransformer = (arg1, arg2) => ({ ...arg1, ...arg2 } as unknown as ShapePropsType),
+  propTransformer = defaultPropTransformer,
   activeClassName = 'recharts-active-shape',
   isActive,
   ...props

--- a/src/util/ActiveShapeUtils.tsx
+++ b/src/util/ActiveShapeUtils.tsx
@@ -6,6 +6,14 @@ import { Sector } from '../shape/Sector';
 import { Layer } from '../container/Layer';
 import { Symbols, SymbolsProps } from '../shape/Symbols';
 
+/**
+ * This is an abstraction for rendering a user defined prop for a customized shape in several forms.
+ * It will handle taking in:
+ *  - an object of svg properties
+ *  - a boolean
+ *  - a render prop(inline function that returns jsx)
+ *  - a react element
+ */
 type ShapeType = 'trapezoid' | 'rectangle' | 'sector' | 'symbols';
 
 export type ShapeProps<OptionType, ExtraProps, ShapePropsType> = {
@@ -72,4 +80,141 @@ export function Shape<OptionType, ExtraProps, ShapePropsType>({
   }
 
   return shape;
+}
+
+/**
+ * This is an abstraction to handle identifying the active index from a tooltip mouse interaction
+ */
+type GraphicalItemShapeKey = 'trapezoids' | 'sectors' | 'points';
+
+type ItemDisplayName = 'Funnel' | 'Pie' | 'Scatter';
+
+type FunnelItem = {
+  x: number;
+  y: number;
+  labelViewBox: { x: number; y: number };
+  tooltipPayload: Array<{ payload: { payload: unknown } }>;
+};
+
+type PieItem = {
+  startAngle: number;
+  endAngle: number;
+  tooltipPayload: Array<{ payload: { payload: unknown } }>;
+};
+
+type ScatterItem = {
+  x: number;
+  y: number;
+  z: number;
+  payload?: unknown;
+};
+
+type ShapeData<DisplayName extends ItemDisplayName> = DisplayName extends 'Funnel'
+  ? FunnelItem
+  : DisplayName extends 'Pie'
+  ? PieItem
+  : DisplayName extends 'Scatter'
+  ? ScatterItem
+  : never;
+
+type GetActiveShapeIndexForTooltip = {
+  itemDisplayName: ItemDisplayName;
+  activeTooltipItem: ShapeData<ItemDisplayName>;
+  graphicalItem: {
+    props: Record<GraphicalItemShapeKey, unknown[]>;
+  };
+  itemData: unknown[];
+};
+
+function isFunnel(itemDisplayName: ItemDisplayName, _item: unknown): _item is FunnelItem {
+  return itemDisplayName === 'Funnel';
+}
+
+function isPie(itemDisplayName: ItemDisplayName, _item: unknown): _item is PieItem {
+  return itemDisplayName === 'Pie';
+}
+
+function isScatter(itemDisplayName: ItemDisplayName, _item: unknown): _item is ScatterItem {
+  return itemDisplayName === 'Scatter';
+}
+
+function getShapeDataKey(itemDisplayName: ItemDisplayName): GraphicalItemShapeKey {
+  let shapeKey: GraphicalItemShapeKey;
+
+  if (itemDisplayName === 'Funnel') {
+    shapeKey = 'trapezoids';
+  } else if (itemDisplayName === 'Pie') {
+    shapeKey = 'sectors';
+  } else if (itemDisplayName === 'Scatter') {
+    shapeKey = 'points';
+  }
+
+  return shapeKey;
+}
+
+/**
+ *
+ * @param {GetActiveShapeIndexForTooltip} arg an object of incoming attributes from Tooltip
+ * @returns {number}
+ *
+ * To handle possible duplicates in the data set,
+ * match both the data value of the active item to a data value on a graph item,
+ * and match the mouse coordinates of the active item to the coordinates of in a particular components shape data.
+ * This assumes equal lengths of shape objects to data items.
+ */
+export function getActiveShapeIndexForTooltip({
+  itemDisplayName,
+  activeTooltipItem,
+  graphicalItem,
+  itemData,
+}: GetActiveShapeIndexForTooltip): number {
+  const shapeKey = getShapeDataKey(itemDisplayName);
+
+  const tooltipPayload: Partial<ShapeData<typeof itemDisplayName>> = isScatter(itemDisplayName, activeTooltipItem)
+    ? activeTooltipItem.payload
+    : activeTooltipItem.tooltipPayload?.[0].payload.payload;
+
+  const activeItemMatches = itemData.filter((datum: any, dataIndex: number) => {
+    const valuesMatch = _.isEqual(tooltipPayload, datum);
+
+    const mouseCoordinateMatches = graphicalItem.props[shapeKey].filter(
+      (shapeData: ShapeData<typeof itemDisplayName>) => {
+        if (isFunnel(itemDisplayName, shapeData) && isFunnel(itemDisplayName, activeTooltipItem)) {
+          const xMatches = shapeData.x === activeTooltipItem?.labelViewBox?.x || shapeData.x === activeTooltipItem.x;
+          const yMatches = shapeData.y === activeTooltipItem?.labelViewBox?.y || shapeData.y === activeTooltipItem.y;
+          return xMatches && yMatches;
+        }
+
+        if (isPie(itemDisplayName, shapeData) && isPie(itemDisplayName, activeTooltipItem)) {
+          const startAngleMatches = shapeData.endAngle === activeTooltipItem.endAngle;
+          const endAngleMatches = shapeData.startAngle === activeTooltipItem.startAngle;
+          return startAngleMatches && endAngleMatches;
+        }
+
+        if (isScatter(itemDisplayName, shapeData) && isScatter(itemDisplayName, activeTooltipItem)) {
+          const xMatches = shapeData.x === activeTooltipItem.x;
+          const yMatches = shapeData.y === activeTooltipItem.y;
+          const zMatches = shapeData.z === activeTooltipItem.z;
+
+          return xMatches && yMatches && zMatches;
+        }
+
+        return false;
+      },
+    );
+
+    // get the last index in case of multiple matches
+    const indexOfMouseCoordinates = graphicalItem.props[shapeKey].indexOf(
+      mouseCoordinateMatches[mouseCoordinateMatches.length - 1],
+    );
+
+    const coordinatesMatch = dataIndex === indexOfMouseCoordinates;
+
+    return valuesMatch && coordinatesMatch;
+  });
+
+  // get the last index in case of multiple matches
+  const activeIndex = itemData.indexOf(activeItemMatches[activeItemMatches.length - 1]);
+
+  return activeIndex;
 }

--- a/src/util/ScatterUtils.tsx
+++ b/src/util/ScatterUtils.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ActiveShape, SymbolType } from './types';
+import { ScatterPointItem } from '../cartesian/Scatter';
+import { Symbols } from '../shape/Symbols';
+import { Shape } from './ActiveShapeUtils';
+
+export function ScatterSymbol({
+  option,
+  isActive,
+  ...props
+}: {
+  option: ActiveShape<ScatterPointItem> | SymbolType;
+  isActive: boolean;
+} & ScatterPointItem) {
+  if (typeof option === 'string') {
+    return <Shape option={<Symbols type={option} {...props} />} isActive={isActive} shapeType="symbols" {...props} />;
+  }
+
+  return <Shape option={option} isActive={isActive} shapeType="symbols" {...props} />;
+}

--- a/storybook/stories/Examples/ScatterChart.stories.tsx
+++ b/storybook/stories/Examples/ScatterChart.stories.tsx
@@ -32,6 +32,7 @@ export const Simple: Meta<ScatterProps> = {
   render: args => {
     const data = [
       { x: 100, y: 200, z: 200 },
+      { x: 100, y: 200, z: 200 },
       { x: 120, y: 100, z: 260 },
       { x: 170, y: 300, z: 400 },
       { x: 140, y: 250, z: 280 },

--- a/storybook/stories/Examples/ScatterChart.stories.tsx
+++ b/storybook/stories/Examples/ScatterChart.stories.tsx
@@ -1,3 +1,4 @@
+import { Meta } from '@storybook/react';
 // eslint-disable-next-line max-classes-per-file
 import React from 'react';
 import {
@@ -14,6 +15,7 @@ import {
   Scatter,
   ZAxis,
 } from '../../../src';
+import { Props as ScatterProps } from '../../../src/cartesian/Scatter';
 
 export default {
   component: LineChart,
@@ -22,8 +24,12 @@ export default {
   },
 };
 
-export const Simple = {
-  render: () => {
+export const Simple: Meta<ScatterProps> = {
+  args: {
+    activeShape: { fill: 'red' },
+    activeIndex: undefined,
+  },
+  render: args => {
     const data = [
       { x: 100, y: 200, z: 200 },
       { x: 120, y: 100, z: 260 },
@@ -47,7 +53,13 @@ export const Simple = {
           <XAxis type="number" dataKey="x" name="stature" unit="cm" />
           <YAxis type="number" dataKey="y" name="weight" unit="kg" />
           <Tooltip cursor={{ strokeDasharray: '3 3' }} />
-          <Scatter name="A school" data={data} fill="#8884d8" />
+          <Scatter
+            activeShape={args.activeShape}
+            activeIndex={args.activeIndex}
+            name="A school"
+            data={data}
+            fill="#8884d8"
+          />
         </ScatterChart>
       </ResponsiveContainer>
     );

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -134,6 +134,32 @@ describe('ScatterChart of two dimension data', () => {
     expect(activeSector).toHaveLength(1);
   });
 
+  test('Renders customized active shape when activeShape set to be an object as symbols props', () => {
+    const { container } = render(
+      <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+        <XAxis dataKey="x" name="stature" unit="cm" />
+        <YAxis dataKey="y" name="weight" unit="kg" />
+        <Scatter
+          line
+          name="A school"
+          data={data}
+          fill="#ff7300"
+          activeShape={{ type: 'triangle', className: 'triangle-symbols-type', fill: 'red' }}
+        />
+        <Tooltip />
+      </ScatterChart>,
+    );
+
+    const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
+    const [sector] = Array.from(sectorNodes);
+    const mouseOverEvent = mockMouseEvent('mouseover', sector, { pageX: 200, pageY: 200 });
+
+    mouseOverEvent.fire();
+
+    const activeSector = container.querySelectorAll('.triangle-symbols-type');
+    expect(activeSector).toHaveLength(1);
+  });
+
   test('Renders customized active shape when activeShape set to be a function', () => {
     const { container } = render(
       <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
-import { ScatterChart, Scatter, CartesianGrid, Tooltip, XAxis, YAxis, ZAxis, Legend } from '../../src';
+import { ScatterChart, Scatter, CartesianGrid, Tooltip, XAxis, YAxis, ZAxis, Legend, Symbols } from '../../src';
+import { mockMouseEvent } from '../helper/mockMouseEvent';
 
 describe('ScatterChart of three dimension data', () => {
   const data01 = [
@@ -111,5 +112,111 @@ describe('ScatterChart of two dimension data', () => {
     );
 
     expect(container.querySelectorAll('.recharts-scatter-line')).toHaveLength(1);
+  });
+
+  test('Renders customized active shape when activeShape set to be an object', () => {
+    const { container } = render(
+      <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+        <XAxis dataKey="x" name="stature" unit="cm" />
+        <YAxis dataKey="y" name="weight" unit="kg" />
+        <Scatter line name="A school" data={data} fill="#ff7300" activeShape={{ fill: 'red' }} />
+        <Tooltip />
+      </ScatterChart>,
+    );
+
+    const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
+    const [sector] = Array.from(sectorNodes);
+    const mouseOverEvent = mockMouseEvent('mouseover', sector, { pageX: 200, pageY: 200 });
+
+    mouseOverEvent.fire();
+
+    const activeSector = container.querySelectorAll('.recharts-active-shape');
+    expect(activeSector).toHaveLength(1);
+  });
+
+  test('Renders customized active shape when activeShape set to be a function', () => {
+    const { container } = render(
+      <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+        <XAxis dataKey="x" name="stature" unit="cm" />
+        <YAxis dataKey="y" name="weight" unit="kg" />
+        <Scatter
+          line
+          name="A school"
+          data={data}
+          fill="#ff7300"
+          activeShape={props => <Symbols {...props} type="circle" fill="red" />}
+        />
+        <Tooltip />
+      </ScatterChart>,
+    );
+
+    const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
+    const [sector] = Array.from(sectorNodes);
+    const mouseOverEvent = mockMouseEvent('mouseover', sector, { pageX: 200, pageY: 200 });
+
+    mouseOverEvent.fire();
+
+    const activeSector = container.querySelectorAll('.recharts-active-shape');
+    expect(activeSector).toHaveLength(1);
+  });
+
+  test('Renders customized active bar when activeBar set to be a ReactElement', () => {
+    const { container } = render(
+      <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+        <XAxis dataKey="x" name="stature" unit="cm" />
+        <YAxis dataKey="y" name="weight" unit="kg" />
+        <Scatter line name="A school" data={data} fill="#ff7300" activeShape={<Symbols type="circle" fill="red" />} />
+        <Tooltip />
+      </ScatterChart>,
+    );
+
+    const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
+    const [sector] = Array.from(sectorNodes);
+    const mouseOverEvent = mockMouseEvent('mouseover', sector, { pageX: 200, pageY: 200 });
+
+    mouseOverEvent.fire();
+
+    const activeSector = container.querySelectorAll('.recharts-active-shape');
+    expect(activeSector).toHaveLength(1);
+  });
+
+  test('Renders customized active bar when activeBar is set to be a truthy boolean', () => {
+    const { container } = render(
+      <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+        <XAxis dataKey="x" name="stature" unit="cm" />
+        <YAxis dataKey="y" name="weight" unit="kg" />
+        <Scatter line name="A school" data={data} fill="#ff7300" activeShape />
+        <Tooltip />
+      </ScatterChart>,
+    );
+
+    const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
+    const [sector] = Array.from(sectorNodes);
+    const mouseOverEvent = mockMouseEvent('mouseover', sector, { pageX: 200, pageY: 200 });
+
+    mouseOverEvent.fire();
+
+    const activeSector = container.querySelectorAll('.recharts-active-shape');
+    expect(activeSector).toHaveLength(1);
+  });
+
+  test('Does not render customized active bar when activeBar set to be a falsy boolean', () => {
+    const { container } = render(
+      <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+        <XAxis dataKey="x" name="stature" unit="cm" />
+        <YAxis dataKey="y" name="weight" unit="kg" />
+        <Scatter line name="A school" data={data} fill="#ff7300" activeShape={false} />
+        <Tooltip />
+      </ScatterChart>,
+    );
+
+    const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
+    const [sector] = Array.from(sectorNodes);
+    const mouseOverEvent = mockMouseEvent('mouseover', sector, { pageX: 200, pageY: 200 });
+
+    mouseOverEvent.fire();
+
+    const activeSector = container.querySelectorAll('.recharts-active-shape');
+    expect(activeSector).toHaveLength(0);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The existing `activeShape` prop on `<Scatter />` should work with the `<Tooltip />` in the same manner as `<Line />` and `<Bar />` do.

## Description

<!--- Describe your changes in detail -->
- #### src/chart/generateCategoricalChart.tsx
  - added a block to `getItemByXY` to set the find and set `activeIndex` when Tooltip is used with Scatter
  
- #### src/cartesian/Scatter.tsx
  - Refactored to use `<Shape />` instead of static method. 
  - Refactored to use `ActiveShape` type for `props.activeShape` and `props.shape`
  
- #### src/util/ActiveShapeUtils.tsx
  - Made `propTransformer` optional.
  - Added case to render a `<Symbols />` component
  
- #### test/chart/ScatterChart.spec.tsx
  - Added unit tests asserting on activeShape rendering with Tooltip
  
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3794 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

To provide a consistent interface between Line / Bar / Funnel / RadialBar / Pie / Scatter and their respective props of activeDot / activeBar / activeShape

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests and storybook

## Screenshots (if appropriate):
<img width="361" alt="Screenshot 2023-10-06 at 10 03 07 AM" src="https://github.com/recharts/recharts/assets/24420033/14061d29-6565-4f46-a791-22d18131c6e5">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
