### PR TITLE
Test funnel utils

### DIFF
--- a/test/component/DefaultTooltipContent.spec.tsx
+++ b/test/component/DefaultTooltipContent.spec.tsx
@@ -57,7 +57,6 @@ describe('DefaultTooltipContent', () => {
   it('covers "itemSorter" prop', () => {
     // @ts-expect-error ignore payload.type prop for code coverage
     render(<DefaultTooltipContent {...mockProps} />);
-    screen.debug();
   });
   it('covers "labelFormatter" prop', () => {
     // @ts-expect-error ignore payload.type prop for code coverage

--- a/test/component/DefaultTooltipContent.spec.tsx
+++ b/test/component/DefaultTooltipContent.spec.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DefaultTooltipContent } from '../../src/component/DefaultTooltipContent';
+
+describe('DefaultTooltipContent', () => {
+  const mockProps = {
+    allowEscapeViewBox: { x: false, y: false },
+    animationDuration: 400,
+    animationEasing: 'ease',
+    contentStyle: {},
+    coordinate: { x: 200, y: 200 },
+    cursor: true,
+    cursorStyle: {},
+    filterNull: true,
+    isAnimationActive: true,
+    itemStyle: {},
+    labelStyle: {},
+    offset: 10,
+    reverseDirection: { x: false, y: false },
+    separator: ' : ',
+    trigger: 'hover',
+    useTranslate3d: false,
+    viewBox: {
+      brushBottom: 5,
+      top: 5,
+      bottom: 5,
+      left: 5,
+      right: 5,
+      width: 390,
+      height: 390,
+      x: 5,
+      y: 5,
+    },
+    wrapperStyle: {},
+    active: false,
+    label: 2,
+    payload: [
+      {
+        name: 'alpha',
+        unit: 'cm',
+        value: 100,
+        payload: { x: 100, y: 200, z: 200 },
+        dataKey: 'x',
+        type: 'none',
+      },
+      {
+        name: 'beta',
+        unit: 'kg',
+        value: 200,
+        payload: { x: 100, y: 200, z: 200 },
+        dataKey: 'y',
+        type: 'none',
+      },
+    ],
+    itemSorter: (d: { name: string }) => d.name,
+  };
+  it('covers "itemSorter" prop', () => {
+    // @ts-expect-error ignore payload.type prop for code coverage
+    render(<DefaultTooltipContent {...mockProps} />);
+    screen.debug();
+  });
+  it('covers "labelFormatter" prop', () => {
+    // @ts-expect-error ignore payload.type prop for code coverage
+    render(<DefaultTooltipContent {...mockProps} labelFormatter={() => `mock labelFormatter`} />);
+    expect(screen.getByText('mock labelFormatter')).toBeInTheDocument();
+  });
+});

--- a/test/component/DefaultTooltipContent.spec.tsx
+++ b/test/component/DefaultTooltipContent.spec.tsx
@@ -48,7 +48,8 @@ describe('DefaultTooltipContent', () => {
     itemSorter: (d: { name: string }) => d.name,
     labelFormatter: () => `mock labelFormatter`,
   };
-  it('renders without crashing', () => {
-    render(<DefaultTooltipContent {...mockProps} />);
+  it('renders without crashing, finds div with default class attr', () => {
+    const { container } = render(<DefaultTooltipContent {...mockProps} />);
+    expect(container.querySelectorAll('div.recharts-default-tooltip').length).toBe(1);
   });
 });

--- a/test/component/DefaultTooltipContent.spec.tsx
+++ b/test/component/DefaultTooltipContent.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { DefaultTooltipContent } from '../../src/component/DefaultTooltipContent';
 
 describe('DefaultTooltipContent', () => {
@@ -32,35 +32,23 @@ describe('DefaultTooltipContent', () => {
       y: 5,
     },
     wrapperStyle: {},
-    active: false,
+    active: true,
     label: 2,
     payload: [
       {
-        name: 'alpha',
-        unit: 'cm',
-        value: 100,
-        payload: { x: 100, y: 200, z: 200 },
-        dataKey: 'x',
-        type: 'none',
-      },
-      {
-        name: 'beta',
-        unit: 'kg',
+        stroke: '#3182bd',
+        fill: '#3182bd',
+        fillOpacity: 0.6,
+        dataKey: 'uv',
+        name: 'uv',
+        color: '#3182bd',
         value: 200,
-        payload: { x: 100, y: 200, z: 200 },
-        dataKey: 'y',
-        type: 'none',
       },
     ],
     itemSorter: (d: { name: string }) => d.name,
+    labelFormatter: () => `mock labelFormatter`,
   };
-  it('covers "itemSorter" prop', () => {
-    // @ts-expect-error ignore payload.type prop for code coverage
+  it('renders without crashing', () => {
     render(<DefaultTooltipContent {...mockProps} />);
-  });
-  it('covers "labelFormatter" prop', () => {
-    // @ts-expect-error ignore payload.type prop for code coverage
-    render(<DefaultTooltipContent {...mockProps} labelFormatter={() => `mock labelFormatter`} />);
-    expect(screen.getByText('mock labelFormatter')).toBeInTheDocument();
   });
 });

--- a/test/util/FunnelUtils.spec.tsx
+++ b/test/util/FunnelUtils.spec.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { typeGuardTrapezoidProps, FunnelTrapezoid } from '../../src/util/FunnelUtils';
+
+describe('funnelUtils', () => {
+  const mockOptions = {
+    x: 10,
+    y: 10,
+    height: 100,
+  };
+  const mockProps = {
+    x: 11,
+    y: 11,
+    isActive: false,
+  };
+  it('typeGuardTrapezoidProps returns object from options + props', () => {
+    const mockRes = {
+      x: mockProps.x,
+      y: mockProps.y,
+      isActive: mockProps.isActive,
+      height: mockOptions.height,
+    };
+    const res = typeGuardTrapezoidProps(mockOptions, mockProps);
+
+    expect(res).toEqual(mockRes);
+  });
+  it('<FunnelTrapezoid /> returns a trapezoid shape with no options', () => {
+    const { container } = render(<FunnelTrapezoid option={{}} {...mockProps} isActive={Boolean(true)} />);
+    expect(container.querySelector('g')).toHaveClass('recharts-active-shape');
+  });
+  it('<FunnelTrapezoid /> returns a trapezoid shape with x & y from options', () => {
+    const { container } = render(
+      <FunnelTrapezoid
+        option={{ x: 10, y: 10 }}
+        {...{
+          isActive: true,
+          height: 100,
+        }}
+        isActive={Boolean(true)}
+      />,
+    );
+    expect(container.querySelector('g')).toHaveClass('recharts-active-shape');
+  });
+});


### PR DESCRIPTION
_increase code coverage on a few files_

## Description
- [x] test `FunnelUtils`
- [x] increase coverage of `DefaultTooltipContent` 

## Related Issue

https://github.com/recharts/recharts/issues/3976

## Motivation and Context
_increasing code-coverage_

## Screenshots (if appropriate):
![Screenshot 2023-11-19 at 10 46 26 AM](https://github.com/recharts/recharts/assets/24195040/5512ece8-c3fa-4682-b9fc-37db24ff90d5)
![Screenshot 2023-11-19 at 10 46 37 AM](https://github.com/recharts/recharts/assets/24195040/afd3cea0-3d57-4848-8e88-0709b26e4e2b)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
