### PR TITLE
Add storybook-addon-performance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ _Before_ submitting a pull request, please make sure the following is done…
 ## <a name="code"></a>Code Guide
 
 Our linter will catch most styling issues that may exist in your code.
-You can check the status of your code styling by simply running: `npm run lint`
+You can check the status of your code styling by running: `npm run lint`
 
 However, there are still some styles that the linter cannot pick up. If you are unsure about something, looking at [Airbnb's Style Guide](https://github.com/airbnb/javascript) will guide you in the right direction.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "reassure": "^0.9.1",
         "rimraf": "^3.0.2",
         "storybook": "^7.4.6",
+        "storybook-addon-performance": "^0.17.1",
         "terser-webpack-plugin": "^5.1.1",
         "ts-jest": "^27.1.5",
         "ts-loader": "^8.0.12",
@@ -13414,6 +13415,29 @@
       },
       "peerDependenciesMeta": {
         "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xstate/react": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.2.2.tgz",
+      "integrity": "sha512-feghXWLedyq8JeL13yda3XnHPZKwYDN5HPBLykpLeuNpr9178tQd2/3d0NrH6gSd0sG5mLuLeuD+ck830fgzLQ==",
+      "dev": true,
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.2",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@xstate/fsm": "^2.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "xstate": "^4.37.2"
+      },
+      "peerDependenciesMeta": {
+        "@xstate/fsm": {
+          "optional": true
+        },
+        "xstate": {
           "optional": true
         }
       }
@@ -31733,6 +31757,25 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/storybook-addon-performance": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/storybook-addon-performance/-/storybook-addon-performance-0.17.1.tgz",
+      "integrity": "sha512-pOt33LwBJU2fWzyawy+i03M5b27gF/+/EgexyvZZtWhab3GLdQcLnIqt7fTMLOievYmibbiD23M64Fbq91POUQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/manager-api": "^7.0.0-beta.12",
+        "@storybook/theming": "^7.0.0-beta.12",
+        "@xstate/react": "^3.0.1",
+        "xstate": "^4.35.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/stream-buffers": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
@@ -33418,6 +33461,20 @@
         }
       }
     },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-resize-observer": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
@@ -33451,6 +33508,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {
@@ -34600,6 +34666,16 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "node_modules/xstate": {
+      "version": "4.38.2",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.2.tgz",
+      "integrity": "sha512-Fba/DwEPDLneHT3tbJ9F3zafbQXszOlyCJyQqqdzmtlY/cwE2th462KK48yaANf98jHlP6lJvxfNtN0LFKXPQg==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/xstate"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -44447,6 +44523,16 @@
       "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
       "dev": true,
       "requires": {}
+    },
+    "@xstate/react": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.2.2.tgz",
+      "integrity": "sha512-feghXWLedyq8JeL13yda3XnHPZKwYDN5HPBLykpLeuNpr9178tQd2/3d0NrH6gSd0sG5mLuLeuD+ck830fgzLQ==",
+      "dev": true,
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.1.2",
+        "use-sync-external-store": "^1.0.0"
+      }
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -58287,6 +58373,18 @@
         "@storybook/cli": "7.4.6"
       }
     },
+    "storybook-addon-performance": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/storybook-addon-performance/-/storybook-addon-performance-0.17.1.tgz",
+      "integrity": "sha512-pOt33LwBJU2fWzyawy+i03M5b27gF/+/EgexyvZZtWhab3GLdQcLnIqt7fTMLOievYmibbiD23M64Fbq91POUQ==",
+      "dev": true,
+      "requires": {
+        "@storybook/manager-api": "^7.0.0-beta.12",
+        "@storybook/theming": "^7.0.0-beta.12",
+        "@xstate/react": "^3.0.1",
+        "xstate": "^4.35.0"
+      }
+    },
     "stream-buffers": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
@@ -59535,6 +59633,13 @@
         "tslib": "^2.0.0"
       }
     },
+    "use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "dev": true,
+      "requires": {}
+    },
     "use-resize-observer": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
@@ -59553,6 +59658,13 @@
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "dev": true,
+      "requires": {}
     },
     "util": {
       "version": "0.12.5",
@@ -60402,6 +60514,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
+    "xstate": {
+      "version": "4.38.2",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.38.2.tgz",
+      "integrity": "sha512-Fba/DwEPDLneHT3tbJ9F3zafbQXszOlyCJyQqqdzmtlY/cwE2th462KK48yaANf98jHlP6lJvxfNtN0LFKXPQg==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "reassure": "^0.9.1",
     "rimraf": "^3.0.2",
     "storybook": "^7.4.6",
+    "storybook-addon-performance": "^0.17.1",
     "terser-webpack-plugin": "^5.1.1",
     "ts-jest": "^27.1.5",
     "ts-loader": "^8.0.12",

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -14,6 +14,7 @@ module.exports = {
     '@storybook/addon-a11y',
     '@storybook/addon-storysource',
     '@storybook/addon-docs',
+    'storybook-addon-performance',
   ],
   framework: {
     name: '@storybook/react-webpack5',

--- a/storybook/preview.ts
+++ b/storybook/preview.ts
@@ -1,6 +1,8 @@
 import { Preview } from '@storybook/react';
 import './global.css';
 import { DocsPage, DocsContainer } from '@storybook/addon-docs';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { withPerformance } from 'storybook-addon-performance';
 
 const preview: Preview = {
   parameters: {
@@ -25,3 +27,5 @@ const preview: Preview = {
 };
 
 export default preview;
+
+export const decorators = [withPerformance];


### PR DESCRIPTION
## Description

I am not immediately certain of the usefulness of this addon since it reports renders in seconds and that will be different in each run and each computer; and it reports all of recharts to have 1 DOM element which makes me suspicious it's not seeing the whole picture.

## Related Issue

https://github.com/recharts/recharts/issues/3437

## Motivation and Context

## How Has This Been Tested?

Storybook

## Screenshots (if appropriate):

<img width="1680" alt="image" src="https://github.com/recharts/recharts/assets/1100170/530dd31e-bf8f-4368-9934-b174f1ac8b15">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
