### PR TITLE
chore: set includeEvent property in filterProps as required!

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -315,7 +315,7 @@ export class Area extends PureComponent<Props, State> {
     }
 
     const { dot, points, dataKey } = this.props;
-    const areaProps = filterProps(this.props);
+    const areaProps = filterProps(this.props, false);
     const customDotProps = filterProps(dot, true);
 
     const dots = points.map((entry: AreaPointItem, i: number) => {
@@ -425,7 +425,7 @@ export class Area extends PureComponent<Props, State> {
         />
         {stroke !== 'none' && (
           <Curve
-            {...filterProps(this.props)}
+            {...filterProps(this.props, false)}
             className="recharts-area-curve"
             layout={layout}
             type={type}
@@ -436,7 +436,7 @@ export class Area extends PureComponent<Props, State> {
         )}
         {stroke !== 'none' && isRange && (
           <Curve
-            {...filterProps(this.props)}
+            {...filterProps(this.props, false)}
             className="recharts-area-curve"
             layout={layout}
             type={type}
@@ -554,7 +554,7 @@ export class Area extends PureComponent<Props, State> {
     const needClipY = yAxis && yAxis.allowDataOverflow;
     const needClip = needClipX || needClipY;
     const clipPathId = isNil(id) ? this.id : id;
-    const { r = 3, strokeWidth = 2 } = filterProps(dot) ?? { r: 3, strokeWidth: 2 };
+    const { r = 3, strokeWidth = 2 } = filterProps(dot, false) ?? { r: 3, strokeWidth: 2 };
     const { clipDot = true } = isDotProps(dot) ? dot : {};
     const dotSize = r * 2 + strokeWidth;
 

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -287,7 +287,7 @@ export class Bar extends PureComponent<Props, State> {
 
   renderRectanglesStatically(data: BarRectangleItem[]) {
     const { shape, dataKey, activeIndex, activeBar } = this.props;
-    const baseProps = filterProps(this.props);
+    const baseProps = filterProps(this.props, false);
 
     return (
       data &&
@@ -389,7 +389,7 @@ export class Bar extends PureComponent<Props, State> {
 
   renderBackground() {
     const { data, dataKey, activeIndex } = this.props;
-    const backgroundProps = filterProps(this.props.background);
+    const backgroundProps = filterProps(this.props.background, false);
 
     return data.map((entry, i) => {
       const { value, background, ...rest } = entry;

--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -492,7 +492,7 @@ export class Brush extends PureComponent<Props, State> {
     const { y, travellerWidth, height, traveller, ariaLabel, data, startIndex, endIndex } = this.props;
     const x = Math.max(travellerX, this.props.x);
     const travellerProps = {
-      ...filterProps(this.props),
+      ...filterProps(this.props, false),
       x,
       y,
       width: travellerWidth,

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -209,8 +209,8 @@ export class CartesianAxis extends Component<Props, IState> {
   renderAxisLine() {
     const { x, y, width, height, orientation, mirror, axisLine } = this.props;
     let props: SVGProps<SVGLineElement> = {
-      ...filterProps(this.props),
-      ...filterProps(axisLine),
+      ...filterProps(this.props, false),
+      ...filterProps(axisLine, false),
       fill: 'none',
     };
 
@@ -267,12 +267,12 @@ export class CartesianAxis extends Component<Props, IState> {
     const finalTicks = getTicks({ ...this.props, ticks }, fontSize, letterSpacing);
     const textAnchor = this.getTickTextAnchor();
     const verticalAnchor = this.getTickVerticalAnchor();
-    const axisProps = filterProps(this.props);
-    const customTickProps = filterProps(tick);
+    const axisProps = filterProps(this.props, false);
+    const customTickProps = filterProps(tick, false);
     const tickLineProps = {
       ...axisProps,
       fill: 'none',
-      ...filterProps(tickLine),
+      ...filterProps(tickLine, false),
     };
     const items = finalTicks.map((entry, i) => {
       const { line: lineCoord, tick: tickCoord } = this.getTickLineCoord(entry);

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -93,7 +93,7 @@ export class CartesianGrid extends PureComponent<Props> {
       lineItem = option(props);
     } else {
       const { x1, y1, x2, y2, key, ...others } = props;
-      const { offset: __, ...restOfFilteredProps } = filterProps(others);
+      const { offset: __, ...restOfFilteredProps } = filterProps(others, false);
       lineItem = <line {...restOfFilteredProps} x1={x1} y1={y1} x2={x2} y2={y2} fill="none" key={key} />;
     }
 

--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -49,7 +49,7 @@ export type Props = SVGProps<SVGLineElement> & ErrorBarProps;
 
 export function ErrorBar(props: Props) {
   const { offset, layout, width, dataKey, data, dataPointFormatter, xAxis, yAxis, ...others } = props;
-  const svgProps = filterProps(others);
+  const svgProps = filterProps(others, false);
 
   invariant(
     !(props.direction === 'x' && xAxis.type !== 'number'),

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -347,7 +347,7 @@ export class Line extends PureComponent<Props, State> {
       return null;
     }
     const { dot, points, dataKey } = this.props;
-    const lineProps = filterProps(this.props);
+    const lineProps = filterProps(this.props, false);
     const customDotProps = filterProps(dot, true);
     const dots = points.map((entry, i) => {
       const dotProps = {
@@ -497,7 +497,7 @@ export class Line extends PureComponent<Props, State> {
     const needClipY = yAxis && yAxis.allowDataOverflow;
     const needClip = needClipX || needClipY;
     const clipPathId = isNil(id) ? this.id : id;
-    const { r = 3, strokeWidth = 2 } = filterProps(dot) ?? { r: 3, strokeWidth: 2 };
+    const { r = 3, strokeWidth = 2 } = filterProps(dot, false) ?? { r: 3, strokeWidth: 2 };
     const { clipDot = true } = isDotProps(dot) ? dot : {};
     const dotSize = r * 2 + strokeWidth;
 

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -267,7 +267,7 @@ export class Scatter extends PureComponent<Props, State> {
 
   renderSymbolsStatically(points: ScatterPointItem[]) {
     const { shape, activeShape, activeIndex } = this.props;
-    const baseProps = filterProps(this.props);
+    const baseProps = filterProps(this.props, false);
 
     return points.map((entry, i) => {
       const isActive = activeIndex === i;
@@ -377,8 +377,8 @@ export class Scatter extends PureComponent<Props, State> {
 
   renderLine() {
     const { points, line, lineType, lineJointType } = this.props;
-    const scatterProps = filterProps(this.props);
-    const customLineProps = filterProps(line);
+    const scatterProps = filterProps(this.props, false);
+    const customLineProps = filterProps(line, false);
     let linePoints, lineItem;
 
     if (lineType === 'joint') {

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -569,7 +569,7 @@ export class Sankey extends PureComponent<Props, State> {
         stroke="#333"
         strokeWidth={linkWidth}
         strokeOpacity="0.2"
-        {...filterProps(others)}
+        {...filterProps(others, false)}
       />
     );
   }
@@ -605,7 +605,7 @@ export class Sankey extends PureComponent<Props, State> {
             linkWidth,
             index: i,
             payload: { ...link, source, target },
-            ...filterProps(linkContent),
+            ...filterProps(linkContent, false),
           };
           const events = {
             onMouseEnter: this.handleMouseEnter.bind(this, linkProps, 'link'),
@@ -632,7 +632,13 @@ export class Sankey extends PureComponent<Props, State> {
     }
 
     return (
-      <Rectangle className="recharts-sankey-node" fill="#0088fe" fillOpacity="0.8" {...filterProps(props)} role="img" />
+      <Rectangle
+        className="recharts-sankey-node"
+        fill="#0088fe"
+        fillOpacity="0.8"
+        {...filterProps(props, false)}
+        role="img"
+      />
     );
   }
 
@@ -646,7 +652,7 @@ export class Sankey extends PureComponent<Props, State> {
         {nodes.map((node, i) => {
           const { x, y, dx, dy } = node;
           const nodeProps = {
-            ...filterProps(nodeContent),
+            ...filterProps(nodeContent, false),
             x: x + left,
             y: y + top,
             width: dx,
@@ -701,7 +707,7 @@ export class Sankey extends PureComponent<Props, State> {
 
     const { width, height, className, style, children, ...others } = this.props;
     const { links, nodes } = this.state;
-    const attrs = filterProps(others);
+    const attrs = filterProps(others, false);
 
     return (
       <div

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -612,7 +612,7 @@ export class Treemap extends PureComponent<Props, State> {
 
   renderNode(root: TreemapNode, node: TreemapNode): React.ReactElement {
     const { content, type } = this.props;
-    const nodeProps = { ...filterProps(this.props), ...node, root };
+    const nodeProps = { ...filterProps(this.props, false), ...node, root };
     const isLeaf = !node.children || !node.children.length;
 
     const { currentRoot } = this.state;
@@ -733,7 +733,7 @@ export class Treemap extends PureComponent<Props, State> {
     }
 
     const { width, height, className, style, children, type, ...others } = this.props;
-    const attrs = filterProps(others);
+    const attrs = filterProps(others, false);
 
     return (
       <div

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1943,7 +1943,7 @@ export const generateCategoricalChart = ({
         payload: activePoint.payload,
         value: activePoint.value,
         key: `${key}-activePoint-${childIndex}`,
-        ...filterProps(activeDot),
+        ...filterProps(activeDot, false),
         ...adaptEventHandlers(activeDot),
       };
 
@@ -2194,7 +2194,7 @@ export const generateCategoricalChart = ({
       }
 
       const { children, className, width, height, style, compact, title, desc, ...others } = this.props;
-      const attrs = filterProps(others);
+      const attrs = filterProps(others, false);
 
       // The "compact" mode is mainly used as the panorama within Brush
       if (compact) {

--- a/src/component/Cursor.tsx
+++ b/src/component/Cursor.tsx
@@ -82,7 +82,7 @@ export function Cursor(props: CursorProps) {
     pointerEvents: 'none',
     ...offset,
     ...restProps,
-    ...filterProps(element.props.cursor),
+    ...filterProps(element.props.cursor, false),
     payload: activePayload,
     payloadIndex: activeTooltipIndex,
     className: 'recharts-tooltip-cursor',

--- a/src/numberAxis/Funnel.tsx
+++ b/src/numberAxis/Funnel.tsx
@@ -92,7 +92,7 @@ export class Funnel extends PureComponent<FunnelProps, State> {
 
   static getRealFunnelData = (item: Funnel) => {
     const { data, children } = item.props;
-    const presentationProps = filterProps(item.props);
+    const presentationProps = filterProps(item.props, false);
     const cells = findAllByType(children, Cell);
 
     if (data && data.length) {

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -173,7 +173,7 @@ export class Pie extends PureComponent<Props, State> {
 
   static getRealPieData = (item: Pie) => {
     const { data, children } = item.props;
-    const presentationProps = filterProps(item.props);
+    const presentationProps = filterProps(item.props, false);
     const cells = findAllByType(children, Cell);
 
     if (data && data.length) {
@@ -431,9 +431,9 @@ export class Pie extends PureComponent<Props, State> {
       return null;
     }
     const { label, labelLine, dataKey, valueKey } = this.props;
-    const pieProps = filterProps(this.props);
-    const customLabelProps = filterProps(label);
-    const customLabelLineProps = filterProps(labelLine);
+    const pieProps = filterProps(this.props, false);
+    const customLabelProps = filterProps(label, false);
+    const customLabelLineProps = filterProps(labelLine, false);
     const offsetRadius = (label && (label as any).offsetRadius) || 20;
 
     const labels = sectors.map((entry, i) => {

--- a/src/polar/PolarAngleAxis.tsx
+++ b/src/polar/PolarAngleAxis.tsx
@@ -86,9 +86,9 @@ export class PolarAngleAxis extends PureComponent<Props> {
   renderAxisLine() {
     const { cx, cy, radius, axisLine, axisLineType } = this.props;
     const props = {
-      ...filterProps(this.props),
+      ...filterProps(this.props, false),
       fill: 'none',
-      ...filterProps(axisLine),
+      ...filterProps(axisLine, false),
     };
 
     if (axisLineType === 'circle') {
@@ -120,12 +120,12 @@ export class PolarAngleAxis extends PureComponent<Props> {
 
   renderTicks() {
     const { ticks, tick, tickLine, tickFormatter, stroke } = this.props;
-    const axisProps = filterProps(this.props);
-    const customTickProps = filterProps(tick);
+    const axisProps = filterProps(this.props, false);
+    const customTickProps = filterProps(tick, false);
     const tickLineProps = {
       ...axisProps,
       fill: 'none',
-      ...filterProps(tickLine),
+      ...filterProps(tickLine, false),
     };
 
     const items = ticks.map((entry, i) => {

--- a/src/polar/PolarGrid.tsx
+++ b/src/polar/PolarGrid.tsx
@@ -51,7 +51,7 @@ const PolarAngles: React.FC<Props> = props => {
   }
   const polarAnglesProps = {
     stroke: '#ccc',
-    ...filterProps(props),
+    ...filterProps(props, false),
   };
 
   return (
@@ -71,7 +71,7 @@ const ConcentricCircle: React.FC<ConcentricProps> = props => {
   const { cx, cy, radius, index } = props;
   const concentricCircleProps = {
     stroke: '#ccc',
-    ...filterProps(props),
+    ...filterProps(props, false),
     fill: 'none',
   };
 
@@ -92,7 +92,7 @@ const ConcentricPolygon: React.FC<ConcentricProps> = props => {
   const { radius, index } = props;
   const concentricPolygonProps = {
     stroke: '#ccc',
-    ...filterProps(props),
+    ...filterProps(props, false),
     fill: 'none',
   };
 

--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -101,9 +101,9 @@ export class PolarRadiusAxis extends PureComponent<Props> {
     const point1 = polarToCartesian(cx, cy, extent[1], angle);
 
     const props = {
-      ...filterProps(others),
+      ...filterProps(others, false),
       fill: 'none',
-      ...filterProps(axisLine),
+      ...filterProps(axisLine, false),
       x1: point0.x,
       y1: point0.y,
       x2: point1.x,
@@ -134,8 +134,8 @@ export class PolarRadiusAxis extends PureComponent<Props> {
   renderTicks() {
     const { ticks, tick, angle, tickFormatter, stroke, ...others } = this.props;
     const textAnchor = this.getTickTextAnchor();
-    const axisProps = filterProps(others);
-    const customTickProps = filterProps(tick);
+    const axisProps = filterProps(others, false);
+    const customTickProps = filterProps(tick, false);
 
     const items = ticks.map((entry, i) => {
       const coord = this.getTickValueCoord(entry);

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -226,7 +226,7 @@ export class Radar extends PureComponent<Props, State> {
 
   renderDots(points: RadarPoint[]) {
     const { dot, dataKey } = this.props;
-    const baseProps = filterProps(this.props);
+    const baseProps = filterProps(this.props, false);
     const customDotProps = filterProps(dot, true);
 
     const dots = points.map((entry, i) => {

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -273,7 +273,7 @@ export class RadialBar extends PureComponent<RadialBarProps, State> {
 
   renderSectorsStatically(sectors: SectorProps[]) {
     const { shape, activeShape, activeIndex, cornerRadius, ...others } = this.props;
-    const baseProps = filterProps(others);
+    const baseProps = filterProps(others, false);
 
     return sectors.map((entry, i) => {
       const isActive = i === activeIndex;
@@ -349,7 +349,7 @@ export class RadialBar extends PureComponent<RadialBarProps, State> {
 
   renderBackground(sectors?: RadialBarDataItem[]) {
     const { cornerRadius } = this.props;
-    const backgroundProps = filterProps(this.props.background);
+    const backgroundProps = filterProps(this.props.background, false);
 
     return sectors.map((entry, i) => {
       const { value, background, ...rest } = entry;

--- a/src/shape/Curve.tsx
+++ b/src/shape/Curve.tsx
@@ -154,7 +154,7 @@ export const Curve: React.FC<Props> = props => {
 
   return (
     <path
-      {...filterProps(props)}
+      {...filterProps(props, false)}
       {...adaptEventHandlers(props)}
       className={clsx('recharts-curve', className)}
       d={realPath}

--- a/src/shape/Dot.tsx
+++ b/src/shape/Dot.tsx
@@ -22,7 +22,14 @@ export const Dot: React.FC<Props> = props => {
 
   if (cx === +cx && cy === +cy && r === +r) {
     return (
-      <circle {...filterProps(props)} {...adaptEventHandlers(props)} className={layerClass} cx={cx} cy={cy} r={r} />
+      <circle
+        {...filterProps(props, false)}
+        {...adaptEventHandlers(props)}
+        className={layerClass}
+        cx={cx}
+        cy={cy}
+        r={r}
+      />
     );
   }
 

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1325,7 +1325,7 @@ export const getTooltipItem = (graphicalItem: ReactElement, payload: any) => {
   const { dataKey, name, unit, formatter, tooltipType, chartType } = graphicalItem.props;
 
   return {
-    ...filterProps(graphicalItem),
+    ...filterProps(graphicalItem, false),
     dataKey,
     unit,
     formatter,

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -317,7 +317,7 @@ export const filterSvgElements = (children: React.ReactElement[]): React.ReactEl
 
 export const filterProps = (
   props: Record<string, any> | Component | FunctionComponent | boolean | unknown,
-  includeEvents?: boolean,
+  includeEvents: boolean,
   svgElementType?: FilteredSvgElementType,
 ) => {
   if (!props || typeof props === 'function' || typeof props === 'boolean') {

--- a/test/util/ReactUtils.spec.tsx
+++ b/test/util/ReactUtils.spec.tsx
@@ -19,15 +19,15 @@ import { adaptEventHandlers, adaptEventsOfChild } from '../../src/util/types';
 describe('ReactUtils untest tests', () => {
   describe('filterProps', () => {
     test.each([true, false, 125, null, undefined])('should return null when called with %s', input => {
-      expect(filterProps(input)).toBeNull();
+      expect(filterProps(input, false)).toBeNull();
     });
 
     test('should filter out non-svg properties from react element props', () => {
-      expect(filterProps(<input id="test" value={1} />)).toEqual({ id: 'test' });
+      expect(filterProps(<input id="test" value={1} />, false)).toEqual({ id: 'test' });
     });
 
     test('should filter out non wanted properties', () => {
-      expect(filterProps({ test: '1234', helloWorld: 1234, viewBox: '0 0 0 0', dx: 1, dy: 1 })).toEqual({
+      expect(filterProps({ test: '1234', helloWorld: 1234, viewBox: '0 0 0 0', dx: 1, dy: 1 }, false)).toEqual({
         dx: 1,
         dy: 1,
       });
@@ -66,11 +66,14 @@ describe('ReactUtils untest tests', () => {
     });
 
     test('filterProps return presentation attributes', () => {
-      const result = filterProps({
-        stroke: '#000',
-        fill: '#000',
-        r: 6,
-      });
+      const result = filterProps(
+        {
+          stroke: '#000',
+          fill: '#000',
+          r: 6,
+        },
+        false,
+      );
 
       expect(Object.keys(result ?? {})).toContain('stroke');
       expect(Object.keys(result ?? {})).toContain('fill');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

`includeEvent` parameter of `filterProps` function in `ReactUtils.ts` which is of type `boolean` was set as optional which caused breaking events in components when not set.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

based on discussions from [#4056 ]

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
