### PR TITLE
Reduce calls to `getStringSize` when calculating visible ticks (#2589)

### DIFF
--- a/src/cartesian/getEquidistantTicks.ts
+++ b/src/cartesian/getEquidistantTicks.ts
@@ -31,11 +31,19 @@ export function getEquidistantTicks(
     }
 
     // Check if the element collides with the next element
-    const size = getTickSize(entry, index);
+    const i = index;
+    let size: number | undefined;
+    const getSize = () => {
+      if (size === undefined) {
+        size = getTickSize(entry, i);
+      }
+
+      return size;
+    };
 
     const tickCoord = entry.coordinate;
     // We will always show the first tick.
-    const isShow = index === 0 || isVisible(sign, tickCoord, () => size, start, end);
+    const isShow = index === 0 || isVisible(sign, tickCoord, getSize, start, end);
 
     if (!isShow) {
       // Start all over with a larger stepsize
@@ -46,7 +54,7 @@ export function getEquidistantTicks(
 
     if (isShow) {
       // If it can be shown, update the start
-      start = tickCoord + sign * (size / 2 + minTickGap);
+      start = tickCoord + sign * (getSize() / 2 + minTickGap);
       index += stepsize;
     }
   }

--- a/src/cartesian/getEquidistantTicks.ts
+++ b/src/cartesian/getEquidistantTicks.ts
@@ -35,7 +35,7 @@ export function getEquidistantTicks(
 
     const tickCoord = entry.coordinate;
     // We will always show the first tick.
-    const isShow = index === 0 || isVisible(sign, tickCoord, size, start, end);
+    const isShow = index === 0 || isVisible(sign, tickCoord, () => size, start, end);
 
     if (!isShow) {
       // Start all over with a larger stepsize

--- a/src/cartesian/getTicks.ts
+++ b/src/cartesian/getTicks.ts
@@ -24,9 +24,11 @@ function getTicksEnd(
 
   for (let i = len - 1; i >= 0; i--) {
     let entry = result[i];
-    const size = getTickSize(entry, i);
+    let size: number | undefined;
+    const getSize = () => size ?? getTickSize(entry, i);
+
     if (i === len - 1) {
-      const gap = sign * (entry.coordinate + (sign * size) / 2 - end);
+      const gap = sign * (entry.coordinate + (sign * getSize()) / 2 - end);
       result[i] = entry = {
         ...entry,
         tickCoord: gap > 0 ? entry.coordinate - gap * sign : entry.coordinate,
@@ -35,10 +37,10 @@ function getTicksEnd(
       result[i] = entry = { ...entry, tickCoord: entry.coordinate };
     }
 
-    const isShow = isVisible(sign, entry.tickCoord, size, start, end);
+    const isShow = isVisible(sign, entry.tickCoord, getSize, start, end);
 
     if (isShow) {
-      end = entry.tickCoord - sign * (size / 2 + minTickGap);
+      end = entry.tickCoord - sign * (getSize() / 2 + minTickGap);
       result[i] = { ...entry, isShow: true };
     }
   }
@@ -69,7 +71,7 @@ function getTicksStart(
       tickCoord: tailGap > 0 ? tail.coordinate - tailGap * sign : tail.coordinate,
     };
 
-    const isTailShow = isVisible(sign, tail.tickCoord, tailSize, start, end);
+    const isTailShow = isVisible(sign, tail.tickCoord, () => tailSize, start, end);
 
     if (isTailShow) {
       end = tail.tickCoord - sign * (tailSize / 2 + minTickGap);
@@ -80,10 +82,11 @@ function getTicksStart(
   const count = preserveEnd ? len - 1 : len;
   for (let i = 0; i < count; i++) {
     let entry = result[i];
-    const size = getTickSize(entry, i);
+    let size: number | undefined;
+    const getSize = () => size ?? getTickSize(entry, i);
 
     if (i === 0) {
-      const gap = sign * (entry.coordinate - (sign * size) / 2 - start);
+      const gap = sign * (entry.coordinate - (sign * getSize()) / 2 - start);
       result[i] = entry = {
         ...entry,
         tickCoord: gap < 0 ? entry.coordinate - gap * sign : entry.coordinate,
@@ -92,10 +95,10 @@ function getTicksStart(
       result[i] = entry = { ...entry, tickCoord: entry.coordinate };
     }
 
-    const isShow = isVisible(sign, entry.tickCoord, size, start, end);
+    const isShow = isVisible(sign, entry.tickCoord, getSize, start, end);
 
     if (isShow) {
-      start = entry.tickCoord + sign * (size / 2 + minTickGap);
+      start = entry.tickCoord + sign * (getSize() / 2 + minTickGap);
       result[i] = { ...entry, isShow: true };
     }
   }

--- a/src/cartesian/getTicks.ts
+++ b/src/cartesian/getTicks.ts
@@ -25,7 +25,13 @@ function getTicksEnd(
   for (let i = len - 1; i >= 0; i--) {
     let entry = result[i];
     let size: number | undefined;
-    const getSize = () => size ?? getTickSize(entry, i);
+    const getSize = () => {
+      if (size === undefined) {
+        size = getTickSize(entry, i);
+      }
+
+      return size;
+    };
 
     if (i === len - 1) {
       const gap = sign * (entry.coordinate + (sign * getSize()) / 2 - end);
@@ -83,7 +89,13 @@ function getTicksStart(
   for (let i = 0; i < count; i++) {
     let entry = result[i];
     let size: number | undefined;
-    const getSize = () => size ?? getTickSize(entry, i);
+    const getSize = () => {
+      if (size === undefined) {
+        size = getTickSize(entry, i);
+      }
+
+      return size;
+    };
 
     if (i === 0) {
       const gap = sign * (entry.coordinate - (sign * getSize()) / 2 - start);

--- a/src/util/TickUtils.ts
+++ b/src/util/TickUtils.ts
@@ -30,6 +30,8 @@ export function isVisible(
   start: number,
   end: number,
 ): boolean {
+  /* Since getSize() is expensive (it reads the ticks' size from the DOM), we do this check first to avoid calculating
+   * the tick's size. */
   if (sign * tickPosition < sign * start || sign * tickPosition > sign * end) {
     return false;
   }

--- a/src/util/TickUtils.ts
+++ b/src/util/TickUtils.ts
@@ -23,7 +23,19 @@ export function getTickBoundaries(viewBox: CartesianViewBox, sign: number, sizeK
   };
 }
 
-export function isVisible(sign: number, tickPosition: number, size: number, start: number, end: number): boolean {
+export function isVisible(
+  sign: number,
+  tickPosition: number,
+  getSize: () => number,
+  start: number,
+  end: number,
+): boolean {
+  if (sign * tickPosition < sign * start || sign * tickPosition > sign * end) {
+    return false;
+  }
+
+  const size = getSize();
+
   return sign * (tickPosition - (sign * size) / 2 - start) >= 0 && sign * (tickPosition + (sign * size) / 2 - end) <= 0;
 }
 

--- a/test/util/TickUtils.spec.ts
+++ b/test/util/TickUtils.spec.ts
@@ -1,0 +1,28 @@
+import { isVisible } from '../../src/util/TickUtils';
+
+describe('isVisible', () => {
+  test.each([
+    { sign: 1, position: 50, size: 10, start: 0, end: 100 },
+    { sign: 1, position: 50, size: 50, start: 0, end: 100 },
+    { sign: 1, position: 50, size: 100, start: 0, end: 100 },
+    { sign: 0, position: 50, size: 10, start: 0, end: 100 },
+    { sign: 0, position: 50, size: 50, start: 0, end: 100 },
+    { sign: 0, position: 50, size: 100, start: 0, end: 100 },
+  ])('is returns true if tick is inside limits: (%o)', ({ sign, position, size, start, end }) => {
+    expect(isVisible(sign, position, () => size, start, end)).toBeTruthy();
+  });
+
+  test.each([
+    { sign: -1, position: 50, size: 10, start: 0, end: 100 },
+    { sign: -1, position: 50, size: 50, start: 0, end: 100 },
+    { sign: -1, position: 50, size: 100, start: 0, end: 100 },
+    { sign: 1, position: 50, size: 101, start: 0, end: 100 },
+    { sign: 1, position: 10, size: 10_000, start: 50, end: 100 },
+    { sign: 1, position: 110, size: 10_000, start: 50, end: 100 },
+    { sign: -1, position: 50, size: 101, start: 0, end: 100 },
+    { sign: -1, position: 10, size: 10_000, start: 50, end: 100 },
+    { sign: -1, position: 110, size: 10_000, start: 50, end: 100 },
+  ])('is returns false if tick is outside limits: (%o)', ({ sign, position, size, start, end }) => {
+    expect(isVisible(sign, position, () => size, start, end)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reduce the number of times `getStringSize` is called when calculating which ticks are rendered.
This optimization is applied to `getTicksEnd, `getTicksStart` and `getEquidistantTicks`, but the latter is unlikely to benefit from it since the algorithm does not iterate over the candidate ticks sequentially. 

I have created [this repository](https://github.com/bernardobelchior/recharts-repro), based on the JSFiddle available in [this issue](https://github.com/recharts/recharts/issues/1465#issue-356913907) to test the changes. It generates a chart with 10000 random data points.

Based on Recharts' master branch (pointing to commit `8cdfab7facc4d1d107c11a1fc3d4a26e716dddca` at the time of writing), the Chrome DevTools' Performance chart is as follows:

![image](https://github.com/recharts/recharts/assets/12778398/52da2b7b-0cef-4ed4-9d47-a9b9fc2d23f2)


You can see that 95% time is taken by `getStringSize()` and descendants, which account for 3.2 seconds on my M1 Macbook Pro from 2020. In fact, I counted and `getStringSize()` is being called around 40k times to render the chart.


Since we know that `getStringSize` is expensive, whatever we can do to reduce the number of times it's called will likely yield a performance improvement. As such, this PR is comprised of two changes:
1. Call `getTickSize` in `getTicksEnd`, `getTicksStart` and `getEquidistantTicks` only when absolutely necessary;
1. Update the `isVisible` calculation to check if the tick won't be visible even before we take size into account: this way we can skip calculating the string size if we already know that the tick won't be visible.


After this change, `getStringSize` still takes up most of the time (88%), but the absolute value is now much smaller (1.8 seconds):

![image](https://github.com/recharts/recharts/assets/12778398/10dd9067-a89f-4b95-b2d2-e22887345dde)

`getStringSize` is now called around 18k times, which means there's still a lot of room for future improvements.


## Related Issue

#2589 
#1465
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Explained above

## How Has This Been Tested?

Added some unit tests. There were none, so it's hard to see if there's no regression, but I ran the new tests against the `isVisible` function before and after these changes and the results were the same.

If there's any edge case you'd like me to test, please let me know 😄 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
