### PR TITLE
Fix labels on XAxis

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -4,7 +4,7 @@
 import type { FunctionComponent, SVGProps } from 'react';
 import React from 'react';
 import clsx from 'clsx';
-import { useViewBox, useXAxisOrThrow } from '../context/chartLayoutContext';
+import { useChartHeight, useChartWidth, useXAxisOrThrow } from '../context/chartLayoutContext';
 import { CartesianAxis } from './CartesianAxis';
 import { BaseAxisProps, AxisInterval } from '../util/types';
 import { getTicksOfAxis } from '../util/ChartUtils';
@@ -37,7 +37,8 @@ interface XAxisProps extends BaseAxisProps {
 export type Props = Omit<SVGProps<SVGElement>, 'scale'> & XAxisProps;
 
 export const XAxis: FunctionComponent<Props> = ({ xAxisId }: Props) => {
-  const viewBox = useViewBox();
+  const width = useChartWidth();
+  const height = useChartHeight();
   const axisOptions = useXAxisOrThrow(xAxisId);
 
   if (axisOptions == null) {
@@ -49,7 +50,7 @@ export const XAxis: FunctionComponent<Props> = ({ xAxisId }: Props) => {
     <CartesianAxis
       {...axisOptions}
       className={clsx(`recharts-${axisOptions.axisType} ${axisOptions.axisType}`, axisOptions.className)}
-      viewBox={viewBox}
+      viewBox={{ x: 0, y: 0, width, height }}
       ticksGenerator={(axis: any) => getTicksOfAxis(axis, true)}
     />
   );

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -2254,7 +2254,12 @@ export const generateCategoricalChart = ({
 
       const events = this.parseEventsOfWrapper();
       return (
-        <ChartLayoutContextProvider state={this.state} clipPathId={this.clipPathId}>
+        <ChartLayoutContextProvider
+          state={this.state}
+          width={this.props.width}
+          height={this.props.height}
+          clipPathId={this.clipPathId}
+        >
           <div
             className={clsx('recharts-wrapper', className)}
             style={{ position: 'relative', cursor: 'default', width, height, ...style }}

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -10,6 +10,8 @@ export const XAxisContext = createContext<XAxisMap | undefined>(undefined);
 export const YAxisContext = createContext<YAxisMap | undefined>(undefined);
 export const ViewBoxContext = createContext<CartesianViewBox | undefined>(undefined);
 export const ClipPathIdContext = createContext<string | undefined>(undefined);
+export const ChartHeightContext = createContext<number>(0);
+export const ChartWidthContext = createContext<number>(0);
 
 /**
  * Will add all the properties required to render all individual Recharts components into a React Context.
@@ -23,11 +25,15 @@ export const ChartLayoutContextProvider = (props: {
   state: CategoricalChartState;
   children: ReactNode;
   clipPathId: string;
+  width: number;
+  height: number;
 }) => {
   const {
     state: { xAxisMap, yAxisMap, offset },
     clipPathId,
     children,
+    width,
+    height,
   } = props;
 
   const viewBox = calculateViewBox(offset);
@@ -49,7 +55,11 @@ export const ChartLayoutContextProvider = (props: {
     <XAxisContext.Provider value={xAxisMap}>
       <YAxisContext.Provider value={yAxisMap}>
         <ViewBoxContext.Provider value={viewBox}>
-          <ClipPathIdContext.Provider value={clipPathId}>{children}</ClipPathIdContext.Provider>
+          <ClipPathIdContext.Provider value={clipPathId}>
+            <ChartHeightContext.Provider value={height}>
+              <ChartWidthContext.Provider value={width}>{children}</ChartWidthContext.Provider>
+            </ChartHeightContext.Provider>
+          </ClipPathIdContext.Provider>
         </ViewBoxContext.Provider>
       </YAxisContext.Provider>
     </XAxisContext.Provider>
@@ -101,4 +111,12 @@ export const useYAxisOrThrow = (yAxisId: string | number): YAxisProps => {
 export const useViewBox = (): CartesianViewBox => {
   const viewBox = useContext(ViewBoxContext);
   return viewBox;
+};
+
+export const useChartWidth = (): number => {
+  return useContext(ChartWidthContext);
+};
+
+export const useChartHeight = (): number => {
+  return useContext(ChartWidthContext);
 };


### PR DESCRIPTION
## Description

Found the problem! So here's why my change broke it:

First I introduced `viewBox` computed as `x: offset.left, y: offset.top,` because that's what `renderReferenceElement` does. I did this when adding `ReferenceLine`.

Later when converting XAxis, I made a mistake to reuse the same viewBox. I should have noticed that the `renderAxis` method actually has `x: 0, y: 0` hardcoded, and uses width + height from props, not from offset.

## Related Issue

following up from https://github.com/recharts/recharts/pull/4054#issuecomment-1894774034

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
