### PR TITLE
fix: cursor key throwing non-unique key error

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1780,9 +1780,11 @@ export const generateCategoricalChart = ({
       // The cursor is a part of the Tooltip, and it should be shown (by default) when the Tooltip is active.
       const isActive: boolean = element.props.active ?? isTooltipActive;
       const { layout } = this.props;
+      const key = element.key || '_recharts-cursor';
 
       return (
         <Cursor
+          key={key}
           activeCoordinate={activeCoordinate}
           activePayload={activePayload}
           activeTooltipIndex={activeTooltipIndex}

--- a/src/component/Cursor.tsx
+++ b/src/component/Cursor.tsx
@@ -76,7 +76,7 @@ export function Cursor(props: CursorProps) {
     restProps = { points: getCursorPoints(layout, activeCoordinate, offset) };
     cursorComp = Curve;
   }
-  const key = element.key || '_recharts-cursor';
+
   const cursorProps = {
     stroke: '#ccc',
     pointerEvents: 'none',
@@ -85,7 +85,6 @@ export function Cursor(props: CursorProps) {
     ...filterProps(element.props.cursor),
     payload: activePayload,
     payloadIndex: activeTooltipIndex,
-    key,
     className: 'recharts-tooltip-cursor',
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
See comment here https://github.com/recharts/recharts/pull/3994/files#r1445550533

Basically `renderByOrder` renders children in an array. React requires the elements in that array to have unique keys. previously the inline cloned element needed it, now `Cursor` needs it.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Prevent key error from making it into the next release

We need storybook to log these errors...

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm test` - see errors
`npm run demo` - see errors

Errors are resolved after change

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
