### PR TITLE
fix: CartesianGrid throws error when xAxis or yAxis doesn't exist

### DIFF
--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -307,10 +307,12 @@ export class CartesianGrid extends PureComponent<Props> {
 
       horizontalPoints = horizontalCoordinatesGenerator(
         {
-          yAxis: {
-            ...yAxis,
-            ticks: isHorizontalValues ? horizontalValues : yAxis.ticks,
-          },
+          yAxis: yAxis
+            ? {
+                ...yAxis,
+                ticks: isHorizontalValues ? horizontalValues : yAxis.ticks,
+              }
+            : undefined,
           width: chartWidth,
           height: chartHeight,
           offset,
@@ -325,10 +327,12 @@ export class CartesianGrid extends PureComponent<Props> {
 
       verticalPoints = verticalCoordinatesGenerator(
         {
-          xAxis: {
-            ...xAxis,
-            ticks: isVerticalValues ? verticalValues : xAxis.ticks,
-          },
+          xAxis: xAxis
+            ? {
+                ...xAxis,
+                ticks: isVerticalValues ? verticalValues : xAxis.ticks,
+              }
+            : undefined,
           width: chartWidth,
           height: chartHeight,
           offset,

--- a/storybook/stories/Examples/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart.stories.tsx
@@ -1,6 +1,8 @@
 // eslint-disable-next-line max-classes-per-file
-import React, { PureComponent, useState } from 'react';
+import { expect } from '@storybook/jest';
 import { StoryObj } from '@storybook/react';
+import React, { PureComponent, useState } from 'react';
+import { userEvent, within } from '@storybook/testing-library';
 import { Impressions, impressionsData, pageData } from '../data';
 import {
   Line,
@@ -816,7 +818,14 @@ export const NegativeValuesWithReferenceLines = {
   },
 };
 
-export const ToggleChildrenComponentsExceptCartesianGrid = {
+export const ToggleChildrenComponentsExceptCartesianGrid: StoryObj = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    expect(canvas.getByText('Page A')).toBeInTheDocument();
+    await userEvent.click(canvas.getByTestId('toggle'));
+    expect(canvas.queryByText('Page A')).not.toBeInTheDocument();
+  },
   render: () => {
     const data = [
       {
@@ -888,11 +897,11 @@ export const ToggleChildrenComponentsExceptCartesianGrid = {
 
     return (
       <div>
-        <button type="button" onClick={() => setBtnClicked(clicked => !clicked)}>
+        <button data-testid="toggle" type="button" onClick={() => setBtnClicked(clicked => !clicked)}>
           Click Me to Simulate Legend
         </button>
         <LineChart width={1300} height={400} margin={{ right: 30, bottom: 40 }} data={data} layout="horizontal">
-          <CartesianGrid strokeDasharray="3 3" />
+          <CartesianGrid data-testid="cartesian" strokeDasharray="3 3" />
           {isBtnClicked ? null : (
             <>
               <XAxis

--- a/storybook/stories/Examples/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart.stories.tsx
@@ -16,6 +16,7 @@ import {
   Area,
   Brush,
   ReferenceArea,
+  DefaultTooltipContent,
 } from '../../../src';
 
 export default {
@@ -811,6 +812,122 @@ export const NegativeValuesWithReferenceLines = {
           <Line strokeWidth={2} data={data} dot={false} type="monotone" dataKey="y" stroke="black" tooltipType="none" />
         </LineChart>
       </ResponsiveContainer>
+    );
+  },
+};
+
+export const ToggleChildrenComponentsExceptCartesianGrid = {
+  render: () => {
+    const data = [
+      {
+        name: 'Page A',
+        uv: 4000,
+        pv: 2400,
+        amt: 2400,
+      },
+      {
+        name: 'Page B',
+        uv: 3000,
+        pv: 1398,
+        amt: 2210,
+      },
+      {
+        name: 'Page C',
+        uv: 2000,
+        pv: 9800,
+        amt: 2290,
+      },
+      {
+        name: 'Page D',
+        uv: 2780,
+        pv: 3908,
+        amt: 2000,
+      },
+      {
+        name: 'Page E',
+        uv: 1890,
+        pv: 4800,
+        amt: 2181,
+      },
+      {
+        name: 'Page F',
+        uv: 2390,
+        pv: 3800,
+        amt: 2500,
+      },
+      {
+        name: 'Page G',
+        uv: 3490,
+        pv: 4300,
+        amt: 2100,
+      },
+    ];
+
+    const yAxes = [
+      { yAxisId: 'one', dataKey: 'pv', orientation: 'left' },
+      { yAxisId: 'two', dataKey: 'uv', orientation: 'left' },
+    ] as const;
+
+    const [isBtnClicked, setBtnClicked] = useState(false);
+
+    const yAxisComponents = yAxes.map(({ yAxisId, dataKey, orientation }) => (
+      <YAxis
+        key={dataKey}
+        axisLine={{ display: 'none' }}
+        tickLine={{ display: 'none' }}
+        orientation={orientation}
+        dataKey={dataKey}
+        yAxisId={yAxisId}
+        tick={{
+          fill: '#555',
+          fontSize: 16,
+          fontWeight: 'bold',
+        }}
+      />
+    ));
+
+    return (
+      <div>
+        <button type="button" onClick={() => setBtnClicked(clicked => !clicked)}>
+          Click Me to Simulate Legend
+        </button>
+        <LineChart width={1300} height={400} margin={{ right: 30, bottom: 40 }} data={data} layout="horizontal">
+          <CartesianGrid strokeDasharray="3 3" />
+          {isBtnClicked ? null : (
+            <>
+              <XAxis
+                dataKey="name"
+                type="category"
+                allowDuplicatedCategory={false}
+                interval={0}
+                ticks={['Page A', 'Page C', 'Page F']}
+                tick={{ fontSize: 14 }}
+                tickMargin={25}
+              />
+              {yAxisComponents}
+              <Tooltip content={<DefaultTooltipContent />} />
+              <Line
+                name="PV"
+                type="monotone"
+                dataKey="pv"
+                stroke="#8884d8"
+                activeDot={{ r: 8 }}
+                yAxisId={yAxisComponents[0].props.yAxisId}
+                dot={false}
+              />
+              <Line
+                name="UV"
+                type="monotone"
+                dataKey="uv"
+                stroke="#82ca9d"
+                yAxisId={yAxisComponents[1].props.yAxisId}
+                dot={false}
+              />
+            </>
+          )}
+        </LineChart>
+        <Legend />
+      </div>
     );
   },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- add: LineChart example toggling children
    This example showcases a LineChart with ability to toggle content of the chart like Line, Tooltip and etc.

    This example introduced to reproduce a bug reported on #3906 where keeping only CartesianGrid rendered would throw an error since the xAxis and yAxis aren't present (not rendered)

- fix: optional xAxis & yAxis access without checks
    xAxis and yAxis are optional and CartesianGrid shouldn't use them if they don't exist.

## Related Issue

Fixes: #3906 #3907

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
