### PR TITLE
Chore: Update keys (stop "new bugs")

### DIFF
--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -626,7 +626,7 @@ export class Treemap extends PureComponent<Props, State> {
 
     return (
       <Layer
-        key={`recharts-treemap-node-${nodeProps.x}-${nodeProps.y}`}
+        key={`recharts-treemap-node-${nodeProps.x}-${nodeProps.y}-${nodeProps.name}`}
         className={`recharts-treemap-depth-${node.depth}`}
       >
         {this.renderItem(content, nodeProps, isLeaf)}

--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -180,11 +180,13 @@ export class DefaultLegendContent extends PureComponent<Props> {
       );
 
       const color = entry.inactive ? inactiveColor : entry.color;
+
       return (
         <li
           className={className}
           style={itemStyle}
-          key={`legend-item-${JSON.stringify(entry)}`}
+          // eslint-disable-next-line react/no-array-index-key
+          key={`legend-item-${i}`}
           {...adaptEventsOfChild(this.props, entry, i)}
         >
           <Surface width={iconSize} height={iconSize} viewBox={viewBox} style={svgStyle}>

--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -184,7 +184,7 @@ export class DefaultLegendContent extends PureComponent<Props> {
         <li
           className={className}
           style={itemStyle}
-          key={`legend-item-${entry.type}-${entry.value}`}
+          key={`legend-item-${JSON.stringify(entry)}`}
           {...adaptEventsOfChild(this.props, entry, i)}
         >
           <Surface width={iconSize} height={iconSize} viewBox={viewBox} style={svgStyle}>

--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -97,9 +97,10 @@ export const DefaultTooltipContent = <TValue extends ValueType, TName extends Na
             finalValue = formatted;
           }
         }
-        const keyVal = isNumOrStr(finalName) ? `${finalValue}-${finalName}` : finalValue;
+
         return (
-          <li className="recharts-tooltip-item" key={`tooltip-item-${keyVal}`} style={finalItemStyle}>
+          // eslint-disable-next-line react/no-array-index-key
+          <li className="recharts-tooltip-item" key={`tooltip-item-${i}`} style={finalItemStyle}>
             {isNumOrStr(finalName) ? <span className="recharts-tooltip-item-name">{finalName}</span> : null}
             {isNumOrStr(finalName) ? <span className="recharts-tooltip-item-separator">{separator}</span> : null}
             <span className="recharts-tooltip-item-value">{finalValue}</span>

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -497,7 +497,8 @@ export class Pie extends PureComponent<Props, State> {
           tabIndex={-1}
           className="recharts-pie-sector"
           {...adaptEventsOfChild(this.props, entry, i)}
-          key={`sector-${entry?.startAngle}-${entry?.endAngle}-${entry.midAngle}`}
+          // eslint-disable-next-line react/no-array-index-key
+          key={`sector-${i}`}
         >
           <Shape option={sectorOptions} isActive={isActive} shapeType="sector" {...sectorProps} />
         </Layer>


### PR DESCRIPTION
## Description
In pursuit of removing all `no-array-index-key` lint-skipping instances, some keys are more complicate to set, particularly
- Labels
- Tooltips
- Pie segments

## Related Issue
[4004](https://github.com/recharts/recharts/issues/4004)  
[3273](https://github.com/recharts/recharts/issues/3273)  

## Motivation and Context
_Remove immediately-discovered console warnings based on demo charts_.  

## How Has This Been Tested?
- [x] manual usage of demo charts
- [x] unit tests are still passing

## Types of changes

- [x] "Bug" fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
