### PR TITLE
tooltip internal payload type

### DIFF
--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -13,45 +13,46 @@ function defaultFormatter<TValue extends ValueType>(value: TValue) {
 export type TooltipType = 'none';
 export type ValueType = number | string | Array<number | string>;
 export type NameType = number | string;
-export type Formatter<TValue extends ValueType, TName extends NameType> = (
+export type PayloadType = number | string | Array<number | string> | { [key: string]: any };
+export type Formatter<TValue extends ValueType, TName extends NameType, TPayload extends PayloadType> = (
   value: TValue,
   name: TName,
-  item: Payload<TValue, TName>,
+  item: Payload<TValue, TName, TPayload>,
   index: number,
-  payload: Array<Payload<TValue, TName>>,
+  payload: Array<Payload<TValue, TName, TPayload>>,
 ) => [React.ReactNode, TName] | React.ReactNode;
 
-export interface Payload<TValue extends ValueType, TName extends NameType> {
+export interface Payload<TValue extends ValueType, TName extends NameType, TPayload extends PayloadType> {
   type?: TooltipType;
   color?: string;
-  formatter?: Formatter<TValue, TName>;
+  formatter?: Formatter<TValue, TName, TPayload>;
   name?: TName;
   value?: TValue;
   unit?: ReactNode;
   dataKey?: string | number;
-  payload?: any;
+  payload?: TPayload;
   chartType?: string;
   stroke?: string;
   strokeDasharray?: string | number;
   strokeWidth?: number | string;
 }
 
-export interface Props<TValue extends ValueType, TName extends NameType> {
+export interface Props<TValue extends ValueType, TName extends NameType, TPayload extends PayloadType> {
   separator?: string;
   wrapperClassName?: string;
   labelClassName?: string;
-  formatter?: Formatter<TValue, TName>;
+  formatter?: Formatter<TValue, TName, TPayload>;
   contentStyle?: CSSProperties;
   itemStyle?: CSSProperties;
   labelStyle?: CSSProperties;
-  labelFormatter?: (label: any, payload: Array<Payload<TValue, TName>>) => ReactNode;
+  labelFormatter?: (label: any, payload: Array<Payload<TValue, TName, TPayload>>) => ReactNode;
   label?: any;
-  payload?: Array<Payload<TValue, TName>>;
-  itemSorter?: (item: Payload<TValue, TName>) => number | string;
+  payload?: Array<Payload<TValue, TName, TPayload>>;
+  itemSorter?: (item: Payload<TValue, TName, TPayload>) => number | string;
 }
 
-export const DefaultTooltipContent = <TValue extends ValueType, TName extends NameType>(
-  props: Props<TValue, TName>,
+export const DefaultTooltipContent = <TValue extends ValueType, TName extends NameType, TPayload extends PayloadType>(
+  props: Props<TValue, TName, TPayload>,
 ) => {
   const {
     separator = ' : ',

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -5,7 +5,14 @@ import React, { PureComponent, CSSProperties, ReactNode, ReactElement, SVGProps 
 import { translateStyle } from 'react-smooth';
 import _ from 'lodash';
 import classNames from 'classnames';
-import { DefaultTooltipContent, ValueType, NameType, Payload, Props as DefaultProps } from './DefaultTooltipContent';
+import {
+  DefaultTooltipContent,
+  ValueType,
+  NameType,
+  Payload,
+  Props as DefaultProps,
+  PayloadType,
+} from './DefaultTooltipContent';
 
 import { Global } from '../util/Global';
 import { isNumber } from '../util/DataUtils';
@@ -14,18 +21,24 @@ import { AnimationDuration, AnimationTiming } from '../util/types';
 const CLS_PREFIX = 'recharts-tooltip-wrapper';
 
 const EPS = 1;
-export type ContentType<TValue extends ValueType, TName extends NameType> =
+export type ContentType<TValue extends ValueType, TName extends NameType, TPayload extends PayloadType> =
   | ReactElement
-  | ((props: TooltipProps<TValue, TName>) => ReactNode);
+  | ((props: TooltipProps<TValue, TName, TPayload>) => ReactNode);
 
-type UniqueFunc<TValue extends ValueType, TName extends NameType> = (entry: Payload<TValue, TName>) => unknown;
-type UniqueOption<TValue extends ValueType, TName extends NameType> = boolean | UniqueFunc<TValue, TName>;
-function defaultUniqBy<TValue extends ValueType, TName extends NameType>(entry: Payload<TValue, TName>) {
+type UniqueFunc<TValue extends ValueType, TName extends NameType, TPayload extends PayloadType> = (
+  entry: Payload<TValue, TName, TPayload>,
+) => unknown;
+type UniqueOption<TValue extends ValueType, TName extends NameType, TPayload extends PayloadType> =
+  | boolean
+  | UniqueFunc<TValue, TName, TPayload>;
+function defaultUniqBy<TValue extends ValueType, TName extends NameType, TPayload extends PayloadType>(
+  entry: Payload<TValue, TName, TPayload>,
+) {
   return entry.dataKey;
 }
-function getUniqPayload<TValue extends ValueType, TName extends NameType>(
-  option: UniqueOption<TValue, TName>,
-  payload: Array<Payload<TValue, TName>>,
+function getUniqPayload<TValue extends ValueType, TName extends NameType, TPayload extends PayloadType>(
+  option: UniqueOption<TValue, TName, TPayload>,
+  payload: Array<Payload<TValue, TName, TPayload>>,
 ) {
   if (option === true) {
     return _.uniqBy(payload, defaultUniqBy);
@@ -38,9 +51,9 @@ function getUniqPayload<TValue extends ValueType, TName extends NameType>(
   return payload;
 }
 
-function renderContent<TValue extends ValueType, TName extends NameType>(
-  content: ContentType<TValue, TName>,
-  props: TooltipProps<TValue, TName>,
+function renderContent<TValue extends ValueType, TName extends NameType, TPayload extends PayloadType>(
+  content: ContentType<TValue, TName, TPayload>,
+  props: TooltipProps<TValue, TName, TPayload>,
 ) {
   if (React.isValidElement(content)) {
     return React.cloneElement(content, props);
@@ -52,7 +65,11 @@ function renderContent<TValue extends ValueType, TName extends NameType>(
   return <DefaultTooltipContent {...props} />;
 }
 
-export type TooltipProps<TValue extends ValueType, TName extends NameType> = DefaultProps<TValue, TName> & {
+export type TooltipProps<TValue extends ValueType, TName extends NameType, TPayload extends PayloadType> = DefaultProps<
+  TValue,
+  TName,
+  TPayload
+> & {
   allowEscapeViewBox?: {
     x?: boolean;
     y?: boolean;
@@ -61,7 +78,7 @@ export type TooltipProps<TValue extends ValueType, TName extends NameType> = Def
     x?: boolean;
     y?: boolean;
   };
-  content?: ContentType<TValue, TName>;
+  content?: ContentType<TValue, TName, TPayload>;
   viewBox?: {
     x?: number;
     y?: number;
@@ -82,7 +99,7 @@ export type TooltipProps<TValue extends ValueType, TName extends NameType> = Def
   };
   trigger?: 'hover' | 'click';
   shared?: boolean;
-  payloadUniqBy?: UniqueOption<TValue, TName>;
+  payloadUniqBy?: UniqueOption<TValue, TName, TPayload>;
   isAnimationActive?: boolean;
   animationDuration?: AnimationDuration;
   animationEasing?: AnimationTiming;
@@ -90,9 +107,11 @@ export type TooltipProps<TValue extends ValueType, TName extends NameType> = Def
   useTranslate3d?: boolean;
 };
 
-export class Tooltip<TValue extends ValueType, TName extends NameType> extends PureComponent<
-  TooltipProps<TValue, TName>
-> {
+export class Tooltip<
+  TValue extends ValueType,
+  TName extends NameType,
+  TPayload extends PayloadType,
+> extends PureComponent<TooltipProps<TValue, TName, TPayload>> {
   static displayName = 'Tooltip';
 
   static defaultProps = {


### PR DESCRIPTION
## Description

adding ```TPayload``` type to the Tooltip generic argument types

## Motivation and Context

I would like to replace the ```payload: any;``` type with ```payload: TPayload``` type in order to control and achieve better type safety additional data when using a Custom Tooltip
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
