### PR TITLE
fix: ref of the responsive container

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -70,21 +70,11 @@ export const ResponsiveContainer = forwardRef<HTMLDivElement | { current: HTMLDi
     onResizeRef.current = onResize;
     useImperativeHandle(ref, () => {
       return Object.assign(containerRef.current, {
-        current: new Proxy(containerRef.current, {
-          get: (target, prop, receiver) => {
-            // eslint-disable-next-line no-console
-            console.warn('The usage of ref.current.current is deprecated and will no longer be supported.');
-
-            const value = Reflect.get(target, prop, receiver);
-            if (typeof value === 'function') {
-              // eslint-disable-next-line func-names
-              return function (...args: unknown[]) {
-                return value.apply(this === receiver ? target : this, args);
-              };
-            }
-            return value;
-          },
-        }),
+        get current() {
+          // eslint-disable-next-line no-console
+          console.warn('The usage of ref.current.current is deprecated and will no longer be supported.');
+          return containerRef.current;
+        },
       });
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I enabled access to both ref.current and ref.current.current, and added a warning when accessing ref.current.current.
also the type changed to union.

## Related Issue

#3718 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
