### PR TITLE
fix: dataEndIndex can be -1

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -647,11 +647,20 @@ const tooltipTicksGenerator = (axisMap: AxisMap) => {
 const createDefaultState = (props: CategoricalChartProps): CategoricalChartState => {
   const { children, defaultShowTooltip } = props;
   const brushItem = findChildByType(children, Brush);
-  const startIndex = (brushItem && brushItem.props && brushItem.props.startIndex) || 0;
-  const endIndex =
-    brushItem?.props?.endIndex !== undefined
-      ? brushItem?.props?.endIndex
-      : (props.data && props.data.length !== 0 && props.data.length - 1) || 0;
+  let startIndex = 0;
+  let endIndex = 0;
+  if (props.data && props.data.length !== 0) {
+    endIndex = props.data.length - 1;
+  }
+
+  if (brushItem && brushItem.props) {
+    if (brushItem.props.startIndex >= 0) {
+      startIndex = brushItem.props.startIndex;
+    }
+    if (brushItem.props.endIndex >= 0) {
+      endIndex = brushItem.props.endIndex;
+    }
+  }
 
   return {
     chartX: 0,

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -644,7 +644,7 @@ const tooltipTicksGenerator = (axisMap: AxisMap) => {
  * @param {Object} props Props object to use when creating the default state
  * @return {Object} Whole new state
  */
-const createDefaultState = (props: CategoricalChartProps): CategoricalChartState => {
+export const createDefaultState = (props: CategoricalChartProps): CategoricalChartState => {
   const { children, defaultShowTooltip } = props;
   const brushItem = findChildByType(children, Brush);
   let startIndex = 0;

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -649,7 +649,9 @@ const createDefaultState = (props: CategoricalChartProps): CategoricalChartState
   const brushItem = findChildByType(children, Brush);
   const startIndex = (brushItem && brushItem.props && brushItem.props.startIndex) || 0;
   const endIndex =
-    brushItem?.props?.endIndex !== undefined ? brushItem?.props?.endIndex : (props.data && props.data.length - 1) || 0;
+    brushItem?.props?.endIndex !== undefined
+      ? brushItem?.props?.endIndex
+      : (props.data && props.data.length !== 0 && props.data.length - 1) || 0;
 
   return {
     chartX: 0,

--- a/test/chart/generateCategoricalChart.spec.tsx
+++ b/test/chart/generateCategoricalChart.spec.tsx
@@ -1,6 +1,7 @@
-import { ReactElement } from 'react';
-import { getAxisMapByAxes, CategoricalChartProps } from '../../src/chart/generateCategoricalChart';
+import React, { ReactElement } from 'react';
+import { getAxisMapByAxes, CategoricalChartProps, createDefaultState } from '../../src/chart/generateCategoricalChart';
 import { AxisStackGroups } from '../../src/util/ChartUtils';
+import { Brush } from '../../src';
 
 const data = [
   {
@@ -228,6 +229,29 @@ describe('generateCategoricalChart', () => {
           },
         }),
       );
+    });
+  });
+
+  describe('createDefaultState', () => {
+    it('Should have the correct dataIndex', () => {
+      let state = createDefaultState({ children: [<Brush endIndex={-1} startIndex={-1} />] });
+      expect(state.dataStartIndex).toEqual(0);
+      expect(state.dataEndIndex).toEqual(0);
+
+      state = createDefaultState({ children: [<Brush endIndex={-1} startIndex={-1} />], data: [] });
+
+      expect(state.dataStartIndex).toEqual(0);
+      expect(state.dataEndIndex).toEqual(0);
+
+      state = createDefaultState({ children: [<Brush endIndex={-1} startIndex={-1} />], data: [1, 2, 3] });
+
+      expect(state.dataStartIndex).toEqual(0);
+      expect(state.dataEndIndex).toEqual(2);
+
+      state = createDefaultState({ children: [<Brush endIndex={1} startIndex={0} />], data: [1, 2, 3] });
+
+      expect(state.dataStartIndex).toEqual(0);
+      expect(state.dataEndIndex).toEqual(1);
     });
   });
 });

--- a/test/chart/generateCategoricalChart.spec.tsx
+++ b/test/chart/generateCategoricalChart.spec.tsx
@@ -234,24 +234,33 @@ describe('generateCategoricalChart', () => {
 
   describe('createDefaultState', () => {
     it('Should have the correct dataIndex', () => {
-      let state = createDefaultState({ children: [<Brush endIndex={-1} startIndex={-1} />] });
-      expect(state.dataStartIndex).toEqual(0);
-      expect(state.dataEndIndex).toEqual(0);
+      it('even when invalid brush index(no data)', () => {
+        const state = createDefaultState({ children: [<Brush endIndex={-1} startIndex={-1} />] });
 
-      state = createDefaultState({ children: [<Brush endIndex={-1} startIndex={-1} />], data: [] });
+        expect(state.dataStartIndex).toEqual(0);
+        expect(state.dataEndIndex).toEqual(0);
+      });
 
-      expect(state.dataStartIndex).toEqual(0);
-      expect(state.dataEndIndex).toEqual(0);
+      it('even when invalid brush index', () => {
+        const state = createDefaultState({ children: [<Brush endIndex={-1} startIndex={-1} />], data: [1, 2, 3] });
 
-      state = createDefaultState({ children: [<Brush endIndex={-1} startIndex={-1} />], data: [1, 2, 3] });
+        expect(state.dataStartIndex).toEqual(0);
+        expect(state.dataEndIndex).toEqual(2);
+      });
 
-      expect(state.dataStartIndex).toEqual(0);
-      expect(state.dataEndIndex).toEqual(2);
+      it('even when data length 0', () => {
+        const state = createDefaultState({ children: [<Brush endIndex={-1} startIndex={-1} />], data: [] });
 
-      state = createDefaultState({ children: [<Brush endIndex={1} startIndex={0} />], data: [1, 2, 3] });
+        expect(state.dataStartIndex).toEqual(0);
+        expect(state.dataEndIndex).toEqual(0);
+      });
 
-      expect(state.dataStartIndex).toEqual(0);
-      expect(state.dataEndIndex).toEqual(1);
+      it('when valid brush index', () => {
+        const state = createDefaultState({ children: [<Brush endIndex={1} startIndex={0} />], data: [1, 2, 3] });
+
+        expect(state.dataStartIndex).toEqual(0);
+        expect(state.dataEndIndex).toEqual(1);
+      });
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As dataEndIndex is -1 in an empty data array, it causes issues with #3987.
It doesn't seem to be intentional

## Related Issue

#3987

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
