### PR TITLE
DO NOT MERGE: RFC: Plan 5b Proof of concept

### DIFF
--- a/src/context/chartContext.tsx
+++ b/src/context/chartContext.tsx
@@ -16,7 +16,7 @@ export type ChartContextType = {
   coordinate: ChartCoordinate;
 };
 
-const defaultValue: ChartContextType = {
+export const defaultValue: ChartContextType = {
   active: false,
   viewBox: undefined,
   label: '',

--- a/src/context/chartContext.tsx
+++ b/src/context/chartContext.tsx
@@ -1,0 +1,40 @@
+import React, { ReactElement, ReactNode, createContext, useContext, useState } from 'react';
+import { ChartCoordinate, ChartOffsetWithXAndY } from '../util/types';
+
+export type TooltipContentType = ReactElement | ((props: any) => ReactNode);
+
+export type AllowInDimension = {
+  x: boolean;
+  y: boolean;
+};
+
+export type ChartContextType = {
+  active: boolean;
+  viewBox: ChartOffsetWithXAndY;
+  label: string;
+  payload: any[];
+  coordinate: ChartCoordinate;
+};
+
+const defaultValue: ChartContextType = {
+  active: false,
+  viewBox: undefined,
+  label: '',
+  payload: [],
+  coordinate: undefined,
+};
+
+export const ChartContext = createContext<
+  [context: ChartContextType, setContext: (newContext: ChartContextType) => void]
+>([defaultValue, () => undefined]);
+
+export function ChartContextContainer(props: { children: ReactNode }) {
+  const context = useState<ChartContextType>(defaultValue);
+  return <ChartContext.Provider value={context}>{props.children}</ChartContext.Provider>;
+}
+
+export function SetChartContext(props: ChartContextType): ReactElement {
+  const [, setContext] = useContext(ChartContext);
+  setContext(props);
+  return null;
+}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1047,6 +1047,11 @@ export interface ChartOffset {
   brushBottom?: number;
 }
 
+export interface ChartOffsetWithXAndY extends ChartOffset {
+  x?: number;
+  y?: number;
+}
+
 export interface Padding {
   top?: number;
   bottom?: number;

--- a/test/chart/context/tooltipContext.test.tsx
+++ b/test/chart/context/tooltipContext.test.tsx
@@ -1,0 +1,76 @@
+import React, { useContext } from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Tooltip, LineChart, Line } from '../../../src';
+import { generateMockData } from '../../helper/generateMockData';
+import { ChartContext } from '../../../src/context/chartContext';
+import { assertNotNull } from '../../helper/assertNotNull';
+
+const TEST_ID = 'mock-test-id';
+
+function MyMockConsumer() {
+  const context = useContext(ChartContext);
+  return <div data-testid={TEST_ID}>{JSON.stringify(context)}</div>;
+}
+
+function readContext(): object {
+  const { textContent } = screen.getByTestId(TEST_ID);
+  assertNotNull(textContent);
+  return JSON.parse(textContent);
+}
+
+describe('generateCategoricalChart tooltip context', () => {
+  it('should set context on first render', () => {
+    render(
+      <LineChart
+        width={600}
+        height={300}
+        margin={{
+          top: 20,
+          right: 20,
+          bottom: 20,
+          left: 20,
+        }}
+        data={generateMockData(100, 87)}
+      >
+        {/*
+         * This is a bit of a hack:
+         * generateCategoricalChart does not actually render any children.
+         * So we cannot read the context directly from there.
+         * React-Testing-Library also does not have any tools for testing context,
+         * other than rendering it as string and then parsing back:
+         * https://testing-library.com/docs/example-react-context/
+         *
+         * Good news is, we can workaround with using the `content` prop
+         * which happens to do exactly what we need for this test:
+         * render arbitrary components directly to DOM. Yay.
+         *
+         * Later, when we make generateCategoricalChart render actual `{children}` as it should,
+         * we can replace this hack.
+         */}
+        <Tooltip content={<MyMockConsumer />} />
+        <Line dataKey="uv" />
+      </LineChart>,
+    );
+    expect(readContext()).toMatchInlineSnapshot(`
+      [
+        {
+          "active": false,
+          "payload": [],
+          "viewBox": {
+            "bottom": 20,
+            "brushBottom": 20,
+            "height": 260,
+            "left": 20,
+            "right": 20,
+            "top": 20,
+            "width": 560,
+            "x": 20,
+            "y": 20,
+          },
+        },
+        null,
+      ]
+    `);
+  });
+});

--- a/test/chart/context/tooltipContext.test.tsx
+++ b/test/chart/context/tooltipContext.test.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { Tooltip, LineChart, Line } from '../../../src';
 import { generateMockData } from '../../helper/generateMockData';
 import { ChartContext } from '../../../src/context/chartContext';
@@ -19,44 +19,97 @@ function readContext(): object {
   return JSON.parse(textContent);
 }
 
+function renderExample() {
+  return render(
+    <LineChart
+      width={600}
+      height={300}
+      margin={{
+        top: 20,
+        right: 20,
+        bottom: 20,
+        left: 20,
+      }}
+      data={generateMockData(100, 87)}
+    >
+      {/*
+       * This is a bit of a hack:
+       * generateCategoricalChart does not actually render any children.
+       * So we cannot read the context directly from there.
+       * React-Testing-Library also does not have any tools for testing context,
+       * other than rendering it as string and then parsing back:
+       * https://testing-library.com/docs/example-react-context/
+       *
+       * Good news is, we can workaround with using the `content` prop
+       * which happens to do exactly what we need for this test:
+       * render arbitrary components directly to DOM. Yay.
+       *
+       * Later, when we make generateCategoricalChart render actual `{children}` as it should,
+       * we can replace this hack.
+       */}
+      <Tooltip content={<MyMockConsumer />} />
+      <Line dataKey="uv" />
+    </LineChart>,
+  );
+}
+
 describe('generateCategoricalChart tooltip context', () => {
   it('should set context on first render', () => {
-    render(
-      <LineChart
-        width={600}
-        height={300}
-        margin={{
-          top: 20,
-          right: 20,
-          bottom: 20,
-          left: 20,
-        }}
-        data={generateMockData(100, 87)}
-      >
-        {/*
-         * This is a bit of a hack:
-         * generateCategoricalChart does not actually render any children.
-         * So we cannot read the context directly from there.
-         * React-Testing-Library also does not have any tools for testing context,
-         * other than rendering it as string and then parsing back:
-         * https://testing-library.com/docs/example-react-context/
-         *
-         * Good news is, we can workaround with using the `content` prop
-         * which happens to do exactly what we need for this test:
-         * render arbitrary components directly to DOM. Yay.
-         *
-         * Later, when we make generateCategoricalChart render actual `{children}` as it should,
-         * we can replace this hack.
-         */}
-        <Tooltip content={<MyMockConsumer />} />
-        <Line dataKey="uv" />
-      </LineChart>,
-    );
+    renderExample();
+    expect(readContext()).toMatchInlineSnapshot(`
+        [
+          {
+            "active": false,
+            "payload": [],
+            "viewBox": {
+              "bottom": 20,
+              "brushBottom": 20,
+              "height": 260,
+              "left": 20,
+              "right": 20,
+              "top": 20,
+              "width": 560,
+              "x": 20,
+              "y": 20,
+            },
+          },
+          null,
+        ]
+      `);
+  });
+
+  it('should set active: true, and coordinates, on mouse hover', () => {
+    const { container } = renderExample();
+
+    const chart = container.querySelector('.recharts-wrapper');
+    assertNotNull(chart);
+    fireEvent.mouseOver(chart, { clientX: 200, clientY: 200 });
+
     expect(readContext()).toMatchInlineSnapshot(`
       [
         {
-          "active": false,
-          "payload": [],
+          "active": true,
+          "coordinate": {
+            "x": 201.010101010101,
+            "y": 200,
+          },
+          "label": 32,
+          "payload": [
+            {
+              "color": "#3182bd",
+              "dataKey": "uv",
+              "fill": "#fff",
+              "name": "uv",
+              "payload": {
+                "label": "Iter: 32",
+                "x": 122,
+                "y": 715,
+                "z": 1162,
+              },
+              "stroke": "#3182bd",
+              "strokeWidth": 1,
+            },
+          ],
           "viewBox": {
             "bottom": 20,
             "brushBottom": 20,

--- a/test/component/Tooltip.spec.tsx
+++ b/test/component/Tooltip.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
+import { vi } from 'vitest';
 
 import {
   Area,
@@ -14,6 +15,7 @@ import {
   XAxis,
   YAxis,
 } from '../../src';
+import { assertNotNull } from '../helper/assertNotNull';
 
 describe('<Tooltip />', () => {
   const data = [
@@ -66,6 +68,7 @@ describe('<Tooltip />', () => {
     );
 
     const chart = container.querySelector('.recharts-wrapper');
+    assertNotNull(chart);
     fireEvent.mouseOver(chart, { clientX: 200, clientY: 200 });
 
     // After the mouse over event over the chart, the tooltip wrapper still is not set to visible,
@@ -94,10 +97,14 @@ describe('<Tooltip />', () => {
     mock.mockRestore();
 
     const chart = container.querySelector('.recharts-wrapper');
+    assertNotNull(chart);
     fireEvent.mouseMove(chart, { clientX: 200, clientY: 200 });
 
     const tooltip = container.querySelector('.recharts-tooltip-wrapper');
-    expect(tooltip.getAttribute('style').includes('translate')).toBe(true);
+    assertNotNull(tooltip);
+    const style = tooltip.getAttribute('style');
+    assertNotNull(style);
+    expect(style.includes('translate')).toBe(true);
   });
 
   test('Mouse over renders content with multiple data sets', () => {
@@ -133,6 +140,7 @@ describe('<Tooltip />', () => {
     );
 
     const chart = container.querySelector('.recharts-wrapper');
+    assertNotNull(chart);
     fireEvent.mouseOver(chart, { clientX: 200, clientY: 200 });
 
     // After the mouse over event over the chart, the tooltip wrapper still is not set to visible,
@@ -183,9 +191,13 @@ describe('<Tooltip />', () => {
     );
 
     const chart = container.querySelector('.recharts-wrapper');
+    assertNotNull(chart);
     fireEvent.mouseOver(chart, { clientX: 200, clientY: 200 });
     expect(tooltipPayload).not.toBeNull();
+    assertNotNull(tooltipPayload);
     expect(tooltipPayload).toHaveLength(2);
+    assertNotNull(tooltipPayload[0]);
+    assertNotNull(tooltipPayload[1]);
     expect(tooltipPayload[0].payload.value).toEqual(0.7);
     expect(tooltipPayload[1].payload.value).toEqual(0.4);
   });
@@ -202,6 +214,7 @@ describe('<Tooltip />', () => {
     );
 
     const chart = container.querySelector('.recharts-wrapper');
+    assertNotNull(chart);
 
     fireEvent.mouseOver(chart, { clientX: 200, clientY: 200 });
 
@@ -225,8 +238,12 @@ describe('<Tooltip />', () => {
       );
 
       const line = container.querySelector('.recharts-cartesian-grid-horizontal line');
+      assertNotNull(line);
       const chart = container.querySelector('.recharts-wrapper');
-      fireEvent.mouseOver(chart, { clientX: +line.getAttribute('x') + 1, clientY: 50 });
+      assertNotNull(chart);
+      const lineX = line.getAttribute('x');
+      assertNotNull(lineX);
+      fireEvent.mouseOver(chart, { clientX: +lineX + 1, clientY: 50 });
       expect(getByText(container, '1398')).toBeVisible();
     });
   });
@@ -244,6 +261,7 @@ describe('<Tooltip />', () => {
       expect(tooltip).not.toBeVisible();
 
       const chart = container.querySelector('.recharts-wrapper');
+      assertNotNull(chart);
       fireEvent.mouseOver(chart, { clientX: 200, clientY: 200 });
 
       expect(tooltip).toBeVisible();
@@ -267,6 +285,7 @@ describe('<Tooltip />', () => {
     expect(tooltip).not.toBeVisible();
 
     const chart = container.querySelector('.recharts-wrapper');
+    assertNotNull(chart);
     fireEvent.mouseOver(chart, { clientX: 200, clientY: 200 });
 
     expect(tooltip).not.toBeVisible();
@@ -288,6 +307,7 @@ describe('<Tooltip />', () => {
     expect(tooltip).not.toBeVisible();
 
     const chart = container.querySelector('.recharts-wrapper');
+    assertNotNull(chart);
     fireEvent.mouseOver(chart, { clientX: 200, clientY: 200 });
 
     expect(tooltip).toBeVisible();

--- a/test/component/Tooltip.spec.tsx
+++ b/test/component/Tooltip.spec.tsx
@@ -16,6 +16,7 @@ import {
   YAxis,
 } from '../../src';
 import { assertNotNull } from '../helper/assertNotNull';
+import { ChartContext, ChartContextType, defaultValue } from '../../src/context/chartContext';
 
 describe('<Tooltip />', () => {
   const data = [
@@ -315,5 +316,39 @@ describe('<Tooltip />', () => {
     fireEvent.mouseOut(chart);
 
     expect(tooltip).not.toBeVisible();
+  });
+
+  describe('context integration', () => {
+    test('is hidden when context.active is false', () => {
+      const activeContext: ChartContextType = {
+        ...defaultValue,
+        active: false,
+        payload: [{ value: 1 }],
+      };
+      const { container } = render(
+        <ChartContext.Provider value={[activeContext, () => undefined]}>
+          <Tooltip />
+        </ChartContext.Provider>,
+      );
+      const tooltipContentValue = container.querySelector('.recharts-tooltip-item-value');
+      expect(tooltipContentValue).not.toBeVisible();
+    });
+
+    test('is visible when context.active is true', () => {
+      const activeContext: ChartContextType = {
+        ...defaultValue,
+        active: true,
+        payload: [{ value: 1 }],
+      };
+      const { container } = render(
+        <ChartContext.Provider value={[activeContext, () => undefined]}>
+          <Tooltip />
+        </ChartContext.Provider>,
+      );
+      const tooltipContentValue = container.querySelector('.recharts-tooltip-item-value');
+      expect(tooltipContentValue).toBeVisible();
+    });
+
+    test.todo('shows recharts-tooltip-item-name');
   });
 });


### PR DESCRIPTION
Compare to https://github.com/recharts/recharts/pull/3852

I myself prefer this approach - I think there's less indirection this way. But I am afraid that some components need props from other components and we end up with a mix anyway. Let's see.

This branch will not pass tests and it doesn't actually render the tooltip in storybooks but it's already 11pm.

I want to show the idea so that we can decide which way forward to go.

## Description

Instead of cloning elements and resetting props, generateCategoricalChart will send the "internal" props through context.

Tooltip reads both props (coming from users) and context (computed internally) and renders.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

https://github.com/recharts/recharts/pull/3852

## Motivation and Context

Solves:
1. Cloning
2. Mixed internal and external props

## How Has This Been Tested?

I tested, doesn't work, don't merge. Only for discussion

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [ ] All new and existing tests passed.
