### PR TITLE
Remove unit test that was comparing new/old reduce-css-calc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,6 @@
         "react-dom": "^16.14.0",
         "react-router-dom": "^5.1.2",
         "reassure": "^0.9.1",
-        "reduce-css-calc": "^2.1.8",
         "rimraf": "^3.0.2",
         "storybook": "^7.4.6",
         "storybook-addon-performance": "^0.17.1",
@@ -17143,12 +17142,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css-unit-converter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
-      "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
-      "dev": true
-    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -30482,22 +30475,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/reduce-css-calc": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
-      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
-      "dev": true,
-      "dependencies": {
-        "css-unit-converter": "^1.1.1",
-        "postcss-value-parser": "^3.3.0"
-      }
-    },
-    "node_modules/reduce-css-calc/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "dev": true
     },
     "node_modules/refractor": {
       "version": "3.6.0",
@@ -47431,12 +47408,6 @@
         "nth-check": "^2.0.1"
       }
     },
-    "css-unit-converter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
-      "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
-      "dev": true
-    },
     "css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -57363,24 +57334,6 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
-      }
-    },
-    "reduce-css-calc": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
-      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
-      "dev": true,
-      "requires": {
-        "css-unit-converter": "^1.1.1",
-        "postcss-value-parser": "^3.3.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
-        }
       }
     },
     "refractor": {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "react-dom": "^16.14.0",
     "react-router-dom": "^5.1.2",
     "reassure": "^0.9.1",
-    "reduce-css-calc": "^2.1.8",
     "rimraf": "^3.0.2",
     "storybook": "^7.4.6",
     "storybook-addon-performance": "^0.17.1",

--- a/test/util/ReduceCssCalcPrototype.spec.ts
+++ b/test/util/ReduceCssCalcPrototype.spec.ts
@@ -1,5 +1,3 @@
-import oldReduceCSSCalc from 'reduce-css-calc';
-import { log } from 'console';
 import { reduceCSSCalc, safeEvaluateExpression } from '../../src/util/ReduceCSSCalc';
 
 describe('number calculate', () => {
@@ -84,7 +82,7 @@ const cssLengthPair = cssLengthUnits.reduce<string[][]>((result, unit1, index1) 
   return result;
 }, []);
 
-describe('reduce-css-calc', () => {
+describe('reduceCSSCalc', () => {
   cssLengthPair.forEach(([unit1, unit2]) => {
     [
       { capHeight: `123${unit1}`, lineHeight: `456${unit2}`, wordsByLines: 3 },
@@ -101,16 +99,7 @@ describe('reduce-css-calc', () => {
           `calc(${capHeight} * -${lineHeight})`,
           `calc(${capHeight} / -${lineHeight})`,
         ].forEach(calcString => {
-          try {
-            const newCalc = reduceCSSCalc(calcString);
-            const prevCalc = oldReduceCSSCalc(calcString);
-
-            if (!(prevCalc.includes('calc') || prevCalc.includes(' '))) {
-              expect(prevCalc).toEqual(newCalc);
-            }
-          } catch (e) {
-            log('prevCalc throw error');
-          }
+          expect(() => reduceCSSCalc(calcString)).not.toThrow();
         });
       });
     });

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,2 @@
 declare module 'recharts-scale';
 declare module 'react-smooth';
-declare module 'reduce-css-calc';


### PR DESCRIPTION
Why? It's not testing anything - it throws, and the error is not reported as a failing test but instead as a log message in the console.

Instead I have replaced it with a `.not.toThrow()` call which at least tests that our new implementation doesn't throw. The old one throws so I removed it completely.

## Description

## Related Issue

https://github.com/recharts/recharts/pull/3820

## Motivation and Context

<img width="294" alt="image" src="https://github.com/recharts/recharts/assets/1100170/3217a808-9cee-4fa5-a37c-afb936114f15">


## How Has This Been Tested?

Jest

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
