### PR TITLE
Chore: Remove a few instances of "no array index key" eslint comment

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -308,7 +308,7 @@ export class Bar extends PureComponent<Props, State> {
           <Layer
             className="recharts-bar-rectangle"
             {...adaptEventsOfChild(this.props, entry, i)}
-            key={`rectangle-${entry?.x}-${entry?.y}`}
+            key={`rectangle-${entry?.x}-${entry?.y}-${entry?.value}`}
           >
             <BarRectangle {...props} />
           </Layer>

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -308,7 +308,7 @@ export class Bar extends PureComponent<Props, State> {
           <Layer
             className="recharts-bar-rectangle"
             {...adaptEventsOfChild(this.props, entry, i)}
-            key={`rectangle-${i}`} // eslint-disable-line react/no-array-index-key
+            key={`rectangle-${entry?.x}-${entry?.y}`}
           >
             <BarRectangle {...props} />
           </Layer>
@@ -450,9 +450,9 @@ export class Bar extends PureComponent<Props, State> {
 
     return (
       <Layer {...errorBarProps}>
-        {errorBarItems.map((item: ReactElement<ErrorBarProps>, i: number) =>
+        {errorBarItems.map((item: ReactElement<ErrorBarProps>) =>
           React.cloneElement(item, {
-            key: `error-bar-${i}`, // eslint-disable-line react/no-array-index-key
+            key: `error-bar-${clipPathId}-${item.props.dataKey}`,
             data,
             xAxis,
             yAxis,

--- a/src/numberAxis/Funnel.tsx
+++ b/src/numberAxis/Funnel.tsx
@@ -32,7 +32,7 @@ import {
 import { FunnelTrapezoid } from '../util/FunnelUtils';
 
 export interface FunnelTrapezoidItem extends TrapezoidProps {
-  value: number | string;
+  value?: number | string;
   payload?: any;
   isActive: boolean;
 }

--- a/src/numberAxis/Funnel.tsx
+++ b/src/numberAxis/Funnel.tsx
@@ -32,7 +32,7 @@ import {
 import { FunnelTrapezoid } from '../util/FunnelUtils';
 
 export interface FunnelTrapezoidItem extends TrapezoidProps {
-  value?: number | string;
+  value: number | string;
   payload?: any;
   isActive: boolean;
 }

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -465,8 +465,7 @@ export class Pie extends PureComponent<Props, State> {
       }
 
       return (
-        // eslint-disable-next-line react/no-array-index-key
-        <Layer key={`label-${i}`}>
+        <Layer key={`label-${entry.startAngle}-${entry.endAngle}`}>
           {labelLine && Pie.renderLabelLineItem(labelLine, lineProps)}
           {Pie.renderLabelItem(label, labelProps, getValueByDataKey(entry, realDataKey))}
         </Layer>
@@ -498,7 +497,7 @@ export class Pie extends PureComponent<Props, State> {
           tabIndex={-1}
           className="recharts-pie-sector"
           {...adaptEventsOfChild(this.props, entry, i)}
-          key={`sector-${i}`} // eslint-disable-line react/no-array-index-key
+          key={`sector-${entry?.startAngle}=${entry?.endAngle}`}
         >
           <Shape option={sectorOptions} isActive={isActive} shapeType="sector" {...sectorProps} />
         </Layer>


### PR DESCRIPTION
## Description
- [x] use values in keys in-place-of indexes in `polar/Pie` and `cartesian/Bar` components

## Related Issue
[3273](https://github.com/recharts/recharts/issues/3273)

## Motivation and Context
- contribute to the repo

## How Has This Been Tested?
- [x] all existing unit tests pass (_no new `duplicate key` errors are present as a result_)

## Types of changes
- [x] Technical Cleanup 

## Checklist:
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
