### PR TITLE
Separate cursor component

### DIFF
--- a/src/component/Cursor.tsx
+++ b/src/component/Cursor.tsx
@@ -1,0 +1,95 @@
+import React, { ReactElement, cloneElement, createElement, isValidElement } from 'react';
+import { ChartCoordinate, ChartOffset, LayoutType, TooltipEventType } from '../util/types';
+import { Curve } from '../shape/Curve';
+import { Cross } from '../shape/Cross';
+import { getCursorRectangle } from '../util/cursor/getCursorRectangle';
+import { Rectangle } from '../shape/Rectangle';
+import { getRadialCursorPoints } from '../util/cursor/getRadialCursorPoints';
+import { Sector } from '../shape/Sector';
+import { getCursorPoints } from '../util/cursor/getCursorPoints';
+import { filterProps } from '../util/ReactUtils';
+
+export type CursorProps = {
+  activeCoordinate: ChartCoordinate;
+  activePayload: any[];
+  activeTooltipIndex: number;
+  chartName: string;
+  element: ReactElement;
+  isActive: boolean;
+  layout: LayoutType;
+  offset: ChartOffset;
+  tooltipAxisBandSize: number;
+  tooltipEventType: TooltipEventType;
+};
+
+/*
+ * Cursor is the background, or a highlight,
+ * that shows when user mouses over or activates
+ * an area.
+ *
+ * It usually shows together with a tooltip
+ * to emphasise which part of the chart does the tooltip refer to.
+ */
+export function Cursor(props: CursorProps) {
+  const {
+    element,
+    tooltipEventType,
+    isActive,
+    activeCoordinate,
+    activePayload,
+    offset,
+    activeTooltipIndex,
+    tooltipAxisBandSize,
+    layout,
+    chartName,
+  } = props;
+  if (
+    !element ||
+    !element.props.cursor ||
+    !isActive ||
+    !activeCoordinate ||
+    (chartName !== 'ScatterChart' && tooltipEventType !== 'axis')
+  ) {
+    return null;
+  }
+  let restProps;
+  let cursorComp: React.ComponentType<any> = Curve;
+
+  if (chartName === 'ScatterChart') {
+    restProps = activeCoordinate;
+    cursorComp = Cross;
+  } else if (chartName === 'BarChart') {
+    restProps = getCursorRectangle(layout, activeCoordinate, offset, tooltipAxisBandSize);
+    cursorComp = Rectangle;
+  } else if (layout === 'radial') {
+    const { cx, cy, radius, startAngle, endAngle } = getRadialCursorPoints(activeCoordinate);
+    restProps = {
+      cx,
+      cy,
+      startAngle,
+      endAngle,
+      innerRadius: radius,
+      outerRadius: radius,
+    };
+    cursorComp = Sector;
+  } else {
+    restProps = { points: getCursorPoints(layout, activeCoordinate, offset) };
+    cursorComp = Curve;
+  }
+  const key = element.key || '_recharts-cursor';
+  const cursorProps = {
+    stroke: '#ccc',
+    pointerEvents: 'none',
+    ...offset,
+    ...restProps,
+    ...filterProps(element.props.cursor),
+    payload: activePayload,
+    payloadIndex: activeTooltipIndex,
+    key,
+    className: 'recharts-tooltip-cursor',
+  };
+
+  return isValidElement(element.props.cursor)
+    ? cloneElement(element.props.cursor, cursorProps)
+    : createElement(cursorComp, cursorProps);
+}

--- a/storybook/stories/Examples/Pie/CustomActiveShapePieChart.stories.tsx
+++ b/storybook/stories/Examples/Pie/CustomActiveShapePieChart.stories.tsx
@@ -1,0 +1,93 @@
+/* eslint-disable no-shadow */
+import React, { useState } from 'react';
+import { Args } from '@storybook/react';
+import { Pie, PieChart, ResponsiveContainer, Sector } from '../../../../src';
+import { PieSectorDataItem } from '../../../../src/polar/Pie';
+
+export default {
+  component: Pie,
+};
+
+const data = [
+  { name: 'Group A', value: 400 },
+  { name: 'Group B', value: 300 },
+  { name: 'Group C', value: 300 },
+  { name: 'Group D', value: 200 },
+];
+
+export const CustomActiveShapePie = {
+  render: (args: Args) => {
+    const [activeIndex, setActiveIndex] = useState<number>(0);
+
+    const onPieEnter = (_: void, index: number) => {
+      setActiveIndex(index);
+    };
+
+    const renderActiveShape = (props: PieSectorDataItem) => {
+      const RADIAN = Math.PI / 180;
+      // @ts-expect-error property payload does not exist on type PieSectorDataItem
+      const { cx, cy, midAngle, innerRadius, outerRadius, startAngle, endAngle, fill, payload, percent, value } = props;
+      const sin = Math.sin(-RADIAN * midAngle);
+      const cos = Math.cos(-RADIAN * midAngle);
+      const sx = cx + (outerRadius + 10) * cos;
+      const sy = cy + (outerRadius + 10) * sin;
+      const mx = cx + (outerRadius + 30) * cos;
+      const my = cy + (outerRadius + 30) * sin;
+      const ex = mx + (cos >= 0 ? 1 : -1) * 22;
+      const ey = my;
+      const textAnchor = cos >= 0 ? 'start' : 'end';
+
+      return (
+        <g>
+          <text x={cx} y={cy} dy={8} textAnchor="middle" fill={fill}>
+            {payload.name}
+          </text>
+          <Sector
+            cx={cx}
+            cy={cy}
+            innerRadius={innerRadius}
+            outerRadius={outerRadius}
+            startAngle={startAngle}
+            endAngle={endAngle}
+            fill={fill}
+          />
+          <Sector
+            cx={cx}
+            cy={cy}
+            startAngle={startAngle}
+            endAngle={endAngle}
+            innerRadius={outerRadius + 6}
+            outerRadius={outerRadius + 10}
+            fill={fill}
+          />
+          <path d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`} stroke={fill} fill="none" />
+          <circle cx={ex} cy={ey} r={2} fill={fill} stroke="none" />
+          <text x={ex + (cos >= 0 ? 1 : -1) * 12} y={ey} textAnchor={textAnchor} fill="#333">{`PV ${value}`}</text>
+          <text x={ex + (cos >= 0 ? 1 : -1) * 12} y={ey} dy={18} textAnchor={textAnchor} fill="#999">
+            {`(Rate ${(percent * 100).toFixed(2)}%)`}
+          </text>
+        </g>
+      );
+    };
+
+    return (
+      <ResponsiveContainer width="100%" height={500}>
+        <PieChart width={400} height={400} {...args}>
+          <Pie
+            activeIndex={activeIndex}
+            activeShape={renderActiveShape}
+            cx="50%"
+            cy="50%"
+            data={data}
+            dataKey="value"
+            fill="#8884d8"
+            innerRadius={60}
+            onMouseEnter={onPieEnter}
+            outerRadius={80}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {},
+};

--- a/storybook/stories/Examples/Pie/CustomActiveShapePieChart.stories.tsx
+++ b/storybook/stories/Examples/Pie/CustomActiveShapePieChart.stories.tsx
@@ -72,22 +72,25 @@ export const CustomActiveShapePie = {
 
     return (
       <ResponsiveContainer width="100%" height={500}>
-        <PieChart width={400} height={400} {...args}>
+        <PieChart width={400} height={400}>
           <Pie
+            dataKey="value"
+            {...args}
             activeIndex={activeIndex}
             activeShape={renderActiveShape}
-            cx="50%"
-            cy="50%"
-            data={data}
-            dataKey="value"
-            fill="#8884d8"
-            innerRadius={60}
             onMouseEnter={onPieEnter}
-            outerRadius={80}
           />
         </PieChart>
       </ResponsiveContainer>
     );
   },
-  args: {},
+  args: {
+    cx: '50%',
+    cy: '50%',
+    data,
+    dataKey: 'value',
+    fill: '#8884d8',
+    innerRadius: 60,
+    outerRadius: 80,
+  },
 };

--- a/storybook/stories/Examples/Pie/PieWithNeedle.stories.tsx
+++ b/storybook/stories/Examples/Pie/PieWithNeedle.stories.tsx
@@ -49,20 +49,20 @@ const Needle = ({ cx, cy, midAngle }: { cx: number; cy: number; midAngle: number
 };
 
 export const PieWithNeedle = {
-  render: (_args: Record<string, any>) => {
+  render: (args: Record<string, any>) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
-        <PieChart>
+        <PieChart {...args}>
           <Pie
-            dataKey="value"
-            startAngle={180}
-            endAngle={0}
-            data={data}
             cx={cx}
             cy={cy}
+            data={data}
+            dataKey="value"
+            endAngle={0}
+            fill="#8884d8"
             innerRadius={iR}
             outerRadius={oR}
-            fill="#8884d8"
+            startAngle={180}
             stroke="none"
           >
             {data.map(entry => (
@@ -91,10 +91,10 @@ export const PieWithNeedle = {
 };
 
 export const PieWithPatterns = {
-  render: (_args: Record<string, any>) => {
+  render: (args: Record<string, any>) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
-        <PieChart>
+        <PieChart {...args}>
           <defs>
             <pattern id="pattern-A" width="10" height="10" patternUnits="userSpaceOnUse">
               <polygon points="0,0 2,5 0,10 5,8 10,10 8,5 10,0 5,2" fill="#f00" />
@@ -107,13 +107,13 @@ export const PieWithPatterns = {
             </pattern>
           </defs>
           <Pie
-            dataKey="value"
-            data={data}
             cx={cx}
             cy={cy}
+            data={data}
+            dataKey="value"
+            fill="#8884d8"
             innerRadius={iR}
             outerRadius={oR}
-            fill="#8884d8"
             stroke="none"
           >
             {data.map(entry => (

--- a/storybook/stories/Examples/Pie/PieWithNeedle.stories.tsx
+++ b/storybook/stories/Examples/Pie/PieWithNeedle.stories.tsx
@@ -52,19 +52,8 @@ export const PieWithNeedle = {
   render: (args: Record<string, any>) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
-        <PieChart {...args}>
-          <Pie
-            cx={cx}
-            cy={cy}
-            data={data}
-            dataKey="value"
-            endAngle={0}
-            fill="#8884d8"
-            innerRadius={iR}
-            outerRadius={oR}
-            startAngle={180}
-            stroke="none"
-          >
+        <PieChart>
+          <Pie dataKey="value" {...args}>
             {data.map(entry => (
               <Cell key={`cell-${entry.name}`} fill={entry.color} />
             ))}
@@ -87,14 +76,25 @@ export const PieWithNeedle = {
       </ResponsiveContainer>
     );
   },
-  args: {},
+  args: {
+    cx,
+    cy,
+    data,
+    dataKey: 'value',
+    endAngle: 0,
+    fill: '#8884d8',
+    innerRadius: iR,
+    outerRadius: oR,
+    startAngle: 180,
+    stroke: 'none',
+  },
 };
 
 export const PieWithPatterns = {
   render: (args: Record<string, any>) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
-        <PieChart {...args}>
+        <PieChart>
           <defs>
             <pattern id="pattern-A" width="10" height="10" patternUnits="userSpaceOnUse">
               <polygon points="0,0 2,5 0,10 5,8 10,10 8,5 10,0 5,2" fill="#f00" />
@@ -106,16 +106,7 @@ export const PieWithPatterns = {
               <rect width="2" height="4" fill="#00f" />
             </pattern>
           </defs>
-          <Pie
-            cx={cx}
-            cy={cy}
-            data={data}
-            dataKey="value"
-            fill="#8884d8"
-            innerRadius={iR}
-            outerRadius={oR}
-            stroke="none"
-          >
+          <Pie dataKey="value" {...args}>
             {data.map(entry => (
               <Cell key={`cell-${entry.name}`} fill={`url(#pattern-${entry.name})`} />
             ))}
@@ -124,5 +115,14 @@ export const PieWithPatterns = {
       </ResponsiveContainer>
     );
   },
-  args: {},
+  args: {
+    cx,
+    cy,
+    data,
+    dataKey: 'value',
+    fill: '#8884d8',
+    innerRadius: iR,
+    outerRadius: oR,
+    stroke: 'none',
+  },
 };

--- a/test/component/Cursor.spec.tsx
+++ b/test/component/Cursor.spec.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Cursor, CursorProps } from '../../src/component/Cursor';
+import { Tooltip, TooltipProps } from '../../src/component/Tooltip';
+import { assertNotNull } from '../helper/assertNotNull';
+
+function getTooltipElement(props: TooltipProps<any, any>) {
+  return <Tooltip {...props} />;
+}
+
+const defaultProps: CursorProps = {
+  activeCoordinate: {
+    x: 0,
+    y: 0,
+  },
+  activePayload: [],
+  activeTooltipIndex: 0,
+  chartName: '',
+  element: getTooltipElement({}),
+  isActive: true,
+  layout: 'horizontal',
+  offset: {},
+  tooltipAxisBandSize: 0,
+  tooltipEventType: 'axis',
+};
+
+describe('Cursor', () => {
+  it('should render curve cursor by default', () => {
+    const { container } = render(<Cursor {...defaultProps} />);
+    const cursor = container.querySelector('.recharts-curve');
+    assertNotNull(cursor);
+    expect(cursor).toBeVisible();
+  });
+
+  it('should render a custom cursor', () => {
+    function MyCustomCursor() {
+      return <p>I am a cursor.</p>;
+    }
+    const props: CursorProps = {
+      ...defaultProps,
+      element: getTooltipElement({ cursor: <MyCustomCursor /> }),
+    };
+    const { getByText } = render(<Cursor {...props} />);
+    expect(getByText('I am a cursor.')).toBeVisible();
+  });
+
+  it('should render cross cursor for scatter chart', () => {
+    const props: CursorProps = {
+      ...defaultProps,
+      chartName: 'ScatterChart',
+    };
+    const { container } = render(<Cursor {...props} />);
+    const cursor = container.querySelector('.recharts-cross');
+    assertNotNull(cursor);
+    expect(cursor).toBeVisible();
+  });
+
+  it('should render rectangle cursor for bar chart', () => {
+    const props: CursorProps = {
+      ...defaultProps,
+      offset: {
+        top: 0,
+        height: 2,
+      },
+      tooltipAxisBandSize: 1,
+      chartName: 'BarChart',
+    };
+    const { container } = render(<Cursor {...props} />);
+    const cursor = container.querySelector('.recharts-rectangle');
+    assertNotNull(cursor);
+    expect(cursor).toBeVisible();
+  });
+
+  it('should render sector cursor for radial layout charts', () => {
+    const props: CursorProps = {
+      ...defaultProps,
+      activeCoordinate: {
+        endAngle: 2,
+        radius: 1,
+        startAngle: 1,
+        x: 0,
+        y: 0,
+      },
+      layout: 'radial',
+    };
+    const { container } = render(<Cursor {...props} />);
+    const cursor = container.querySelector('.recharts-sector');
+    assertNotNull(cursor);
+    expect(cursor).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description

Following up from @nikolasrieble's suggestion in https://github.com/recharts/recharts/pull/3852#discussion_r1390416484 I am moving towards merging Cursor and Tooltip component. Cursor depends on Tooltip props anyway so it's a natural refactor.

Baby steps. First I move the Cursor rendering as-is to its own component. In a followup PR, I will make it read props from Tooltip directly and remove `renderCursor` method from generateCategoricalChart.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Small step towards breaking down generateCategoricalChart

## How Has This Been Tested?

`npm test`, storybooks

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
