### PR TITLE
Adding types to renderCursor

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -2,6 +2,7 @@ import React, { Component, cloneElement, isValidElement, createElement, ReactEle
 import classNames from 'classnames';
 import _, { isArray, isBoolean } from 'lodash';
 import invariant from 'tiny-invariant';
+import { getRadialCursorPoints } from '../util/cursor/getRadialCursorPoints';
 import { getTicks } from '../cartesian/getTicks';
 import { Surface } from '../container/Surface';
 import { Layer } from '../container/Layer';
@@ -1303,7 +1304,7 @@ export const generateCategoricalChart = ({
       return null;
     }
 
-    getCursorRectangle(): any {
+    getCursorRectangle() {
       const { layout } = this.props;
       const { activeCoordinate, offset, tooltipAxisBandSize } = this.state;
       const halfSize = tooltipAxisBandSize / 2;
@@ -1318,7 +1319,7 @@ export const generateCategoricalChart = ({
       };
     }
 
-    getCursorPoints(): any {
+    getCursorPoints() {
       const { layout } = this.props;
       const { activeCoordinate, offset } = this.state;
       let x1, y1, x2, y2;
@@ -1343,18 +1344,7 @@ export const generateCategoricalChart = ({
           x2 = outerPoint.x;
           y2 = outerPoint.y;
         } else {
-          const { cx, cy, radius, startAngle, endAngle } = activeCoordinate;
-          const startPoint = polarToCartesian(cx, cy, radius, startAngle);
-          const endPoint = polarToCartesian(cx, cy, radius, endAngle);
-
-          return {
-            points: [startPoint, endPoint],
-            cx,
-            cy,
-            radius,
-            startAngle,
-            endAngle,
-          };
+          return getRadialCursorPoints(activeCoordinate);
         }
       }
 
@@ -1778,7 +1768,7 @@ export const generateCategoricalChart = ({
       return null;
     }
 
-    renderCursor = (element: any) => {
+    renderCursor = (element: ReactElement) => {
       const { isTooltipActive, activeCoordinate, activePayload, offset, activeTooltipIndex } = this.state;
       const tooltipEventType = this.getTooltipEventType();
 
@@ -1793,7 +1783,7 @@ export const generateCategoricalChart = ({
       }
       const { layout } = this.props;
       let restProps;
-      let cursorComp: any = Curve;
+      let cursorComp: React.ComponentType<any> = Curve;
 
       if (chartName === 'ScatterChart') {
         restProps = activeCoordinate;
@@ -1802,7 +1792,7 @@ export const generateCategoricalChart = ({
         restProps = this.getCursorRectangle();
         cursorComp = Rectangle;
       } else if (layout === 'radial') {
-        const { cx, cy, radius, startAngle, endAngle }: any = this.getCursorPoints();
+        const { cx, cy, radius, startAngle, endAngle } = getRadialCursorPoints(activeCoordinate);
         restProps = {
           cx,
           cy,

--- a/src/util/cursor/getRadialCursorPoints.ts
+++ b/src/util/cursor/getRadialCursorPoints.ts
@@ -1,0 +1,31 @@
+import { polarToCartesian } from '../PolarUtils';
+import { ChartCoordinate, Coordinate } from '../types';
+
+export type RadialCursorPoints = {
+  points: [startPoint: Coordinate, endPoint: Coordinate];
+  cx?: number;
+  cy?: number;
+  radius?: number;
+  startAngle?: number;
+  endAngle?: number;
+};
+
+/**
+ * Only applicable for radial layouts
+ * @param {Object} activeCoordinate ChartCoordinate
+ * @returns {Object} RadialCursorPoints
+ */
+export function getRadialCursorPoints(activeCoordinate: ChartCoordinate): RadialCursorPoints {
+  const { cx, cy, radius, startAngle, endAngle } = activeCoordinate;
+  const startPoint = polarToCartesian(cx, cy, radius, startAngle);
+  const endPoint = polarToCartesian(cx, cy, radius, endAngle);
+
+  return {
+    points: [startPoint, endPoint],
+    cx,
+    cy,
+    radius,
+    startAngle,
+    endAngle,
+  };
+}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1266,11 +1266,13 @@ export const adaptEventsOfChild = (
   return out;
 };
 
+export type TooltipEventType = 'axis' | 'item';
+
 export interface CategoricalChartOptions {
   chartName?: string;
   GraphicalChild?: any;
-  defaultTooltipEventType?: string;
-  validateTooltipEventTypes?: string[];
+  defaultTooltipEventType?: TooltipEventType;
+  validateTooltipEventTypes?: ReadonlyArray<TooltipEventType>;
   axisComponents?: BaseAxisProps[];
   legendContent?: 'children';
   formatAxisMap?: any;

--- a/test/util/cursor/getRadialCursorPoints.spec.ts
+++ b/test/util/cursor/getRadialCursorPoints.spec.ts
@@ -1,0 +1,49 @@
+import { RadialCursorPoints, getRadialCursorPoints } from '../../../src/util/cursor/getRadialCursorPoints';
+import { ChartCoordinate } from '../../../src/util/types';
+
+describe('getRadialCursorPoints', () => {
+  it('should return undefineds and NaNs when passed trivial ChartCoordinate', () => {
+    const activeCoordinate: ChartCoordinate = {
+      x: 0,
+      y: 0,
+    };
+    const result = getRadialCursorPoints(activeCoordinate);
+    const expected: RadialCursorPoints = {
+      points: [
+        { x: NaN, y: NaN },
+        { x: NaN, y: NaN },
+      ],
+      cx: undefined,
+      cy: undefined,
+      radius: undefined,
+      startAngle: undefined,
+      endAngle: undefined,
+    };
+    expect(result).toEqual(expected);
+  });
+
+  it('should add cartesian startPoint and endPoint to activeCoordinate', () => {
+    const activeCoordinate: ChartCoordinate = {
+      x: 0,
+      y: 0,
+      cx: 10,
+      cy: 15,
+      radius: 5,
+      startAngle: 30,
+      endAngle: 60,
+    };
+    const result = getRadialCursorPoints(activeCoordinate);
+    const expected: RadialCursorPoints = {
+      points: [
+        { x: 14.330127018922195, y: 12.5 },
+        { x: 12.5, y: 10.669872981077807 },
+      ],
+      cx: 10,
+      cy: 15,
+      radius: 5,
+      startAngle: 30,
+      endAngle: 60,
+    };
+    expect(result).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Bonus: extracted getRadialCursorPoints function so that I can have it typed differently from the rest: it returns different object. And added unit test.

## Description

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

I think I can now make sense of the Tooltip rendering and proceed with https://github.com/recharts/recharts/issues/3823

## How Has This Been Tested?

TS, Jest

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
