### PR TITLE
Add `dataKey` prop on `CategoricalChartProps`

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -72,6 +72,7 @@ import {
   adaptEventHandlers,
   GeometrySector,
   AxisType,
+  DataKey,
 } from '../util/types';
 import { AccessibilityManager } from './AccessibilityManager';
 import { isDomainSpecifiedByUser } from '../util/isDomainSpecifiedByUser';
@@ -821,6 +822,7 @@ export interface CategoricalChartState {
 
   legendBBox?: DOMRect | null;
 
+  prevDataKey?: DataKey<any>;
   prevData?: any[];
   prevWidth?: number;
   prevHeight?: number;
@@ -840,6 +842,7 @@ export interface CategoricalChartProps {
   compact?: boolean;
   width?: number;
   height?: number;
+  dataKey?: DataKey<any>;
   data?: any[];
   layout?: LayoutType;
   stackOffset?: StackOffsetType;
@@ -1180,7 +1183,7 @@ export const generateCategoricalChart = ({
       nextProps: CategoricalChartProps,
       prevState: CategoricalChartState,
     ): CategoricalChartState => {
-      const { data, children, width, height, layout, stackOffset, margin } = nextProps;
+      const { dataKey, data, children, width, height, layout, stackOffset, margin } = nextProps;
 
       if (_.isNil(prevState.updateId)) {
         const defaultState = createDefaultState(nextProps);
@@ -1197,6 +1200,7 @@ export const generateCategoricalChart = ({
             prevState,
           ),
 
+          prevDataKey: dataKey,
           prevData: data,
           prevWidth: width,
           prevHeight: height,
@@ -1207,6 +1211,7 @@ export const generateCategoricalChart = ({
         };
       }
       if (
+        dataKey !== prevState.prevDataKey ||
         data !== prevState.prevData ||
         width !== prevState.prevWidth ||
         height !== prevState.prevHeight ||
@@ -1249,6 +1254,7 @@ export const generateCategoricalChart = ({
             },
             prevState,
           ),
+          prevDataKey: dataKey,
           prevData: data,
           prevWidth: width,
           prevHeight: height,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Introducing a `dataKey` prop on `CategoricalChartProps`, so we could rely on it to fire whether the chart should animate between two states. `dataKey` is an explicit prop to controller whether the `dataKey` changes or not and if we should animate to accommodate for the possibility that `data` doesn't change, but we toggle between `dataKey`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes https://github.com/recharts/recharts/issues/846.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

As described in #846—an issue reported six years ago—where changing the `dataKey` on the chart's elements doesn't trigger an animation between the two states. Instead, it just happens right away.

The reason why this is happening is behind the [`getDerivedStateFromProps`](https://react.dev/reference/react/Component#static-getderivedstatefromprops) lifecycle function:

https://github.com/recharts/recharts/blob/9b6046b141be493f64291909fe8439c5fae715de/src/chart/generateCategoricalChart.tsx#L1207-L1214

It means that the animation between two states will only happen if at least one of the listed props here changes: `data`, `width`, `height`, `layout`, `stackOffset`, `margin`, and `children`. One way to assert this is that changing `stackOffset`, which uses a primitive type, simultaneously changing the `dataKey` used on the chart's elements will trigger the animation between two states as expected. Unfortunately, that behavior isn't explicit at all.

## How Has This Been Tested?

### Current behavior as of `2.9.0`

Behavior: It just happens.

🔗  CodeSandbox: https://codesandbox.io/s/recharts-current-3sskmy

https://github.com/recharts/recharts/assets/7189823/1ea667da-2d0f-4893-9cf2-da6bec41ac88

### Using `dataKey` as `key` prop

React supports a `key` prop to explicitly tell React to re-render a component based on the provided `key`. We can leverage this by passing `dataKey`. Unfortunately, it isn't working as expected (or it does, actually). It will have the same effect if we also define a `key` prop on the chart's elements (e.g., `<Line>`).

Behavior: Re-renders the full chart like its first render.

🔗 CodeSandbox: https://codesandbox.io/s/recharts-datakey-as-key-mr4dk5

https://github.com/recharts/recharts/assets/7189823/678b7255-92f1-4541-aacd-b4433f9a65c8

### Proposed solution: supports `dataKey` on the chart

Behavior: Animates between two states

🔗 CodeSandbox: https://codesandbox.io/s/recharts-fix-proposal-hkyzn9

https://github.com/recharts/recharts/assets/7189823/a1b13600-e437-4911-95c1-2da098b07cf6

## Screenshots (if appropriate):

Provided in the previous section.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [ ] All new and existing tests passed.
