### PR TITLE
fix(Line): onClick for activeDot is incorrectly typed

### DIFF
--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -65,7 +65,7 @@ interface LineProps extends InternalLineProps {
   hide?: boolean;
 
   // whether have dot in line
-  activeDot?: ActiveShape<DotProps>;
+  activeDot?: ActiveShape<DotProps> | DotProps;
   dot?: LineDot;
 
   onAnimationStart?: () => void;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fix(Line): onClick for activeDot is incorrectly typed

## Description

<!--- Describe your changes in detail -->

Have `activeDot` include the type for `DotProps` which fixes the incorrect types for the event handlers that are added in [line 2036 in generateCategoricalChart](https://github.com/recharts/recharts/blob/master/src/chart/generateCategoricalChart.tsx#L2036
) which give a different payload to the callback mentioned in the issue.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3922 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes incorrect types that introduced a breaking change 

## How Has This Been Tested?
Manually. It's a purely typescript issue. Screenshot below.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="669" alt="Screenshot 2023-10-31 at 4 22 50 PM" src="https://github.com/recharts/recharts/assets/24420033/6eff15ec-e7cc-4056-92ed-f44ba3d007a2">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
