### PR TITLE
fix(tooltip): getTooltipContent should avoid undefined

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -233,7 +233,7 @@ const getTooltipContent = (
      * Defaulting to chartData below to fix an edge case where the tooltip does not include data from all charts
      * when a separate dataset is passed to chart prop data and specified on Line/Area/etc prop data
      */
-    const data = (child.props.data ?? chartData).slice(state.dataStartIndex, state.dataEndIndex + 1);
+    const data = (child.props.data ?? chartData)?.slice(state.dataStartIndex, state.dataEndIndex + 1);
 
     let payload;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a follow-up fix for #3932
addressing an error occurring when data is undefined

## Related Issue

https://github.com/recharts/recharts/pull/3932#issuecomment-1809139750
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
