### PR TITLE
Chartlayoutcontext split

### DIFF
--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -5,7 +5,6 @@ import React, { ReactElement, SVGProps } from 'react';
 import isFunction from 'lodash/isFunction';
 import some from 'lodash/some';
 import clsx from 'clsx';
-import invariant from 'tiny-invariant';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelType, Label } from '../component/Label';
 import { IfOverflow, ifOverflowMatches } from '../util/IfOverflowMatches';
@@ -16,7 +15,7 @@ import { CartesianViewBox, D3Scale } from '../util/types';
 import { Props as XAxisProps } from './XAxis';
 import { Props as YAxisProps } from './YAxis';
 import { filterProps } from '../util/ReactUtils';
-import { useChartLayoutContext } from '../context/chartLayoutContext';
+import { useClipPathId, useViewBox, useXAxisOrThrow, useYAxisOrThrow } from '../context/chartLayoutContext';
 
 interface InternalReferenceLineProps {
   viewBox?: CartesianViewBox;
@@ -138,27 +137,16 @@ export const getEndPoints = (
   return null;
 };
 
-function getKeysForDebug(object: Record<string, unknown>) {
-  const keys = Object.keys(object);
-  if (keys.length === 0) {
-    return 'There are no available ids.';
-  }
-  return `Available ids are: ${keys}.`;
-}
-
 export function ReferenceLine(props: Props) {
   const { x: fixedX, y: fixedY, segment, xAxisId, yAxisId, shape, className, alwaysShow } = props;
 
-  const { xAxisMap, yAxisMap, viewBox, clipPathId } = useChartLayoutContext();
-  if (!clipPathId || !xAxisMap || !yAxisMap || !viewBox) {
+  const clipPathId = useClipPathId();
+  const xAxis = useXAxisOrThrow(xAxisId);
+  const yAxis = useYAxisOrThrow(yAxisId);
+  const viewBox = useViewBox();
+  if (!clipPathId || !viewBox) {
     return null;
   }
-  const xAxis: XAxisProps | null = xAxisMap[xAxisId];
-  const yAxis: YAxisProps | null = yAxisMap[yAxisId];
-
-  invariant(xAxis != null, `Could not find xAxis by id "${xAxisId}" [${typeof xAxisId}]. ${getKeysForDebug(xAxisMap)}`);
-
-  invariant(yAxis != null, `Could not find yAxis by id "${yAxisId}" [${typeof yAxisId}]. ${getKeysForDebug(yAxisMap)}`);
 
   warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
 

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -2,7 +2,12 @@
  * @fileOverview X Axis
  */
 import type { FunctionComponent, SVGProps } from 'react';
+import React from 'react';
+import clsx from 'clsx';
+import { useViewBox, useXAxisOrThrow } from '../context/chartLayoutContext';
+import { CartesianAxis } from './CartesianAxis';
 import { BaseAxisProps, AxisInterval } from '../util/types';
+import { getTicksOfAxis } from '../util/ChartUtils';
 
 /** Define of XAxis props */
 interface XAxisProps extends BaseAxisProps {
@@ -31,7 +36,24 @@ interface XAxisProps extends BaseAxisProps {
 
 export type Props = Omit<SVGProps<SVGElement>, 'scale'> & XAxisProps;
 
-export const XAxis: FunctionComponent<Props> = () => null;
+export const XAxis: FunctionComponent<Props> = ({ xAxisId }: Props) => {
+  const viewBox = useViewBox();
+  const axisOptions = useXAxisOrThrow(xAxisId);
+
+  if (axisOptions == null) {
+    return null;
+  }
+
+  return (
+    // @ts-expect-error the axisOptions type is not exactly what CartesianAxis is expecting.
+    <CartesianAxis
+      {...axisOptions}
+      className={clsx(`recharts-${axisOptions.axisType} ${axisOptions.axisType}`, axisOptions.className)}
+      viewBox={viewBox}
+      ticksGenerator={(axis: any) => getTicksOfAxis(axis, true)}
+    />
+  );
+};
 
 XAxis.displayName = 'XAxis';
 XAxis.defaultProps = {

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1756,13 +1756,6 @@ export const generateCategoricalChart = ({
       });
     };
 
-    renderXAxis = (element: any, displayName: string, index: number) => {
-      const { xAxisMap } = this.state;
-      const axisObj = xAxisMap[element.props.xAxisId];
-
-      return this.renderAxis(axisObj, element, displayName, index);
-    };
-
     renderYAxis = (element: any, displayName: string, index: number) => {
       const { yAxisMap } = this.state;
       const axisObj = yAxisMap[element.props.yAxisId];
@@ -2206,7 +2199,7 @@ export const generateCategoricalChart = ({
       ReferenceArea: { handler: this.renderReferenceElement },
       ReferenceLine: { handler: renderAsIs },
       ReferenceDot: { handler: this.renderReferenceElement },
-      XAxis: { handler: this.renderXAxis },
+      XAxis: { handler: renderAsIs },
       YAxis: { handler: this.renderYAxis },
       Brush: { handler: this.renderBrush, once: true },
       Bar: { handler: this.renderGraphicChild },

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -2261,7 +2261,7 @@ export const generateCategoricalChart = ({
 
       const events = this.parseEventsOfWrapper();
       return (
-        <ChartLayoutContextProvider value={this.state}>
+        <ChartLayoutContextProvider state={this.state} clipPathId={this.clipPathId}>
           <div
             className={clsx('recharts-wrapper', className)}
             style={{ position: 'relative', cursor: 'default', width, height, ...style }}

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -87,7 +87,8 @@ import { AccessibilityManager } from './AccessibilityManager';
 import { isDomainSpecifiedByUser } from '../util/isDomainSpecifiedByUser';
 import { getActiveShapeIndexForTooltip, isFunnel, isPie, isScatter } from '../util/ActiveShapeUtils';
 import { Cursor } from '../component/Cursor';
-import { ChartLayoutContext } from '../context/chartLayoutContext';
+import { ChartLayoutContextProvider } from '../context/chartLayoutContext';
+import { AxisMap, CategoricalChartState } from './types';
 
 export interface MousePointer {
   pageX: number;
@@ -792,83 +793,9 @@ const calculateOffset = (
   };
 };
 
-type AxisMap = {
-  [axisId: string]: BaseAxisProps;
-};
-
 type AxisMapMap = {
   [axisMapId: string]: AxisMap;
 };
-
-export interface CategoricalChartState {
-  chartX?: number;
-
-  chartY?: number;
-
-  dataStartIndex?: number;
-
-  dataEndIndex?: number;
-
-  activeTooltipIndex?: number;
-
-  isTooltipActive?: boolean;
-
-  updateId?: number;
-
-  xAxisMap?: AxisMap;
-
-  yAxisMap?: AxisMap;
-
-  zAxisMap?: AxisMap;
-
-  orderedTooltipTicks?: any;
-
-  tooltipAxis?: BaseAxisProps;
-
-  tooltipTicks?: TickItem[];
-
-  graphicalItems?: ReadonlyArray<ReactElement>;
-
-  activeCoordinate?: ChartCoordinate;
-
-  offset?: ChartOffset;
-
-  angleAxisMap?: any;
-
-  radiusAxisMap?: any;
-
-  formattedGraphicalItems?: any;
-
-  /** active tooltip payload */
-  activePayload?: any[];
-
-  tooltipAxisBandSize?: number;
-
-  /** active item */
-  activeItem?: any;
-
-  /** Active label of data */
-  activeLabel?: string;
-
-  activeIndex?: number;
-
-  xValue?: number;
-
-  yValue?: number;
-
-  legendBBox?: DOMRect | null;
-
-  prevDataKey?: DataKey<any>;
-  prevData?: any[];
-  prevWidth?: number;
-  prevHeight?: number;
-  prevLayout?: LayoutType;
-  prevStackOffset?: StackOffsetType;
-  prevMargin?: Margin;
-  prevChildren?: any;
-
-  stackGroups?: AxisStackGroups;
-}
 
 export type CategoricalChartFunc = (nextState: CategoricalChartState, event: any) => void;
 
@@ -2303,7 +2230,6 @@ export const generateCategoricalChart = ({
       }
 
       const { children, className, width, height, style, compact, title, desc, ...others } = this.props;
-      const { xAxisMap, yAxisMap, offset } = this.state;
       const attrs = filterProps(others);
 
       // The "compact" mode is mainly used as the panorama within Brush
@@ -2335,19 +2261,7 @@ export const generateCategoricalChart = ({
 
       const events = this.parseEventsOfWrapper();
       return (
-        <ChartLayoutContext.Provider
-          value={{
-            xAxisMap,
-            yAxisMap,
-            viewBox: {
-              x: offset.left,
-              y: offset.top,
-              width: offset.width,
-              height: offset.height,
-            },
-            clipPathId: this.clipPathId,
-          }}
-        >
+        <ChartLayoutContextProvider value={this.state}>
           <div
             className={clsx('recharts-wrapper', className)}
             style={{ position: 'relative', cursor: 'default', width, height, ...style }}
@@ -2364,7 +2278,7 @@ export const generateCategoricalChart = ({
             {this.renderLegend()}
             {this.renderTooltip()}
           </div>
-        </ChartLayoutContext.Provider>
+        </ChartLayoutContextProvider>
       );
     }
   };

--- a/src/chart/types.ts
+++ b/src/chart/types.ts
@@ -1,0 +1,86 @@
+import { ReactElement } from 'react';
+import {
+  BaseAxisProps,
+  ChartCoordinate,
+  ChartOffset,
+  DataKey,
+  LayoutType,
+  Margin,
+  StackOffsetType,
+  TickItem,
+} from '../util/types';
+import { AxisStackGroups } from '../util/ChartUtils';
+
+export type AxisMap = {
+  [axisId: string]: BaseAxisProps;
+};
+
+export interface CategoricalChartState {
+  chartX?: number;
+
+  chartY?: number;
+
+  dataStartIndex?: number;
+
+  dataEndIndex?: number;
+
+  activeTooltipIndex?: number;
+
+  isTooltipActive?: boolean;
+
+  updateId?: number;
+
+  xAxisMap?: AxisMap;
+
+  yAxisMap?: AxisMap;
+
+  zAxisMap?: AxisMap;
+
+  orderedTooltipTicks?: any;
+
+  tooltipAxis?: BaseAxisProps;
+
+  tooltipTicks?: TickItem[];
+
+  graphicalItems?: ReadonlyArray<ReactElement>;
+
+  activeCoordinate?: ChartCoordinate;
+
+  offset?: ChartOffset;
+
+  angleAxisMap?: any;
+
+  radiusAxisMap?: any;
+
+  formattedGraphicalItems?: any;
+
+  /** active tooltip payload */
+  activePayload?: any[];
+
+  tooltipAxisBandSize?: number;
+
+  /** active item */
+  activeItem?: any;
+
+  /** Active label of data */
+  activeLabel?: string;
+
+  activeIndex?: number;
+
+  xValue?: number;
+
+  yValue?: number;
+
+  legendBBox?: DOMRect | null;
+
+  prevDataKey?: DataKey<any>;
+  prevData?: any[];
+  prevWidth?: number;
+  prevHeight?: number;
+  prevLayout?: LayoutType;
+  prevStackOffset?: StackOffsetType;
+  prevMargin?: Margin;
+  prevChildren?: any;
+
+  stackGroups?: AxisStackGroups;
+}

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -71,7 +71,10 @@ function getKeysForDebug(object: Record<string, unknown>) {
 export const useXAxisOrThrow = (xAxisId: string | number): XAxisProps => {
   const xAxisMap = useContext(XAxisContext);
 
-  invariant(xAxisMap != null, 'Could not find xAxisMap; are you sure this is rendered inside a Recharts context?');
+  invariant(
+    xAxisMap != null,
+    'Could not find Recharts context; are you sure this is rendered inside a Recharts wrapper component?',
+  );
 
   const xAxis: XAxisProps | undefined = xAxisMap[xAxisId];
 
@@ -83,7 +86,10 @@ export const useXAxisOrThrow = (xAxisId: string | number): XAxisProps => {
 export const useYAxisOrThrow = (yAxisId: string | number): YAxisProps => {
   const yAxisMap = useContext(YAxisContext);
 
-  invariant(yAxisMap != null, 'Could not find yAxisMap; are you sure this is rendered inside a Recharts context?');
+  invariant(
+    yAxisMap != null,
+    'Could not find Recharts context; are you sure this is rendered inside a Recharts wrapper component?',
+  );
 
   const yAxis: YAxisProps | undefined = yAxisMap[yAxisId];
 

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -3,6 +3,7 @@ import invariant from 'tiny-invariant';
 import { CartesianViewBox, XAxisMap, YAxisMap } from '../util/types';
 import type { CategoricalChartState } from '../chart/types';
 import type { Props as XAxisProps } from '../cartesian/XAxis';
+import type { Props as YAxisProps } from '../cartesian/YAxis';
 
 type ChartLayoutContextInitializing = {
   xAxisMap: null;
@@ -89,4 +90,16 @@ export const useXAxisOrThrow = (xAxisId: string): XAxisProps => {
   invariant(xAxis != null, `Could not find xAxis by id "${xAxisId}" [${typeof xAxisId}]. ${getKeysForDebug(xAxisMap)}`);
 
   return xAxis;
+};
+
+export const useYAxisOrThrow = (yAxisId: string): YAxisProps => {
+  const yAxisMap = useContext(YAxisContext);
+
+  invariant(yAxisMap != null, 'Could not find yAxisMap; are you sure this is rendered inside a Recharts context?');
+
+  const yAxis: YAxisProps | undefined = yAxisMap[yAxisId];
+
+  invariant(yAxis != null, `Could not find yAxis by id "${yAxisId}" [${typeof yAxisId}]. ${getKeysForDebug(yAxisMap)}`);
+
+  return yAxis;
 };

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -1,5 +1,8 @@
-import { createContext, useContext } from 'react';
+import React, { ReactNode, createContext, useContext } from 'react';
+import invariant from 'tiny-invariant';
 import { CartesianViewBox, XAxisMap, YAxisMap } from '../util/types';
+import type { CategoricalChartState } from '../chart/types';
+import type { Props as XAxisProps } from '../cartesian/XAxis';
 
 type ChartLayoutContextInitializing = {
   xAxisMap: null;
@@ -24,6 +27,66 @@ const defaultValue: ChartLayoutContextType = {
   clipPathId: null,
 };
 
-export const ChartLayoutContext = createContext<ChartLayoutContextType>(defaultValue);
+const ChartLayoutContext = createContext<ChartLayoutContextType>(defaultValue);
+
+const XAxisContext = createContext<XAxisMap | undefined>(undefined);
+const YAxisContext = createContext<YAxisMap | undefined>(undefined);
+const ViewBoxContext = createContext<CartesianViewBox | undefined>(undefined);
+const ClipPathIdContext = createContext<string | undefined>(undefined);
+
+export const ChartLayoutContextProvider = (props: {
+  state: CategoricalChartState;
+  children: ReactNode;
+  clipPathId: string;
+}) => {
+  const {
+    state: { xAxisMap, yAxisMap, offset },
+    clipPathId,
+    children,
+  } = props;
+
+  const viewBox = offset
+    ? {
+        x: offset.left,
+        y: offset.top,
+        width: offset.width,
+        height: offset.height,
+      }
+    : undefined;
+
+  return (
+    <XAxisContext.Provider value={xAxisMap}>
+      <YAxisContext.Provider value={yAxisMap}>
+        <ViewBoxContext.Provider value={viewBox}>
+          <ClipPathIdContext.Provider value={clipPathId}>{children}</ClipPathIdContext.Provider>
+        </ViewBoxContext.Provider>
+      </YAxisContext.Provider>
+    </XAxisContext.Provider>
+  );
+};
 
 export const useChartLayoutContext = () => useContext(ChartLayoutContext);
+
+export const useClipPathId = (): string | undefined => {
+  return useContext(ClipPathIdContext);
+};
+
+function getKeysForDebug(object: Record<string, unknown>) {
+  const keys = Object.keys(object);
+  if (keys.length === 0) {
+    return 'There are no available ids.';
+  }
+  return `Available ids are: ${keys}.`;
+}
+
+export const useXAxisOrThrow = (xAxisId: string): XAxisProps => {
+  const xAxisMap = useContext(XAxisContext);
+
+  invariant(xAxisMap != null, 'Could not find xAxisMap; are you sure this is rendered inside a Recharts context?');
+
+  const xAxis: XAxisProps | undefined = xAxisMap[xAxisId];
+
+  invariant(xAxis != null, `Could not find xAxis by id "${xAxisId}" [${typeof xAxisId}]. ${getKeysForDebug(xAxisMap)}`);
+
+  return xAxis;
+};

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -4,6 +4,7 @@ import { CartesianViewBox, XAxisMap, YAxisMap } from '../util/types';
 import type { CategoricalChartState } from '../chart/types';
 import type { Props as XAxisProps } from '../cartesian/XAxis';
 import type { Props as YAxisProps } from '../cartesian/YAxis';
+import { calculateViewBox } from '../util/calculateViewBox';
 
 type ChartLayoutContextInitializing = {
   xAxisMap: null;
@@ -46,14 +47,7 @@ export const ChartLayoutContextProvider = (props: {
     children,
   } = props;
 
-  const viewBox = offset
-    ? {
-        x: offset.left,
-        y: offset.top,
-        width: offset.width,
-        height: offset.height,
-      }
-    : undefined;
+  const viewBox = calculateViewBox(offset);
 
   return (
     <XAxisContext.Provider value={xAxisMap}>
@@ -102,4 +96,9 @@ export const useYAxisOrThrow = (yAxisId: string): YAxisProps => {
   invariant(yAxis != null, `Could not find yAxis by id "${yAxisId}" [${typeof yAxisId}]. ${getKeysForDebug(yAxisMap)}`);
 
   return yAxis;
+};
+
+export const useViewBox = (): CartesianViewBox => {
+  const viewBox = useContext(ViewBoxContext);
+  return viewBox;
 };

--- a/src/util/Events.ts
+++ b/src/util/Events.ts
@@ -1,6 +1,5 @@
 import EventEmitter from 'eventemitter3';
-
-type CategoricalChartState = import('../chart/generateCategoricalChart').CategoricalChartState;
+import { CategoricalChartState } from '../chart/types';
 
 const eventCenter: EventEmitter<EventTypes> = new EventEmitter();
 

--- a/src/util/calculateViewBox.ts
+++ b/src/util/calculateViewBox.ts
@@ -1,0 +1,14 @@
+import memoize from 'lodash/memoize';
+import { CartesianViewBox, ChartOffset } from './types';
+
+export const calculateViewBox: (offset: ChartOffset) => CartesianViewBox = memoize(
+  (offset: ChartOffset): CartesianViewBox => {
+    return {
+      x: offset.left,
+      y: offset.top,
+      width: offset.width,
+      height: offset.height,
+    };
+  },
+  offset => ['l', offset.left, 't', offset.top, 'w', offset.width, 'h', offset.height].join(''),
+);

--- a/src/util/calculateViewBox.ts
+++ b/src/util/calculateViewBox.ts
@@ -1,6 +1,13 @@
 import memoize from 'lodash/memoize';
 import { CartesianViewBox, ChartOffset } from './types';
 
+/**
+ * This is memoized because the viewBox is unlikely to change often
+ * - but because it is computed from offset, any change to it would re-render all children.
+ *
+ * And because we have many readers of the viewBox, and update it only rarely,
+ * then let's optimize with memoization.
+ */
 export const calculateViewBox: (offset: ChartOffset) => CartesianViewBox = memoize(
   (offset: ChartOffset): CartesianViewBox => {
     return {

--- a/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
+++ b/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
@@ -358,7 +358,7 @@ describe('<ReferenceLine />', () => {
 
   test('throws when rendered alone, outside of context', () => {
     expect(() => render(<ReferenceLine x={20} />)).toThrow(
-      'Invariant failed: Could not find xAxisMap; are you sure this is rendered inside a Recharts context?',
+      'Invariant failed: Could not find Recharts context; are you sure this is rendered inside a Recharts wrapper component?',
     );
   });
 

--- a/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
+++ b/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
@@ -356,9 +356,10 @@ describe('<ReferenceLine />', () => {
     );
   });
 
-  test('does not return anything when rendered alone, outside of context', () => {
-    const { container } = render(<ReferenceLine x={20} />);
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);
+  test('throws when rendered alone, outside of context', () => {
+    expect(() => render(<ReferenceLine x={20} />)).toThrow(
+      'Invariant failed: Could not find xAxisMap; are you sure this is rendered inside a Recharts context?',
+    );
   });
 
   test('does not return anything when rendered as a nested child', () => {

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -34,7 +34,7 @@ describe('<XAxis />', () => {
 
   it('should throw when attempting to render outside of Chart', () => {
     expect(() => render(<XAxis dataKey="x" name="stature" unit="cm" />)).toThrow(
-      'Invariant failed: Could not find xAxisMap; are you sure this is rendered inside a Recharts context?',
+      'Invariant failed: Could not find Recharts context; are you sure this is rendered inside a Recharts wrapper component?',
     );
   });
 

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import { Surface, ScatterChart, Scatter, LineChart, Line, XAxis, YAxis, BarChart, Bar } from '../../src';
+import { ScatterChart, Scatter, LineChart, Line, XAxis, YAxis, BarChart, Bar } from '../../src';
 
 describe('<XAxis />', () => {
   const data = [
@@ -32,16 +32,10 @@ describe('<XAxis />', () => {
     expect(container.querySelectorAll('.recharts-cartesian-axis-line')).toHaveLength(2);
   });
 
-  it("Don't render anything", () => {
-    render(
-      <Surface width={500} height={500}>
-        <XAxis dataKey="x" name="stature" unit="cm" />
-      </Surface>,
+  it('should throw when attempting to render outside of Chart', () => {
+    expect(() => render(<XAxis dataKey="x" name="stature" unit="cm" />)).toThrow(
+      'Invariant failed: Could not find xAxisMap; are you sure this is rendered inside a Recharts context?',
     );
-    const svg = document.querySelector('svg');
-
-    expect(svg).toBeInTheDocument();
-    expect(svg?.children).toHaveLength(2);
   });
 
   it("Don't render x-axis when hide is set to be true", () => {

--- a/test/chart/Treemap.spec.tsx
+++ b/test/chart/Treemap.spec.tsx
@@ -69,10 +69,10 @@ describe('<Treemap />', () => {
           </Treemap>
         ),
         ({ clipPathId, viewBox, xAxisMap, yAxisMap }) => {
-          expect(clipPathId).toBe(null);
-          expect(viewBox).toBe(null);
-          expect(xAxisMap).toBe(null);
-          expect(yAxisMap).toBe(null);
+          expect(clipPathId).toBe(undefined);
+          expect(viewBox).toBe(undefined);
+          expect(xAxisMap).toBe(undefined);
+          expect(yAxisMap).toBe(undefined);
         },
       ),
     );
@@ -88,10 +88,10 @@ describe('<Treemap />', () => {
           </Treemap>
         ),
         ({ clipPathId, viewBox, xAxisMap, yAxisMap }) => {
-          expect(clipPathId).toBe(null);
-          expect(viewBox).toBe(null);
-          expect(xAxisMap).toBe(null);
-          expect(yAxisMap).toBe(null);
+          expect(clipPathId).toBe(undefined);
+          expect(viewBox).toBe(undefined);
+          expect(xAxisMap).toBe(undefined);
+          expect(yAxisMap).toBe(undefined);
         },
       ),
     );

--- a/test/context/chartLayoutContext.spec.tsx
+++ b/test/context/chartLayoutContext.spec.tsx
@@ -1,0 +1,460 @@
+import React, { memo } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { ChartLayoutContextProvider, useClipPathId, useXAxisOrThrow } from '../../src/context/chartLayoutContext';
+import { CategoricalChartState } from '../../src/chart/types';
+import { XAxisMap } from '../../src/util/types';
+
+describe('ChartLayoutContextProvider', () => {
+  describe('ClipPathIdContext', () => {
+    it('should add clipPathId to context', () => {
+      expect.assertions(1);
+      const MockConsumer = () => {
+        const clipPathId = useClipPathId();
+        expect(clipPathId).toBe('my mock ID');
+        return null;
+      };
+      render(
+        <ChartLayoutContextProvider clipPathId="my mock ID" state={{}}>
+          <MockConsumer />
+        </ChartLayoutContextProvider>,
+      );
+    });
+
+    it('should return undefined when using the hook outside of context', () => {
+      expect.assertions(1);
+      const MockComponent = () => {
+        const clipPathId = useClipPathId();
+        expect(clipPathId).toBe(undefined);
+        return null;
+      };
+      render(<MockComponent />);
+    });
+
+    describe('vanilla children', () => {
+      it('should re-render children every time even when nothing changes', () => {
+        let renderCount = 0;
+        const MockConsumer = () => {
+          renderCount++;
+          return null;
+        };
+        const mockState: CategoricalChartState = {};
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(2);
+      });
+    });
+
+    describe('children using React.memo()', () => {
+      it('should render memo children only once if the clipPathId does not change', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          renderCount++;
+          return null;
+        });
+        const mockState: CategoricalChartState = {};
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+
+      it('should render memo children only once even if the clipPathId changes!', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          renderCount++;
+          return null;
+        });
+        const mockState: CategoricalChartState = {};
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID but this time different" state={mockState}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+    });
+
+    describe('children that read the context using a hook', () => {
+      it('should render a context-aware children only once', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          useClipPathId();
+          renderCount++;
+          return null;
+        });
+        const mockState: CategoricalChartState = {};
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+
+      it('should re-render a context-aware children if the clipPathId changes', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          useClipPathId();
+          renderCount++;
+          return null;
+        });
+        const mockState: CategoricalChartState = {};
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID but this time different" state={mockState}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(2);
+      });
+
+      it('should not re-render context-aware children if unrelated property changes', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          useClipPathId();
+          renderCount++;
+          return null;
+        });
+        const mockState1: CategoricalChartState = {};
+        const mockState2: CategoricalChartState = {};
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState2}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+    });
+  });
+
+  describe('XAxisContext', () => {
+    const exampleXAxisMap: XAxisMap = {
+      a: {
+        width: 200,
+        height: 10,
+      },
+    };
+
+    const exampleXAxisMap2: XAxisMap = {
+      a: {
+        width: 200,
+        height: 10,
+      },
+    };
+
+    const mockState1: CategoricalChartState = {
+      xAxisMap: exampleXAxisMap,
+    };
+
+    const mockState2: CategoricalChartState = {
+      xAxisMap: exampleXAxisMap2,
+    };
+
+    describe('error cases', () => {
+      let originalConsoleError;
+      beforeAll(() => {
+        originalConsoleError = console.error;
+        console.error = vi.fn();
+      });
+
+      afterAll(() => {
+        console.error = originalConsoleError;
+        originalConsoleError = null;
+      });
+
+      it('should throw when reading axis but the xAxisMap is undefined', () => {
+        const MockConsumer = () => {
+          useXAxisOrThrow('a');
+          return null;
+        };
+        expect(() =>
+          render(
+            <ChartLayoutContextProvider clipPathId="" state={{}}>
+              <MockConsumer />
+            </ChartLayoutContextProvider>,
+          ),
+        ).toThrow('Could not find xAxisMap; are you sure this is rendered inside a Recharts context?');
+      });
+
+      it('should throw when reading axis outside of Recharts context', () => {
+        const MockConsumer = () => {
+          useXAxisOrThrow('a');
+          return null;
+        };
+        expect(() => render(<MockConsumer />)).toThrow(
+          'Could not find xAxisMap; are you sure this is rendered inside a Recharts context?',
+        );
+      });
+
+      it('should throw when reading axis but the xAxisMap is empty object', () => {
+        const MockConsumer = () => {
+          useXAxisOrThrow('a');
+          return null;
+        };
+
+        const xAxisMap: XAxisMap = {};
+        expect(() =>
+          render(
+            <ChartLayoutContextProvider clipPathId="" state={{ xAxisMap }}>
+              <MockConsumer />
+            </ChartLayoutContextProvider>,
+          ),
+        ).toThrow('Invariant failed: Could not find xAxis by id "a" [string]. There are no available ids.');
+      });
+
+      it('should throw when axes are set but the ID is wrong', () => {
+        const xAxisMap: XAxisMap = {
+          a: {
+            width: 200,
+            height: 10,
+          },
+        };
+        const MockConsumer = () => {
+          useXAxisOrThrow('wrong ID');
+          return null;
+        };
+        expect(() =>
+          render(
+            <ChartLayoutContextProvider clipPathId="" state={{ xAxisMap }}>
+              <MockConsumer />
+            </ChartLayoutContextProvider>,
+          ),
+        ).toThrow('Invariant failed: Could not find xAxis by id "wrong ID" [string]. Available ids are: a.');
+      });
+    });
+
+    it('should add xAxis to context', () => {
+      expect.assertions(2);
+      const xAxisMap: XAxisMap = {
+        a: {
+          width: 200,
+          height: 10,
+        },
+      };
+      const MockConsumer = () => {
+        const xAxis = useXAxisOrThrow('a');
+        expect(xAxis).toEqual({
+          width: 200,
+          height: 10,
+        });
+        expect(xAxis).toBe(xAxisMap.a);
+        return null;
+      };
+      render(
+        <ChartLayoutContextProvider clipPathId="" state={{ xAxisMap }}>
+          <MockConsumer />
+        </ChartLayoutContextProvider>,
+      );
+    });
+
+    describe('vanilla children', () => {
+      it('should re-render children every time even when nothing changes', () => {
+        let renderCount = 0;
+        const MockConsumer = () => {
+          renderCount++;
+          return null;
+        };
+        const mockState: CategoricalChartState = {
+          xAxisMap: exampleXAxisMap,
+        };
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(2);
+      });
+    });
+
+    describe('children using React.memo()', () => {
+      it('should render memo children only once if the xAxisMap does not change', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          renderCount++;
+          return null;
+        });
+
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID is different now" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+
+      it('should render memo children only once even if the xAxisMap changes!', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          renderCount++;
+          return null;
+        });
+
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID but this time different" state={mockState2}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+    });
+
+    describe('children that read the context using a hook', () => {
+      it('should render a context-aware children only once', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          useXAxisOrThrow('a');
+          renderCount++;
+          return null;
+        });
+
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+
+      it('should re-render a context-aware children if the xAxisMap changes', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          useXAxisOrThrow('a');
+          renderCount++;
+          return null;
+        });
+
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID is not important for this hook" state={mockState2}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(2);
+      });
+
+      it('should not re-render context-aware children if unrelated property changes', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          useXAxisOrThrow('a');
+          renderCount++;
+          return null;
+        });
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider
+            clipPathId="my mock ID has changed but that should not affect xAxis hook"
+            state={mockState1}
+          >
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect.soft(renderCount).toBe(1);
+        const mockStateWithYAxisMap: CategoricalChartState = {
+          ...mockState1,
+          yAxisMap: {
+            y: {
+              allowDecimals: false,
+              label: 'yAxisMap is different and that still should not affect the xAxis hook',
+            },
+          },
+        };
+        rerender(
+          <ChartLayoutContextProvider
+            clipPathId="my mock ID has changed but that should not affect xAxis hook"
+            state={mockStateWithYAxisMap}
+          >
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+    });
+  });
+});

--- a/test/context/chartLayoutContext.spec.tsx
+++ b/test/context/chartLayoutContext.spec.tsx
@@ -1,9 +1,14 @@
 import React, { memo } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
-import { ChartLayoutContextProvider, useClipPathId, useXAxisOrThrow } from '../../src/context/chartLayoutContext';
+import {
+  ChartLayoutContextProvider,
+  useClipPathId,
+  useXAxisOrThrow,
+  useYAxisOrThrow,
+} from '../../src/context/chartLayoutContext';
 import { CategoricalChartState } from '../../src/chart/types';
-import { XAxisMap } from '../../src/util/types';
+import { XAxisMap, YAxisMap } from '../../src/util/types';
 
 describe('ChartLayoutContextProvider', () => {
   describe('ClipPathIdContext', () => {
@@ -184,8 +189,8 @@ describe('ChartLayoutContextProvider', () => {
 
     const exampleXAxisMap2: XAxisMap = {
       a: {
-        width: 200,
-        height: 10,
+        width: 300,
+        height: 40,
       },
     };
 
@@ -250,19 +255,13 @@ describe('ChartLayoutContextProvider', () => {
       });
 
       it('should throw when axes are set but the ID is wrong', () => {
-        const xAxisMap: XAxisMap = {
-          a: {
-            width: 200,
-            height: 10,
-          },
-        };
         const MockConsumer = () => {
           useXAxisOrThrow('wrong ID');
           return null;
         };
         expect(() =>
           render(
-            <ChartLayoutContextProvider clipPathId="" state={{ xAxisMap }}>
+            <ChartLayoutContextProvider clipPathId="" state={mockState1}>
               <MockConsumer />
             </ChartLayoutContextProvider>,
           ),
@@ -301,18 +300,15 @@ describe('ChartLayoutContextProvider', () => {
           renderCount++;
           return null;
         };
-        const mockState: CategoricalChartState = {
-          xAxisMap: exampleXAxisMap,
-        };
         expect(renderCount).toBe(0);
         const { rerender } = render(
-          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
             <MockConsumer />
           </ChartLayoutContextProvider>,
         );
         expect(renderCount).toBe(1);
         rerender(
-          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
             <MockConsumer />
           </ChartLayoutContextProvider>,
         );
@@ -442,6 +438,281 @@ describe('ChartLayoutContextProvider', () => {
             y: {
               allowDecimals: false,
               label: 'yAxisMap is different and that still should not affect the xAxis hook',
+            },
+          },
+        };
+        rerender(
+          <ChartLayoutContextProvider
+            clipPathId="my mock ID has changed but that should not affect xAxis hook"
+            state={mockStateWithYAxisMap}
+          >
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+    });
+  });
+
+  describe('YAxisContext', () => {
+    const exampleYAxisMap: YAxisMap = {
+      m: {
+        width: 200,
+        height: 10,
+      },
+    };
+
+    const exampleYAxisMap2: YAxisMap = {
+      m: {
+        width: 200,
+        height: 10,
+      },
+    };
+
+    const mockState1: CategoricalChartState = {
+      yAxisMap: exampleYAxisMap,
+    };
+
+    const mockState2: CategoricalChartState = {
+      yAxisMap: exampleYAxisMap2,
+    };
+
+    describe('error cases', () => {
+      let originalConsoleError;
+      beforeAll(() => {
+        originalConsoleError = console.error;
+        console.error = vi.fn();
+      });
+
+      afterAll(() => {
+        console.error = originalConsoleError;
+        originalConsoleError = null;
+      });
+
+      it('should throw when reading axis but the yAxisMap is undefined', () => {
+        const MockConsumer = () => {
+          useYAxisOrThrow('a');
+          return null;
+        };
+        expect(() =>
+          render(
+            <ChartLayoutContextProvider clipPathId="" state={{}}>
+              <MockConsumer />
+            </ChartLayoutContextProvider>,
+          ),
+        ).toThrow('Could not find yAxisMap; are you sure this is rendered inside a Recharts context?');
+      });
+
+      it('should throw when reading axis outside of Recharts context', () => {
+        const MockConsumer = () => {
+          useYAxisOrThrow('a');
+          return null;
+        };
+        expect(() => render(<MockConsumer />)).toThrow(
+          'Could not find yAxisMap; are you sure this is rendered inside a Recharts context?',
+        );
+      });
+
+      it('should throw when reading axis but the xAxisMap is empty object', () => {
+        const MockConsumer = () => {
+          useYAxisOrThrow('a');
+          return null;
+        };
+
+        const yAxisMap: YAxisMap = {};
+        expect(() =>
+          render(
+            <ChartLayoutContextProvider clipPathId="" state={{ yAxisMap }}>
+              <MockConsumer />
+            </ChartLayoutContextProvider>,
+          ),
+        ).toThrow('Invariant failed: Could not find yAxis by id "a" [string]. There are no available ids.');
+      });
+
+      it('should throw when axes are set but the ID is wrong', () => {
+        const MockConsumer = () => {
+          useYAxisOrThrow('wrong ID');
+          return null;
+        };
+        expect(() =>
+          render(
+            <ChartLayoutContextProvider clipPathId="" state={mockState1}>
+              <MockConsumer />
+            </ChartLayoutContextProvider>,
+          ),
+        ).toThrow('Invariant failed: Could not find yAxis by id "wrong ID" [string]. Available ids are: m.');
+      });
+    });
+
+    it('should add xAxis to context', () => {
+      expect.assertions(2);
+      const xAxisMap: XAxisMap = {
+        a: {
+          width: 200,
+          height: 10,
+        },
+      };
+      const MockConsumer = () => {
+        const xAxis = useXAxisOrThrow('a');
+        expect(xAxis).toEqual({
+          width: 200,
+          height: 10,
+        });
+        expect(xAxis).toBe(xAxisMap.a);
+        return null;
+      };
+      render(
+        <ChartLayoutContextProvider clipPathId="" state={{ xAxisMap }}>
+          <MockConsumer />
+        </ChartLayoutContextProvider>,
+      );
+    });
+
+    describe('vanilla children', () => {
+      it('should re-render children every time even when nothing changes', () => {
+        let renderCount = 0;
+        const MockConsumer = () => {
+          renderCount++;
+          return null;
+        };
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(2);
+      });
+    });
+
+    describe('children using React.memo()', () => {
+      it('should render memo children only once if the yAxisMap does not change', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          renderCount++;
+          return null;
+        });
+
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID is different now" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+
+      it('should render memo children only once even if the yAxisMap changes!', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          renderCount++;
+          return null;
+        });
+
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID but this time different" state={mockState2}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+    });
+
+    describe('children that read the context using a hook', () => {
+      it('should render a context-aware children only once', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          useYAxisOrThrow('m');
+          renderCount++;
+          return null;
+        });
+
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+
+      it('should re-render a context-aware children if the yAxisMap changes', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          useYAxisOrThrow('m');
+          renderCount++;
+          return null;
+        });
+
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID is not important for this hook" state={mockState2}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(2);
+      });
+
+      it('should not re-render context-aware children if unrelated property changes', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          useYAxisOrThrow('m');
+          renderCount++;
+          return null;
+        });
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider
+            clipPathId="my mock ID has changed but that should not affect xAxis hook"
+            state={mockState1}
+          >
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect.soft(renderCount).toBe(1);
+        const mockStateWithYAxisMap: CategoricalChartState = {
+          ...mockState1,
+          xAxisMap: {
+            x: {
+              allowDecimals: false,
+              label: 'xAxisMap is different and that still should not affect the yAxis hook',
             },
           },
         };

--- a/test/context/chartLayoutContext.spec.tsx
+++ b/test/context/chartLayoutContext.spec.tsx
@@ -227,7 +227,9 @@ describe('ChartLayoutContextProvider', () => {
               <MockConsumer />
             </ChartLayoutContextProvider>,
           ),
-        ).toThrow('Could not find xAxisMap; are you sure this is rendered inside a Recharts context?');
+        ).toThrow(
+          'Could not find Recharts context; are you sure this is rendered inside a Recharts wrapper component?',
+        );
       });
 
       it('should throw when reading axis outside of Recharts context', () => {
@@ -236,7 +238,7 @@ describe('ChartLayoutContextProvider', () => {
           return null;
         };
         expect(() => render(<MockConsumer />)).toThrow(
-          'Could not find xAxisMap; are you sure this is rendered inside a Recharts context?',
+          'Could not find Recharts context; are you sure this is rendered inside a Recharts wrapper component?',
         );
       });
 
@@ -498,7 +500,9 @@ describe('ChartLayoutContextProvider', () => {
               <MockConsumer />
             </ChartLayoutContextProvider>,
           ),
-        ).toThrow('Could not find yAxisMap; are you sure this is rendered inside a Recharts context?');
+        ).toThrow(
+          'Could not find Recharts context; are you sure this is rendered inside a Recharts wrapper component?',
+        );
       });
 
       it('should throw when reading axis outside of Recharts context', () => {
@@ -507,7 +511,7 @@ describe('ChartLayoutContextProvider', () => {
           return null;
         };
         expect(() => render(<MockConsumer />)).toThrow(
-          'Could not find yAxisMap; are you sure this is rendered inside a Recharts context?',
+          'Could not find Recharts context; are you sure this is rendered inside a Recharts wrapper component?',
         );
       });
 

--- a/test/context/chartLayoutContext.spec.tsx
+++ b/test/context/chartLayoutContext.spec.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react';
 import {
   ChartLayoutContextProvider,
   useClipPathId,
+  useViewBox,
   useXAxisOrThrow,
   useYAxisOrThrow,
 } from '../../src/context/chartLayoutContext';
@@ -11,6 +12,10 @@ import { CategoricalChartState } from '../../src/chart/types';
 import { XAxisMap, YAxisMap } from '../../src/util/types';
 
 describe('ChartLayoutContextProvider', () => {
+  const minimalState: CategoricalChartState = {
+    offset: {},
+  };
+
   describe('ClipPathIdContext', () => {
     it('should add clipPathId to context', () => {
       expect.assertions(1);
@@ -20,7 +25,7 @@ describe('ChartLayoutContextProvider', () => {
         return null;
       };
       render(
-        <ChartLayoutContextProvider clipPathId="my mock ID" state={{}}>
+        <ChartLayoutContextProvider clipPathId="my mock ID" state={minimalState}>
           <MockConsumer />
         </ChartLayoutContextProvider>,
       );
@@ -43,16 +48,15 @@ describe('ChartLayoutContextProvider', () => {
           renderCount++;
           return null;
         };
-        const mockState: CategoricalChartState = {};
         expect(renderCount).toBe(0);
         const { rerender } = render(
-          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={minimalState}>
             <MockConsumer />
           </ChartLayoutContextProvider>,
         );
         expect(renderCount).toBe(1);
         rerender(
-          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={minimalState}>
             <MockConsumer />
           </ChartLayoutContextProvider>,
         );
@@ -67,16 +71,15 @@ describe('ChartLayoutContextProvider', () => {
           renderCount++;
           return null;
         });
-        const mockState: CategoricalChartState = {};
         expect(renderCount).toBe(0);
         const { rerender } = render(
-          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={minimalState}>
             <MockConsumer />
           </ChartLayoutContextProvider>,
         );
         expect(renderCount).toBe(1);
         rerender(
-          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={minimalState}>
             <MockConsumer />
           </ChartLayoutContextProvider>,
         );
@@ -89,16 +92,15 @@ describe('ChartLayoutContextProvider', () => {
           renderCount++;
           return null;
         });
-        const mockState: CategoricalChartState = {};
         expect(renderCount).toBe(0);
         const { rerender } = render(
-          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={minimalState}>
             <MockConsumer />
           </ChartLayoutContextProvider>,
         );
         expect(renderCount).toBe(1);
         rerender(
-          <ChartLayoutContextProvider clipPathId="my mock ID but this time different" state={mockState}>
+          <ChartLayoutContextProvider clipPathId="my mock ID but this time different" state={minimalState}>
             <MockConsumer />
           </ChartLayoutContextProvider>,
         );
@@ -107,46 +109,44 @@ describe('ChartLayoutContextProvider', () => {
     });
 
     describe('children that read the context using a hook', () => {
-      it('should render a context-aware children only once', () => {
+      it('should render context-aware children only once', () => {
         let renderCount = 0;
         const MockConsumer = memo(() => {
           useClipPathId();
           renderCount++;
           return null;
         });
-        const mockState: CategoricalChartState = {};
         expect(renderCount).toBe(0);
         const { rerender } = render(
-          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={minimalState}>
             <MockConsumer />
           </ChartLayoutContextProvider>,
         );
         expect(renderCount).toBe(1);
         rerender(
-          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={minimalState}>
             <MockConsumer />
           </ChartLayoutContextProvider>,
         );
         expect(renderCount).toBe(1);
       });
 
-      it('should re-render a context-aware children if the clipPathId changes', () => {
+      it('should re-render context-aware children if the clipPathId changes', () => {
         let renderCount = 0;
         const MockConsumer = memo(() => {
           useClipPathId();
           renderCount++;
           return null;
         });
-        const mockState: CategoricalChartState = {};
         expect(renderCount).toBe(0);
         const { rerender } = render(
-          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState}>
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={minimalState}>
             <MockConsumer />
           </ChartLayoutContextProvider>,
         );
         expect(renderCount).toBe(1);
         rerender(
-          <ChartLayoutContextProvider clipPathId="my mock ID but this time different" state={mockState}>
+          <ChartLayoutContextProvider clipPathId="my mock ID but this time different" state={minimalState}>
             <MockConsumer />
           </ChartLayoutContextProvider>,
         );
@@ -160,8 +160,8 @@ describe('ChartLayoutContextProvider', () => {
           renderCount++;
           return null;
         });
-        const mockState1: CategoricalChartState = {};
-        const mockState2: CategoricalChartState = {};
+        const mockState1: CategoricalChartState = { ...minimalState };
+        const mockState2: CategoricalChartState = { ...minimalState };
         expect(renderCount).toBe(0);
         const { rerender } = render(
           <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
@@ -195,10 +195,12 @@ describe('ChartLayoutContextProvider', () => {
     };
 
     const mockState1: CategoricalChartState = {
+      ...minimalState,
       xAxisMap: exampleXAxisMap,
     };
 
     const mockState2: CategoricalChartState = {
+      ...minimalState,
       xAxisMap: exampleXAxisMap2,
     };
 
@@ -221,7 +223,7 @@ describe('ChartLayoutContextProvider', () => {
         };
         expect(() =>
           render(
-            <ChartLayoutContextProvider clipPathId="" state={{}}>
+            <ChartLayoutContextProvider clipPathId="" state={minimalState}>
               <MockConsumer />
             </ChartLayoutContextProvider>,
           ),
@@ -247,7 +249,7 @@ describe('ChartLayoutContextProvider', () => {
         const xAxisMap: XAxisMap = {};
         expect(() =>
           render(
-            <ChartLayoutContextProvider clipPathId="" state={{ xAxisMap }}>
+            <ChartLayoutContextProvider clipPathId="" state={{ ...minimalState, xAxisMap }}>
               <MockConsumer />
             </ChartLayoutContextProvider>,
           ),
@@ -271,23 +273,17 @@ describe('ChartLayoutContextProvider', () => {
 
     it('should add xAxis to context', () => {
       expect.assertions(2);
-      const xAxisMap: XAxisMap = {
-        a: {
-          width: 200,
-          height: 10,
-        },
-      };
       const MockConsumer = () => {
         const xAxis = useXAxisOrThrow('a');
         expect(xAxis).toEqual({
           width: 200,
           height: 10,
         });
-        expect(xAxis).toBe(xAxisMap.a);
+        expect(xAxis).toBe(exampleXAxisMap.a);
         return null;
       };
       render(
-        <ChartLayoutContextProvider clipPathId="" state={{ xAxisMap }}>
+        <ChartLayoutContextProvider clipPathId="" state={mockState1}>
           <MockConsumer />
         </ChartLayoutContextProvider>,
       );
@@ -363,7 +359,7 @@ describe('ChartLayoutContextProvider', () => {
     });
 
     describe('children that read the context using a hook', () => {
-      it('should render a context-aware children only once', () => {
+      it('should render context-aware children only once', () => {
         let renderCount = 0;
         const MockConsumer = memo(() => {
           useXAxisOrThrow('a');
@@ -386,7 +382,7 @@ describe('ChartLayoutContextProvider', () => {
         expect(renderCount).toBe(1);
       });
 
-      it('should re-render a context-aware children if the xAxisMap changes', () => {
+      it('should re-render context-aware children if the xAxisMap changes', () => {
         let renderCount = 0;
         const MockConsumer = memo(() => {
           useXAxisOrThrow('a');
@@ -470,10 +466,12 @@ describe('ChartLayoutContextProvider', () => {
     };
 
     const mockState1: CategoricalChartState = {
+      ...minimalState,
       yAxisMap: exampleYAxisMap,
     };
 
     const mockState2: CategoricalChartState = {
+      ...minimalState,
       yAxisMap: exampleYAxisMap2,
     };
 
@@ -496,7 +494,7 @@ describe('ChartLayoutContextProvider', () => {
         };
         expect(() =>
           render(
-            <ChartLayoutContextProvider clipPathId="" state={{}}>
+            <ChartLayoutContextProvider clipPathId="" state={minimalState}>
               <MockConsumer />
             </ChartLayoutContextProvider>,
           ),
@@ -522,7 +520,7 @@ describe('ChartLayoutContextProvider', () => {
         const yAxisMap: YAxisMap = {};
         expect(() =>
           render(
-            <ChartLayoutContextProvider clipPathId="" state={{ yAxisMap }}>
+            <ChartLayoutContextProvider clipPathId="" state={{ ...minimalState, yAxisMap }}>
               <MockConsumer />
             </ChartLayoutContextProvider>,
           ),
@@ -544,25 +542,19 @@ describe('ChartLayoutContextProvider', () => {
       });
     });
 
-    it('should add xAxis to context', () => {
+    it('should add yAxis to context', () => {
       expect.assertions(2);
-      const xAxisMap: XAxisMap = {
-        a: {
-          width: 200,
-          height: 10,
-        },
-      };
       const MockConsumer = () => {
-        const xAxis = useXAxisOrThrow('a');
-        expect(xAxis).toEqual({
+        const yAxis = useYAxisOrThrow('m');
+        expect(yAxis).toEqual({
           width: 200,
           height: 10,
         });
-        expect(xAxis).toBe(xAxisMap.a);
+        expect(yAxis).toBe(exampleYAxisMap.m);
         return null;
       };
       render(
-        <ChartLayoutContextProvider clipPathId="" state={{ xAxisMap }}>
+        <ChartLayoutContextProvider clipPathId="" state={mockState1}>
           <MockConsumer />
         </ChartLayoutContextProvider>,
       );
@@ -638,7 +630,7 @@ describe('ChartLayoutContextProvider', () => {
     });
 
     describe('children that read the context using a hook', () => {
-      it('should render a context-aware children only once', () => {
+      it('should render context-aware children only once', () => {
         let renderCount = 0;
         const MockConsumer = memo(() => {
           useYAxisOrThrow('m');
@@ -661,7 +653,7 @@ describe('ChartLayoutContextProvider', () => {
         expect(renderCount).toBe(1);
       });
 
-      it('should re-render a context-aware children if the yAxisMap changes', () => {
+      it('should re-render context-aware children if the yAxisMap changes', () => {
         let renderCount = 0;
         const MockConsumer = memo(() => {
           useYAxisOrThrow('m');
@@ -707,7 +699,7 @@ describe('ChartLayoutContextProvider', () => {
           </ChartLayoutContextProvider>,
         );
         expect.soft(renderCount).toBe(1);
-        const mockStateWithYAxisMap: CategoricalChartState = {
+        const mockStateWithXAxisMap: CategoricalChartState = {
           ...mockState1,
           xAxisMap: {
             x: {
@@ -719,7 +711,241 @@ describe('ChartLayoutContextProvider', () => {
         rerender(
           <ChartLayoutContextProvider
             clipPathId="my mock ID has changed but that should not affect xAxis hook"
-            state={mockStateWithYAxisMap}
+            state={mockStateWithXAxisMap}
+          >
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+    });
+  });
+
+  describe('ViewBoxContext', () => {
+    const exampleOffset: CategoricalChartState['offset'] = {
+      top: 10,
+      left: 20,
+      width: 100,
+      height: 200,
+    };
+
+    const exampleOffset2: CategoricalChartState['offset'] = {
+      top: 5,
+      left: 19,
+      width: 300,
+      height: 500,
+    };
+
+    const mockState1: CategoricalChartState = {
+      offset: exampleOffset,
+    };
+
+    const mockState2: CategoricalChartState = {
+      offset: exampleOffset2,
+    };
+
+    describe('error cases', () => {
+      it('should throw if there is no offset', () => {
+        expect(() =>
+          render(
+            <ChartLayoutContextProvider clipPathId="" state={{}}>
+              Children are required
+            </ChartLayoutContextProvider>,
+          ),
+        ).toThrow();
+      });
+    });
+
+    it('should set viewBox to all undefined properties if there is offset but it is missing properties', () => {
+      expect.assertions(1);
+      const MockConsumer = () => {
+        const viewBox = useViewBox();
+        expect(viewBox).toEqual({
+          x: undefined,
+          y: undefined,
+          height: undefined,
+          width: undefined,
+        });
+        return null;
+      };
+      render(
+        <ChartLayoutContextProvider clipPathId="" state={{ offset: {} }}>
+          <MockConsumer />
+        </ChartLayoutContextProvider>,
+      );
+    });
+
+    it('should add viewBox to context', () => {
+      expect.assertions(1);
+      const MockConsumer = () => {
+        const viewBox = useViewBox();
+        expect(viewBox).toEqual({
+          y: 10,
+          x: 20,
+          width: 100,
+          height: 200,
+        });
+        return null;
+      };
+      render(
+        <ChartLayoutContextProvider clipPathId="" state={mockState1}>
+          <MockConsumer />
+        </ChartLayoutContextProvider>,
+      );
+    });
+
+    describe('vanilla children', () => {
+      it('should re-render children every time even when nothing changes', () => {
+        let renderCount = 0;
+        const MockConsumer = () => {
+          renderCount++;
+          return null;
+        };
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(2);
+      });
+    });
+
+    describe('children using React.memo()', () => {
+      it('should render memo children only once if the offset does not change', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          renderCount++;
+          return null;
+        });
+
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID is different now" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+
+      it('should render memo children only once even if the offset changes!', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          renderCount++;
+          return null;
+        });
+
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID but this time different" state={mockState2}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+    });
+
+    describe('children that read the context using a hook', () => {
+      it('should render context-aware children only once', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          useViewBox();
+          renderCount++;
+          return null;
+        });
+
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+      });
+
+      it('should re-render context-aware children if the viewBox changes', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          useViewBox();
+          renderCount++;
+          return null;
+        });
+
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider clipPathId="my mock ID is not important for this hook" state={mockState2}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(2);
+      });
+
+      it('should not re-render context-aware children if unrelated property changes', () => {
+        let renderCount = 0;
+        const MockConsumer = memo(() => {
+          useViewBox();
+          renderCount++;
+          return null;
+        });
+        expect(renderCount).toBe(0);
+        const { rerender } = render(
+          <ChartLayoutContextProvider clipPathId="my mock ID" state={mockState1}>
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect(renderCount).toBe(1);
+        rerender(
+          <ChartLayoutContextProvider
+            clipPathId="my mock ID has changed but that should not affect viewBox hook"
+            state={mockState1}
+          >
+            <MockConsumer />
+          </ChartLayoutContextProvider>,
+        );
+        expect.soft(renderCount).toBe(1);
+        const mockStateWithXAxisMap: CategoricalChartState = {
+          ...mockState1,
+          xAxisMap: {
+            x: {
+              allowDecimals: false,
+              label: 'xAxisMap is different and that still should not affect viewBox hook',
+            },
+          },
+        };
+        rerender(
+          <ChartLayoutContextProvider
+            clipPathId="my mock ID has changed but that should not affect viewBox hook"
+            state={mockStateWithXAxisMap}
           >
             <MockConsumer />
           </ChartLayoutContextProvider>,

--- a/test/util/calculateViewBox.spec.ts
+++ b/test/util/calculateViewBox.spec.ts
@@ -3,6 +3,11 @@ import { ChartOffset } from '../../src/util/types';
 import { calculateViewBox } from '../../src/util/calculateViewBox';
 
 describe('calculateViewBox', () => {
+  test('should throw if offset is undefined', () => {
+    // @ts-expect-error this should show an error - the function will not accept undefined, so typescript should highlight that too
+    expect(() => calculateViewBox(undefined)).toThrow();
+  });
+
   test('should memoize results when passed identical offset', () => {
     const offset: ChartOffset = {
       left: 10,

--- a/test/util/calculateViewBox.spec.ts
+++ b/test/util/calculateViewBox.spec.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from 'vitest';
+import { ChartOffset } from '../../src/util/types';
+import { calculateViewBox } from '../../src/util/calculateViewBox';
+
+describe('calculateViewBox', () => {
+  test('should memoize results when passed identical offset', () => {
+    const offset: ChartOffset = {
+      left: 10,
+      top: 20,
+      width: 200,
+      height: 150,
+    };
+    const result1 = calculateViewBox(offset);
+    const result2 = calculateViewBox(offset);
+    expect(result1).toEqual(result2);
+    expect(result1).toBe(result2);
+  });
+
+  test('should memoize results when passed different offset but with the same values', () => {
+    const offset1: ChartOffset = {
+      left: 10,
+      top: 20,
+      width: 200,
+      height: 150,
+    };
+    const offset2: ChartOffset = {
+      left: 10,
+      top: 20,
+      width: 200,
+      height: 150,
+    };
+    const result1 = calculateViewBox(offset1);
+    const result2 = calculateViewBox(offset2);
+    expect(result1).toEqual(result2);
+    expect(result1).toBe(result2);
+  });
+
+  test('should return new instance when width and height changes', () => {
+    const offset1: ChartOffset = {
+      brushBottom: 5,
+      top: 5,
+      bottom: 5,
+      left: 5,
+      right: 5,
+      width: 490,
+      height: 290,
+    };
+    const offset2: ChartOffset = {
+      brushBottom: 5,
+      top: 5,
+      bottom: 5,
+      left: 5,
+      right: 5,
+      width: 90,
+      height: 40,
+    };
+    const result1 = calculateViewBox(offset1);
+    const result2 = calculateViewBox(offset2);
+    expect(result1).not.toEqual(result2);
+    expect(result1).not.toBe(result2);
+  });
+});

--- a/test/util/context.tsx
+++ b/test/util/context.tsx
@@ -1,7 +1,15 @@
-import React, { ComponentType, ReactNode } from 'react';
+import React, { ComponentType, ReactNode, useContext } from 'react';
 import { render } from '@testing-library/react';
-import { ChartLayoutContextType, useChartLayoutContext } from '../../src/context/chartLayoutContext';
+import { XAxisContext, YAxisContext, useClipPathId, useViewBox } from '../../src/context/chartLayoutContext';
 import { Tooltip } from '../../src/component/Tooltip';
+import { CartesianViewBox, XAxisMap, YAxisMap } from '../../src/util/types';
+
+type AllContextPropertiesMixed = {
+  clipPathId: string | undefined;
+  xAxisMap: XAxisMap | undefined;
+  yAxisMap: YAxisMap | undefined;
+  viewBox: CartesianViewBox | undefined;
+};
 
 export function testChartLayoutContext(
   /**
@@ -13,7 +21,7 @@ export function testChartLayoutContext(
   /**
    * Write your `expect(context).toEqual(xyz)` inside this callback
    */
-  assertions: (context: ChartLayoutContextType) => void,
+  assertions: (context: AllContextPropertiesMixed) => void,
 ) {
   return () => {
     /*
@@ -24,7 +32,11 @@ export function testChartLayoutContext(
      */
     expect.hasAssertions();
     function Spy() {
-      const context: ChartLayoutContextType = useChartLayoutContext();
+      const clipPathId = useClipPathId();
+      const viewBox = useViewBox();
+      const xAxisMap = useContext(XAxisContext);
+      const yAxisMap = useContext(YAxisContext);
+      const context: AllContextPropertiesMixed = { clipPathId, viewBox, xAxisMap, yAxisMap };
       assertions(context);
       return <></>;
     }


### PR DESCRIPTION
## Description

OK so this is necessary if we want to render `XAxis` from context but not make it re-render everytime anything in the `CategoricalChartState` changes.

## Related Issue

https://recharts.slack.com/archives/C042Q5K5UDC/p1704889920155939

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Plan 5b! 

## How Has This Been Tested?

npm test

storybooks

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
