### PR TITLE
fix: Line never checks for new totalLength on component update

### DIFF
--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -184,6 +184,17 @@ export class Line extends PureComponent<Props, State> {
     this.setState({ totalLength });
   }
 
+  componentDidUpdate(): void {
+    if (!this.props.isAnimationActive) {
+      return;
+    }
+
+    const totalLength = this.getTotalLength();
+    if (totalLength != null && totalLength !== this.state.totalLength) {
+      this.setState({ totalLength });
+    }
+  }
+
   static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
     if (nextProps.animationId !== prevState.prevAnimationId) {
       return {

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -190,7 +190,7 @@ export class Line extends PureComponent<Props, State> {
     }
 
     const totalLength = this.getTotalLength();
-    if (totalLength != null && totalLength !== this.state.totalLength) {
+    if (totalLength !== this.state.totalLength) {
       this.setState({ totalLength });
     }
   }

--- a/storybook/stories/Examples/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart.stories.tsx
@@ -959,3 +959,32 @@ export const WithBrush: StoryObj = {
     );
   },
 };
+
+export const HideOnLegendClick: StoryObj = {
+  render: () => {
+    const [activeSeries, setActiveSeries] = React.useState<Array<string>>([]);
+
+    const handleLegendClick = (dataKey: string) => {
+      if (activeSeries.includes(dataKey)) {
+        setActiveSeries(activeSeries.filter(el => el !== dataKey));
+      } else {
+        setActiveSeries(prev => [...prev, dataKey]);
+      }
+    };
+
+    return (
+      <ResponsiveContainer height={400}>
+        <LineChart data={pageData}>
+          <XAxis dataKey="name" />
+          <YAxis />
+          <CartesianGrid strokeDasharray="3 3" />
+          <Tooltip />
+          <Legend height={36} iconType="circle" onClick={props => handleLegendClick(props.dataKey)} />
+
+          <Line hide={activeSeries.includes('uv')} type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+          <Line hide={activeSeries.includes('pv')} type="monotone" dataKey="pv" stroke="#987" fill="#8884d8" />
+        </LineChart>
+      </ResponsiveContainer>
+    );
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
`getTotalLength` only gets called on initial render in Line. When hiding and showing `Line` components in a specific chart the total length remains the same as it was before, when in fact it is now different (chart adjusts based on available space). In some cases this leads to the charts `strokeDasharray` not being correct and sometimes partially showing during animation. See videos

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes https://github.com/recharts/recharts/issues/3359

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix bug

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See videos 

- add storybook entry for toggling `Line` components via `Legend` click


#### Before

https://github.com/recharts/recharts/assets/25180830/55e4baa3-d10e-4d44-bfa1-0703a6d75cae




#### After

https://github.com/recharts/recharts/assets/25180830/e81226ff-f12b-40ec-b79f-30c33afe41ec






## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
