### PR TITLE
Change in the value of CategoricalChartFunc

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1593,9 +1593,7 @@ export const generateCategoricalChart = ({
           mouse = this.getMouseInfo(e as React.MouseEvent);
         }
 
-        const handler = event;
-
-        handler(mouse, e);
+        event(mouse ?? {}, e);
       }
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We cannot predict null as a type, but the value can be null.
If you are not going to change the type definition of CategoricalChartFunc, it would be better to return an empty object.

## Related Issue

#2329

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [ ] All new and existing tests passed.
