### PR TITLE
Add aria-label attribute (and associated props) for wrapper divs

### DIFF
--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -10,6 +10,7 @@ import { Tooltip } from '../component/Tooltip';
 import { Rectangle, Props as RectangleProps } from '../shape/Rectangle';
 import { shallowEqual } from '../util/ShallowEqual';
 import { filterSvgElements, validateWidthHeight, findChildByType, filterProps } from '../util/ReactUtils';
+import { uniqueId } from '../util/DataUtils';
 import { getValueByDataKey } from '../util/ChartUtils';
 import { Margin, DataKey, SankeyLink, SankeyNode } from '../util/types';
 
@@ -385,6 +386,8 @@ interface SankeyProps {
   onMouseLeave?: any;
 
   sort?: boolean;
+
+  wrapperAriaLabel?: string;
 }
 
 type Props = SVGProps<SVGElement> & SankeyProps;
@@ -428,6 +431,13 @@ export class Sankey extends PureComponent<Props, State> {
     nodes: [] as SankeyNode[],
     links: [] as SankeyLink[],
   };
+
+  private wrapperAriaLabel: string;
+
+  constructor(props: Props) {
+    super(props);
+    this.wrapperAriaLabel = props.wrapperAriaLabel ?? uniqueId('Recharts Sankey Chart ');
+  }
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
     const { data, width, height, margin, iterations, nodeWidth, nodePadding, sort } = nextProps;
@@ -705,6 +715,7 @@ export class Sankey extends PureComponent<Props, State> {
         className={classNames('recharts-wrapper', className)}
         style={{ ...style, position: 'relative', cursor: 'default', width, height }}
         role="region"
+        aria-label={this.wrapperAriaLabel}
       >
         <Surface {...attrs} width={width} height={height}>
           {filterSvgElements(children)}

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -432,7 +432,7 @@ export class Sankey extends PureComponent<Props, State> {
     links: [] as SankeyLink[],
   };
 
-  private wrapperAriaLabel: string;
+  wrapperAriaLabel: string;
 
   constructor(props: Props) {
     super(props);

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -259,6 +259,8 @@ export interface Props {
   animationDuration?: AnimationDuration;
 
   animationEasing?: AnimationTiming;
+
+  wrapperAriaLabel?: string;
 }
 
 interface State {
@@ -318,6 +320,14 @@ export class Treemap extends PureComponent<Props, State> {
   state = {
     ...defaultState,
   };
+
+  private wrapperAriaLabel: string;
+
+  constructor(props: Props) {
+    super(props);
+
+    this.wrapperAriaLabel = props.wrapperAriaLabel && uniqueId('Rechards Treemap Chart ');
+  }
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
     if (
@@ -734,6 +744,7 @@ export class Treemap extends PureComponent<Props, State> {
         className={classNames('recharts-wrapper', className)}
         style={{ ...style, position: 'relative', cursor: 'default', width, height }}
         role="region"
+        aria-label={this.wrapperAriaLabel}
       >
         <Surface {...attrs} width={width} height={type === 'nest' ? height - 30 : height}>
           {this.renderAllNodes()}

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -321,7 +321,7 @@ export class Treemap extends PureComponent<Props, State> {
     ...defaultState,
   };
 
-  private wrapperAriaLabel: string;
+  wrapperAriaLabel: string;
 
   constructor(props: Props) {
     super(props);

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1121,7 +1121,7 @@ export const generateCategoricalChart = ({
       super(props);
 
       this.clipPathId = `${props.id ?? uniqueId('recharts')}-clip`;
-      this.wrapperLabel = _.isNil(props.wrapperLabel) ? uniqueId(`Recharts ${chartName}`) : props.wrapperLabel;
+      this.wrapperLabel = _.isNil(props.wrapperLabel) ? uniqueId(`Recharts ${chartName} `) : props.wrapperLabel;
 
       if (props.throttleDelay) {
         this.triggeredAfterMouseMove = _.throttle(this.triggeredAfterMouseMove, props.throttleDelay);

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1121,7 +1121,7 @@ export const generateCategoricalChart = ({
       super(props);
 
       this.clipPathId = `${props.id ?? uniqueId('recharts')}-clip`;
-      this.wrapperLabel = _.isNil(props.wrapperLabel) ? uniqueId(`Recharts ${chartName} `) : props.wrapperLabel;
+      this.wrapperLabel = props.wrapperLabel ?? props.title ?? uniqueId(`Recharts ${chartName} `);
 
       if (props.throttleDelay) {
         this.triggeredAfterMouseMove = _.throttle(this.triggeredAfterMouseMove, props.throttleDelay);

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -864,6 +864,7 @@ export interface CategoricalChartProps {
   onMouseUp?: CategoricalChartFunc;
   reverseStackOrder?: boolean;
   id?: string;
+  wrapperLabel?: string;
 
   startAngle?: number;
   endAngle?: number;
@@ -1100,6 +1101,8 @@ export const generateCategoricalChart = ({
 
     accessibilityManager = new AccessibilityManager();
 
+    wrapperLabel: string;
+
     // todo join specific chart propTypes
     static defaultProps: CategoricalChartProps = {
       layout: 'horizontal',
@@ -1118,6 +1121,7 @@ export const generateCategoricalChart = ({
       super(props);
 
       this.clipPathId = `${props.id ?? uniqueId('recharts')}-clip`;
+      this.wrapperLabel = _.isNil(props.wrapperLabel) ? uniqueId(`Recharts ${chartName}`) : props.wrapperLabel;
 
       if (props.throttleDelay) {
         this.triggeredAfterMouseMove = _.throttle(this.triggeredAfterMouseMove, props.throttleDelay);
@@ -2345,6 +2349,7 @@ export const generateCategoricalChart = ({
             this.container = node;
           }}
           role="region"
+          aria-label={this.wrapperLabel}
         >
           <Surface {...attrs} width={width} height={height} title={title} desc={desc}>
             {this.renderClipPath()}

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -864,7 +864,7 @@ export interface CategoricalChartProps {
   onMouseUp?: CategoricalChartFunc;
   reverseStackOrder?: boolean;
   id?: string;
-  wrapperLabel?: string;
+  wrapperAriaLabel?: string;
 
   startAngle?: number;
   endAngle?: number;
@@ -1121,7 +1121,7 @@ export const generateCategoricalChart = ({
       super(props);
 
       this.clipPathId = `${props.id ?? uniqueId('recharts')}-clip`;
-      this.wrapperAriaLabel = props.wrapperLabel ?? props.title ?? uniqueId(`Recharts ${chartName} `);
+      this.wrapperAriaLabel = props.wrapperAriaLabel ?? props.title ?? uniqueId(`Recharts ${chartName} `);
 
       if (props.throttleDelay) {
         this.triggeredAfterMouseMove = _.throttle(this.triggeredAfterMouseMove, props.throttleDelay);

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1101,7 +1101,7 @@ export const generateCategoricalChart = ({
 
     accessibilityManager = new AccessibilityManager();
 
-    wrapperLabel: string;
+    wrapperAriaLabel: string;
 
     // todo join specific chart propTypes
     static defaultProps: CategoricalChartProps = {
@@ -1121,7 +1121,7 @@ export const generateCategoricalChart = ({
       super(props);
 
       this.clipPathId = `${props.id ?? uniqueId('recharts')}-clip`;
-      this.wrapperLabel = props.wrapperLabel ?? props.title ?? uniqueId(`Recharts ${chartName} `);
+      this.wrapperAriaLabel = props.wrapperLabel ?? props.title ?? uniqueId(`Recharts ${chartName} `);
 
       if (props.throttleDelay) {
         this.triggeredAfterMouseMove = _.throttle(this.triggeredAfterMouseMove, props.throttleDelay);
@@ -2349,7 +2349,7 @@ export const generateCategoricalChart = ({
             this.container = node;
           }}
           role="region"
-          aria-label={this.wrapperLabel}
+          aria-label={this.wrapperAriaLabel}
         >
           <Surface {...attrs} width={width} height={height} title={title} desc={desc}>
             {this.renderClipPath()}

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -88,7 +88,7 @@ export type TooltipProps<TValue extends ValueType, TName extends NameType> = Def
   animationEasing?: AnimationTiming;
   filterNull?: boolean;
   useTranslate3d?: boolean;
-  ariaLabel?: string;
+  wrapperAriaLabel?: string;
 };
 
 export class Tooltip<TValue extends ValueType, TName extends NameType> extends PureComponent<
@@ -132,7 +132,7 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
   constructor(props: TooltipProps<TValue, TName>) {
     super(props);
 
-    this.wrapperAriaLabel = props.ariaLabel ?? uniqueId('Recharts Dialog ');
+    this.wrapperAriaLabel = props.wrapperAriaLabel ?? uniqueId('Recharts Dialog ');
   }
 
   componentDidMount() {

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import { DefaultTooltipContent, ValueType, NameType, Payload, Props as DefaultProps } from './DefaultTooltipContent';
 
 import { Global } from '../util/Global';
-import { isNumber } from '../util/DataUtils';
+import { isNumber, uniqueId } from '../util/DataUtils';
 import { AnimationDuration, AnimationTiming } from '../util/types';
 
 const CLS_PREFIX = 'recharts-tooltip-wrapper';
@@ -88,6 +88,7 @@ export type TooltipProps<TValue extends ValueType, TName extends NameType> = Def
   animationEasing?: AnimationTiming;
   filterNull?: boolean;
   useTranslate3d?: boolean;
+  ariaLabel?: string;
 };
 
 export class Tooltip<TValue extends ValueType, TName extends NameType> extends PureComponent<
@@ -125,6 +126,14 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
   };
 
   private wrapperNode: HTMLDivElement;
+
+  private wrapperAriaLabel: string;
+
+  constructor(props: TooltipProps<TValue, TName>) {
+    super(props);
+
+    this.wrapperAriaLabel = props.ariaLabel ?? uniqueId('Recharts Dialog ');
+  }
 
   componentDidMount() {
     this.updateBBox();
@@ -294,6 +303,7 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
       <div
         tabIndex={-1}
         role="dialog"
+        aria-label={this.wrapperAriaLabel}
         className={cls}
         style={outerStyle}
         ref={node => {

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React, { Children, Component, FunctionComponent, isValidElement, ReactNode } from 'react';
 import { isFragment } from 'react-is';
 import { DotProps } from '..';
-import { isNumber, uniqueId } from './DataUtils';
+import { isNumber } from './DataUtils';
 import { shallowEqual } from './ShallowEqual';
 import { FilteredSvgElementType, FilteredElementKeyMap, SVGElementPropKeys, EventKeys } from './types';
 import { AreaDot } from '../cartesian/Area';
@@ -447,8 +447,4 @@ export const getReactEventByType = (e: { type?: string }): string => {
 
 export const parseChildIndex = (child: any, children: any[]) => {
   return toArray(children).indexOf(child);
-};
-
-export const getUniqueWrapperLabel = (component: React.ComponentType) => {
-  return `Recharts ${getDisplayName(component)} ${uniqueId()}`;
 };

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React, { Children, Component, FunctionComponent, isValidElement, ReactNode } from 'react';
 import { isFragment } from 'react-is';
 import { DotProps } from '..';
-import { isNumber } from './DataUtils';
+import { isNumber, uniqueId } from './DataUtils';
 import { shallowEqual } from './ShallowEqual';
 import { FilteredSvgElementType, FilteredElementKeyMap, SVGElementPropKeys, EventKeys } from './types';
 import { AreaDot } from '../cartesian/Area';
@@ -447,4 +447,8 @@ export const getReactEventByType = (e: { type?: string }): string => {
 
 export const parseChildIndex = (child: any, children: any[]) => {
   return toArray(children).indexOf(child);
+};
+
+export const getUniqueWrapperLabel = (component: React.ComponentType) => {
+  return `Recharts ${getDisplayName(component)} ${uniqueId()}`;
 };

--- a/storybook/stories/API/chart/Sankey.stories.tsx
+++ b/storybook/stories/API/chart/Sankey.stories.tsx
@@ -18,6 +18,7 @@ export default {
     margin,
     data,
     sort: { description: 'Whether to sort the data or not' },
+    wrapperAriaLabel: { description: 'Optional aria-label applied to the wrapper <div> element of the chart' },
   },
   component: Sankey,
 };

--- a/storybook/stories/API/chart/Treemap.stories.tsx
+++ b/storybook/stories/API/chart/Treemap.stories.tsx
@@ -71,6 +71,7 @@ export default {
     onClick,
     onMouseEnter,
     onMouseLeave,
+    wrapperAriaLabel: { description: 'Optional aria-label applied to the wrapper <div> element of the chart' },
   },
   component: Treemap,
 };

--- a/storybook/stories/API/props/ChartProps.ts
+++ b/storybook/stories/API/props/ChartProps.ts
@@ -275,7 +275,7 @@ toggling between multiple dataKey.`,
   },
   stackOffset: {
     description: `Determines how values are stacked:
-    
+
 - \`none\` is the default, it adds values on top of each other. No smarts. Negative values will overlap.
 - \`expand\` make it so that the values always add up to 1 - so the chart will look like a rectangle.
 - \`wiggle\` and \`silhouette\` tries to keep the chart centered.
@@ -337,6 +337,18 @@ Also see https://d3js.org/d3-shape/stack#stack-offsets
       type: {
         summary: 'String',
       },
+      category: 'General',
+    },
+  },
+  wrapperLabel: {
+    description: `An optional value to be used as the aria-label for the wrapper element. When no value is provided
+      the aria-label will be set to the value of the \`title\` prop; if present; otherwise
+      the aria-label will be set to a unique generated (human-readable, but not meaningful) value.`,
+    table: {
+      type: {
+        summary: 'String',
+      },
+      defaultValue: false,
       category: 'General',
     },
   },


### PR DESCRIPTION
## Description

This PR adds the following functionality to Recharts:

**For charts**:
- Adds the `aria-label` attribute required by the ARIA role of `region` defined on the wrapper `<div>` for `generateCategoricalChart`, `Sankey`, and `TreeMap`;
- Allows developers to supply a value for the `aria-label` attribute using the `ariaLabel` prop;
- Generates a fallback value if `ariaLabel` is `undefined`.

**For tooltips**:
- The same as for charts, except the `aria-label` is required by the ARIA role of `dialog`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3816 

## Motivation and Context

Accessibility rules dictate that, on any given page, multiple elements with the same ARIA role need to have unique identifiers. The `aria-label` attribute is the most straightforward way to supply these unique identifiers.

## How Has This Been Tested?

I’ve tested these changes against the existing Recharts test suite as well as our project’s accessibility test suite, which applies WCAG rules to a set of automated browser tests using Playwright.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
