### PR TITLE
fix: label list offset prop

### DIFF
--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -11,38 +11,40 @@ import { ViewBox, PolarViewBox, CartesianViewBox } from '../util/types';
 
 export type ContentType = ReactElement | ((props: Props) => ReactNode);
 
+export type LabelPosition =
+  | 'top'
+  | 'left'
+  | 'right'
+  | 'bottom'
+  | 'inside'
+  | 'outside'
+  | 'insideLeft'
+  | 'insideRight'
+  | 'insideTop'
+  | 'insideBottom'
+  | 'insideTopLeft'
+  | 'insideBottomLeft'
+  | 'insideTopRight'
+  | 'insideBottomRight'
+  | 'insideStart'
+  | 'insideEnd'
+  | 'end'
+  | 'center'
+  | 'centerTop'
+  | 'centerBottom'
+  | 'middle'
+  | {
+      x?: number;
+      y?: number;
+    };
+
 interface LabelProps {
   viewBox?: ViewBox;
   parentViewBox?: ViewBox;
   formatter?: Function;
   value?: number | string;
   offset?: number;
-  position?:
-    | 'top'
-    | 'left'
-    | 'right'
-    | 'bottom'
-    | 'inside'
-    | 'outside'
-    | 'insideLeft'
-    | 'insideRight'
-    | 'insideTop'
-    | 'insideBottom'
-    | 'insideTopLeft'
-    | 'insideBottomLeft'
-    | 'insideTopRight'
-    | 'insideBottomRight'
-    | 'insideStart'
-    | 'insideEnd'
-    | 'end'
-    | 'center'
-    | 'centerTop'
-    | 'centerBottom'
-    | 'middle'
-    | {
-        x?: number;
-        y?: number;
-      };
+  position?: LabelPosition;
   children?: ReactNode;
   className?: string;
   content?: ContentType;

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -4,7 +4,7 @@ import isObject from 'lodash/isObject';
 import isFunction from 'lodash/isFunction';
 import last from 'lodash/last';
 
-import { Label, ContentType, Props as LabelProps } from './Label';
+import { Label, ContentType, Props as LabelProps, LabelPosition } from './Label';
 import { Layer } from '../container/Layer';
 import { findAllByType, filterProps } from '../util/ReactUtils';
 import { getValueByDataKey } from '../util/ChartUtils';
@@ -24,12 +24,13 @@ interface LabelListProps<T extends Data> {
   dataKey?: DataKey<T>;
   content?: ContentType;
   textBreakAll?: boolean;
-  position?: LabelProps['position'];
+  position?: LabelPosition;
+  offset?: LabelProps['offset'];
   angle?: number;
   formatter?: Function;
 }
 
-export type Props<T extends Data> = Omit<SVGProps<SVGTextElement>, 'offset'> & LabelListProps<T>;
+export type Props<T extends Data> = SVGProps<SVGTextElement> & LabelListProps<T>;
 
 export type ImplicitLabelListType<T extends Data> =
   | boolean

--- a/test/component/LabelList.spec.tsx
+++ b/test/component/LabelList.spec.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 
-import { LabelList, Scatter, ScatterChart, XAxis, YAxis, ZAxis } from '../../src';
+import { Bar, BarChart, LabelList, Scatter, ScatterChart, XAxis, YAxis, ZAxis } from '../../src';
 
 describe('<LabelList />', () => {
   it('Render labels in ScatterChart', () => {
@@ -27,5 +27,34 @@ describe('<LabelList />', () => {
     const label = container.querySelectorAll('.recharts-label');
 
     expect(label?.length).toEqual(data.length);
+  });
+
+  it('Render labels in BarChart with an offset', () => {
+    const data = [
+      { x: 100, y: '200' },
+      { x: 120, y: '100' },
+      { x: 170, y: '300' },
+      { x: 140, y: '250' },
+      { x: 150, y: '400' },
+      { x: 110, y: '280' },
+    ];
+    const { container } = render(
+      <BarChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20 }} data={data}>
+        <XAxis dataKey="x" />
+        <YAxis />
+
+        <Bar dataKey="y" name="A school" isAnimationActive={false}>
+          {/* offset only works with 'position' set */}
+          <LabelList dataKey="x" offset={40} position="top" />
+        </Bar>
+      </BarChart>,
+    );
+
+    const label = container.querySelectorAll('.recharts-label');
+    expect(label?.length).toEqual(data.length);
+
+    const text = label[0].closest('text');
+    expect(text).toBeInTheDocument();
+    expect(text).toHaveAttribute('offset', '40');
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
While refactoring I accidentally Omitted the `offset` prop entirely from `LabelList`

Add it explicitly instead of relying on implicit types from SVGTextElement

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/3986

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes unintentional TS breaking change

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Add one unit test to add offset
- Run storybook, functionality is the same
- no more type error

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
