### PR TITLE
docs: add controlled brush storybook entry

### DIFF
--- a/storybook/stories/Examples/cartesian/Brush/Brush.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Brush/Brush.stories.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { ComposedChart, ResponsiveContainer, Line, Brush } from '../../../../../src';
+import { pageData } from '../../../data';
+
+export default {
+  component: Brush,
+};
+
+export const ControlledBrush = {
+  render: () => {
+    const [startIndex, setStartIndex] = useState<number | undefined>(3);
+    const [endIndex, setEndIndex] = useState<number | undefined>(pageData.length - 1);
+
+    return (
+      <>
+        <ResponsiveContainer width="100%" height={400}>
+          <ComposedChart data={pageData}>
+            <Line dataKey="uv" />
+
+            <Brush
+              startIndex={startIndex}
+              endIndex={endIndex}
+              onChange={e => {
+                setEndIndex(e.endIndex);
+                setStartIndex(e.startIndex);
+              }}
+            />
+          </ComposedChart>
+        </ResponsiveContainer>
+        <input
+          type="number"
+          aria-label="startIndex"
+          value={startIndex}
+          onChange={evt => setStartIndex(Number(evt.target.value))}
+        />
+        <input
+          type="number"
+          aria-label="endIndex"
+          value={endIndex}
+          onChange={evt => setEndIndex(Number(evt.target.value))}
+        />
+      </>
+    );
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add storybook entry for a controlled brush component. Use as a reproduction of current issue where changing start and end index via state does not update the chart

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/2404

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
reproduction of https://github.com/recharts/recharts/issues/2404 in storybook. Cannot control via updating props

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate):
![image](https://github.com/recharts/recharts/assets/25180830/a2a58caf-6279-4ac1-951a-8fde4597a9a1)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] docs

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
