### PR TITLE
Reuse assertNotNull in AccessibilityLayer.spec.tsx

### DIFF
--- a/test/chart/AccessibilityLayer.spec.tsx
+++ b/test/chart/AccessibilityLayer.spec.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { fireEvent, render } from '@testing-library/react';
+import { vi, describe, test } from 'vitest';
 import { Area, AreaChart, CartesianGrid, Legend, Tooltip, XAxis, YAxis } from '../../src';
-import { vi } from 'vitest';
+import { assertNotNull } from '../helper/assertNotNull';
 
 describe('AccessibilityLayer', () => {
   const data = [
@@ -67,13 +68,9 @@ describe('AccessibilityLayer', () => {
     expect(mockMouseMovements.mock.instances).toHaveLength(0);
 
     // Once the chart receives focus, the tooltip should display
-    svg?.focus();
+    svg.focus();
     expect(tooltip).toHaveTextContent('Page A');
     expect(mockMouseMovements.mock.instances).toHaveLength(1);
-
-    if (svg === null) {
-      return;
-    }
 
     // Ignore left arrow when you're already at the left
     fireEvent.keyDown(svg, {
@@ -148,19 +145,16 @@ describe('AccessibilityLayer', () => {
     );
 
     const svg = container.querySelector('svg');
+    assertNotNull(svg);
     const tooltip = container.querySelector('.recharts-tooltip-wrapper');
 
     expect(tooltip?.textContent).toBe('');
     expect(mockMouseMovements.mock.instances).toHaveLength(0);
 
     // Once the chart receives focus, the tooltip should display
-    svg?.focus();
+    svg.focus();
     expect(tooltip).toHaveTextContent('');
     expect(mockMouseMovements.mock.instances).toHaveLength(0);
-
-    if (svg === null) {
-      return;
-    }
 
     // Vertical charts aren't supported, so right arrow key should be ignored
     fireEvent.keyDown(svg, {
@@ -208,18 +202,15 @@ describe('AccessibilityLayer', () => {
 
     const pre = container.querySelector('pre');
     const svg = container.querySelector('svg');
+    assertNotNull(svg);
     const tooltip = container.querySelector('.recharts-tooltip-wrapper');
 
     expect(tooltip?.textContent).toBe('');
     expect(pre?.textContent).toBe('6');
 
     // Once the chart receives focus, the tooltip should display
-    svg?.focus();
+    svg.focus();
     expect(tooltip).toHaveTextContent('Page A');
-
-    if (svg === null) {
-      return;
-    }
 
     fireEvent.keyDown(svg, {
       key: 'ArrowRight',
@@ -327,12 +318,8 @@ describe('AccessibilityLayer', () => {
     expect(tooltip?.textContent).toBe('');
 
     // Once the chart receives focus, the tooltip should display
-    svg?.focus();
+    svg.focus();
     expect(tooltip).toHaveTextContent('Page A');
-
-    if (svg === null) {
-      return;
-    }
 
     // Ignore left arrow when you're already at the left
     fireEvent.keyDown(svg, {
@@ -379,17 +366,13 @@ describe('AccessibilityLayer', () => {
     const { container } = render(<BugExample />);
 
     const svg = container.querySelector('svg');
+    assertNotNull(svg);
     const tooltip = container.querySelector('.recharts-tooltip-wrapper');
 
     expect(tooltip?.textContent).toBe('');
 
-    svg?.focus();
+    svg.focus();
     expect(tooltip).toHaveTextContent('Page A');
-
-    // This makes typescript happy
-    if (svg === null) {
-      return;
-    }
 
     // Make sure we move around, to get the AccessibilityManager's active index above 0
     fireEvent.keyDown(svg, {
@@ -403,7 +386,7 @@ describe('AccessibilityLayer', () => {
     expect(container.querySelector('.recharts-tooltip-wrapper')).toBeNull();
 
     expect(() => {
-      svg?.focus();
+      svg.focus();
       fireEvent.keyDown(svg, {
         key: 'ArrowRight',
       });

--- a/test/helper/assertNotNull.ts
+++ b/test/helper/assertNotNull.ts
@@ -1,0 +1,5 @@
+export function assertNotNull<T>(item: T): asserts item is NonNullable<T> {
+  if (item == null) {
+    throw new Error('Unexpected null');
+  }
+}

--- a/test/util/ChartUtils/getLegendProps.spec.tsx
+++ b/test/util/ChartUtils/getLegendProps.spec.tsx
@@ -3,6 +3,7 @@ import { vi } from 'vitest';
 import { FormattedGraphicalItem, getLegendProps } from '../../../src/util/ChartUtils';
 import { findChildByType } from '../../../src/util/ReactUtils';
 import { Legend } from '../../../src/component/Legend';
+import { assertNotNull } from '../../helper/assertNotNull';
 
 vi.mock('../../../src/util/ReactUtils');
 
@@ -32,12 +33,6 @@ function createFormattedGraphicalItem({
   };
 }
 
-function assertNonNull<T>(item: T): asserts item is NonNullable<T> {
-  if (item == null) {
-    throw new Error('Unexpected null result');
-  }
-}
-
 describe('getLegendProps', () => {
   it('should call findChildByType to find Legend element', () => {
     const children = createChildren();
@@ -54,14 +49,14 @@ describe('getLegendProps', () => {
   it('if a Legend is defined then it returns it as `item`', () => {
     const item = { props: {} };
     const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
-    assertNonNull(result);
+    assertNotNull(result);
     expect(result.item).toBe(item);
   });
 
   it('should pass through all existing legendItem props', () => {
     const item = { props: { align: 1, alphabetic: true } };
     const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
-    assertNonNull(result);
+    assertNotNull(result);
     expect(result.align).toBe(1);
     expect(result.alphabetic).toBe(true);
   });
@@ -70,14 +65,14 @@ describe('getLegendProps', () => {
     it('should not add height nor width', () => {
       const item = { props: {} };
       const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.width).toBe(undefined);
       expect(result.height).toBe(undefined);
     });
     it('should pass through height and width', () => {
       const item = { props: { width: 1, height: 2 } };
       const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.width).toBe(1);
       expect(result.height).toBe(2);
     });
@@ -87,7 +82,7 @@ describe('getLegendProps', () => {
     it('should pass through both width and height if layout is `vertical`', () => {
       const item = { props: { layout: 'vertical', width: 1, height: 2 } };
       const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.width).toBe(1);
       expect(result.height).toBe(2);
     });
@@ -95,7 +90,7 @@ describe('getLegendProps', () => {
     it('should return height: undefined if layout is `vertical` but height is not defined', () => {
       const item = { props: { layout: 'vertical' } };
       const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.width).toBe(undefined);
       expect(result.height).toBe(undefined);
     });
@@ -105,7 +100,7 @@ describe('getLegendProps', () => {
     it('should default width to `legendWidth` if width is not defined', () => {
       const item = { props: { layout: 'horizontal' } };
       const result = getLegendProps({ children: createChildren(item), legendWidth: 10 });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.width).toBe(10);
       expect(result.height).toBe(undefined);
     });
@@ -113,7 +108,7 @@ describe('getLegendProps', () => {
     it('should default width to `legendWidth` if width is 0', () => {
       const item = { props: { layout: 'horizontal', width: 0 } };
       const result = getLegendProps({ children: createChildren(item), legendWidth: 10 });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.width).toBe(10);
       expect(result.height).toBe(undefined);
     });
@@ -121,7 +116,7 @@ describe('getLegendProps', () => {
     it('should pass through both width and height', () => {
       const item = { props: { layout: 'horizontal', width: 0 } };
       const result = getLegendProps({ children: createChildren(item), legendWidth: 10 });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.width).toBe(10);
       expect(result.height).toBe(undefined);
     });
@@ -131,13 +126,13 @@ describe('getLegendProps', () => {
     it('should pass it through unchanged', () => {
       const item = { props: { payload: ['defined'] } };
       const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload).toBe(item.props.payload);
     });
     it('should pass it through unchanged even if legendContent ==="children"', () => {
       const item = { props: { legendContent: 'children', payload: ['defined'] } };
       const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload).toBe(item.props.payload);
     });
   });
@@ -151,7 +146,7 @@ describe('getLegendProps', () => {
         legendWidth: 0,
         legendContent: 'children',
       });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload).toEqual([]);
     });
 
@@ -163,7 +158,7 @@ describe('getLegendProps', () => {
         legendWidth: 0,
         legendContent: 'children',
       });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload).toEqual([]);
     });
 
@@ -184,7 +179,7 @@ describe('getLegendProps', () => {
         legendWidth: 0,
         legendContent: 'children',
       });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload).toEqual([]);
     });
 
@@ -207,7 +202,7 @@ describe('getLegendProps', () => {
         legendWidth: 0,
         legendContent: 'children',
       });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload).toEqual([]);
     });
 
@@ -247,7 +242,7 @@ describe('getLegendProps', () => {
         legendWidth: 0,
         legendContent: 'children',
       });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload).toEqual([
         {
           color: 'red',
@@ -324,7 +319,7 @@ describe('getLegendProps', () => {
         legendWidth: 0,
         legendContent: 'children',
       });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload?.[0].type).toEqual('circle');
     });
 
@@ -346,7 +341,7 @@ describe('getLegendProps', () => {
         legendWidth: 0,
         legendContent: 'children',
       });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload?.[0].type).toEqual('diamond');
     });
   });
@@ -355,7 +350,7 @@ describe('getLegendProps', () => {
     it('should return empty payload if formattedGraphicalItems is an empty array', () => {
       const item = { props: {} };
       const result = getLegendProps({ children: createChildren(item), formattedGraphicalItems: [], legendWidth: 0 });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload).toEqual([]);
     });
 
@@ -366,7 +361,7 @@ describe('getLegendProps', () => {
         formattedGraphicalItems: undefined,
         legendWidth: 0,
       });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload).toEqual([]);
     });
 
@@ -405,7 +400,7 @@ describe('getLegendProps', () => {
         ],
         legendWidth: 0,
       });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload).toEqual([
         {
           color: undefined,
@@ -477,7 +472,7 @@ describe('getLegendProps', () => {
         ],
         legendWidth: 0,
       });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload?.[0]?.value).toEqual('myDataKey');
     });
 
@@ -498,7 +493,7 @@ describe('getLegendProps', () => {
         ],
         legendWidth: 0,
       });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload?.[0]?.type).toEqual('star');
     });
 
@@ -518,7 +513,7 @@ describe('getLegendProps', () => {
         ],
         legendWidth: 0,
       });
-      assertNonNull(result);
+      assertNotNull(result);
       expect(result.payload?.[0]?.type).toEqual('square');
     });
   });


### PR DESCRIPTION
I am debugging a problem with the AccessibilityLayer and this change can be in master.

## Description

## Related Issue


## Motivation and Context

The `if (svg == null) { return }` check works but it makes the test green if svg is undefined - I want the test to fail instead.

## How Has This Been Tested?

Vitest

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
