### PR TITLE
Add tests and types for getStackGroupsByAxisId

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -639,16 +639,16 @@ const hasGraphicalBarItem = (graphicalItems: any[]): any[] | boolean => {
 
 const getAxisNameByLayout = (layout: LayoutType) => {
   if (layout === 'horizontal') {
-    return { numericAxisName: 'yAxis', cateAxisName: 'xAxis' };
+    return { numericAxisName: 'yAxis', cateAxisName: 'xAxis' } as const;
   }
   if (layout === 'vertical') {
-    return { numericAxisName: 'xAxis', cateAxisName: 'yAxis' };
+    return { numericAxisName: 'xAxis', cateAxisName: 'yAxis' } as const;
   }
   if (layout === 'centric') {
-    return { numericAxisName: 'radiusAxis', cateAxisName: 'angleAxis' };
+    return { numericAxisName: 'radiusAxis', cateAxisName: 'angleAxis' } as const;
   }
 
-  return { numericAxisName: 'angleAxis', cateAxisName: 'radiusAxis' };
+  return { numericAxisName: 'angleAxis', cateAxisName: 'radiusAxis' } as const;
 };
 
 /**

--- a/test/util/ChartUtils/getStackGroupsByAxisId.spec.ts
+++ b/test/util/ChartUtils/getStackGroupsByAxisId.spec.ts
@@ -1,0 +1,219 @@
+import { ReactElement } from 'react';
+import { getStackGroupsByAxisId } from '../../../src/util/ChartUtils';
+import { createSeries, createSeriesPoint } from './getStackedData.spec';
+
+function makeItem(props: {}): ReactElement {
+  // @ts-expect-error incomplete mock of ReactElement
+  return {
+    props,
+  };
+}
+
+const data: ReadonlyArray<Record<string, unknown>> = [
+  {
+    name: 'Page A',
+    uv: 590,
+    pv: 800,
+    amt: 1400,
+  },
+  {
+    name: 'Page B',
+    uv: 868,
+    pv: 967,
+    amt: 1506,
+  },
+  {
+    name: 'Page C',
+    uv: 729,
+    pv: 918,
+    amt: 123,
+  },
+  {
+    name: 'Page D',
+    uv: 943,
+    pv: 185,
+    amt: 52,
+  },
+  {
+    name: 'Page E',
+    uv: 9834,
+    pv: 293,
+    amt: 4568,
+  },
+];
+
+let items: Array<ReactElement>;
+
+describe('getStackGroupsByAxisId', () => {
+  beforeEach(() => {
+    items = [
+      makeItem({ dataKey: 'uv', stackId: 'a', numericAxisId: 'x' }),
+      makeItem({ dataKey: 'pv', stackId: 'a', numericAxisId: 'y' }),
+    ];
+  });
+  it('should group data by axisId and then stackId', () => {
+    const result = getStackGroupsByAxisId(data, items, 'numericAxisId', 'cateAxisId', 'none', false);
+
+    expect(Object.keys(result)).toEqual(['x', 'y']);
+
+    expect(result.x).toEqual({
+      hasStack: true,
+      stackGroups: {
+        a: {
+          cateAxisId: 'cateAxisId',
+          items: [{ props: { dataKey: 'uv', numericAxisId: 'x', stackId: 'a' } }],
+          numericAxisId: 'numericAxisId',
+          stackedData: [
+            createSeries('uv', 0, [
+              createSeriesPoint(0, 590, data[0]),
+              createSeriesPoint(0, 868, data[1]),
+              createSeriesPoint(0, 729, data[2]),
+              createSeriesPoint(0, 943, data[3]),
+              createSeriesPoint(0, 9834, data[4]),
+            ]),
+          ],
+        },
+      },
+    });
+
+    expect(result.y).toEqual({
+      hasStack: true,
+      stackGroups: {
+        a: {
+          cateAxisId: 'cateAxisId',
+          items: [{ props: { dataKey: 'pv', numericAxisId: 'y', stackId: 'a' } }],
+          numericAxisId: 'numericAxisId',
+          stackedData: [
+            createSeries('pv', 0, [
+              createSeriesPoint(0, 800, data[0]),
+              createSeriesPoint(0, 967, data[1]),
+              createSeriesPoint(0, 918, data[2]),
+              createSeriesPoint(0, 185, data[3]),
+              createSeriesPoint(0, 293, data[4]),
+            ]),
+          ],
+        },
+      },
+    });
+  });
+
+  it('should return Series with no SeriesPoints if data is an empty array', () => {
+    const result = getStackGroupsByAxisId([], items, 'numericAxisId', 'cateAxisId', 'none', false);
+
+    expect(result.x).toEqual({
+      hasStack: true,
+      stackGroups: {
+        a: {
+          cateAxisId: 'cateAxisId',
+          items: [{ props: { dataKey: 'uv', numericAxisId: 'x', stackId: 'a' } }],
+          numericAxisId: 'numericAxisId',
+          stackedData: [createSeries('uv', 0, [])],
+        },
+      },
+    });
+
+    expect(result.y).toEqual({
+      hasStack: true,
+      stackGroups: {
+        a: {
+          cateAxisId: 'cateAxisId',
+          items: [{ props: { dataKey: 'pv', numericAxisId: 'y', stackId: 'a' } }],
+          numericAxisId: 'numericAxisId',
+          stackedData: [createSeries('pv', 0, [])],
+        },
+      },
+    });
+  });
+
+  it('should return null if data is undefined', () => {
+    const result = getStackGroupsByAxisId(undefined, items, 'numericAxisId', 'cateAxisId', 'none', false);
+    expect(result).toEqual(null);
+  });
+
+  it('should return empty object if items are empty', () => {
+    const result = getStackGroupsByAxisId(data, [], 'numericAxisId', 'cateAxisId', 'none', false);
+    expect(result).toEqual({});
+  });
+
+  it('should return empty object if all items have hide: true', () => {
+    const allHiddenItems = [
+      makeItem({ dataKey: 'uv', stackId: 'a', numericAxisId: 'x', hide: true }),
+      makeItem({ dataKey: 'pv', stackId: 'a', numericAxisId: 'y', hide: true }),
+    ];
+    const result = getStackGroupsByAxisId(data, allHiddenItems, 'numericAxisId', 'cateAxisId', 'none', false);
+    expect(result).toEqual({});
+  });
+
+  it('if reverseStackOrder is true the result should be exactly the same as if it is false', () => {
+    const result = getStackGroupsByAxisId([], items, 'numericAxisId', 'cateAxisId', 'none', true);
+
+    expect(result.x).toEqual({
+      hasStack: true,
+      stackGroups: {
+        a: {
+          cateAxisId: 'cateAxisId',
+          items: [{ props: { dataKey: 'uv', numericAxisId: 'x', stackId: 'a' } }],
+          numericAxisId: 'numericAxisId',
+          stackedData: [createSeries('uv', 0, [])],
+        },
+      },
+    });
+
+    expect(result.y).toEqual({
+      hasStack: true,
+      stackGroups: {
+        a: {
+          cateAxisId: 'cateAxisId',
+          items: [{ props: { dataKey: 'pv', numericAxisId: 'y', stackId: 'a' } }],
+          numericAxisId: 'numericAxisId',
+          stackedData: [createSeries('pv', 0, [])],
+        },
+      },
+    });
+  });
+
+  it('if reverseStackOrder is true the order of axis in the result object should be flipped', () => {
+    const resultFalse = getStackGroupsByAxisId([], items, 'numericAxisId', 'cateAxisId', 'none', false);
+    expect(Object.keys(resultFalse)).toEqual(['x', 'y']);
+    const resultTrue = getStackGroupsByAxisId([], items, 'numericAxisId', 'cateAxisId', 'none', true);
+    expect(Object.keys(resultTrue)).toEqual(['y', 'x']);
+  });
+
+  it('should mutate items array if reverseStackOrder is true', () => {
+    const itemsInput = [makeItem({ name: 'a' }), makeItem({ name: 'b' }), makeItem({ name: 'c' })];
+    getStackGroupsByAxisId(data, itemsInput, 'numericAxisId', 'cateAxisId', 'none', true);
+    expect(itemsInput).toEqual([makeItem({ name: 'c' }), makeItem({ name: 'b' }), makeItem({ name: 'a' })]);
+  });
+
+  it('should autogenerate stackId and do not generate stackedData if stackId is not defined', () => {
+    const itemsWithoutStackId = [
+      makeItem({ dataKey: 'uv', numericAxisId: 'x' }),
+      makeItem({ dataKey: 'pv', numericAxisId: 'y' }),
+    ];
+    const result = getStackGroupsByAxisId(data, itemsWithoutStackId, 'numericAxisId', 'cateAxisId', 'none', false);
+
+    expect(Object.keys(result)).toEqual(['x', 'y']);
+
+    expect(result.x).toEqual({
+      hasStack: false,
+      stackGroups: {
+        _stackId_4: {
+          cateAxisId: 'cateAxisId',
+          items: [{ props: { dataKey: 'uv', numericAxisId: 'x' } }],
+          numericAxisId: 'numericAxisId',
+        },
+      },
+    });
+
+    expect(result.y).toEqual({
+      hasStack: false,
+      stackGroups: {
+        _stackId_5: {
+          cateAxisId: 'cateAxisId',
+          items: [{ props: { dataKey: 'pv', numericAxisId: 'y' } }],
+          numericAxisId: 'numericAxisId',
+        },
+      },
+    });
+  });
+});

--- a/test/util/ChartUtils/getStackedData.spec.ts
+++ b/test/util/ChartUtils/getStackedData.spec.ts
@@ -6,7 +6,7 @@ function createDataKeyProps(dataKey: DataKey<any>) {
   return { props: { dataKey } };
 }
 
-function createSeries(
+export function createSeries(
   key: string,
   index: number,
   data: Array<SeriesPoint<Record<string, unknown>>> = [],
@@ -14,7 +14,7 @@ function createSeries(
   return Object.assign(data, { key, index });
 }
 
-function createSeriesPoint(
+export function createSeriesPoint(
   first: number,
   second: number,
   data: Record<string, unknown>,

--- a/test/util/ChartUtils/getStackedDataOfItem.spec.ts
+++ b/test/util/ChartUtils/getStackedDataOfItem.spec.ts
@@ -1,6 +1,8 @@
+import { ReactElement } from 'react';
 import { getStackedDataOfItem } from '../../../src/util/ChartUtils';
 
-function makeItem<T>(stackId: T) {
+function makeItem<T>(stackId: T): ReactElement {
+  // @ts-expect-error incomplete mock of ReactElement
   return {
     props: { stackId },
   };
@@ -8,21 +10,22 @@ function makeItem<T>(stackId: T) {
 
 describe('getStackedDataOfItem', () => {
   it('should return null if stackId is undefined', () => {
-    const item = { props: {} };
+    // @ts-expect-error incomplete mock of ReactElement
+    const item: ReactElement = { props: {} };
     const result = getStackedDataOfItem(item, {});
     expect(result).toBe(null);
   });
 
   it('should return null if stackId is a symbol', () => {
-    const item = { props: { stackId: Symbol('mock symbol') } };
-    expect(getStackedDataOfItem<symbol>(item, {})).toBe(null);
+    const item = makeItem(Symbol('mock symbol'));
+    expect(getStackedDataOfItem(item, {})).toBe(null);
   });
 
   it('should return undefined if stack group is undefined', () => {
     const item = makeItem<string>('a');
     const stackedData: Array<unknown> = [];
     const stackGroups = { a: { stackedData, items: [item] } };
-    const result = getStackedDataOfItem<string>(item, stackGroups);
+    const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(undefined);
   });
 
@@ -31,7 +34,7 @@ describe('getStackedDataOfItem', () => {
     const group = Symbol('my mock group');
     const items: Array<typeof item> = [];
     const stackGroups = { a: { stackedData: [group], items } };
-    const result = getStackedDataOfItem<string>(item, stackGroups);
+    const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(null);
   });
 
@@ -40,7 +43,7 @@ describe('getStackedDataOfItem', () => {
     const item2 = makeItem<string>('a');
     const group = Symbol('my mock group');
     const stackGroups = { a: { stackedData: [group], items: [item1] } };
-    const result = getStackedDataOfItem<string>(item2, stackGroups);
+    const result = getStackedDataOfItem(item2, stackGroups);
     expect(result).toBe(null);
   });
 
@@ -48,7 +51,7 @@ describe('getStackedDataOfItem', () => {
     const item = makeItem<string>('a');
     const group = Symbol('my mock group');
     const stackGroups = { a: { stackedData: [group], items: [item] } };
-    const result = getStackedDataOfItem<string>(item, stackGroups);
+    const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(group);
   });
 
@@ -56,7 +59,7 @@ describe('getStackedDataOfItem', () => {
     const item = makeItem<number>(7);
     const group = Symbol('my mock group');
     const stackGroups = { 7: { stackedData: [group], items: [item] } };
-    const result = getStackedDataOfItem<number>(item, stackGroups);
+    const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(group);
   });
 
@@ -64,7 +67,7 @@ describe('getStackedDataOfItem', () => {
     const item = makeItem<symbol>(Symbol.for('mock stack ID'));
     const group = Symbol('my mock group');
     const stackGroups = { [Symbol.for('mock stack ID')]: { stackedData: [group], items: [item] } };
-    const result = getStackedDataOfItem<symbol>(item, stackGroups);
+    const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(null);
   });
 });


### PR DESCRIPTION
## Description

I want to have props and state in generateCategoricalChart typed before I attempt the proof of concept

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Confidence

## How Has This Been Tested?

TS, Jest

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
