### PR TITLE
Add stackGroups and zAxisMap to CategoricalChartState, fix types

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -859,6 +859,23 @@ export interface CategoricalChartProps {
   tabIndex?: number;
 }
 
+type AxisObj = {
+  xAxis?: BaseAxisProps;
+  xAxisTicks?: Array<TickItem>;
+
+  yAxis?: BaseAxisProps;
+  yAxisTicks?: Array<TickItem>;
+
+  zAxis?: BaseAxisProps;
+  zAxisTicks?: Array<TickItem>;
+
+  angleAxis?: BaseAxisProps;
+  angleAxisTicks?: Array<TickItem>;
+
+  radiusAxis?: BaseAxisProps;
+  radiusAxisTicks?: Array<TickItem>;
+};
+
 export const generateCategoricalChart = ({
   chartName,
   GraphicalChild,
@@ -884,23 +901,6 @@ export const generateCategoricalChart = ({
       const numericAxisId = item.props[`${numericAxisName}Id`];
       // axisId of the categorical axis
       const cateAxisId = item.props[`${cateAxisName}Id`];
-
-      type AxisObj = {
-        xAxis?: BaseAxisProps;
-        xAxisTicks?: Array<TickItem>;
-
-        yAxis?: BaseAxisProps;
-        yAxisTicks?: Array<TickItem>;
-
-        zAxis?: BaseAxisProps;
-        zAxisTicks?: Array<TickItem>;
-
-        angleAxis?: BaseAxisProps;
-        angleAxisTicks?: Array<TickItem>;
-
-        radiusAxis?: BaseAxisProps;
-        radiusAxisTicks?: Array<TickItem>;
-      };
 
       const axisObjInitialValue: AxisObj = {};
 

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -51,6 +51,7 @@ import {
   parseDomainOfCategoryAxis,
   getTooltipItem,
   BarPosition,
+  AxisStackGroups,
 } from '../util/ChartUtils';
 import { detectReferenceElementsDomain } from '../util/DetectReferenceElementsDomain';
 import { inRangeOfSector, polarToCartesian } from '../util/PolarUtils';
@@ -151,7 +152,11 @@ const getActiveCoordinate = (
 
 const getDisplayedData = (
   data: any[],
-  { graphicalItems, dataStartIndex, dataEndIndex }: CategoricalChartState,
+  {
+    graphicalItems,
+    dataStartIndex,
+    dataEndIndex,
+  }: Pick<CategoricalChartState, 'graphicalItems' | 'dataStartIndex' | 'dataEndIndex'>,
   item?: ReactElement,
 ): any[] => {
   const itemsData = (graphicalItems || []).reduce((result, child) => {
@@ -293,7 +298,7 @@ export const getAxisMapByAxes = (
     graphicalItems: ReadonlyArray<ReactElement>;
     axisType: AxisType;
     axisIdKey: string;
-    stackGroups: any;
+    stackGroups: AxisStackGroups;
     dataStartIndex: number;
     dataEndIndex: number;
   },
@@ -465,7 +470,23 @@ export const getAxisMapByAxes = (
  */
 const getAxisMapByItems = (
   props: CategoricalChartProps,
-  { graphicalItems, Axis, axisType, axisIdKey, stackGroups, dataStartIndex, dataEndIndex }: any,
+  {
+    graphicalItems,
+    Axis,
+    axisType,
+    axisIdKey,
+    stackGroups,
+    dataStartIndex,
+    dataEndIndex,
+  }: {
+    axisIdKey: string;
+    axisType?: AxisType;
+    Axis?: React.ComponentType<BaseAxisProps>;
+    graphicalItems: ReadonlyArray<ReactElement>;
+    stackGroups: AxisStackGroups;
+    dataStartIndex: number;
+    dataEndIndex: number;
+  },
 ): AxisMap => {
   const { layout, children } = props;
   const displayedData = getDisplayedData(props.data, {
@@ -555,7 +576,7 @@ const getAxisMap = (
     axisType?: AxisType;
     AxisComp?: React.ComponentType;
     graphicalItems: ReadonlyArray<ReactElement>;
-    stackGroups: any;
+    stackGroups: AxisStackGroups;
     dataStartIndex: number;
     dataEndIndex: number;
   },
@@ -745,6 +766,8 @@ export interface CategoricalChartState {
 
   yAxisMap?: AxisMap;
 
+  zAxisMap?: AxisMap;
+
   orderedTooltipTicks?: any;
 
   tooltipAxis?: BaseAxisProps;
@@ -789,6 +812,8 @@ export interface CategoricalChartState {
   prevStackOffset?: StackOffsetType;
   prevMargin?: Margin;
   prevChildren?: any;
+
+  stackGroups?: AxisStackGroups;
 }
 
 export type CategoricalChartFunc = (nextState: CategoricalChartState, event: any) => void;
@@ -844,7 +869,7 @@ export const generateCategoricalChart = ({
   formatAxisMap,
   defaultProps,
 }: CategoricalChartOptions) => {
-  const getFormatItems = (props: CategoricalChartProps, currentState: any): any[] => {
+  const getFormatItems = (props: CategoricalChartProps, currentState: CategoricalChartState): any[] => {
     const { graphicalItems, stackGroups, offset, updateId, dataStartIndex, dataEndIndex } = currentState;
     const { barSize, layout, barGap, barCategoryGap, maxBarSize: globalMaxBarSize } = props;
     const { numericAxisName, cateAxisName } = getAxisNameByLayout(layout);
@@ -859,11 +884,31 @@ export const generateCategoricalChart = ({
       const numericAxisId = item.props[`${numericAxisName}Id`];
       // axisId of the categorical axis
       const cateAxisId = item.props[`${cateAxisName}Id`];
-      const axisObj = axisComponents.reduce((result: any, entry: BaseAxisProps) => {
+
+      type AxisObj = {
+        xAxis?: BaseAxisProps;
+        xAxisTicks?: Array<TickItem>;
+
+        yAxis?: BaseAxisProps;
+        yAxisTicks?: Array<TickItem>;
+
+        zAxis?: BaseAxisProps;
+        zAxisTicks?: Array<TickItem>;
+
+        angleAxis?: BaseAxisProps;
+        angleAxisTicks?: Array<TickItem>;
+
+        radiusAxis?: BaseAxisProps;
+        radiusAxisTicks?: Array<TickItem>;
+      };
+
+      const axisObjInitialValue: AxisObj = {};
+
+      const axisObj: AxisObj = axisComponents.reduce((result: AxisObj, entry: BaseAxisProps): AxisObj => {
         // map of axisId to axis for a specific axis type
-        const axisMap: AxisMap | undefined = currentState[`${entry.axisType}Map`];
+        const axisMap: AxisMap | undefined = currentState[`${entry.axisType}Map` as const];
         // axisId of axis we are currently computing
-        const id = item.props[`${entry.axisType}Id`];
+        const id: string = item.props[`${entry.axisType}Id`];
 
         /**
          * tell the user in dev mode that their configuration is incorrect if we cannot find a match between
@@ -886,9 +931,9 @@ export const generateCategoricalChart = ({
           [entry.axisType]: axis,
           [`${entry.axisType}Ticks`]: getTicksOfAxis(axis),
         };
-      }, {});
+      }, axisObjInitialValue);
       const cateAxis = axisObj[cateAxisName];
-      const cateTicks = axisObj[`${cateAxisName}Ticks`];
+      const cateTicks = axisObj[`${cateAxisName}Ticks` as const];
       const stackedData =
         stackGroups &&
         stackGroups[numericAxisId] &&
@@ -976,7 +1021,7 @@ export const generateCategoricalChart = ({
     const { children, layout, stackOffset, data, reverseStackOrder } = props;
     const { numericAxisName, cateAxisName } = getAxisNameByLayout(layout);
     const graphicalItems = findAllByType(children, GraphicalChild);
-    const stackGroups = getStackGroupsByAxisId(
+    const stackGroups: AxisStackGroups = getStackGroupsByAxisId(
       data,
       graphicalItems,
       `${numericAxisName}Id`,

--- a/test/chart/generateCategoricalChart.test.ts
+++ b/test/chart/generateCategoricalChart.test.ts
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 import { getAxisMapByAxes, CategoricalChartProps } from '../../src/chart/generateCategoricalChart';
+import { AxisStackGroups } from '../../src/util/ChartUtils';
 
 const data = [
   {
@@ -41,7 +42,7 @@ const data = [
 ];
 
 describe('generateCategoricalChart', () => {
-  const graphicalItems: ReadonlyArray<ReactElement> = [
+  const graphicalItems: Array<ReactElement> = [
     // @ts-expect-error this isn't a proper ReactElement
     {
       props: {
@@ -120,9 +121,18 @@ describe('generateCategoricalChart', () => {
       height: 500,
     };
 
-    const stackGroups = [
-      { hasStack: false, stackGroups: { _stackId_49: { cateAxisId: 'xAxisId', items: graphicalItems } } },
-    ];
+    const stackGroups: AxisStackGroups = {
+      '0': {
+        hasStack: false,
+        stackGroups: {
+          _stackId_49: {
+            cateAxisId: 'xAxisId',
+            items: graphicalItems,
+            numericAxisId: '',
+          },
+        },
+      },
+    };
 
     const input = {
       axes: xAxes,

--- a/test/util/ChartUtils/getStackedDataOfItem.spec.ts
+++ b/test/util/ChartUtils/getStackedDataOfItem.spec.ts
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react';
-import { getStackedDataOfItem } from '../../../src/util/ChartUtils';
+import { GenericChildStackGroup, StackId, getStackedDataOfItem } from '../../../src/util/ChartUtils';
 
 function makeItem<T>(stackId: T): ReactElement {
   // @ts-expect-error incomplete mock of ReactElement
@@ -23,8 +23,15 @@ describe('getStackedDataOfItem', () => {
 
   it('should return undefined if stack group is undefined', () => {
     const item = makeItem<string>('a');
-    const stackedData: Array<unknown> = [];
-    const stackGroups = { a: { stackedData, items: [item] } };
+    const stackedData: Array<string> = [];
+    const stackGroups: Record<StackId, GenericChildStackGroup<string>> = {
+      a: {
+        stackedData,
+        items: [item],
+        numericAxisId: '',
+        cateAxisId: '',
+      },
+    };
     const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(undefined);
   });
@@ -32,8 +39,15 @@ describe('getStackedDataOfItem', () => {
   it('should return null if stack group has empty items', () => {
     const item = makeItem<string>('a');
     const group = Symbol('my mock group');
-    const items: Array<typeof item> = [];
-    const stackGroups = { a: { stackedData: [group], items } };
+    const items: Array<ReactElement> = [];
+    const stackGroups: Record<StackId, GenericChildStackGroup<typeof group>> = {
+      a: {
+        stackedData: [group],
+        items,
+        numericAxisId: '',
+        cateAxisId: '',
+      },
+    };
     const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(null);
   });
@@ -42,7 +56,14 @@ describe('getStackedDataOfItem', () => {
     const item1 = makeItem<string>('a');
     const item2 = makeItem<string>('a');
     const group = Symbol('my mock group');
-    const stackGroups = { a: { stackedData: [group], items: [item1] } };
+    const stackGroups: Record<StackId, GenericChildStackGroup<typeof group>> = {
+      a: {
+        stackedData: [group],
+        items: [item1],
+        numericAxisId: '',
+        cateAxisId: '',
+      },
+    };
     const result = getStackedDataOfItem(item2, stackGroups);
     expect(result).toBe(null);
   });
@@ -50,7 +71,14 @@ describe('getStackedDataOfItem', () => {
   it('should return stackedData if stack group contains the item matched by string', () => {
     const item = makeItem<string>('a');
     const group = Symbol('my mock group');
-    const stackGroups = { a: { stackedData: [group], items: [item] } };
+    const stackGroups: Record<StackId, GenericChildStackGroup<typeof group>> = {
+      a: {
+        stackedData: [group],
+        items: [item],
+        numericAxisId: '',
+        cateAxisId: '',
+      },
+    };
     const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(group);
   });
@@ -58,7 +86,9 @@ describe('getStackedDataOfItem', () => {
   it('should return stackedData if stack group contains the item matched by number', () => {
     const item = makeItem<number>(7);
     const group = Symbol('my mock group');
-    const stackGroups = { 7: { stackedData: [group], items: [item] } };
+    const stackGroups: Record<StackId, GenericChildStackGroup<typeof group>> = {
+      7: { stackedData: [group], items: [item], numericAxisId: '', cateAxisId: '' },
+    };
     const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(group);
   });
@@ -66,7 +96,9 @@ describe('getStackedDataOfItem', () => {
   it('should return null if stack group contains the item matched by symbol', () => {
     const item = makeItem<symbol>(Symbol.for('mock stack ID'));
     const group = Symbol('my mock group');
-    const stackGroups = { [Symbol.for('mock stack ID')]: { stackedData: [group], items: [item] } };
+    const stackGroups: Record<StackId, GenericChildStackGroup<typeof group>> = {
+      [Symbol.for('mock stack ID')]: { stackedData: [group], items: [item], cateAxisId: '', numericAxisId: '' },
+    };
     const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(null);
   });

--- a/test/util/ChartUtils/getStackedDataOfItem.spec.ts
+++ b/test/util/ChartUtils/getStackedDataOfItem.spec.ts
@@ -8,6 +8,21 @@ function makeItem<T>(stackId: T): ReactElement {
   };
 }
 
+function createStackGroups<T>(
+  key: PropertyKey,
+  stackedData: ReadonlyArray<T>,
+  items: Array<ReactElement>,
+): Record<StackId, GenericChildStackGroup<T>> {
+  return {
+    [key]: {
+      stackedData,
+      items,
+      numericAxisId: '',
+      cateAxisId: '',
+    },
+  };
+}
+
 describe('getStackedDataOfItem', () => {
   it('should return null if stackId is undefined', () => {
     // @ts-expect-error incomplete mock of ReactElement
@@ -24,14 +39,7 @@ describe('getStackedDataOfItem', () => {
   it('should return undefined if stack group is undefined', () => {
     const item = makeItem<string>('a');
     const stackedData: Array<string> = [];
-    const stackGroups: Record<StackId, GenericChildStackGroup<string>> = {
-      a: {
-        stackedData,
-        items: [item],
-        numericAxisId: '',
-        cateAxisId: '',
-      },
-    };
+    const stackGroups = createStackGroups('a', stackedData, [item]);
     const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(undefined);
   });
@@ -40,14 +48,7 @@ describe('getStackedDataOfItem', () => {
     const item = makeItem<string>('a');
     const group = Symbol('my mock group');
     const items: Array<ReactElement> = [];
-    const stackGroups: Record<StackId, GenericChildStackGroup<typeof group>> = {
-      a: {
-        stackedData: [group],
-        items,
-        numericAxisId: '',
-        cateAxisId: '',
-      },
-    };
+    const stackGroups = createStackGroups('a', [group], items);
     const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(null);
   });
@@ -56,14 +57,7 @@ describe('getStackedDataOfItem', () => {
     const item1 = makeItem<string>('a');
     const item2 = makeItem<string>('a');
     const group = Symbol('my mock group');
-    const stackGroups: Record<StackId, GenericChildStackGroup<typeof group>> = {
-      a: {
-        stackedData: [group],
-        items: [item1],
-        numericAxisId: '',
-        cateAxisId: '',
-      },
-    };
+    const stackGroups = createStackGroups('a', [group], [item1]);
     const result = getStackedDataOfItem(item2, stackGroups);
     expect(result).toBe(null);
   });
@@ -71,14 +65,7 @@ describe('getStackedDataOfItem', () => {
   it('should return stackedData if stack group contains the item matched by string', () => {
     const item = makeItem<string>('a');
     const group = Symbol('my mock group');
-    const stackGroups: Record<StackId, GenericChildStackGroup<typeof group>> = {
-      a: {
-        stackedData: [group],
-        items: [item],
-        numericAxisId: '',
-        cateAxisId: '',
-      },
-    };
+    const stackGroups = createStackGroups('a', [group], [item]);
     const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(group);
   });
@@ -86,9 +73,7 @@ describe('getStackedDataOfItem', () => {
   it('should return stackedData if stack group contains the item matched by number', () => {
     const item = makeItem<number>(7);
     const group = Symbol('my mock group');
-    const stackGroups: Record<StackId, GenericChildStackGroup<typeof group>> = {
-      7: { stackedData: [group], items: [item], numericAxisId: '', cateAxisId: '' },
-    };
+    const stackGroups = createStackGroups(7, [group], [item]);
     const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(group);
   });
@@ -96,9 +81,7 @@ describe('getStackedDataOfItem', () => {
   it('should return null if stack group contains the item matched by symbol', () => {
     const item = makeItem<symbol>(Symbol.for('mock stack ID'));
     const group = Symbol('my mock group');
-    const stackGroups: Record<StackId, GenericChildStackGroup<typeof group>> = {
-      [Symbol.for('mock stack ID')]: { stackedData: [group], items: [item], cateAxisId: '', numericAxisId: '' },
-    };
+    const stackGroups = createStackGroups(Symbol.for('mock stack ID'), [group], [item]);
     const result = getStackedDataOfItem(item, stackGroups);
     expect(result).toBe(null);
   });

--- a/test/util/DataUtils.spec.ts
+++ b/test/util/DataUtils.spec.ts
@@ -72,6 +72,15 @@ describe('is functions', () => {
         expect(isNumber(value)).toBe(result);
       });
     });
+
+    it('should allow type refinement', () => {
+      const arr: unknown[] = ['a', 1, false, NaN];
+      // @ts-expect-error typescript should highlight this - invalid assignment
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const invalid: number[] = arr;
+      const result: number[] = arr.filter(isNumber);
+      expect(result).toEqual([1]);
+    });
   });
 
   describe('isNumOrStr', () => {


### PR DESCRIPTION
## Description

Types!

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

One less `any`

## How Has This Been Tested?

TS, Jest

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
