### PR TITLE
Chore: adjust pie sector key value

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -479,6 +479,7 @@ export class Pie extends PureComponent<Props, State> {
   renderSectorsStatically(sectors: PieSectorDataItem[]) {
     const { activeShape, blendStroke, inactiveShape: inactiveShapeProp } = this.props;
     return sectors.map((entry, i) => {
+      if (entry?.startAngle === 0 && entry?.endAngle === 0 && sectors.length !== 1) return null;
       const isActive = this.isActiveIndex(i);
       const inactiveShape = inactiveShapeProp && this.hasActiveIndex() ? inactiveShapeProp : null;
       const sectorOptions = isActive ? activeShape : inactiveShape;
@@ -497,8 +498,7 @@ export class Pie extends PureComponent<Props, State> {
           tabIndex={-1}
           className="recharts-pie-sector"
           {...adaptEventsOfChild(this.props, entry, i)}
-          // eslint-disable-next-line react/no-array-index-key
-          key={`sector-${i}`}
+          key={`sector-${entry?.startAngle}-${entry?.endAngle}-${entry.midAngle}`}
         >
           <Shape option={sectorOptions} isActive={isActive} shapeType="sector" {...sectorProps} />
         </Layer>

--- a/test/chart/PieChart.spec.tsx
+++ b/test/chart/PieChart.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, Mock } from 'vitest';
 import { PieChart, Pie, Legend, Cell, Tooltip, Sector, SectorProps } from '../../src';
@@ -35,20 +35,13 @@ describe('<PieChart />', () => {
   test('Renders 6 sectors circles in simple PieChart', () => {
     const { container } = render(
       <PieChart width={800} height={400}>
-        <Pie
-          dataKey="value"
-          isAnimationActive={false}
-          data={data}
-          cx={200}
-          cy={200}
-          outerRadius={80}
-          fill="#ff7300"
-          label
-        />
+        <Pie dataKey="value" isAnimationActive data={data} cx={200} cy={200} outerRadius={80} fill="#ff7300" label />
       </PieChart>,
     );
 
-    expect(container.querySelectorAll('.recharts-pie-sector')).toHaveLength(data.length);
+    waitFor(() => {
+      expect(container.querySelectorAll('.recharts-pie-sector')).toHaveLength(data.length);
+    });
   });
 
   test('Renders 6 sectors circles in simple PieChart with animation', () => {

--- a/test/chart/PieChart.spec.tsx
+++ b/test/chart/PieChart.spec.tsx
@@ -6,14 +6,32 @@ import { PieChart, Pie, Legend, Cell, Tooltip, Sector, SectorProps } from '../..
 
 describe('<PieChart />', () => {
   const data = [
-    { name: 'Group A', value: 400 },
-    { name: 'Group B', value: 300 },
-    { name: 'Group C', value: 300 },
-    { name: 'Group D', value: 200 },
-    { name: 'Group E', value: 278 },
-    { name: 'Group F', value: 189 },
+    { name: 'Group A', value: 400, v: 89 },
+    { name: 'Group B', value: 300, v: 100 },
+    { name: 'Group C', value: 200, v: 200 },
+    { name: 'Group D', value: 200, v: 20 },
+    { name: 'Group E', value: 278, v: 40 },
+    { name: 'Group F', value: 189, v: 60 },
   ];
 
+  test('Renders 1 sector with animation, simple PieChart', () => {
+    const { container } = render(
+      <PieChart width={800} height={400}>
+        <Pie
+          dataKey="value"
+          isAnimationActive
+          data={[data[0]]}
+          cx={200}
+          cy={200}
+          outerRadius={80}
+          fill="#ff7300"
+          label
+        />
+      </PieChart>,
+    );
+
+    expect(container.querySelectorAll('.recharts-pie-sector')).toHaveLength(1);
+  });
   test('Renders 6 sectors circles in simple PieChart', () => {
     const { container } = render(
       <PieChart width={800} height={400}>


### PR DESCRIPTION
## Description
Updates the `sector` (pie "slice") rendering logic to render `null` at the "beginning" of an animation.  
This allows for more explicit key values of sectors once the sectors have starting+ending angles.    
The `no-array-index-key` seems to _only be appearing_ in pie chart sectors when (1) **animation is enabled** (2) **the first rendering** of each slice where each slice has _"nothing" to render that can uniquely identify each sector_. Once the slices "have size" in the animation, the `no-array-index-key` stops appearing.

## Related Issue
[3273](https://github.com/recharts/recharts/issues/3273)

## Motivation and Context
set more explicit key value in a pie chart.

## How Has This Been Tested?
- [x] pie demos work without key error: Pie, PieChart, ResponsiveContainer, all "manual" testing
- [x] unit tests are updated & pass

## Types of changes
- [x] technical detail

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes
  - assert 1-slice pie renders with animation
  - update 6-slice pie to include animation & `v` attribute seen in `demo` data code
- [x] All new and existing tests passed
