### PR TITLE
allow className to be passed to Radial Bar background

### DIFF
--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -367,7 +367,7 @@ export class RadialBar extends PureComponent<RadialBarProps, State> {
         ...adaptEventsOfChild(this.props, entry, i),
         index: i,
         key: `sector-${i}`,
-        className: 'recharts-radial-bar-background-sector',
+        className: clsx('recharts-radial-bar-background-sector', backgroundProps?.className),
         option: background,
         isActive: false,
       };

--- a/test/chart/PieChart.spec.tsx
+++ b/test/chart/PieChart.spec.tsx
@@ -35,7 +35,17 @@ describe('<PieChart />', () => {
   test('Renders 6 sectors circles in simple PieChart', () => {
     const { container } = render(
       <PieChart width={800} height={400}>
-        <Pie dataKey="value" isAnimationActive data={data} cx={200} cy={200} outerRadius={80} fill="#ff7300" label />
+        <Pie
+          dataKey="value"
+          isAnimationActive
+          data={data}
+          animationDuration={0}
+          cx={200}
+          cy={200}
+          outerRadius={80}
+          fill="#ff7300"
+          label
+        />
       </PieChart>,
     );
 

--- a/test/chart/RadialBarChart.spec.tsx
+++ b/test/chart/RadialBarChart.spec.tsx
@@ -32,6 +32,32 @@ describe('<RadialBarChart />', () => {
     expect(container.querySelectorAll('.recharts-radial-bar-sector')).toHaveLength(data.length);
   });
 
+  test('Adds className when set on radial bar and radial bar background', () => {
+    const label = { orientation: 'outer' };
+    const { container } = render(
+      <RadialBarChart
+        width={500}
+        height={300}
+        cx={150}
+        cy={150}
+        innerRadius={20}
+        outerRadius={140}
+        barSize={10}
+        data={data}
+      >
+        <RadialBar
+          className="test-radial-bar"
+          label={label}
+          background={{ className: 'test-custom-background' }}
+          dataKey="uv"
+          isAnimationActive={false}
+        />
+      </RadialBarChart>,
+    );
+    expect(container.querySelectorAll('.test-radial-bar')).toHaveLength(1);
+    expect(container.querySelectorAll('.test-custom-background')).toHaveLength(data.length);
+  });
+
   test("Don't renders any sectors when no RadialBar is added", () => {
     const { container } = render(
       <RadialBarChart

--- a/test/component/Cursor.spec.tsx
+++ b/test/component/Cursor.spec.tsx
@@ -27,7 +27,11 @@ const defaultProps: CursorProps = {
 
 describe('Cursor', () => {
   it('should render curve cursor by default', () => {
-    const { container } = render(<Cursor {...defaultProps} />);
+    const { container } = render(
+      <svg width={100} height={100}>
+        <Cursor {...defaultProps} />
+      </svg>,
+    );
     const cursor = container.querySelector('.recharts-curve');
     assertNotNull(cursor);
     expect(cursor).toBeVisible();
@@ -41,7 +45,11 @@ describe('Cursor', () => {
       ...defaultProps,
       element: getTooltipElement({ cursor: <MyCustomCursor /> }),
     };
-    const { getByText } = render(<Cursor {...props} />);
+    const { getByText } = render(
+      <svg width={100} height={100}>
+        <Cursor {...props} />
+      </svg>,
+    );
     expect(getByText('I am a cursor.')).toBeVisible();
   });
 
@@ -50,7 +58,11 @@ describe('Cursor', () => {
       ...defaultProps,
       chartName: 'ScatterChart',
     };
-    const { container } = render(<Cursor {...props} />);
+    const { container } = render(
+      <svg width={100} height={100}>
+        <Cursor {...props} />
+      </svg>,
+    );
     const cursor = container.querySelector('.recharts-cross');
     assertNotNull(cursor);
     expect(cursor).toBeVisible();
@@ -66,7 +78,11 @@ describe('Cursor', () => {
       tooltipAxisBandSize: 1,
       chartName: 'BarChart',
     };
-    const { container } = render(<Cursor {...props} />);
+    const { container } = render(
+      <svg width={100} height={100}>
+        <Cursor {...props} />
+      </svg>,
+    );
     const cursor = container.querySelector('.recharts-rectangle');
     assertNotNull(cursor);
     expect(cursor).toBeVisible();
@@ -84,7 +100,11 @@ describe('Cursor', () => {
       },
       layout: 'radial',
     };
-    const { container } = render(<Cursor {...props} />);
+    const { container } = render(
+      <svg width={100} height={100}>
+        <Cursor {...props} />
+      </svg>,
+    );
     const cursor = container.querySelector('.recharts-sector');
     assertNotNull(cursor);
     expect(cursor).toBeVisible();

--- a/test/shape/ActiveShape.spec.tsx
+++ b/test/shape/ActiveShape.spec.tsx
@@ -175,7 +175,7 @@ describe('Active Shape', () => {
   // testing that the activeShape prop is rendered via tooltip
   test.each(funnelActiveShapes)('$name', ({ element, activeClass, expectedLength, shapeClass }) => {
     const { container } = render(element);
-    const shapes = container.querySelectorAll(shapeClass);
+    const shapes = container.querySelectorAll(shapeClass ?? '');
     const [shape] = Array.from(shapes);
     fireEvent.mouseOver(shape);
     const activeShape = container.querySelectorAll(activeClass);

--- a/test/util/FunnelUtils.spec.tsx
+++ b/test/util/FunnelUtils.spec.tsx
@@ -25,19 +25,25 @@ describe('funnelUtils', () => {
     expect(res).toEqual(mockRes);
   });
   it('<FunnelTrapezoid /> returns a trapezoid shape with no options', () => {
-    const { container } = render(<FunnelTrapezoid option={{}} {...mockProps} isActive={Boolean(true)} />);
+    const { container } = render(
+      <svg width={100} height={100}>
+        <FunnelTrapezoid option={{}} {...mockProps} isActive={Boolean(true)} />
+      </svg>,
+    );
     expect(container.querySelector('g')).toHaveClass('recharts-active-shape');
   });
   it('<FunnelTrapezoid /> returns a trapezoid shape with x & y from options', () => {
     const { container } = render(
-      <FunnelTrapezoid
-        option={{ x: 10, y: 10 }}
-        {...{
-          isActive: true,
-          height: 100,
-        }}
-        isActive={Boolean(true)}
-      />,
+      <svg width={100} height={100}>
+        <FunnelTrapezoid
+          option={{ x: 10, y: 10 }}
+          {...{
+            isActive: true,
+            height: 100,
+          }}
+          isActive={Boolean(true)}
+        />
+      </svg>,
     );
     expect(container.querySelector('g')).toHaveClass('recharts-active-shape');
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

* Fix issue where className is ignored if sending for RadialBar `background` prop
* Fix some additional issues in tests which were giving me trouble (wrap some items in `svg`)

Note:

The pie test was failing because of animation, it was flaky though. I'm running it on a pretty beefy box so I think the tests finished before the default animation time could.

The others don't fail but they log annoying messages in the console and that could potentially produce the wrong behavior. SVG elements without their container aren't usually able to be used for much

## Related Issue

#4011 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix a small fix

## How Has This Been Tested?

See added unit test

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
