### PR TITLE
Referenceline get end points tests

### DIFF
--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -28,6 +28,8 @@ export type Segment = {
   y?: number | string;
 };
 
+type ReferenceLinePosition = 'middle' | 'start' | 'end';
+
 interface ReferenceLineProps extends InternalReferenceLineProps {
   isFront?: boolean;
   /** @deprecated use ifOverflow="extendDomain"  */
@@ -39,7 +41,7 @@ interface ReferenceLineProps extends InternalReferenceLineProps {
 
   segment?: ReadonlyArray<Segment>;
 
-  position?: 'middle' | 'start' | 'end';
+  position?: ReferenceLinePosition;
 
   className?: number | string;
   yAxisId?: number | string;
@@ -64,8 +66,29 @@ const renderLine = (option: ReferenceLineProps['shape'], props: any) => {
   return line;
 };
 
+type EndPointsPropsSubset = {
+  alwaysShow?: boolean;
+  ifOverflow?: IfOverflow;
+  viewBox?: CartesianViewBox;
+  xAxis?: {
+    orientation?: XAxisProps['orientation'];
+  };
+  yAxis?: {
+    orientation?: YAxisProps['orientation'];
+  };
+  position?: ReferenceLinePosition;
+  segment?: ReadonlyArray<Segment>;
+  x?: number | string;
+  y?: number | string;
+};
 // TODO: ScaleHelper
-export const getEndPoints = (scales: any, isFixedX: boolean, isFixedY: boolean, isSegment: boolean, props: Props) => {
+export const getEndPoints = (
+  scales: any,
+  isFixedX: boolean,
+  isFixedY: boolean,
+  isSegment: boolean,
+  props: EndPointsPropsSubset,
+) => {
   const {
     viewBox: { x, y, width, height },
     position,

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -28,7 +28,7 @@ export type Segment = {
   y?: number | string;
 };
 
-type ReferenceLinePosition = 'middle' | 'start' | 'end';
+export type ReferenceLinePosition = 'middle' | 'start' | 'end';
 
 interface ReferenceLineProps extends InternalReferenceLineProps {
   isFront?: boolean;

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -50,7 +50,13 @@ interface ReferenceLineProps extends InternalReferenceLineProps {
   label?: ImplicitLabelType;
 }
 
-export type Props = SVGProps<SVGLineElement> & ReferenceLineProps;
+/**
+ * This excludes `viewBox` prop from svg for two reasons:
+ * 1. The components wants viewBox of object type, and svg wants string
+ *    - so there's a conflict, and the component will throw if it gets string
+ * 2. Internally the component calls `filterProps` which filters the viewBox away anyway
+ */
+export type Props = Omit<SVGProps<SVGLineElement>, 'viewBox'> & ReferenceLineProps;
 
 const renderLine = (option: ReferenceLineProps['shape'], props: any) => {
   let line;

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -23,6 +23,11 @@ interface InternalReferenceLineProps {
   clipPathId?: number | string;
 }
 
+export type Segment = {
+  x?: number | string;
+  y?: number | string;
+};
+
 interface ReferenceLineProps extends InternalReferenceLineProps {
   isFront?: boolean;
   /** @deprecated use ifOverflow="extendDomain"  */
@@ -32,10 +37,7 @@ interface ReferenceLineProps extends InternalReferenceLineProps {
   x?: number | string;
   y?: number | string;
 
-  segment?: Array<{
-    x?: number | string;
-    y?: number | string;
-  }>;
+  segment?: ReadonlyArray<Segment>;
 
   position?: 'middle' | 'start' | 'end';
 
@@ -63,7 +65,7 @@ const renderLine = (option: ReferenceLineProps['shape'], props: any) => {
 };
 
 // TODO: ScaleHelper
-const getEndPoints = (scales: any, isFixedX: boolean, isFixedY: boolean, isSegment: boolean, props: Props) => {
+export const getEndPoints = (scales: any, isFixedX: boolean, isFixedY: boolean, isSegment: boolean, props: Props) => {
   const {
     viewBox: { x, y, width, height },
     position,

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -316,7 +316,7 @@ export const filterSvgElements = (children: React.ReactElement[]): React.ReactEl
 };
 
 export const filterProps = (
-  props: Record<string, any> | Component | FunctionComponent | boolean,
+  props: Record<string, any> | Component | FunctionComponent | boolean | unknown,
   includeEvents?: boolean,
   svgElementType?: FilteredSvgElementType,
 ) => {

--- a/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
+++ b/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { vi } from 'vitest';
 import { screen, render } from '@testing-library/react';
-import { BarChart, ReferenceLine, Bar, XAxis, YAxis } from '../../src';
+import { BarChart, ReferenceLine, Bar, XAxis, YAxis } from '../../../src';
 
 describe('<ReferenceLine />', () => {
   const consoleSpy = vi.spyOn(console, 'warn').mockImplementation((): void => undefined);

--- a/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
+++ b/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
@@ -279,7 +279,6 @@ describe('<ReferenceLine />', () => {
         <XAxis dataKey="name" />
         <YAxis tickCount={7} />
         <Bar dataKey="uv" />
-        {/* @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging */}
         <ReferenceLine y={20} stroke="#666" ifOverflow="visible" shape={spy} viewBox={viewBox} />
       </BarChart>,
     );

--- a/test/cartesian/ReferenceLine/getEndPoints.spec.tsx
+++ b/test/cartesian/ReferenceLine/getEndPoints.spec.tsx
@@ -1,0 +1,466 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getEndPoints } from '../../../src/cartesian/ReferenceLine';
+import { XAxisProps, YAxisProps } from '../../../src';
+import { CartesianViewBox, D3Scale } from '../../../src/util/types';
+
+describe('getEndPoints', () => {
+  it('should return null if X, Y are not fixed and isSegment is false too', () => {
+    const result = getEndPoints(null, false, false, false, { viewBox: '' });
+    expect(result).toEqual(null);
+  });
+
+  describe('fixed Y location when out of range', () => {
+    const position = 'start';
+    const coord = Symbol('coord');
+    const scales = {
+      y: {
+        apply: vi.fn(),
+        isInRange: vi.fn(),
+      },
+    };
+
+    beforeEach(() => {
+      scales.y.apply.mockReset();
+      scales.y.apply.mockImplementation(() => coord);
+      scales.y.isInRange.mockReset();
+      scales.y.isInRange.mockImplementation(() => false);
+    });
+
+    it('should return null when set to discard overflow', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'left',
+      };
+      const lineLocationY = 9;
+      const result = getEndPoints(scales, false, true, false, {
+        position,
+        viewBox: '',
+        yAxis,
+        y: lineLocationY,
+        ifOverflow: 'discard',
+      });
+      expect(result).toEqual(null);
+
+      expect(scales.y.apply).toHaveBeenCalledTimes(1);
+      expect(scales.y.apply).toHaveBeenCalledWith(lineLocationY, { position });
+
+      expect(scales.y.isInRange).toBeCalledTimes(1);
+      expect(scales.y.isInRange).toBeCalledWith(coord);
+    });
+
+    it('should return gibberish when viewBox is empty', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'left',
+      };
+      const viewBox: CartesianViewBox = {};
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, false, true, false, { position, viewBox, yAxis, ifOverflow: 'visible' });
+
+      const expected = [
+        { x: undefined, y: coord },
+        { x: NaN, y: coord },
+      ];
+      expect(result).toEqual(expected);
+    });
+
+    it('should return coordinates when set to display overflow when orientation is "right"', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'right',
+      };
+      const viewBox: CartesianViewBox = {
+        x: 10,
+        width: 5,
+      };
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, false, true, false, { position, viewBox, yAxis, ifOverflow: 'visible' });
+
+      const expected = [
+        { x: 15, y: coord },
+        { x: 10, y: coord },
+      ];
+      expect(result).toEqual(expected);
+    });
+
+    it('should reverse first and second point if yAxis orientation is "left"', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'left',
+      };
+      const viewBox: CartesianViewBox = {
+        x: 10,
+        width: 5,
+      };
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, false, true, false, { position, viewBox, yAxis, ifOverflow: 'visible' });
+
+      const expected = [
+        { x: 10, y: coord },
+        { x: 15, y: coord },
+      ];
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('fixed Y location when in range', () => {
+    const position = 'start';
+    const coord = Symbol('coord');
+    const scales = {
+      y: {
+        apply: vi.fn(),
+        isInRange: vi.fn(),
+      },
+    };
+
+    beforeEach(() => {
+      scales.y.apply.mockReset();
+      scales.y.apply.mockImplementation(() => coord);
+      scales.y.isInRange.mockReset();
+      scales.y.isInRange.mockImplementation(() => true);
+    });
+
+    it('should return coordinates when set to discard overflow', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'right',
+      };
+      const viewBox: CartesianViewBox = {
+        x: 10,
+        width: 5,
+      };
+      const lineLocationY = 9;
+      const result = getEndPoints(scales, false, true, false, {
+        position,
+        // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+        viewBox,
+        yAxis,
+        y: lineLocationY,
+        ifOverflow: 'discard',
+      });
+      const expected = [
+        { x: 15, y: coord },
+        { x: 10, y: coord },
+      ];
+      expect(result).toEqual(expected);
+
+      expect(scales.y.apply).toHaveBeenCalledTimes(1);
+      expect(scales.y.apply).toHaveBeenCalledWith(lineLocationY, { position });
+
+      expect(scales.y.isInRange).toBeCalledTimes(1);
+      expect(scales.y.isInRange).toBeCalledWith(coord);
+    });
+
+    it('should return gibberish when viewBox is empty', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'left',
+      };
+      const viewBox: CartesianViewBox = {};
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, false, true, false, { position, viewBox, yAxis, ifOverflow: 'visible' });
+
+      const expected = [
+        { x: undefined, y: coord },
+        { x: NaN, y: coord },
+      ];
+      expect(result).toEqual(expected);
+    });
+
+    it('should return coordinates when set to display overflow when orientation is "right"', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'right',
+      };
+      const viewBox: CartesianViewBox = {
+        x: 10,
+        width: 5,
+      };
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, false, true, false, { position, viewBox, yAxis, ifOverflow: 'visible' });
+
+      const expected = [
+        { x: 15, y: coord },
+        { x: 10, y: coord },
+      ];
+      expect(result).toEqual(expected);
+    });
+
+    it('should reverse first and second point if yAxis orientation is "left"', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'left',
+      };
+      const viewBox: CartesianViewBox = {
+        x: 10,
+        width: 5,
+      };
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, false, true, false, { position, viewBox, yAxis, ifOverflow: 'visible' });
+
+      const expected = [
+        { x: 10, y: coord },
+        { x: 15, y: coord },
+      ];
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('fixed X location when out of range', () => {
+    const position = 'start';
+    const coord = Symbol('coord');
+    const scales = {
+      x: {
+        apply: vi.fn(),
+        isInRange: vi.fn(),
+      },
+    };
+
+    beforeEach(() => {
+      scales.x.apply.mockReset();
+      scales.x.apply.mockImplementation(() => coord);
+      scales.x.isInRange.mockReset();
+      scales.x.isInRange.mockImplementation(() => false);
+    });
+
+    it('should return null when set to discard overflow', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'bottom',
+      };
+      const lineLocationX = 9;
+      const result = getEndPoints(scales, true, false, false, {
+        position,
+        viewBox: '',
+        xAxis,
+        x: lineLocationX,
+        ifOverflow: 'discard',
+      });
+      expect(result).toEqual(null);
+
+      expect(scales.x.apply).toHaveBeenCalledTimes(1);
+      expect(scales.x.apply).toHaveBeenCalledWith(lineLocationX, { position });
+
+      expect(scales.x.isInRange).toBeCalledTimes(1);
+      expect(scales.x.isInRange).toBeCalledWith(coord);
+    });
+
+    it('should return gibberish when viewBox is empty', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'bottom',
+      };
+      const viewBox: CartesianViewBox = {};
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, true, false, false, { position, viewBox, xAxis, ifOverflow: 'visible' });
+
+      const expected = [
+        { x: coord, y: NaN },
+        { x: coord, y: undefined },
+      ];
+      expect(result).toEqual(expected);
+    });
+
+    it('should return coordinates when set to display overflow when orientation is "top"', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'top',
+      };
+      const viewBox: CartesianViewBox = {
+        y: 10,
+        height: 5,
+      };
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, true, false, false, { position, viewBox, xAxis, ifOverflow: 'visible' });
+
+      const expected = [
+        { x: coord, y: 10 },
+        { x: coord, y: 15 },
+      ];
+      expect(result).toEqual(expected);
+    });
+
+    it('should reverse first and second point if xAxis orientation is "top"', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'top',
+      };
+      const viewBox: CartesianViewBox = {
+        y: 10,
+        height: 5,
+      };
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, true, false, false, { position, viewBox, xAxis, ifOverflow: 'visible' });
+
+      const expected = [
+        { x: coord, y: 10 },
+        { x: coord, y: 15 },
+      ];
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('fixed X location when in range', () => {
+    const position = 'start';
+    const coord = Symbol('coord');
+    const scales = {
+      x: {
+        apply: vi.fn(),
+        isInRange: vi.fn(),
+      },
+    };
+
+    beforeEach(() => {
+      scales.x.apply.mockReset();
+      scales.x.apply.mockImplementation(() => coord);
+      scales.x.isInRange.mockReset();
+      scales.x.isInRange.mockImplementation(() => true);
+    });
+
+    it('should return coordinates when set to discard overflow', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'bottom',
+      };
+      const lineLocationX = 9;
+      const viewBox: CartesianViewBox = {
+        y: 10,
+        height: 5,
+      };
+      const result = getEndPoints(scales, true, false, false, {
+        position,
+        // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+        viewBox,
+        xAxis,
+        x: lineLocationX,
+        ifOverflow: 'discard',
+      });
+      const expected = [
+        { x: coord, y: 15 },
+        { x: coord, y: 10 },
+      ];
+      expect(result).toEqual(expected);
+
+      expect(scales.x.apply).toHaveBeenCalledTimes(1);
+      expect(scales.x.apply).toHaveBeenCalledWith(lineLocationX, { position });
+
+      expect(scales.x.isInRange).toBeCalledTimes(1);
+      expect(scales.x.isInRange).toBeCalledWith(coord);
+    });
+
+    it('should return gibberish when viewBox is empty', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'bottom',
+      };
+      const viewBox: CartesianViewBox = {};
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, true, false, false, { position, viewBox, xAxis, ifOverflow: 'visible' });
+
+      const expected = [
+        { x: coord, y: NaN },
+        { x: coord, y: undefined },
+      ];
+      expect(result).toEqual(expected);
+    });
+
+    it('should return coordinates when set to display overflow when orientation is "top"', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'top',
+      };
+      const viewBox: CartesianViewBox = {
+        y: 10,
+        height: 5,
+      };
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, true, false, false, { position, viewBox, xAxis, ifOverflow: 'visible' });
+
+      const expected = [
+        { x: coord, y: 10 },
+        { x: coord, y: 15 },
+      ];
+      expect(result).toEqual(expected);
+    });
+
+    it('should reverse first and second point if xAxis orientation is "top"', () => {
+      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
+      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+        orientation: 'top',
+      };
+      const viewBox: CartesianViewBox = {
+        y: 10,
+        height: 5,
+      };
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, true, false, false, { position, viewBox, xAxis, ifOverflow: 'visible' });
+
+      const expected = [
+        { x: coord, y: 10 },
+        { x: coord, y: 15 },
+      ];
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('segment', () => {
+    it('should return empty array if segment array is empty', () => {
+      const result = getEndPoints(null, false, false, true, {
+        segment: [],
+        // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+        viewBox: {},
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('should pass every segment into scales function', () => {
+      const segment = [{ x: 1 }, { x: 2 }, { x: 3 }];
+      const scales = {
+        apply: vi.fn(_ => _),
+        isInRange: vi.fn(),
+      };
+      const position = 9;
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      getEndPoints(scales, false, false, true, { viewBox: {}, segment, position });
+      expect(scales.apply).toHaveBeenCalledTimes(3);
+      expect(scales.apply).toHaveBeenCalledWith({ x: 1 }, { position });
+      expect(scales.apply).toHaveBeenCalledWith({ x: 2 }, { position });
+      expect(scales.apply).toHaveBeenCalledWith({ x: 3 }, { position });
+      expect(scales.isInRange).toHaveBeenCalledTimes(0);
+    });
+
+    it('should pass every segment into isInRange function if overflow set to discard', () => {
+      const segment = [{ x: 1 }, { x: 2 }, { x: 3 }];
+      const scales = {
+        apply: vi.fn(_ => _),
+        isInRange: vi.fn(() => true),
+      };
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      getEndPoints(scales, false, false, true, { viewBox: {}, segment, ifOverflow: 'discard' });
+      expect(scales.apply).toHaveBeenCalledTimes(3);
+      expect(scales.isInRange).toHaveBeenCalledTimes(3);
+    });
+
+    it('should return null if outside of scale and overflow set to discard', () => {
+      const segment = [{ x: 1 }, { x: 2 }, { x: 3 }];
+      const scales = {
+        apply: vi.fn(_ => _),
+        isInRange: vi.fn(() => false),
+      };
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, false, false, true, { viewBox: {}, segment, ifOverflow: 'discard' });
+      expect(result).toEqual(null);
+    });
+
+    it('should return whatever scales returned if in range', () => {
+      const segment = [{ x: 1 }, { x: 2 }, { x: 3 }];
+      const scales = {
+        apply: vi.fn(({ x }) => x * 2),
+        isInRange: vi.fn(() => true),
+      };
+      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const result = getEndPoints(scales, false, false, true, { viewBox: {}, segment, ifOverflow: 'discard' });
+      expect(result).toEqual([2, 4, 6]);
+    });
+  });
+});

--- a/test/cartesian/ReferenceLine/getEndPoints.spec.tsx
+++ b/test/cartesian/ReferenceLine/getEndPoints.spec.tsx
@@ -5,7 +5,7 @@ import { CartesianViewBox, D3Scale } from '../../../src/util/types';
 
 describe('getEndPoints', () => {
   it('should return null if X, Y are not fixed and isSegment is false too', () => {
-    const result = getEndPoints(null, false, false, false, { viewBox: '' });
+    const result = getEndPoints(null, false, false, false, { viewBox: {} });
     expect(result).toEqual(null);
   });
 
@@ -34,7 +34,7 @@ describe('getEndPoints', () => {
       const lineLocationY = 9;
       const result = getEndPoints(scales, false, true, false, {
         position,
-        viewBox: '',
+        viewBox: {},
         yAxis,
         y: lineLocationY,
         ifOverflow: 'discard',
@@ -54,7 +54,6 @@ describe('getEndPoints', () => {
         orientation: 'left',
       };
       const viewBox: CartesianViewBox = {};
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, false, true, false, { position, viewBox, yAxis, ifOverflow: 'visible' });
 
       const expected = [
@@ -73,7 +72,6 @@ describe('getEndPoints', () => {
         x: 10,
         width: 5,
       };
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, false, true, false, { position, viewBox, yAxis, ifOverflow: 'visible' });
 
       const expected = [
@@ -92,7 +90,6 @@ describe('getEndPoints', () => {
         x: 10,
         width: 5,
       };
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, false, true, false, { position, viewBox, yAxis, ifOverflow: 'visible' });
 
       const expected = [
@@ -132,7 +129,6 @@ describe('getEndPoints', () => {
       const lineLocationY = 9;
       const result = getEndPoints(scales, false, true, false, {
         position,
-        // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
         viewBox,
         yAxis,
         y: lineLocationY,
@@ -157,7 +153,6 @@ describe('getEndPoints', () => {
         orientation: 'left',
       };
       const viewBox: CartesianViewBox = {};
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, false, true, false, { position, viewBox, yAxis, ifOverflow: 'visible' });
 
       const expected = [
@@ -176,7 +171,6 @@ describe('getEndPoints', () => {
         x: 10,
         width: 5,
       };
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, false, true, false, { position, viewBox, yAxis, ifOverflow: 'visible' });
 
       const expected = [
@@ -195,7 +189,6 @@ describe('getEndPoints', () => {
         x: 10,
         width: 5,
       };
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, false, true, false, { position, viewBox, yAxis, ifOverflow: 'visible' });
 
       const expected = [
@@ -231,7 +224,7 @@ describe('getEndPoints', () => {
       const lineLocationX = 9;
       const result = getEndPoints(scales, true, false, false, {
         position,
-        viewBox: '',
+        viewBox: {},
         xAxis,
         x: lineLocationX,
         ifOverflow: 'discard',
@@ -251,7 +244,6 @@ describe('getEndPoints', () => {
         orientation: 'bottom',
       };
       const viewBox: CartesianViewBox = {};
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, true, false, false, { position, viewBox, xAxis, ifOverflow: 'visible' });
 
       const expected = [
@@ -270,7 +262,6 @@ describe('getEndPoints', () => {
         y: 10,
         height: 5,
       };
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, true, false, false, { position, viewBox, xAxis, ifOverflow: 'visible' });
 
       const expected = [
@@ -289,7 +280,6 @@ describe('getEndPoints', () => {
         y: 10,
         height: 5,
       };
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, true, false, false, { position, viewBox, xAxis, ifOverflow: 'visible' });
 
       const expected = [
@@ -329,7 +319,6 @@ describe('getEndPoints', () => {
       };
       const result = getEndPoints(scales, true, false, false, {
         position,
-        // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
         viewBox,
         xAxis,
         x: lineLocationX,
@@ -354,7 +343,6 @@ describe('getEndPoints', () => {
         orientation: 'bottom',
       };
       const viewBox: CartesianViewBox = {};
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, true, false, false, { position, viewBox, xAxis, ifOverflow: 'visible' });
 
       const expected = [
@@ -373,7 +361,6 @@ describe('getEndPoints', () => {
         y: 10,
         height: 5,
       };
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, true, false, false, { position, viewBox, xAxis, ifOverflow: 'visible' });
 
       const expected = [
@@ -392,7 +379,6 @@ describe('getEndPoints', () => {
         y: 10,
         height: 5,
       };
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, true, false, false, { position, viewBox, xAxis, ifOverflow: 'visible' });
 
       const expected = [
@@ -407,7 +393,6 @@ describe('getEndPoints', () => {
     it('should return empty array if segment array is empty', () => {
       const result = getEndPoints(null, false, false, true, {
         segment: [],
-        // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
         viewBox: {},
       });
       expect(result).toEqual([]);
@@ -435,7 +420,6 @@ describe('getEndPoints', () => {
         apply: vi.fn(_ => _),
         isInRange: vi.fn(() => true),
       };
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       getEndPoints(scales, false, false, true, { viewBox: {}, segment, ifOverflow: 'discard' });
       expect(scales.apply).toHaveBeenCalledTimes(3);
       expect(scales.isInRange).toHaveBeenCalledTimes(3);
@@ -447,7 +431,6 @@ describe('getEndPoints', () => {
         apply: vi.fn(_ => _),
         isInRange: vi.fn(() => false),
       };
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, false, false, true, { viewBox: {}, segment, ifOverflow: 'discard' });
       expect(result).toEqual(null);
     });
@@ -458,7 +441,6 @@ describe('getEndPoints', () => {
         apply: vi.fn(({ x }) => x * 2),
         isInRange: vi.fn(() => true),
       };
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
       const result = getEndPoints(scales, false, false, true, { viewBox: {}, segment, ifOverflow: 'discard' });
       expect(result).toEqual([2, 4, 6]);
     });

--- a/test/cartesian/ReferenceLine/getEndPoints.spec.tsx
+++ b/test/cartesian/ReferenceLine/getEndPoints.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { getEndPoints } from '../../../src/cartesian/ReferenceLine';
 import { XAxisProps, YAxisProps } from '../../../src';
-import { CartesianViewBox, D3Scale } from '../../../src/util/types';
+import { CartesianViewBox } from '../../../src/util/types';
 
 describe('getEndPoints', () => {
   it('should return null if X, Y are not fixed and isSegment is false too', () => {
@@ -27,8 +27,9 @@ describe('getEndPoints', () => {
     });
 
     it('should return null when set to discard overflow', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const yAxis: {
+        orientation?: YAxisProps['orientation'];
+      } = {
         orientation: 'left',
       };
       const lineLocationY = 9;
@@ -49,8 +50,9 @@ describe('getEndPoints', () => {
     });
 
     it('should return gibberish when viewBox is empty', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const yAxis: {
+        orientation?: YAxisProps['orientation'];
+      } = {
         orientation: 'left',
       };
       const viewBox: CartesianViewBox = {};
@@ -64,8 +66,9 @@ describe('getEndPoints', () => {
     });
 
     it('should return coordinates when set to display overflow when orientation is "right"', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const yAxis: {
+        orientation?: YAxisProps['orientation'];
+      } = {
         orientation: 'right',
       };
       const viewBox: CartesianViewBox = {
@@ -82,8 +85,9 @@ describe('getEndPoints', () => {
     });
 
     it('should reverse first and second point if yAxis orientation is "left"', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const yAxis: {
+        orientation?: YAxisProps['orientation'];
+      } = {
         orientation: 'left',
       };
       const viewBox: CartesianViewBox = {
@@ -118,8 +122,9 @@ describe('getEndPoints', () => {
     });
 
     it('should return coordinates when set to discard overflow', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const yAxis: {
+        orientation?: YAxisProps['orientation'];
+      } = {
         orientation: 'right',
       };
       const viewBox: CartesianViewBox = {
@@ -148,8 +153,9 @@ describe('getEndPoints', () => {
     });
 
     it('should return gibberish when viewBox is empty', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const yAxis: {
+        orientation?: YAxisProps['orientation'];
+      } = {
         orientation: 'left',
       };
       const viewBox: CartesianViewBox = {};
@@ -163,8 +169,9 @@ describe('getEndPoints', () => {
     });
 
     it('should return coordinates when set to display overflow when orientation is "right"', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const yAxis: {
+        orientation?: YAxisProps['orientation'];
+      } = {
         orientation: 'right',
       };
       const viewBox: CartesianViewBox = {
@@ -181,8 +188,9 @@ describe('getEndPoints', () => {
     });
 
     it('should reverse first and second point if yAxis orientation is "left"', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const yAxis: {
+        orientation?: YAxisProps['orientation'];
+      } = {
         orientation: 'left',
       };
       const viewBox: CartesianViewBox = {
@@ -217,8 +225,9 @@ describe('getEndPoints', () => {
     });
 
     it('should return null when set to discard overflow', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const xAxis: {
+        orientation?: XAxisProps['orientation'];
+      } = {
         orientation: 'bottom',
       };
       const lineLocationX = 9;
@@ -239,8 +248,9 @@ describe('getEndPoints', () => {
     });
 
     it('should return gibberish when viewBox is empty', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const xAxis: {
+        orientation?: XAxisProps['orientation'];
+      } = {
         orientation: 'bottom',
       };
       const viewBox: CartesianViewBox = {};
@@ -254,8 +264,9 @@ describe('getEndPoints', () => {
     });
 
     it('should return coordinates when set to display overflow when orientation is "top"', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const xAxis: {
+        orientation?: XAxisProps['orientation'];
+      } = {
         orientation: 'top',
       };
       const viewBox: CartesianViewBox = {
@@ -272,8 +283,9 @@ describe('getEndPoints', () => {
     });
 
     it('should reverse first and second point if xAxis orientation is "top"', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const xAxis: {
+        orientation?: XAxisProps['orientation'];
+      } = {
         orientation: 'top',
       };
       const viewBox: CartesianViewBox = {
@@ -308,8 +320,9 @@ describe('getEndPoints', () => {
     });
 
     it('should return coordinates when set to discard overflow', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const xAxis: {
+        orientation?: XAxisProps['orientation'];
+      } = {
         orientation: 'bottom',
       };
       const lineLocationX = 9;
@@ -338,8 +351,9 @@ describe('getEndPoints', () => {
     });
 
     it('should return gibberish when viewBox is empty', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const xAxis: {
+        orientation?: XAxisProps['orientation'];
+      } = {
         orientation: 'bottom',
       };
       const viewBox: CartesianViewBox = {};
@@ -353,8 +367,9 @@ describe('getEndPoints', () => {
     });
 
     it('should return coordinates when set to display overflow when orientation is "top"', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const xAxis: {
+        orientation?: XAxisProps['orientation'];
+      } = {
         orientation: 'top',
       };
       const viewBox: CartesianViewBox = {
@@ -371,8 +386,9 @@ describe('getEndPoints', () => {
     });
 
     it('should reverse first and second point if xAxis orientation is "top"', () => {
-      // @ts-expect-error TODO this mock is incomplete and I am going to fix it before merging
-      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const xAxis: {
+        orientation?: XAxisProps['orientation'];
+      } = {
         orientation: 'top',
       };
       const viewBox: CartesianViewBox = {

--- a/test/cartesian/ReferenceLine/getEndPoints.spec.tsx
+++ b/test/cartesian/ReferenceLine/getEndPoints.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { getEndPoints } from '../../../src/cartesian/ReferenceLine';
+import { ReferenceLinePosition, getEndPoints } from '../../../src/cartesian/ReferenceLine';
 import { XAxisProps, YAxisProps } from '../../../src';
 import { CartesianViewBox } from '../../../src/util/types';
 
@@ -420,8 +420,7 @@ describe('getEndPoints', () => {
         apply: vi.fn(_ => _),
         isInRange: vi.fn(),
       };
-      const position = 9;
-      // @ts-expect-error TODO viewBox from recharts conflicts with viewBox from svg props; fix before merging
+      const position: ReferenceLinePosition = 'middle';
       getEndPoints(scales, false, false, true, { viewBox: {}, segment, position });
       expect(scales.apply).toHaveBeenCalledTimes(3);
       expect(scales.apply).toHaveBeenCalledWith({ x: 1 }, { position });

--- a/test/util/ReactUtils.spec.tsx
+++ b/test/util/ReactUtils.spec.tsx
@@ -18,30 +18,36 @@ import { adaptEventHandlers, adaptEventsOfChild } from '../../src/util/types';
 
 describe('ReactUtils untest tests', () => {
   describe('filterProps', () => {
-    test('should call filterProps wtesth any boolean and return a null result', () => {
-      expect(filterProps(true)).toBeNull();
-      expect(filterProps(false)).toBeNull();
+    test.each([true, false, 125, null, undefined])('should return null when called with %s', input => {
+      expect(filterProps(input)).toBeNull();
     });
 
-    test('should call filterProps wtesth a non-object and return null', () => {
-      expect(filterProps(125 as {})).toBeNull();
-    });
-
-    test('should call filterProps wtesth a react element extract properties and filter out non-svg properties', () => {
+    test('should filter out non-svg properties from react element props', () => {
       expect(filterProps(<input id="test" value={1} />)).toEqual({ id: 'test' });
     });
 
-    test('should pass props and filter out non wanted properties', () => {
+    test('should filter out non wanted properties', () => {
       expect(filterProps({ test: '1234', helloWorld: 1234, viewBox: '0 0 0 0', dx: 1, dy: 1 })).toEqual({
         dx: 1,
         dy: 1,
       });
     });
 
-    test('should expect viewBox on type "svg"', () => {
+    test('should return viewBox string on type "svg"', () => {
       expect(filterProps({ test: '1234', helloWorld: 1234, viewBox: '0 0 0 0' }, false, 'svg')).toEqual({
         viewBox: '0 0 0 0',
       });
+    });
+
+    test('should return viewBox object on type "svg"', () => {
+      // I think this is a bug because SVG wants a string viewBox and this will let the object through
+      expect(filterProps({ test: '1234', helloWorld: 1234, viewBox: { x: 1, y: 2 } }, false, 'svg')).toEqual({
+        viewBox: { x: 1, y: 2 },
+      });
+    });
+
+    test('should filter away viewBox object on undefined type', () => {
+      expect(filterProps({ test: '1234', helloWorld: 1234, viewBox: { x: 1, y: 2 } }, false)).toEqual({});
     });
 
     test('should include events when includeEvents is true', () => {

--- a/test/util/ifOverflowMatches.spec.ts
+++ b/test/util/ifOverflowMatches.spec.ts
@@ -17,6 +17,8 @@ describe('ifOverflowMatches', () => {
     expect(ifOverflowMatches({ ifOverflow: 'visible', alwaysShow: false }, 'visible')).toBe(true);
     expect(ifOverflowMatches({ ifOverflow: 'visible' }, 'hidden')).toBe(false);
     expect(ifOverflowMatches({ ifOverflow: 'visible' }, 'extendDomain')).toBe(false);
+    expect(ifOverflowMatches({ ifOverflow: 'visible' }, 'discard')).toBe(false);
+    expect(ifOverflowMatches({ ifOverflow: 'discard' }, 'discard')).toBe(true);
   });
 
   it('should ignore ifOverflow prop when alwaysShow is true', () => {


### PR DESCRIPTION
## Description

## Related Issue

## Motivation and Context

I am trying to apply plan 5b on the ReferenceLine, and I found this `getEndPoints` function and realized I do not feel comfortable making changes in there so I wrote some tests and improved some of the types and made it a separate PR.

## How Has This Been Tested?

git push

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
