### PR TITLE
Move getCursorPoints and getCursorRectangle to their own files

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -78,6 +78,7 @@ import { deferer, CancelFunction } from '../util/deferer';
 import { getActiveShapeIndexForTooltip, isFunnel, isPie, isScatter } from '../util/ActiveShapeUtils';
 import { Props as YAxisProps } from '../cartesian/YAxis';
 import { Props as XAxisProps } from '../cartesian/XAxis';
+import { getCursorPoints } from '../util/cursor/getCursorPoints';
 
 export type GraphicalItem<Props = Record<string, any>> = ReactElement<
   Props,
@@ -1332,41 +1333,6 @@ export const generateCategoricalChart = ({
       };
     }
 
-    getCursorPoints() {
-      const { layout } = this.props;
-      const { activeCoordinate, offset } = this.state;
-      let x1, y1, x2, y2;
-
-      if (layout === 'horizontal') {
-        x1 = activeCoordinate.x;
-        x2 = x1;
-        y1 = offset.top;
-        y2 = offset.top + offset.height;
-      } else if (layout === 'vertical') {
-        y1 = activeCoordinate.y;
-        y2 = y1;
-        x1 = offset.left;
-        x2 = offset.left + offset.width;
-      } else if (!_.isNil(activeCoordinate.cx) || !_.isNil(activeCoordinate.cy)) {
-        if (layout === 'centric') {
-          const { cx, cy, innerRadius, outerRadius, angle } = activeCoordinate;
-          const innerPoint = polarToCartesian(cx, cy, innerRadius, angle);
-          const outerPoint = polarToCartesian(cx, cy, outerRadius, angle);
-          x1 = innerPoint.x;
-          y1 = innerPoint.y;
-          x2 = outerPoint.x;
-          y2 = outerPoint.y;
-        } else {
-          return getRadialCursorPoints(activeCoordinate);
-        }
-      }
-
-      return [
-        { x: x1, y: y1 },
-        { x: x2, y: y2 },
-      ];
-    }
-
     inRange(x: number, y: number, scale = 1): any {
       const { layout } = this.props;
 
@@ -1816,7 +1782,7 @@ export const generateCategoricalChart = ({
         };
         cursorComp = Sector;
       } else {
-        restProps = { points: this.getCursorPoints() };
+        restProps = { points: getCursorPoints(layout, activeCoordinate, offset) };
         cursorComp = Curve;
       }
       const key = element.key || '_recharts-cursor';

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -79,6 +79,7 @@ import { getActiveShapeIndexForTooltip, isFunnel, isPie, isScatter } from '../ut
 import { Props as YAxisProps } from '../cartesian/YAxis';
 import { Props as XAxisProps } from '../cartesian/XAxis';
 import { getCursorPoints } from '../util/cursor/getCursorPoints';
+import { getCursorRectangle } from '../util/cursor/getCursorRectangle';
 
 export type GraphicalItem<Props = Record<string, any>> = ReactElement<
   Props,
@@ -1318,21 +1319,6 @@ export const generateCategoricalChart = ({
       return null;
     }
 
-    getCursorRectangle() {
-      const { layout } = this.props;
-      const { activeCoordinate, offset, tooltipAxisBandSize } = this.state;
-      const halfSize = tooltipAxisBandSize / 2;
-
-      return {
-        stroke: 'none',
-        fill: '#ccc',
-        x: layout === 'horizontal' ? activeCoordinate.x - halfSize : offset.left + 0.5,
-        y: layout === 'horizontal' ? offset.top + 0.5 : activeCoordinate.y - halfSize,
-        width: layout === 'horizontal' ? tooltipAxisBandSize : offset.width - 1,
-        height: layout === 'horizontal' ? offset.height - 1 : tooltipAxisBandSize,
-      };
-    }
-
     inRange(x: number, y: number, scale = 1): any {
       const { layout } = this.props;
 
@@ -1748,7 +1734,8 @@ export const generateCategoricalChart = ({
     }
 
     renderCursor = (element: ReactElement) => {
-      const { isTooltipActive, activeCoordinate, activePayload, offset, activeTooltipIndex } = this.state;
+      const { isTooltipActive, activeCoordinate, activePayload, offset, activeTooltipIndex, tooltipAxisBandSize } =
+        this.state;
       const tooltipEventType = this.getTooltipEventType();
 
       if (
@@ -1768,7 +1755,7 @@ export const generateCategoricalChart = ({
         restProps = activeCoordinate;
         cursorComp = Cross;
       } else if (chartName === 'BarChart') {
-        restProps = this.getCursorRectangle();
+        restProps = getCursorRectangle(layout, activeCoordinate, offset, tooltipAxisBandSize);
         cursorComp = Rectangle;
       } else if (layout === 'radial') {
         const { cx, cy, radius, startAngle, endAngle } = getRadialCursorPoints(activeCoordinate);

--- a/src/util/cursor/getCursorPoints.ts
+++ b/src/util/cursor/getCursorPoints.ts
@@ -1,0 +1,41 @@
+import _ from 'lodash';
+import { polarToCartesian } from '../PolarUtils';
+import { ChartCoordinate, Coordinate, ChartOffset, LayoutType } from '../types';
+import { RadialCursorPoints, getRadialCursorPoints } from './getRadialCursorPoints';
+
+export function getCursorPoints(
+  layout: LayoutType,
+  activeCoordinate: ChartCoordinate,
+  offset: ChartOffset,
+): [Coordinate, Coordinate] | RadialCursorPoints {
+  let x1, y1, x2, y2;
+
+  if (layout === 'horizontal') {
+    x1 = activeCoordinate.x;
+    x2 = x1;
+    y1 = offset.top;
+    y2 = offset.top + offset.height;
+  } else if (layout === 'vertical') {
+    y1 = activeCoordinate.y;
+    y2 = y1;
+    x1 = offset.left;
+    x2 = offset.left + offset.width;
+  } else if (!_.isNil(activeCoordinate.cx) || !_.isNil(activeCoordinate.cy)) {
+    if (layout === 'centric') {
+      const { cx, cy, innerRadius, outerRadius, angle } = activeCoordinate;
+      const innerPoint = polarToCartesian(cx, cy, innerRadius, angle);
+      const outerPoint = polarToCartesian(cx, cy, outerRadius, angle);
+      x1 = innerPoint.x;
+      y1 = innerPoint.y;
+      x2 = outerPoint.x;
+      y2 = outerPoint.y;
+    } else {
+      return getRadialCursorPoints(activeCoordinate);
+    }
+  }
+
+  return [
+    { x: x1, y: y1 },
+    { x: x2, y: y2 },
+  ];
+}

--- a/src/util/cursor/getCursorPoints.ts
+++ b/src/util/cursor/getCursorPoints.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { polarToCartesian } from '../PolarUtils';
 import { ChartCoordinate, Coordinate, ChartOffset, LayoutType } from '../types';
 import { RadialCursorPoints, getRadialCursorPoints } from './getRadialCursorPoints';
@@ -20,7 +19,7 @@ export function getCursorPoints(
     y2 = y1;
     x1 = offset.left;
     x2 = offset.left + offset.width;
-  } else if (!_.isNil(activeCoordinate.cx) || !_.isNil(activeCoordinate.cy)) {
+  } else if (activeCoordinate.cx != null && activeCoordinate.cy != null) {
     if (layout === 'centric') {
       const { cx, cy, innerRadius, outerRadius, angle } = activeCoordinate;
       const innerPoint = polarToCartesian(cx, cy, innerRadius, angle);

--- a/src/util/cursor/getCursorRectangle.ts
+++ b/src/util/cursor/getCursorRectangle.ts
@@ -1,0 +1,28 @@
+import { ChartCoordinate, ChartOffset, LayoutType } from '../types';
+
+export type CursorRectangle = {
+  stroke: string;
+  fill: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export function getCursorRectangle(
+  layout: LayoutType,
+  activeCoordinate: ChartCoordinate,
+  offset: ChartOffset,
+  tooltipAxisBandSize: number,
+): CursorRectangle {
+  const halfSize = tooltipAxisBandSize / 2;
+
+  return {
+    stroke: 'none',
+    fill: '#ccc',
+    x: layout === 'horizontal' ? activeCoordinate.x - halfSize : offset.left + 0.5,
+    y: layout === 'horizontal' ? offset.top + 0.5 : activeCoordinate.y - halfSize,
+    width: layout === 'horizontal' ? tooltipAxisBandSize : offset.width - 1,
+    height: layout === 'horizontal' ? offset.height - 1 : tooltipAxisBandSize,
+  };
+}

--- a/test/util/cursor/getCursorPoints.spec.ts
+++ b/test/util/cursor/getCursorPoints.spec.ts
@@ -1,0 +1,169 @@
+import { RADIAN } from '../../../src/util/PolarUtils';
+import { getCursorPoints } from '../../../src/util/cursor/getCursorPoints';
+import { ChartCoordinate, ChartOffset, Coordinate } from '../../../src/util/types';
+import { getRadialCursorPoints } from '../../../src/util/cursor/getRadialCursorPoints';
+
+jest.mock('../../../src/util/cursor/getRadialCursorPoints');
+
+const spy = jest.mocked(getRadialCursorPoints);
+
+describe('getCursorPoints', () => {
+  describe('horizontal layout', () => {
+    it('should return coordinates based on X dimension', () => {
+      const activeCoordinate: ChartCoordinate = {
+        x: 18,
+        y: 0,
+      };
+      const offset: ChartOffset = {
+        top: 12,
+        height: 10,
+      };
+      const result = getCursorPoints('horizontal', activeCoordinate, offset);
+      const expected: [Coordinate, Coordinate] = [
+        {
+          x: 18,
+          y: 12,
+        },
+        {
+          x: 18,
+          y: 22,
+        },
+      ];
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('vertical layout', () => {
+    it('should return coordinates based on Y dimension', () => {
+      const activeCoordinate: ChartCoordinate = {
+        x: 18,
+        y: 99,
+      };
+      const offset: ChartOffset = {
+        left: 42,
+        width: 60,
+      };
+      const result = getCursorPoints('vertical', activeCoordinate, offset);
+      const expected: [Coordinate, Coordinate] = [
+        {
+          x: 42,
+          y: 99,
+        },
+        {
+          x: 102,
+          y: 99,
+        },
+      ];
+      expect(result).toEqual(expected);
+    });
+  });
+  describe('centric layout', () => {
+    it('should return undefineds if cx or cy is not defined', () => {
+      const activeCoordinate: ChartCoordinate = {
+        x: 1,
+        y: 1,
+      };
+      const offset: ChartOffset = {};
+      const result = getCursorPoints('centric', activeCoordinate, offset);
+      const expected: object[] = [
+        {
+          x: undefined,
+          y: undefined,
+        },
+        {
+          x: undefined,
+          y: undefined,
+        },
+      ];
+      expect(result).toEqual(expected);
+    });
+    it('should return cartesian coordinates', () => {
+      const activeCoordinate: ChartCoordinate = {
+        cx: 18,
+        cy: 99,
+        innerRadius: 7,
+        outerRadius: 9,
+        angle: RADIAN / 4,
+        x: 0,
+        y: 0,
+      };
+      const offset: ChartOffset = {};
+      const result = getCursorPoints('centric', activeCoordinate, offset);
+      const expected: [Coordinate, Coordinate] = [
+        {
+          x: 24.999999979701798,
+          y: 98.99946691951588,
+        },
+        {
+          x: 26.999999973902312,
+          y: 98.99931461080614,
+        },
+      ];
+      expect(result).toEqual(expected);
+    });
+    it('should ignore offset', () => {
+      const activeCoordinate: ChartCoordinate = {
+        cx: 18,
+        cy: 99,
+        innerRadius: 7,
+        outerRadius: 9,
+        angle: RADIAN / 4,
+        x: 0,
+        y: 0,
+      };
+      const emptyOffset: ChartOffset = {};
+      const fullOffset: ChartOffset = {
+        bottom: 87,
+        brushBottom: 23,
+        height: 35,
+        left: 1,
+        right: 9,
+        top: 43,
+        width: 4573,
+      };
+      const resultWithoutOffset = getCursorPoints('centric', activeCoordinate, emptyOffset);
+      const resultWithOffset = getCursorPoints('centric', activeCoordinate, fullOffset);
+
+      expect(resultWithoutOffset).toEqual(resultWithOffset);
+    });
+  });
+  describe('radial layout', () => {
+    it('should return undefineds if cx or cy is not defined', () => {
+      const activeCoordinate: ChartCoordinate = {
+        x: 1,
+        y: 1,
+      };
+      const offset: ChartOffset = {};
+      const result = getCursorPoints('radial', activeCoordinate, offset);
+      const expected: object[] = [
+        {
+          x: undefined,
+          y: undefined,
+        },
+        {
+          x: undefined,
+          y: undefined,
+        },
+      ];
+      expect(result).toEqual(expected);
+    });
+    it('should call getRadialCursorPoints', () => {
+      const activeCoordinate: ChartCoordinate = {
+        cx: 18,
+        cy: 99,
+        innerRadius: 7,
+        outerRadius: 9,
+        angle: RADIAN / 4,
+        x: 0,
+        y: 0,
+      };
+      const offset: ChartOffset = {
+        left: 42,
+        width: 60,
+      };
+      getCursorPoints('radial', activeCoordinate, offset);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(activeCoordinate);
+    });
+  });
+});

--- a/test/util/cursor/getCursorRectangle.spec.ts
+++ b/test/util/cursor/getCursorRectangle.spec.ts
@@ -1,0 +1,48 @@
+import { CursorRectangle, getCursorRectangle } from '../../../src/util/cursor/getCursorRectangle';
+import { ChartCoordinate, ChartOffset, LayoutType } from '../../../src/util/types';
+
+const activeCoordinate: ChartCoordinate = {
+  x: 100,
+  y: 170,
+};
+const offset: ChartOffset = {
+  left: 10,
+  top: 80,
+  width: 13,
+  height: 17,
+};
+const tooltipAxisBandSize = 256;
+
+describe('getCursorRectangle', () => {
+  describe('horizontal layout', () => {
+    it('should return rectangle props', () => {
+      const layout = 'horizontal';
+      const result = getCursorRectangle(layout, activeCoordinate, offset, tooltipAxisBandSize);
+      const expected: CursorRectangle = {
+        stroke: 'none',
+        fill: '#ccc',
+        x: -28,
+        y: 80.5,
+        width: 256,
+        height: 16,
+      };
+      expect(result).toEqual(expected);
+    });
+  });
+
+  const otherLayouts: ReadonlyArray<LayoutType> = ['vertical', 'centric', 'radial'];
+  describe.each(otherLayouts)('%s layout', (layout: LayoutType) => {
+    it('should return rectangle props', () => {
+      const result = getCursorRectangle(layout, activeCoordinate, offset, tooltipAxisBandSize);
+      const expected: CursorRectangle = {
+        stroke: 'none',
+        fill: '#ccc',
+        x: 10.5,
+        y: 42,
+        width: 12,
+        height: 256,
+      };
+      expect(result).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
And add unit tests

## Description

## Related Issue

https://github.com/recharts/recharts/issues/3823

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

For the PoC I want to call these two functions from outside of `getCategoricalChart` but I figured that master will benefit from this change too: 1. it makes the mammoth file a bit smaller and 2. makes it easier to unit test so I did that too.

Also got rid of unnecessary lodash call in the spirit of https://github.com/recharts/recharts/issues/3752

## How Has This Been Tested?

Jest, TS

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
