### PR TITLE
Split Tooltip into TooltipBoundingBox

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -2,15 +2,19 @@
  * @fileOverview Tooltip
  */
 import React, { PureComponent, CSSProperties, ReactNode, ReactElement, SVGProps } from 'react';
-import { translateStyle } from 'react-smooth';
-import { DefaultTooltipContent, ValueType, NameType, Payload, Props as DefaultProps } from './DefaultTooltipContent';
+import {
+  DefaultTooltipContent,
+  ValueType,
+  NameType,
+  Payload,
+  Props as ToltipContentProps,
+} from './DefaultTooltipContent';
+import { TooltipBoundingBox } from './TooltipBoundingBox';
 
 import { Global } from '../util/Global';
 import { UniqueOption, getUniqPayload } from '../util/payload/getUniqPayload';
-import { AllowInDimension, AnimationDuration, AnimationTiming, Coordinate } from '../util/types';
-import { getTooltipTranslate } from '../util/tooltip/translate';
+import { AllowInDimension, AnimationDuration, AnimationTiming, CartesianViewBox, Coordinate } from '../util/types';
 
-const EPS = 1;
 export type ContentType<TValue extends ValueType, TName extends NameType> =
   | ReactElement
   | ((props: TooltipProps<TValue, TName>) => ReactNode);
@@ -22,7 +26,7 @@ function defaultUniqBy<TValue extends ValueType, TName extends NameType>(entry: 
 function renderContent<TValue extends ValueType, TName extends NameType>(
   content: ContentType<TValue, TName>,
   props: TooltipProps<TValue, TName>,
-) {
+): ReactNode {
   if (React.isValidElement(content)) {
     return React.cloneElement(content, props);
   }
@@ -33,30 +37,25 @@ function renderContent<TValue extends ValueType, TName extends NameType>(
   return <DefaultTooltipContent {...props} />;
 }
 
-export type TooltipProps<TValue extends ValueType, TName extends NameType> = DefaultProps<TValue, TName> & {
-  allowEscapeViewBox?: AllowInDimension;
-  reverseDirection?: AllowInDimension;
-  content?: ContentType<TValue, TName>;
-  viewBox?: {
-    x?: number;
-    y?: number;
-    width?: number;
-    height?: number;
-  };
+export type TooltipProps<TValue extends ValueType, TName extends NameType> = ToltipContentProps<TValue, TName> & {
   active?: boolean;
-  offset?: number;
-  wrapperStyle?: CSSProperties;
-  cursor?: boolean | ReactElement | SVGProps<SVGElement>;
-  coordinate?: Partial<Coordinate>;
-  position?: Partial<Coordinate>;
-  trigger?: 'hover' | 'click';
-  shared?: boolean;
-  payloadUniqBy?: UniqueOption<Payload<TValue, TName>>;
-  isAnimationActive?: boolean;
+  allowEscapeViewBox?: AllowInDimension;
   animationDuration?: AnimationDuration;
   animationEasing?: AnimationTiming;
+  content?: ContentType<TValue, TName>;
+  coordinate?: Partial<Coordinate>;
+  cursor?: boolean | ReactElement | SVGProps<SVGElement>;
   filterNull?: boolean;
+  isAnimationActive?: boolean;
+  offset?: number;
+  payloadUniqBy?: UniqueOption<Payload<TValue, TName>>;
+  position?: Partial<Coordinate>;
+  reverseDirection?: AllowInDimension;
+  shared?: boolean;
+  trigger?: 'hover' | 'click';
   useTranslate3d?: boolean;
+  viewBox?: CartesianViewBox;
+  wrapperStyle?: CSSProperties;
 };
 
 export class Tooltip<TValue extends ValueType, TName extends NameType> extends PureComponent<
@@ -67,91 +66,24 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
   static defaultProps = {
     active: false,
     allowEscapeViewBox: { x: false, y: false },
-    reverseDirection: { x: false, y: false },
-    offset: 10,
-    viewBox: { x: 0, y: 0, height: 0, width: 0 },
-    coordinate: { x: 0, y: 0 },
-    cursorStyle: {},
-    separator: ' : ',
-    wrapperStyle: {},
+    animationDuration: 400,
+    animationEasing: 'ease',
     contentStyle: {},
+    coordinate: { x: 0, y: 0 },
+    cursor: true,
+    cursorStyle: {},
+    filterNull: true,
+    isAnimationActive: !Global.isSsr,
     itemStyle: {},
     labelStyle: {},
-    cursor: true,
+    offset: 10,
+    reverseDirection: { x: false, y: false },
+    separator: ' : ',
     trigger: 'hover',
-    isAnimationActive: !Global.isSsr,
-    animationEasing: 'ease',
-    animationDuration: 400,
-    filterNull: true,
     useTranslate3d: false,
+    viewBox: { x: 0, y: 0, height: 0, width: 0 },
+    wrapperStyle: {},
   };
-
-  state = {
-    dismissed: false,
-    dismissedAtCoordinate: { x: 0, y: 0 },
-  };
-
-  lastBoundingBox = {
-    width: -1,
-    height: -1,
-  };
-
-  private wrapperNode: HTMLDivElement;
-
-  componentDidMount() {
-    document.addEventListener('keydown', this.handleKeyDown);
-    this.updateBBox();
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keydown', this.handleKeyDown);
-  }
-
-  componentDidUpdate() {
-    if (this.props.active) {
-      this.updateBBox();
-    }
-
-    if (!this.state.dismissed) {
-      return;
-    }
-
-    if (
-      this.props.coordinate?.x !== this.state.dismissedAtCoordinate.x ||
-      this.props.coordinate?.y !== this.state.dismissedAtCoordinate.y
-    ) {
-      this.state.dismissed = false;
-    }
-  }
-
-  handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      this.setState({
-        dismissed: true,
-        dismissedAtCoordinate: {
-          x: this.props.coordinate?.x ?? 0,
-          y: this.props.coordinate?.y ?? 0,
-        },
-      });
-    }
-  };
-
-  updateBBox() {
-    if (this.wrapperNode && this.wrapperNode.getBoundingClientRect) {
-      const box = this.wrapperNode.getBoundingClientRect();
-
-      if (
-        Math.abs(box.width - this.lastBoundingBox.width) > EPS ||
-        Math.abs(box.height - this.lastBoundingBox.height) > EPS
-      ) {
-        this.lastBoundingBox.width = box.width;
-        this.lastBoundingBox.height = box.height;
-      }
-    } else if (this.lastBoundingBox.width !== -1 || this.lastBoundingBox.height !== -1) {
-      this.lastBoundingBox.width = -1;
-      this.lastBoundingBox.height = -1;
-    }
-  }
 
   render() {
     const {
@@ -182,49 +114,26 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
       );
     }
 
-    const hasPayload = finalPayload.length;
-
-    const { cssClasses, cssProperties } = getTooltipTranslate({
-      allowEscapeViewBox,
-      coordinate,
-      offsetTopLeft: offset,
-      position,
-      reverseDirection,
-      tooltipBox: {
-        height: this.lastBoundingBox.height,
-        width: this.lastBoundingBox.width,
-      },
-      useTranslate3d,
-      viewBox,
-    });
-
-    const outerStyle: CSSProperties = {
-      ...(isAnimationActive &&
-        active &&
-        translateStyle({ transition: `transform ${animationDuration}ms ${animationEasing}` })),
-      ...cssProperties,
-      pointerEvents: 'none',
-      visibility: !this.state.dismissed && active && hasPayload ? 'visible' : 'hidden',
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      ...wrapperStyle,
-    };
+    const hasPayload = finalPayload.length > 0;
 
     return (
-      // ESLint is disabled to allow listening to the `Escape` key. Refer to
-      // https://github.com/recharts/recharts/pull/2925
-      <div
-        tabIndex={-1}
-        role="dialog"
-        className={cssClasses}
-        style={outerStyle}
-        ref={node => {
-          this.wrapperNode = node;
-        }}
+      <TooltipBoundingBox
+        allowEscapeViewBox={allowEscapeViewBox}
+        animationDuration={animationDuration}
+        animationEasing={animationEasing}
+        isAnimationActive={isAnimationActive}
+        active={active}
+        coordinate={coordinate}
+        hasPayload={hasPayload}
+        offset={offset}
+        position={position}
+        reverseDirection={reverseDirection}
+        useTranslate3d={useTranslate3d}
+        viewBox={viewBox}
+        wrapperStyle={wrapperStyle}
       >
         {renderContent(content, { ...this.props, payload: finalPayload })}
-      </div>
+      </TooltipBoundingBox>
     );
   }
 }

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -5,19 +5,19 @@ import { getTooltipTranslate } from '../util/tooltip/translate';
 
 export type TooltipBoundingBoxProps = {
   active: boolean;
-  allowEscapeViewBox?: AllowInDimension;
-  animationDuration?: AnimationDuration;
-  animationEasing?: AnimationTiming;
+  allowEscapeViewBox: AllowInDimension;
+  animationDuration: AnimationDuration;
+  animationEasing: AnimationTiming;
   children: ReactNode;
-  coordinate: Coordinate;
-  isAnimationActive?: boolean;
-  offset?: number;
-  position?: Partial<Coordinate>;
-  reverseDirection?: AllowInDimension;
-  useTranslate3d?: boolean;
-  viewBox?: CartesianViewBox;
-  wrapperStyle?: CSSProperties;
+  coordinate: Partial<Coordinate>;
   hasPayload: boolean;
+  isAnimationActive: boolean;
+  offset: number;
+  position: Partial<Coordinate>;
+  reverseDirection: AllowInDimension;
+  useTranslate3d: boolean;
+  viewBox: CartesianViewBox;
+  wrapperStyle: CSSProperties;
 };
 
 type State = {

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -1,0 +1,159 @@
+import React, { CSSProperties, PureComponent, ReactNode } from 'react';
+import { translateStyle } from 'react-smooth';
+import { AllowInDimension, AnimationDuration, AnimationTiming, CartesianViewBox, Coordinate } from '../util/types';
+import { getTooltipTranslate } from '../util/tooltip/translate';
+
+export type TooltipBoundingBoxProps = {
+  active: boolean;
+  allowEscapeViewBox?: AllowInDimension;
+  animationDuration?: AnimationDuration;
+  animationEasing?: AnimationTiming;
+  children: ReactNode;
+  coordinate: Coordinate;
+  isAnimationActive?: boolean;
+  offset?: number;
+  position?: Partial<Coordinate>;
+  reverseDirection?: AllowInDimension;
+  useTranslate3d?: boolean;
+  viewBox?: CartesianViewBox;
+  wrapperStyle?: CSSProperties;
+  hasPayload: boolean;
+};
+
+type State = {
+  dismissed: boolean;
+  dismissedAtCoordinate: Coordinate;
+};
+
+const EPS = 1;
+
+export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, State> {
+  state = {
+    dismissed: false,
+    dismissedAtCoordinate: { x: 0, y: 0 },
+  };
+
+  lastBoundingBox = {
+    width: -1,
+    height: -1,
+  };
+
+  private wrapperNode: HTMLDivElement;
+
+  updateBBox() {
+    if (this.wrapperNode && this.wrapperNode.getBoundingClientRect) {
+      const box = this.wrapperNode.getBoundingClientRect();
+
+      if (
+        Math.abs(box.width - this.lastBoundingBox.width) > EPS ||
+        Math.abs(box.height - this.lastBoundingBox.height) > EPS
+      ) {
+        this.lastBoundingBox.width = box.width;
+        this.lastBoundingBox.height = box.height;
+      }
+    } else if (this.lastBoundingBox.width !== -1 || this.lastBoundingBox.height !== -1) {
+      this.lastBoundingBox.width = -1;
+      this.lastBoundingBox.height = -1;
+    }
+  }
+
+  componentDidMount() {
+    document.addEventListener('keydown', this.handleKeyDown);
+    this.updateBBox();
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.handleKeyDown);
+  }
+
+  componentDidUpdate() {
+    if (this.props.active) {
+      this.updateBBox();
+    }
+
+    if (!this.state.dismissed) {
+      return;
+    }
+
+    if (
+      this.props.coordinate?.x !== this.state.dismissedAtCoordinate.x ||
+      this.props.coordinate?.y !== this.state.dismissedAtCoordinate.y
+    ) {
+      this.state.dismissed = false;
+    }
+  }
+
+  handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      this.setState({
+        dismissed: true,
+        dismissedAtCoordinate: {
+          x: this.props.coordinate?.x ?? 0,
+          y: this.props.coordinate?.y ?? 0,
+        },
+      });
+    }
+  };
+
+  render() {
+    const {
+      active,
+      allowEscapeViewBox,
+      animationDuration,
+      animationEasing,
+      children,
+      coordinate,
+      hasPayload,
+      isAnimationActive,
+      offset,
+      position,
+      reverseDirection,
+      useTranslate3d,
+      viewBox,
+      wrapperStyle,
+    } = this.props;
+
+    const { cssClasses, cssProperties } = getTooltipTranslate({
+      allowEscapeViewBox,
+      coordinate,
+      offsetTopLeft: offset,
+      position,
+      reverseDirection,
+      tooltipBox: {
+        height: this.lastBoundingBox.height,
+        width: this.lastBoundingBox.width,
+      },
+      useTranslate3d,
+      viewBox,
+    });
+
+    const outerStyle: CSSProperties = {
+      ...(isAnimationActive &&
+        active &&
+        translateStyle({ transition: `transform ${animationDuration}ms ${animationEasing}` })),
+      ...cssProperties,
+      pointerEvents: 'none',
+      visibility: !this.state.dismissed && active && hasPayload ? 'visible' : 'hidden',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      ...wrapperStyle,
+    };
+
+    return (
+      // This element allow listening to the `Escape` key.
+      // See https://github.com/recharts/recharts/pull/2925
+      <div
+        tabIndex={-1}
+        role="dialog"
+        className={cssClasses}
+        style={outerStyle}
+        ref={node => {
+          this.wrapperNode = node;
+        }}
+      >
+        {children}
+      </div>
+    );
+  }
+}

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -25,7 +25,7 @@ type State = {
   dismissedAtCoordinate: Coordinate;
 };
 
-const EPS = 1;
+const EPSILON = 1;
 
 export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, State> {
   state = {
@@ -45,8 +45,8 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
       const box = this.wrapperNode.getBoundingClientRect();
 
       if (
-        Math.abs(box.width - this.lastBoundingBox.width) > EPS ||
-        Math.abs(box.height - this.lastBoundingBox.height) > EPS
+        Math.abs(box.width - this.lastBoundingBox.width) > EPSILON ||
+        Math.abs(box.height - this.lastBoundingBox.height) > EPSILON
       ) {
         this.lastBoundingBox.width = box.width;
         this.lastBoundingBox.height = box.height;

--- a/test/component/TooltipBoundingBox.spec.tsx
+++ b/test/component/TooltipBoundingBox.spec.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import { TooltipBoundingBox, TooltipBoundingBoxProps } from '../../src/component/TooltipBoundingBox';
+
+describe('TooltipBoundingBox', () => {
+  const defaultProps: TooltipBoundingBoxProps = {
+    active: true,
+    hasPayload: true,
+    children: 'Hello world!',
+    coordinate: undefined,
+  };
+  it('should render children when active prop is true', () => {
+    render(<TooltipBoundingBox {...defaultProps} />);
+    expect(screen.getByText('Hello world!')).toBeInTheDocument();
+    expect(screen.getByText('Hello world!')).toBeVisible();
+  });
+
+  it('should hide children when active prop is false', () => {
+    render(<TooltipBoundingBox {...defaultProps} active={false} />);
+    expect(screen.getByText('Hello world!')).toBeInTheDocument();
+    expect(screen.getByText('Hello world!')).not.toBeVisible();
+  });
+
+  it('should hide children when there is no payload', () => {
+    render(<TooltipBoundingBox {...defaultProps} hasPayload={false} />);
+    expect(screen.getByText('Hello world!')).toBeInTheDocument();
+    expect(screen.getByText('Hello world!')).not.toBeVisible();
+  });
+
+  it('should hide children when dismissed using Escape key', () => {
+    render(<TooltipBoundingBox {...defaultProps} active={false} />);
+    userEvent.keyboard('{Escape}');
+    screen.debug();
+    expect(screen.getByText('Hello world!')).toBeInTheDocument();
+    expect(screen.getByText('Hello world!')).not.toBeVisible();
+  });
+});

--- a/test/component/TooltipBoundingBox.spec.tsx
+++ b/test/component/TooltipBoundingBox.spec.tsx
@@ -10,6 +10,22 @@ describe('TooltipBoundingBox', () => {
     hasPayload: true,
     children: 'Hello world!',
     coordinate: undefined,
+    allowEscapeViewBox: {
+      x: false,
+      y: false,
+    },
+    animationDuration: 0,
+    animationEasing: 'ease',
+    isAnimationActive: false,
+    offset: 0,
+    position: undefined,
+    reverseDirection: {
+      x: false,
+      y: false,
+    },
+    useTranslate3d: false,
+    viewBox: undefined,
+    wrapperStyle: undefined,
   };
   it('should render children when active prop is true', () => {
     render(<TooltipBoundingBox {...defaultProps} />);


### PR DESCRIPTION
## Description

I think this is an opportunity to have two clearly defined components with split responsibility. One doing the position (BoundingBox) and one doing the content (Tooltip).

## Related Issue

## Motivation and Context

## How Has This Been Tested?

unit tests

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
