### PR TITLE
fix: don't allow negative height and width values

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -752,11 +752,15 @@ const calculateOffset = (
     offset = appendOffsetOfLegend(offset, graphicalItems, props, prevLegendBBox);
   }
 
+  const offsetWidth = width - offset.left - offset.right;
+  const offsetHeight = height - offset.top - offset.bottom;
+
   return {
     brushBottom,
     ...offset,
-    width: width - offset.left - offset.right,
-    height: height - offset.top - offset.bottom,
+    // never return negative values for height and width
+    width: offsetWidth > 0 ? offsetWidth : 0,
+    height: offsetHeight > 0 ? offsetHeight : 0,
   };
 };
 

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -759,8 +759,8 @@ const calculateOffset = (
     brushBottom,
     ...offset,
     // never return negative values for height and width
-    width: offsetWidth > 0 ? offsetWidth : 0,
-    height: offsetHeight > 0 ? offsetHeight : 0,
+    width: Math.max(offsetWidth, 0),
+    height: Math.max(offsetHeight, 0),
   };
 };
 

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -323,4 +323,35 @@ describe('<BarChart />', () => {
       expect(rectangleProps).toHaveAttribute('height', '10');
     });
   });
+
+  test('Renders a (Bar) chart with less width than left, right margin and less height than top, bottom margin', () => {
+    const { container } = render(
+      <BarChart
+        width={50}
+        height={80}
+        data={data}
+        margin={{
+          top: 50,
+          right: 100,
+          left: 100,
+          bottom: 50,
+        }}
+        layout="vertical"
+      >
+        <XAxis type="number" />
+        <YAxis dataKey="name" type="category" />
+        <Bar dataKey="pv" fill="#8884d8" isAnimationActive={false} />
+      </BarChart>,
+    );
+
+    // expect nothing to render because height and width are 0
+    expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(0);
+
+    const clipPath = container.querySelector('#recharts53-clip');
+    expect(clipPath.children[0]).not.toBeNull();
+
+    // expect clipPath rect to have a width and height of 0
+    expect(clipPath.children[0]).toHaveAttribute('width', '0');
+    expect(clipPath.children[0]).toHaveAttribute('height', '0');
+  });
 });

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -324,6 +324,7 @@ describe('<BarChart />', () => {
     });
   });
 
+  // guard against negative values in clipPath - ref https://github.com/recharts/recharts/issues/2009
   test('Renders a (Bar) chart with less width than left, right margin and less height than top, bottom margin', () => {
     const { container } = render(
       <BarChart


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix negative values being able to be passed to clipPath via the subtraction of margin from height/width. Negative values are not valid in any SVG context

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/2009

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes an issue that has been around for quite some time and has some recent +1s

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit test
  - Reproduce negative values in unit test
  - Confirm fixed after change
- Reproduction in storybook + confirmed reproduction is now fixed

## Screenshots (if appropriate):
N/A no visual change

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
