### PR TITLE
Lodash: Only use where needed - isNil

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -5,6 +5,7 @@ import React, { PureComponent, ReactElement, SVGProps } from 'react';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
 import _ from 'lodash';
+import { isNil } from '../util/isNil';
 import { Curve, CurveType, Point as CurvePoint } from '../shape/Curve';
 import { Dot, Props as DotProps } from '../shape/Dot';
 import { Layer } from '../container/Layer';
@@ -207,7 +208,7 @@ export class Area extends PureComponent<Props, State> {
         }
       }
 
-      const isBreakPoint = _.isNil(value[1]) || (hasStack && _.isNil(originalValue));
+      const isBreakPoint = isNil(value[1]) || (hasStack && isNil(originalValue));
       if (layout === 'horizontal') {
         return {
           x: getCateCoordinateOfLine({ axis: xAxis, ticks: xAxisTicks, bandSize, entry, index }),
@@ -232,13 +233,13 @@ export class Area extends PureComponent<Props, State> {
           return {
             x: entry.x,
             y:
-              !_.isNil(_.get(entry, 'value[0]')) && !_.isNil(_.get(entry, 'y'))
+              !isNil(_.get(entry, 'value[0]')) && !isNil(_.get(entry, 'y'))
                 ? yAxis.scale(_.get(entry, 'value[0]'))
                 : null,
           };
         }
         return {
-          x: !_.isNil(_.get(entry, 'value[0]')) ? xAxis.scale(_.get(entry, 'value[0]')) : null,
+          x: !isNil(_.get(entry, 'value[0]')) ? xAxis.scale(_.get(entry, 'value[0]')) : null,
           y: entry.y,
         };
       });
@@ -457,7 +458,7 @@ export class Area extends PureComponent<Props, State> {
     const { points, baseLine, isAnimationActive, animationBegin, animationDuration, animationEasing, animationId } =
       this.props;
     const { prevPoints, prevBaseLine } = this.state;
-    // const clipPathId = _.isNil(id) ? this.id : id;
+    // const clipPathId = isNil(id) ? this.id : id;
 
     return (
       <Animate
@@ -492,7 +493,7 @@ export class Area extends PureComponent<Props, State> {
             if (isNumber(baseLine) && typeof baseLine === 'number') {
               const interpolator = interpolateNumber(prevBaseLine as number, baseLine);
               stepBaseLine = interpolator(t);
-            } else if (_.isNil(baseLine) || _.isNaN(baseLine)) {
+            } else if (isNil(baseLine) || _.isNaN(baseLine)) {
               const interpolator = interpolateNumber(prevBaseLine as number, 0);
               stepBaseLine = interpolator(t);
             } else {
@@ -557,7 +558,7 @@ export class Area extends PureComponent<Props, State> {
     const needClipX = xAxis && xAxis.allowDataOverflow;
     const needClipY = yAxis && yAxis.allowDataOverflow;
     const needClip = needClipX || needClipY;
-    const clipPathId = _.isNil(id) ? this.id : id;
+    const clipPathId = isNil(id) ? this.id : id;
     const { r = 3, strokeWidth = 2 } = filterProps(dot) ?? { r: 3, strokeWidth: 2 };
     const { clipDot = true } = isDotProps(dot) ? dot : {};
     const dotSize = r * 2 + strokeWidth;

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -5,6 +5,7 @@ import React, { Key, PureComponent, ReactElement } from 'react';
 import classNames from 'classnames';
 import Animate from 'react-smooth';
 import _ from 'lodash';
+import { isNil } from '../util/isNil';
 import { Props as RectangleProps } from '../shape/Rectangle';
 import { Layer } from '../container/Layer';
 import { ErrorBar, Props as ErrorBarProps, ErrorBarDataPointFormatter } from './ErrorBar';
@@ -475,7 +476,7 @@ export class Bar extends PureComponent<Props, State> {
     const needClipX = xAxis && xAxis.allowDataOverflow;
     const needClipY = yAxis && yAxis.allowDataOverflow;
     const needClip = needClipX || needClipY;
-    const clipPathId = _.isNil(id) ? this.id : id;
+    const clipPathId = isNil(id) ? this.id : id;
 
     return (
       <Layer className={layerClass}>

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -5,6 +5,7 @@ import React, { PureComponent, ReactElement } from 'react';
 import Animate from 'react-smooth';
 import classNames from 'classnames';
 import _ from 'lodash';
+import { isNil } from '../util/isNil';
 import { Curve, CurveType, Props as CurveProps, Point as CurvePoint } from '../shape/Curve';
 import { Dot, Props as DotProps } from '../shape/Dot';
 import { Layer } from '../container/Layer';
@@ -148,14 +149,14 @@ export class Line extends PureComponent<Props, State> {
       if (layout === 'horizontal') {
         return {
           x: getCateCoordinateOfLine({ axis: xAxis, ticks: xAxisTicks, bandSize, entry, index }),
-          y: _.isNil(value) ? null : yAxis.scale(value),
+          y: isNil(value) ? null : yAxis.scale(value),
           value,
           payload: entry,
         };
       }
 
       return {
-        x: _.isNil(value) ? null : xAxis.scale(value),
+        x: isNil(value) ? null : xAxis.scale(value),
         y: getCateCoordinateOfLine({ axis: yAxis, ticks: yAxisTicks, bandSize, entry, index }),
         value,
         payload: entry,
@@ -474,7 +475,7 @@ export class Line extends PureComponent<Props, State> {
     const needClipX = xAxis && xAxis.allowDataOverflow;
     const needClipY = yAxis && yAxis.allowDataOverflow;
     const needClip = needClipX || needClipY;
-    const clipPathId = _.isNil(id) ? this.id : id;
+    const clipPathId = isNil(id) ? this.id : id;
     const { r = 3, strokeWidth = 2 } = filterProps(dot) ?? { r: 3, strokeWidth: 2 };
     const { clipDot = true } = isDotProps(dot) ? dot : {};
     const dotSize = r * 2 + strokeWidth;

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -5,6 +5,7 @@ import React, { PureComponent, ReactElement } from 'react';
 import Animate from 'react-smooth';
 import classNames from 'classnames';
 import _ from 'lodash';
+import { isNil } from '../util/isNil';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelListType, LabelList } from '../component/LabelList';
 import { findAllByType, filterProps } from '../util/ReactUtils';
@@ -148,8 +149,8 @@ export class Scatter extends PureComponent<Props, State> {
   }) => {
     const { tooltipType } = item.props;
     const cells = findAllByType(item.props.children, Cell);
-    const xAxisDataKey = _.isNil(xAxis.dataKey) ? item.props.dataKey : xAxis.dataKey;
-    const yAxisDataKey = _.isNil(yAxis.dataKey) ? item.props.dataKey : yAxis.dataKey;
+    const xAxisDataKey = isNil(xAxis.dataKey) ? item.props.dataKey : xAxis.dataKey;
+    const yAxisDataKey = isNil(yAxis.dataKey) ? item.props.dataKey : yAxis.dataKey;
     const zAxisDataKey = zAxis && zAxis.dataKey;
     const defaultRangeZ = zAxis ? zAxis.range : ZAxis.defaultProps.range;
     const defaultZ = defaultRangeZ && defaultRangeZ[0];
@@ -158,10 +159,10 @@ export class Scatter extends PureComponent<Props, State> {
     const points = displayedData.map((entry, index) => {
       const x = getValueByDataKey(entry, xAxisDataKey);
       const y = getValueByDataKey(entry, yAxisDataKey);
-      const z = (!_.isNil(zAxisDataKey) && getValueByDataKey(entry, zAxisDataKey)) || '-';
+      const z = (!isNil(zAxisDataKey) && getValueByDataKey(entry, zAxisDataKey)) || '-';
       const tooltipPayload = [
         {
-          name: _.isNil(xAxis.dataKey) ? item.props.name : xAxis.name || xAxis.dataKey,
+          name: isNil(xAxis.dataKey) ? item.props.name : xAxis.name || xAxis.dataKey,
           unit: xAxis.unit || '',
           value: x,
           payload: entry,
@@ -169,7 +170,7 @@ export class Scatter extends PureComponent<Props, State> {
           type: tooltipType,
         },
         {
-          name: _.isNil(yAxis.dataKey) ? item.props.name : yAxis.name || yAxis.dataKey,
+          name: isNil(yAxis.dataKey) ? item.props.name : yAxis.name || yAxis.dataKey,
           unit: yAxis.unit || '',
           value: y,
           payload: entry,
@@ -422,7 +423,7 @@ export class Scatter extends PureComponent<Props, State> {
     const needClipX = xAxis && xAxis.allowDataOverflow;
     const needClipY = yAxis && yAxis.allowDataOverflow;
     const needClip = needClipX || needClipY;
-    const clipPathId = _.isNil(id) ? this.id : id;
+    const clipPathId = isNil(id) ? this.id : id;
 
     return (
       <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -2,6 +2,7 @@ import React, { Component, cloneElement, isValidElement, createElement, ReactEle
 import classNames from 'classnames';
 import _, { isArray, isBoolean } from 'lodash';
 import invariant from 'tiny-invariant';
+import { isNil } from '../util/isNil';
 import { getRadialCursorPoints } from '../util/cursor/getRadialCursorPoints';
 import { getTicks } from '../cartesian/getTicks';
 import { Surface } from '../container/Surface';
@@ -380,14 +381,12 @@ export const getAxisMapByAxes = (
           if (!allowDuplicatedCategory) {
             domain = parseDomainOfCategoryAxis(childDomain, domain, child).reduce(
               (finalDomain: any, entry: any) =>
-                finalDomain.indexOf(entry) >= 0 || entry === '' || _.isNil(entry)
-                  ? finalDomain
-                  : [...finalDomain, entry],
+                finalDomain.indexOf(entry) >= 0 || entry === '' || isNil(entry) ? finalDomain : [...finalDomain, entry],
               [],
             );
           } else {
             // eliminate undefined or null or empty string
-            domain = domain.filter((entry: any) => entry !== '' && !_.isNil(entry));
+            domain = domain.filter((entry: any) => entry !== '' && !isNil(entry));
           }
         } else if (type === 'number') {
           // the field type is numerical
@@ -648,7 +647,7 @@ const createDefaultState = (props: CategoricalChartProps): CategoricalChartState
     dataStartIndex: startIndex,
     dataEndIndex: endIndex,
     activeTooltipIndex: -1,
-    isTooltipActive: !_.isNil(defaultShowTooltip) ? defaultShowTooltip : false,
+    isTooltipActive: !isNil(defaultShowTooltip) ? defaultShowTooltip : false,
   };
 };
 
@@ -961,7 +960,7 @@ export const generateCategoricalChart = ({
 
       if (itemIsBar) {
         // 如果是bar，计算bar的位置
-        const maxBarSize: number = _.isNil(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
+        const maxBarSize: number = isNil(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
         const barBandSize: number = getBandSizeOfAxis(cateAxis, cateTicks, true) ?? maxBarSize ?? 0;
         barPosition = getBarPosition({
           barGap,
@@ -1116,7 +1115,7 @@ export const generateCategoricalChart = ({
     constructor(props: CategoricalChartProps) {
       super(props);
 
-      this.uniqueChartId = _.isNil(props.id) ? uniqueId('recharts') : props.id;
+      this.uniqueChartId = isNil(props.id) ? uniqueId('recharts') : props.id;
       this.clipPathId = `${this.uniqueChartId}-clip`;
 
       if (props.throttleDelay) {
@@ -1127,7 +1126,7 @@ export const generateCategoricalChart = ({
     }
 
     componentDidMount() {
-      if (!_.isNil(this.props.syncId)) {
+      if (!isNil(this.props.syncId)) {
         this.addListener();
       }
 
@@ -1182,7 +1181,7 @@ export const generateCategoricalChart = ({
     ): CategoricalChartState => {
       const { data, children, width, height, layout, stackOffset, margin } = nextProps;
 
-      if (_.isNil(prevState.updateId)) {
+      if (isNil(prevState.updateId)) {
         const defaultState = createDefaultState(nextProps);
 
         return {
@@ -1260,7 +1259,7 @@ export const generateCategoricalChart = ({
       }
       if (!isChildrenEqual(children, prevState.prevChildren)) {
         // update configuration in children
-        const hasGlobalData = !_.isNil(data);
+        const hasGlobalData = !isNil(data);
         const newUpdateId = hasGlobalData ? prevState.updateId : prevState.updateId + 1;
 
         return {
@@ -1282,18 +1281,18 @@ export const generateCategoricalChart = ({
 
     componentDidUpdate(prevProps: CategoricalChartProps) {
       // add syncId
-      if (_.isNil(prevProps.syncId) && !_.isNil(this.props.syncId)) {
+      if (isNil(prevProps.syncId) && !isNil(this.props.syncId)) {
         this.addListener();
       }
       // remove syncId
-      if (!_.isNil(prevProps.syncId) && _.isNil(this.props.syncId)) {
+      if (!isNil(prevProps.syncId) && isNil(this.props.syncId)) {
         this.removeListener();
       }
     }
 
     componentWillUnmount() {
       this.clearDefer();
-      if (!_.isNil(this.props.syncId)) {
+      if (!isNil(this.props.syncId)) {
         this.removeListener();
       }
       this.cancelThrottledTriggerAfterMouseMove();
@@ -1661,7 +1660,7 @@ export const generateCategoricalChart = ({
     triggerSyncEvent(data: CategoricalChartState) {
       const { syncId } = this.props;
 
-      if (!_.isNil(syncId)) {
+      if (!isNil(syncId)) {
         eventCenter.emit(SYNC_EVENT, syncId, this.uniqueChartId, data);
       }
     }
@@ -1671,7 +1670,7 @@ export const generateCategoricalChart = ({
       const { updateId } = this.state;
       const { dataStartIndex, dataEndIndex } = data;
 
-      if (!_.isNil(data.dataStartIndex) || !_.isNil(data.dataEndIndex)) {
+      if (!isNil(data.dataStartIndex) || !isNil(data.dataEndIndex)) {
         this.setState({
           dataStartIndex,
           dataEndIndex,
@@ -1685,7 +1684,7 @@ export const generateCategoricalChart = ({
             this.state,
           ),
         });
-      } else if (!_.isNil(data.activeTooltipIndex)) {
+      } else if (!isNil(data.activeTooltipIndex)) {
         const { chartX, chartY } = data;
         let { activeTooltipIndex } = data;
         const { offset, tooltipTicks } = this.state;
@@ -2143,7 +2142,7 @@ export const generateCategoricalChart = ({
             return [cloneElement(element, { ...item.props, ...itemEvents, activeIndex }), null, null];
           }
 
-          if (!_.isNil(activePoint)) {
+          if (!isNil(activePoint)) {
             return [
               graphicalItem,
               ...this.renderActivePoints({

--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import React, { CSSProperties, ReactNode } from 'react';
 import classNames from 'classnames';
 import { isNumOrStr } from '../util/DataUtils';
+import { isNil } from '../util/isNil';
 
 function defaultFormatter<TValue extends ValueType>(value: TValue) {
   return _.isArray(value) && isNumOrStr(value[0]) && isNumOrStr(value[1]) ? (value.join(' ~ ') as TValue) : value;
@@ -129,7 +130,7 @@ export const DefaultTooltipContent = <TValue extends ValueType, TName extends Na
     margin: 0,
     ...labelStyle,
   };
-  const hasLabel = !_.isNil(label);
+  const hasLabel = !isNil(label);
   let finalLabel = hasLabel ? label : '';
   const wrapperCN = classNames('recharts-default-tooltip', wrapperClassName);
   const labelCN = classNames('recharts-tooltip-label', labelClassName);

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -1,6 +1,7 @@
 import React, { cloneElement, isValidElement, ReactNode, ReactElement, createElement, SVGProps } from 'react';
 import _ from 'lodash';
 import classNames from 'classnames';
+import { isNil } from '../util/isNil';
 import { Text } from './Text';
 import { findAllByType, filterProps } from '../util/ReactUtils';
 import { isNumOrStr, isNumber, isPercent, getPercentValue, uniqueId, mathSign } from '../util/DataUtils';
@@ -60,7 +61,7 @@ export type ImplicitLabelType =
 
 const getLabel = (props: Props) => {
   const { value, formatter } = props;
-  const label = _.isNil(props.children) ? value : props.children;
+  const label = isNil(props.children) ? value : props.children;
 
   if (_.isFunction(formatter)) {
     return formatter(label);
@@ -102,7 +103,7 @@ const renderRadialLabel = (labelProps: Props, label: ReactNode, attrs: SVGProps<
   const path = `M${startPoint.x},${startPoint.y}
     A${radius},${radius},0,1,${direction ? 0 : 1},
     ${endPoint.x},${endPoint.y}`;
-  const id = _.isNil(labelProps.id) ? uniqueId('recharts-radial-line-') : labelProps.id;
+  const id = isNil(labelProps.id) ? uniqueId('recharts-radial-line-') : labelProps.id;
 
   return (
     <text {...attrs} dominantBaseline="central" className={classNames('recharts-radial-bar-label', className)}>
@@ -377,7 +378,7 @@ export function Label({ offset = 5, ...restProps }: Props) {
   const props = { offset, ...restProps };
   const { viewBox, position, value, children, content, className = '', textBreakAll } = props;
 
-  if (!viewBox || (_.isNil(value) && _.isNil(children) && !isValidElement(content) && !_.isFunction(content))) {
+  if (!viewBox || (isNil(value) && isNil(children) && !isValidElement(content) && !_.isFunction(content))) {
     return null;
   }
 

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -1,5 +1,6 @@
 import React, { cloneElement, ReactElement, ReactNode, SVGProps } from 'react';
 import _ from 'lodash';
+import { isNil } from '../util/isNil';
 import { Label, ContentType, Props as LabelProps } from './Label';
 import { Layer } from '../container/Layer';
 import { findAllByType, filterProps } from '../util/ReactUtils';
@@ -45,10 +46,8 @@ export function LabelList<T extends Data>({ valueAccessor = defaultAccessor, ...
   return (
     <Layer className="recharts-label-list">
       {data.map((entry, index) => {
-        const value = _.isNil(dataKey)
-          ? valueAccessor(entry, index)
-          : getValueByDataKey(entry && entry.payload, dataKey);
-        const idProps = _.isNil(id) ? {} : { id: `${id}-${index}` };
+        const value = isNil(dataKey) ? valueAccessor(entry, index) : getValueByDataKey(entry && entry.payload, dataKey);
+        const idProps = isNil(id) ? {} : { id: `${id}-${index}` };
 
         return (
           <Label
@@ -59,7 +58,7 @@ export function LabelList<T extends Data>({ valueAccessor = defaultAccessor, ...
             index={index}
             value={value}
             textBreakAll={textBreakAll}
-            viewBox={Label.parseViewBox(_.isNil(clockWise) ? entry : { ...entry, clockWise })}
+            viewBox={Label.parseViewBox(isNil(clockWise) ? entry : { ...entry, clockWise })}
             key={`label-${index}`} // eslint-disable-line react/no-array-index-key
           />
         );

--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, SVGProps, useMemo } from 'react';
 import classNames from 'classnames';
-import _ from 'lodash';
+import { isNil } from '../util/isNil';
 import { isNumber, isNumOrStr } from '../util/DataUtils';
 import { Global } from '../util/Global';
 import { filterProps } from '../util/ReactUtils';
@@ -24,7 +24,7 @@ type CalculateWordWidthsParam = Pick<Props, 'children' | 'breakAll' | 'style'>;
 const calculateWordWidths = ({ children, breakAll, style }: CalculateWordWidthsParam): CalculatedWordWidths => {
   try {
     let words: string[] = [];
-    if (!_.isNil(children)) {
+    if (!isNil(children)) {
       if (breakAll) {
         words = children.toString().split('');
       } else {
@@ -155,7 +155,7 @@ const calculateWordsByLines = (
 };
 
 const getWordsWithoutCalculate = (children: React.ReactNode): Array<Words> => {
-  const words = !_.isNil(children) ? children.toString().split(BREAKING_SPACES) : [];
+  const words = !isNil(children) ? children.toString().split(BREAKING_SPACES) : [];
   return [{ words }];
 };
 

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -5,6 +5,7 @@ import React, { PureComponent, CSSProperties, ReactNode, ReactElement, SVGProps 
 import { translateStyle } from 'react-smooth';
 import _ from 'lodash';
 import classNames from 'classnames';
+import { isNil } from '../util/isNil';
 import { DefaultTooltipContent, ValueType, NameType, Payload, Props as DefaultProps } from './DefaultTooltipContent';
 
 import { Global } from '../util/Global';
@@ -223,7 +224,7 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
     const { payload, isAnimationActive, animationDuration, animationEasing, filterNull, payloadUniqBy } = this.props;
     const finalPayload = getUniqPayload(
       payloadUniqBy,
-      filterNull && payload && payload.length ? payload.filter(entry => !_.isNil(entry.value)) : payload,
+      filterNull && payload && payload.length ? payload.filter(entry => !isNil(entry.value)) : payload,
     );
     const hasPayload = finalPayload && finalPayload.length;
     const { content, viewBox, coordinate, position, active, wrapperStyle } = this.props;

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -5,6 +5,7 @@ import React, { PureComponent, ReactElement, ReactNode, SVGProps } from 'react';
 import Animate from 'react-smooth';
 import classNames from 'classnames';
 import _ from 'lodash';
+import { isNil } from '../util/isNil';
 import { Layer } from '../container/Layer';
 import { Props as SectorProps } from '../shape/Sector';
 import { Curve } from '../shape/Curve';
@@ -212,14 +213,14 @@ export class Pie extends PureComponent<Props, State> {
 
     let realDataKey = dataKey;
 
-    if (_.isNil(dataKey) && _.isNil(valueKey)) {
+    if (isNil(dataKey) && isNil(valueKey)) {
       warn(
         false,
         `Use "dataKey" to specify the value of pie,
       the props "valueKey" will be deprecated in 1.1.0`,
       );
       realDataKey = 'value';
-    } else if (_.isNil(dataKey)) {
+    } else if (isNil(dataKey)) {
       warn(
         false,
         `Use "dataKey" to specify the value of pie,
@@ -454,9 +455,9 @@ export class Pie extends PureComponent<Props, State> {
       };
       let realDataKey = dataKey;
       // TODO: compatible to lower versions
-      if (_.isNil(dataKey) && _.isNil(valueKey)) {
+      if (isNil(dataKey) && isNil(valueKey)) {
         realDataKey = 'value';
-      } else if (_.isNil(dataKey)) {
+      } else if (isNil(dataKey)) {
         realDataKey = valueKey;
       }
 

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -5,6 +5,7 @@ import React, { PureComponent, ReactElement, MouseEvent, SVGProps } from 'react'
 import Animate from 'react-smooth';
 import classNames from 'classnames';
 import _ from 'lodash';
+import { isNil } from '../util/isNil';
 import { interpolateNumber } from '../util/DataUtils';
 import { Global } from '../util/Global';
 import { polarToCartesian } from '../util/PolarUtils';
@@ -111,7 +112,7 @@ export class Radar extends PureComponent<Props, State> {
       const value = getValueByDataKey(entry, dataKey);
       const angle = angleAxis.scale(name) + (bandSize || 0);
       const pointValue = _.isArray(value) ? _.last(value) : value;
-      const radius = _.isNil(pointValue) ? undefined : radiusAxis.scale(pointValue);
+      const radius = isNil(pointValue) ? undefined : radiusAxis.scale(pointValue);
 
       if (_.isArray(value) && value.length >= 2) {
         isRange = true;
@@ -134,7 +135,7 @@ export class Radar extends PureComponent<Props, State> {
       points.forEach(point => {
         if (_.isArray(point.value)) {
           const baseValue = _.first(point.value);
-          const radius = _.isNil(baseValue) ? undefined : radiusAxis.scale(baseValue);
+          const radius = isNil(baseValue) ? undefined : radiusAxis.scale(baseValue);
 
           baseLinePoints.push({
             ...point,

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -11,6 +11,7 @@ import {
 import _ from 'lodash';
 import { ReactElement, ReactNode } from 'react';
 import { getNiceTickValues, getTickValuesFixedDomain } from 'recharts-scale';
+import { isNil } from './isNil';
 
 import { ErrorBar } from '../cartesian/ErrorBar';
 import { findEntryInArray, getPercentValue, isNumber, isNumOrStr, mathSign, uniqueId } from './DataUtils';
@@ -37,7 +38,7 @@ import { getLegendProps } from './getLegendProps';
 export { getLegendProps };
 
 export function getValueByDataKey<T>(obj: T, dataKey: DataKey<T>, defaultValue?: any) {
-  if (_.isNil(obj) || _.isNil(dataKey)) {
+  if (isNil(obj) || isNil(dataKey)) {
     return defaultValue;
   }
 
@@ -74,7 +75,7 @@ export function getDomainOfDataByKey<T>(
     return domain.length ? [_.min(domain), _.max(domain)] : [Infinity, -Infinity];
   }
 
-  const validateData = filterNil ? flattenData.filter(entry => !_.isNil(entry)) : flattenData;
+  const validateData = filterNil ? flattenData.filter(entry => !isNil(entry)) : flattenData;
 
   // Supports x-axis of Date type
   return validateData.map(entry => (isNumOrStr(entry) || entry instanceof Date ? entry : ''));
@@ -242,7 +243,7 @@ export const getBarSizeList = ({
         result[cateId].push({
           item: barItems[0],
           stackList: barItems.slice(1),
-          barSize: _.isNil(selfSize) ? globalSize : selfSize,
+          barSize: isNil(selfSize) ? globalSize : selfSize,
         });
       }
     }
@@ -418,7 +419,7 @@ export const appendOffsetOfLegend = (
 };
 
 const isErrorBarRelevantForAxis = (layout?: LayoutType, axisType?: AxisType, direction?: 'x' | 'y'): boolean => {
-  if (_.isNil(axisType)) {
+  if (isNil(axisType)) {
     return true;
   }
 
@@ -487,7 +488,7 @@ export const parseErrorBarsOfAxis = (
 ): NumberDomain | null => {
   const domains = items
     .map(item => getDomainOfErrorBars(data, item, dataKey, layout, axisType))
-    .filter(entry => !_.isNil(entry));
+    .filter(entry => !isNil(entry));
 
   if (domains && domains.length) {
     return domains.reduce(
@@ -1086,7 +1087,7 @@ export const getCateCoordinateOfLine = ({
 }) => {
   if (axis.type === 'category') {
     // find coordinate of category axis by the value of category
-    if (!axis.allowDuplicatedCategory && axis.dataKey && !_.isNil(entry[axis.dataKey])) {
+    if (!axis.allowDuplicatedCategory && axis.dataKey && !isNil(entry[axis.dataKey])) {
       const matchedTick = findEntryInArray(ticks, 'value', entry[axis.dataKey]);
 
       if (matchedTick) {
@@ -1097,9 +1098,9 @@ export const getCateCoordinateOfLine = ({
     return ticks[index] ? ticks[index].coordinate + bandSize / 2 : null;
   }
 
-  const value = getValueByDataKey(entry, !_.isNil(dataKey) ? dataKey : axis.dataKey);
+  const value = getValueByDataKey(entry, !isNil(dataKey) ? dataKey : axis.dataKey);
 
-  return !_.isNil(value) ? axis.scale(value) : null;
+  return !isNil(value) ? axis.scale(value) : null;
 };
 
 export const getCateCoordinateOfBar = ({
@@ -1122,7 +1123,7 @@ export const getCateCoordinateOfBar = ({
   }
   const value = getValueByDataKey(entry, axis.dataKey, axis.domain[index]);
 
-  return !_.isNil(value) ? axis.scale(value) - bandSize / 2 + offset : null;
+  return !isNil(value) ? axis.scale(value) - bandSize / 2 + offset : null;
 };
 
 export const getBaseValueOfBar = ({

--- a/src/util/PolarUtils.ts
+++ b/src/util/PolarUtils.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { getPercentValue } from './DataUtils';
 import { parseScale, checkDomainOfScale, getTicksOfScale } from './ChartUtils';
 import { Coordinate, ChartOffset, GeometrySector } from './types';

--- a/src/util/PolarUtils.ts
+++ b/src/util/PolarUtils.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import { getPercentValue } from './DataUtils';
 import { parseScale, checkDomainOfScale, getTicksOfScale } from './ChartUtils';
 import { Coordinate, ChartOffset, GeometrySector } from './types';
+import { isNil } from './isNil';
 
 export const RADIAN = Math.PI / 180;
 
@@ -59,7 +60,7 @@ export const formatAxisMap = (
     const { domain, reversed } = axis;
     let range;
 
-    if (_.isNil(axis.range)) {
+    if (isNil(axis.range)) {
       if (axisType === 'angleAxis') {
         range = [startAngle, endAngle];
       } else if (axisType === 'radiusAxis') {

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -7,6 +7,7 @@ import { shallowEqual } from './ShallowEqual';
 import { FilteredSvgElementType, FilteredElementKeyMap, SVGElementPropKeys, EventKeys } from './types';
 import { AreaDot } from '../cartesian/Area';
 import { LineDot } from '../cartesian/Line';
+import { isNil } from './isNil';
 
 const REACT_BROWSER_EVENT_MAP: Record<string, string> = {
   click: 'onClick',
@@ -83,7 +84,7 @@ export const toArray = <T extends ReactNode>(children: T | T[]): T[] => {
   }
   let result: T[] = [];
   Children.forEach(children, child => {
-    if (_.isNil(child)) return;
+    if (isNil(child)) return;
     if (isFragment(child)) {
       result = result.concat(toArray(child.props.children));
     } else {
@@ -392,10 +393,10 @@ export const isChildrenEqual = (nextChildren: React.ReactElement[], prevChildren
 };
 
 export const isSingleChildEqual = (nextChild: React.ReactElement, prevChild: React.ReactElement): boolean => {
-  if (_.isNil(nextChild) && _.isNil(prevChild)) {
+  if (isNil(nextChild) && isNil(prevChild)) {
     return true;
   }
-  if (!_.isNil(nextChild) && !_.isNil(prevChild)) {
+  if (!isNil(nextChild) && !isNil(prevChild)) {
     const { children: nextChildren, ...nextProps } = nextChild.props || {};
     const { children: prevChildren, ...prevProps } = prevChild.props || {};
 

--- a/src/util/isNil.ts
+++ b/src/util/isNil.ts
@@ -1,0 +1,3 @@
+export function isNil(value: unknown) {
+  return value == null;
+}

--- a/src/util/isNil.ts
+++ b/src/util/isNil.ts
@@ -1,3 +1,3 @@
-export function isNil(value: unknown) {
+export function isNil(value: unknown): value is null | undefined {
   return value == null;
 }

--- a/test/util/isNil.spec.ts
+++ b/test/util/isNil.spec.ts
@@ -1,0 +1,19 @@
+import { isNil } from '../../src/util/isNil';
+
+describe('isNil', () => {
+  test('detects undefined', () => {
+    const isUndefinedNil = isNil(undefined);
+    expect(isUndefinedNil).toBe(true);
+  });
+
+  test('detects null', () => {
+    const isNullNil = isNil(null);
+    expect(isNullNil).toBe(true);
+  });
+
+  test('can be used in Array.prototype.filter', () => {
+    const array = [undefined, null, 0, '1', NaN, ''];
+    const filtered = array.filter(isNil);
+    expect(filtered).toEqual([undefined, null]);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L11973

No need to import lodash for checking whether something `== null`
The only reason could be readability, so I instead added a helper function isNil. 

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/recharts/recharts/issues/3752

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [ ] All new and existing tests passed.
