### PR TITLE
fix: missing index on LabelProps type

### DIFF
--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -48,6 +48,7 @@ interface LabelProps {
   content?: ContentType;
   textBreakAll?: boolean;
   angle?: number;
+  index?: number;
 }
 
 export type Props = Omit<SVGProps<SVGTextElement>, 'viewBox'> & LabelProps;

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -29,7 +29,7 @@ interface LabelListProps<T extends Data> {
   formatter?: Function;
 }
 
-export type Props<T extends Data> = SVGProps<SVGElement> & LabelListProps<T>;
+export type Props<T extends Data> = Omit<SVGProps<SVGTextElement>, 'offset'> & LabelListProps<T>;
 
 export type ImplicitLabelListType<T extends Data> =
   | boolean
@@ -54,15 +54,15 @@ export function LabelList<T extends Data>({ valueAccessor = defaultAccessor, ...
 
         return (
           <Label
-            {...(filterProps(entry, true) as any)}
+            {...filterProps(entry, true)}
             {...others}
             {...idProps}
             parentViewBox={entry.parentViewBox}
-            index={index}
             value={value}
             textBreakAll={textBreakAll}
             viewBox={Label.parseViewBox(isNil(clockWise) ? entry : { ...entry, clockWise })}
             key={`label-${index}`} // eslint-disable-line react/no-array-index-key
+            index={index}
           />
         );
       })}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
`index` is a valid property on `Label` although it is only used to reference which label is which in a `LabelList`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/3938

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- Removes a cast to `any`
- Narrows type of `LabelList` correctly (anything that wasn't a property that could be used on `SVGTextElement` wasn't being used properly anyways. If this change breaks people they can mitigate by removing incorrectly used properties.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tests continue to pass
- Imported type contains `index` property
- 

## Screenshots (if appropriate):
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
