### PR TITLE
fix: Errorbar breaking at category XAxis type!

### DIFF
--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -51,7 +51,10 @@ export function ErrorBar(props: Props) {
   const { offset, layout, width, dataKey, data, dataPointFormatter, xAxis, yAxis, ...others } = props;
   const svgProps = filterProps(others);
 
-  invariant(!(props.direction === 'x' && xAxis.type !== 'number'), 'Errorbar requires Axis type to be "number".');
+  invariant(
+    !(props.direction === 'x' && xAxis.type !== 'number'),
+    'ErrorBar requires Axis type property to be "number".',
+  );
 
   const errorBars = data.map((entry: any) => {
     const { x, y, value, errorVal } = dataPointFormatter(entry, dataKey);

--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -2,6 +2,7 @@
  * @fileOverview Render a group of error bar
  */
 import React, { SVGProps } from 'react';
+import invariant from 'tiny-invariant';
 import { Layer } from '../container/Layer';
 import { Props as XAxisProps } from './XAxis';
 import { Props as YAxisProps } from './YAxis';
@@ -49,6 +50,9 @@ export type Props = SVGProps<SVGLineElement> & ErrorBarProps;
 export function ErrorBar(props: Props) {
   const { offset, layout, width, dataKey, data, dataPointFormatter, xAxis, yAxis, ...others } = props;
   const svgProps = filterProps(others);
+
+  invariant(!(props.direction === 'x' && xAxis.type !== 'number'), 'Errorbar requires Axis type to be "number".');
+
   const errorBars = data.map((entry: any) => {
     const { x, y, value, errorVal } = dataPointFormatter(entry, dataKey);
 

--- a/storybook/stories/API/cartesian/ErrorBar.mdx
+++ b/storybook/stories/API/cartesian/ErrorBar.mdx
@@ -3,6 +3,8 @@ import * as ComponentStories from './ErrorBar.stories';
 
 # ErrorBar
 
+ErrorBar requires Axis type property to be a  `number` to which direction it is used.
+
 <Meta of={ComponentStories} />
 
 <Canvas>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added invariant that checks for x direction and category type.

<!--- Describe your changes in detail -->

## Related Issue

Closes [#3812 ]

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
