### PR TITLE
CartesianGrid now has tests, and is split in smaller components

### DIFF
--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -28,7 +28,7 @@ export type HorizontalCoordinatesGenerator = (
   syncWithTicks: boolean,
 ) => number[];
 
-type VerticalCoordinatesGenerator = (
+export type VerticalCoordinatesGenerator = (
   props: {
     xAxis: any;
     width: number;
@@ -344,7 +344,6 @@ export class CartesianGrid extends PureComponent<Props> {
       warn(
         Array.isArray(generatorResult),
         `horizontalCoordinatesGenerator should return Array but instead it returned [${typeof generatorResult}]`,
-        `horizontalCoordinatesGenerator should return Array but instead it returned [${typeof generatorResult}]`,
       );
       if (Array.isArray(generatorResult)) {
         horizontalPoints = generatorResult;
@@ -355,7 +354,7 @@ export class CartesianGrid extends PureComponent<Props> {
     if ((!verticalPoints || !verticalPoints.length) && isFunction(verticalCoordinatesGenerator)) {
       const isVerticalValues = verticalValues && verticalValues.length;
 
-      verticalPoints = verticalCoordinatesGenerator(
+      const generatorResult = verticalCoordinatesGenerator(
         {
           xAxis: xAxis
             ? {
@@ -369,6 +368,13 @@ export class CartesianGrid extends PureComponent<Props> {
         },
         isVerticalValues ? true : syncWithTicks,
       );
+      warn(
+        Array.isArray(generatorResult),
+        `verticalCoordinatesGenerator should return Array but instead it returned [${typeof generatorResult}]`,
+      );
+      if (Array.isArray(generatorResult)) {
+        verticalPoints = generatorResult;
+      }
     }
 
     return (
@@ -383,7 +389,7 @@ export class CartesianGrid extends PureComponent<Props> {
         />
         <HorizontalGridLines {...this.props} horizontalPoints={horizontalPoints} />
 
-        <VerticalGridLines {...this.props} />
+        <VerticalGridLines {...this.props} verticalPoints={verticalPoints} />
 
         {horizontal && this.renderHorizontalStripes(horizontalPoints)}
         {vertical && this.renderVerticalStripes(verticalPoints)}

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -107,9 +107,11 @@ interface CartesianGridProps extends InternalCartesianGridProps {
   verticalValues?: number[] | string[];
 }
 
-export type Props = SVGProps<SVGElement> & CartesianGridProps;
+type AcceptedSvgProps = Omit<SVGProps<SVGElement>, 'offset'>;
 
-const Background = (props: Pick<SVGProps<SVGElement>, 'fill' | 'fillOpacity' | 'x' | 'y' | 'width' | 'height'>) => {
+export type Props = AcceptedSvgProps & CartesianGridProps;
+
+const Background = (props: Pick<AcceptedSvgProps, 'fill' | 'fillOpacity' | 'x' | 'y' | 'width' | 'height'>) => {
   const { fill } = props;
 
   if (!fill || fill === 'none') {

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -364,6 +364,7 @@ export class CartesianGrid extends PureComponent<Props> {
         `horizontalCoordinatesGenerator should return Array but instead it returned [${typeof generatorResult}]`,
       );
       if (Array.isArray(generatorResult)) {
+        console.log({ generatorResult });
         horizontalPoints = generatorResult;
       }
     }

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -364,7 +364,6 @@ export class CartesianGrid extends PureComponent<Props> {
         `horizontalCoordinatesGenerator should return Array but instead it returned [${typeof generatorResult}]`,
       );
       if (Array.isArray(generatorResult)) {
-        console.log({ generatorResult });
         horizontalPoints = generatorResult;
       }
     }

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -145,6 +145,30 @@ function HorizontalGridLines(props: Props) {
   return <g className="recharts-cartesian-grid-horizontal">{items}</g>;
 }
 
+function VerticalGridLines(props: Props) {
+  const { y, height, vertical, verticalPoints } = props;
+
+  if (!vertical || !verticalPoints || !verticalPoints.length) {
+    return null;
+  }
+
+  const items = verticalPoints.map((entry, i) => {
+    const lineItemProps: LineItemProps = {
+      ...props,
+      x1: entry,
+      y1: y,
+      x2: entry,
+      y2: y + height,
+      key: `line-${i}`,
+      index: i,
+    };
+
+    return renderLineItem(vertical, lineItemProps);
+  });
+
+  return <g className="recharts-cartesian-grid-vertical">{items}</g>;
+}
+
 export class CartesianGrid extends PureComponent<Props> {
   static displayName = 'CartesianGrid';
 
@@ -162,35 +186,6 @@ export class CartesianGrid extends PureComponent<Props> {
     verticalFill: [],
     horizontalFill: [],
   };
-
-  /**
-   * Draw vertical grid lines
-   * @param {Array} verticalPoints either passed in as props or generated from function
-   * @return {Group} Vertical lines
-   */
-  renderVertical(verticalPoints: number[]) {
-    const { y, height, vertical } = this.props;
-
-    if (!verticalPoints || !verticalPoints.length) {
-      return null;
-    }
-
-    const items = verticalPoints.map((entry, i) => {
-      const props: LineItemProps = {
-        ...this.props,
-        x1: entry,
-        y1: y,
-        x2: entry,
-        y2: y + height,
-        key: `line-${i}`,
-        index: i,
-      };
-
-      return renderLineItem(vertical, props);
-    });
-
-    return <g className="recharts-cartesian-grid-vertical">{items}</g>;
-  }
 
   /**
    * Draw vertical grid stripes filled by colors
@@ -364,7 +359,7 @@ export class CartesianGrid extends PureComponent<Props> {
           height={this.props.height}
         />
         <HorizontalGridLines {...this.props} />
-        {vertical && this.renderVertical(verticalPoints)}
+        <VerticalGridLines {...this.props} />
 
         {horizontal && this.renderHorizontalStripes(horizontalPoints)}
         {vertical && this.renderVerticalStripes(verticalPoints)}

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -245,6 +245,44 @@ function HorizontalStripes(props: Props) {
   return <g className="recharts-cartesian-gridstripes-horizontal">{items}</g>;
 }
 
+function VerticalStripes(props: Props) {
+  const { vertical, verticalFill, fillOpacity, x, y, width, height, verticalPoints } = props;
+  if (!vertical || !verticalFill || !verticalFill.length) {
+    return null;
+  }
+
+  const roundedSortedVerticalPoints = verticalPoints.map(e => Math.round(e + x - x)).sort((a, b) => a - b);
+
+  if (x !== roundedSortedVerticalPoints[0]) {
+    roundedSortedVerticalPoints.unshift(0);
+  }
+
+  const items = roundedSortedVerticalPoints.map((entry, i) => {
+    const lastStripe = !roundedSortedVerticalPoints[i + 1];
+    const lineWidth = lastStripe ? x + width - entry : roundedSortedVerticalPoints[i + 1] - entry;
+
+    if (lineWidth <= 0) {
+      return null;
+    }
+    const colorIndex = i % verticalFill.length;
+    return (
+      <rect
+        key={`react-${i}`} // eslint-disable-line react/no-array-index-key
+        x={entry}
+        y={y}
+        width={lineWidth}
+        height={height}
+        stroke="none"
+        fill={verticalFill[colorIndex]}
+        fillOpacity={fillOpacity}
+        className="recharts-cartesian-grid-bg"
+      />
+    );
+  });
+
+  return <g className="recharts-cartesian-gridstripes-vertical">{items}</g>;
+}
+
 export class CartesianGrid extends PureComponent<Props> {
   static displayName = 'CartesianGrid';
 
@@ -263,57 +301,12 @@ export class CartesianGrid extends PureComponent<Props> {
     horizontalFill: [],
   };
 
-  /**
-   * Draw vertical grid stripes filled by colors
-   * @param {Array} verticalPoints either passed in as props or generated from function
-   * @return {Group} Vertical stripes
-   */
-  renderVerticalStripes(verticalPoints: number[]) {
-    const { verticalFill } = this.props;
-    if (!verticalFill || !verticalFill.length) {
-      return null;
-    }
-
-    const { fillOpacity, x, y, width, height } = this.props;
-    const roundedSortedVerticalPoints = verticalPoints.map(e => Math.round(e + x - x)).sort((a, b) => a - b);
-
-    if (x !== roundedSortedVerticalPoints[0]) {
-      roundedSortedVerticalPoints.unshift(0);
-    }
-
-    const items = roundedSortedVerticalPoints.map((entry, i) => {
-      const lastStripe = !roundedSortedVerticalPoints[i + 1];
-      const lineWidth = lastStripe ? x + width - entry : roundedSortedVerticalPoints[i + 1] - entry;
-
-      if (lineWidth <= 0) {
-        return null;
-      }
-      const colorIndex = i % verticalFill.length;
-      return (
-        <rect
-          key={`react-${i}`} // eslint-disable-line react/no-array-index-key
-          x={entry}
-          y={y}
-          width={lineWidth}
-          height={height}
-          stroke="none"
-          fill={verticalFill[colorIndex]}
-          fillOpacity={fillOpacity}
-          className="recharts-cartesian-grid-bg"
-        />
-      );
-    });
-
-    return <g className="recharts-cartesian-gridstripes-vertical">{items}</g>;
-  }
-
   render() {
     const {
       x,
       y,
       width,
       height,
-      vertical,
       horizontalCoordinatesGenerator,
       verticalCoordinatesGenerator,
       xAxis,
@@ -410,7 +403,8 @@ export class CartesianGrid extends PureComponent<Props> {
         <VerticalGridLines {...this.props} verticalPoints={verticalPoints} />
 
         <HorizontalStripes {...this.props} horizontalPoints={horizontalPoints} />
-        {vertical && this.renderVerticalStripes(verticalPoints)}
+
+        <VerticalStripes {...this.props} verticalPoints={verticalPoints} />
       </g>
     );
   }

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -65,7 +65,29 @@ interface CartesianGridProps extends InternalCartesianGridProps {
    * Has priority over syncWithTicks and horizontalValues.
    */
   verticalPoints?: number[];
+  /**
+   * Defines background color of stripes.
+   *
+   * The values from this array will be passed in as the `fill` property in a `rect` SVG element.
+   * For possible values see: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill#rect
+   *
+   * In case there are more stripes than colors, the colors will start from beginning
+   * So for example: verticalFill['yellow', 'black'] produces a pattern of yellow|black|yellow|black
+   *
+   * If this is undefined, or an empty array, then there is no background fill.
+   */
   verticalFill?: string[];
+  /**
+   * Defines background color of stripes.
+   *
+   * The values from this array will be passed in as the `fill` property in a `rect` SVG element.
+   * For possible values see: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill#rect
+   *
+   * In case there are more stripes than colors, the colors will start from beginning
+   * So for example: horizontalFill['yellow', 'black'] produces a pattern of yellow|black|yellow|black
+   *
+   * If this is undefined, or an empty array, then there is no background fill.
+   */
   horizontalFill?: string[];
   /**
    * If true, only the lines that correspond to the axes ticks values will be drawn.
@@ -258,12 +280,15 @@ export class CartesianGrid extends PureComponent<Props> {
     }
 
     const { fillOpacity, x, y, width, height } = this.props;
+    // Why =y -y? I was trying to find any difference that this makes, with floating point numbers and edge cases but ... nothing.
     const roundedSortedHorizontalPoints = horizontalPoints.map(e => Math.round(e + y - y)).sort((a, b) => a - b);
+    // Why is this condition `!==` instead of `<=` ?
     if (y !== roundedSortedHorizontalPoints[0]) {
       roundedSortedHorizontalPoints.unshift(0);
     }
 
     const items = roundedSortedHorizontalPoints.map((entry, i) => {
+      // Why do we strip only the last stripe if it is invisible, and not all invisible stripes?
       const lastStripe = !roundedSortedHorizontalPoints[i + 1];
       const lineHeight = lastStripe ? y + height - entry : roundedSortedHorizontalPoints[i + 1] - entry;
       if (lineHeight <= 0) {

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -95,10 +95,20 @@ const Background = (props: Pick<SVGProps<SVGElement>, 'fill' | 'fillOpacity' | '
   );
 };
 
-function renderLineItem(option: GridLineType, props: any) {
+type LineItemProps = Props & {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  key: string;
+  index: number;
+};
+
+function renderLineItem(option: GridLineType, props: LineItemProps) {
   let lineItem;
 
   if (React.isValidElement(option)) {
+    // @ts-expect-error typescript does not see the props type when cloning an element
     lineItem = React.cloneElement(option, props);
   } else if (isFunction(option)) {
     lineItem = option(props);
@@ -142,7 +152,7 @@ export class CartesianGrid extends PureComponent<Props> {
     }
 
     const items = horizontalPoints.map((entry, i) => {
-      const props = {
+      const props: LineItemProps = {
         ...this.props,
         x1: x,
         y1: entry,
@@ -171,7 +181,7 @@ export class CartesianGrid extends PureComponent<Props> {
     }
 
     const items = verticalPoints.map((entry, i) => {
-      const props = {
+      const props: LineItemProps = {
         ...this.props,
         x1: entry,
         y1: y,

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -121,6 +121,30 @@ function renderLineItem(option: GridLineType, props: LineItemProps) {
   return lineItem;
 }
 
+function HorizontalGridLines(props: Props) {
+  const { x, width, horizontal, horizontalPoints } = props;
+
+  if (!horizontal || !horizontalPoints || !horizontalPoints.length) {
+    return null;
+  }
+
+  const items = horizontalPoints.map((entry, i) => {
+    const lineItemProps: LineItemProps = {
+      ...props,
+      x1: x,
+      y1: entry,
+      x2: x + width,
+      y2: entry,
+      key: `line-${i}`,
+      index: i,
+    };
+
+    return renderLineItem(horizontal, lineItemProps);
+  });
+
+  return <g className="recharts-cartesian-grid-horizontal">{items}</g>;
+}
+
 export class CartesianGrid extends PureComponent<Props> {
   static displayName = 'CartesianGrid';
 
@@ -138,35 +162,6 @@ export class CartesianGrid extends PureComponent<Props> {
     verticalFill: [],
     horizontalFill: [],
   };
-
-  /**
-   * Draw the horizontal grid lines
-   * @param {Array} horizontalPoints either passed in as props or generated from function
-   * @return {Group} Horizontal lines
-   */
-  renderHorizontal(horizontalPoints: number[]) {
-    const { x, width, horizontal } = this.props;
-
-    if (!horizontalPoints || !horizontalPoints.length) {
-      return null;
-    }
-
-    const items = horizontalPoints.map((entry, i) => {
-      const props: LineItemProps = {
-        ...this.props,
-        x1: x,
-        y1: entry,
-        x2: x + width,
-        y2: entry,
-        key: `line-${i}`,
-        index: i,
-      };
-
-      return renderLineItem(horizontal, props);
-    });
-
-    return <g className="recharts-cartesian-grid-horizontal">{items}</g>;
-  }
 
   /**
    * Draw vertical grid lines
@@ -368,7 +363,7 @@ export class CartesianGrid extends PureComponent<Props> {
           width={this.props.width}
           height={this.props.height}
         />
-        {horizontal && this.renderHorizontal(horizontalPoints)}
+        <HorizontalGridLines {...this.props} />
         {vertical && this.renderVertical(verticalPoints)}
 
         {horizontal && this.renderHorizontalStripes(horizontalPoints)}

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -22,8 +22,14 @@ interface InternalCartesianGridProps {
   y?: number;
   width?: number;
   height?: number;
-  horizontalCoordinatesGenerator?: (props: any, syncWithTicks: boolean) => number[];
-  verticalCoordinatesGenerator?: (props: any, syncWithTicks: boolean) => number[];
+  horizontalCoordinatesGenerator?: (
+    props: { yAxis: any; width: number; height: number; offset: ChartOffset },
+    syncWithTicks: boolean,
+  ) => number[];
+  verticalCoordinatesGenerator?: (
+    props: { xAxis: any; width: number; height: number; offset: ChartOffset },
+    syncWithTicks: boolean,
+  ) => number[];
   xAxis?: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> };
   yAxis?: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> };
   offset?: ChartOffset;
@@ -66,22 +72,45 @@ interface CartesianGridProps extends InternalCartesianGridProps {
 
 export type Props = SVGProps<SVGElement> & CartesianGridProps;
 
+const Background = (props: Pick<SVGProps<SVGElement>, 'fill' | 'fillOpacity' | 'x' | 'y' | 'width' | 'height'>) => {
+  const { fill } = props;
+
+  if (!fill || fill === 'none') {
+    return null;
+  }
+
+  const { fillOpacity, x, y, width, height } = props;
+
+  return (
+    <rect
+      x={x}
+      y={y}
+      width={width}
+      height={height}
+      stroke="none"
+      fill={fill}
+      fillOpacity={fillOpacity}
+      className="recharts-cartesian-grid-bg"
+    />
+  );
+};
+
 export class CartesianGrid extends PureComponent<Props> {
   static displayName = 'CartesianGrid';
 
-  static defaultProps = {
+  static defaultProps: Partial<Props> = {
     horizontal: true,
     vertical: true,
     // The ordinates of horizontal grid lines
-    horizontalPoints: [] as CartesianGridProps['horizontalPoints'],
+    horizontalPoints: [],
     // The abscissas of vertical grid lines
-    verticalPoints: [] as CartesianGridProps['verticalPoints'],
+    verticalPoints: [],
 
     stroke: '#ccc',
     fill: 'none',
     // The fill of colors of grid lines
-    verticalFill: [] as CartesianGridProps['verticalFill'],
-    horizontalFill: [] as CartesianGridProps['horizontalFill'],
+    verticalFill: [],
+    horizontalFill: [],
   };
 
   static renderLineItem(option: GridLineType, props: any) {
@@ -244,29 +273,6 @@ export class CartesianGrid extends PureComponent<Props> {
     return <g className="recharts-cartesian-gridstripes-horizontal">{items}</g>;
   }
 
-  renderBackground() {
-    const { fill } = this.props;
-
-    if (!fill || fill === 'none') {
-      return null;
-    }
-
-    const { fillOpacity, x, y, width, height } = this.props;
-
-    return (
-      <rect
-        x={x}
-        y={y}
-        width={width}
-        height={height}
-        stroke="none"
-        fill={fill}
-        fillOpacity={fillOpacity}
-        className="recharts-cartesian-grid-bg"
-      />
-    );
-  }
-
   render() {
     const {
       x,
@@ -344,7 +350,14 @@ export class CartesianGrid extends PureComponent<Props> {
 
     return (
       <g className="recharts-cartesian-grid">
-        {this.renderBackground()}
+        <Background
+          fill={this.props.fill}
+          fillOpacity={this.props.fillOpacity}
+          x={this.props.x}
+          y={this.props.y}
+          width={this.props.width}
+          height={this.props.height}
+        />
         {horizontal && this.renderHorizontal(horizontalPoints)}
         {vertical && this.renderVertical(verticalPoints)}
 

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -95,6 +95,22 @@ const Background = (props: Pick<SVGProps<SVGElement>, 'fill' | 'fillOpacity' | '
   );
 };
 
+function renderLineItem(option: GridLineType, props: any) {
+  let lineItem;
+
+  if (React.isValidElement(option)) {
+    lineItem = React.cloneElement(option, props);
+  } else if (isFunction(option)) {
+    lineItem = option(props);
+  } else {
+    const { x1, y1, x2, y2, key, ...others } = props;
+    const { offset: __, ...restOfFilteredProps } = filterProps(others, false);
+    lineItem = <line {...restOfFilteredProps} x1={x1} y1={y1} x2={x2} y2={y2} fill="none" key={key} />;
+  }
+
+  return lineItem;
+}
+
 export class CartesianGrid extends PureComponent<Props> {
   static displayName = 'CartesianGrid';
 
@@ -112,22 +128,6 @@ export class CartesianGrid extends PureComponent<Props> {
     verticalFill: [],
     horizontalFill: [],
   };
-
-  static renderLineItem(option: GridLineType, props: any) {
-    let lineItem;
-
-    if (React.isValidElement(option)) {
-      lineItem = React.cloneElement(option, props);
-    } else if (isFunction(option)) {
-      lineItem = option(props);
-    } else {
-      const { x1, y1, x2, y2, key, ...others } = props;
-      const { offset: __, ...restOfFilteredProps } = filterProps(others, false);
-      lineItem = <line {...restOfFilteredProps} x1={x1} y1={y1} x2={x2} y2={y2} fill="none" key={key} />;
-    }
-
-    return lineItem;
-  }
 
   /**
    * Draw the horizontal grid lines
@@ -152,7 +152,7 @@ export class CartesianGrid extends PureComponent<Props> {
         index: i,
       };
 
-      return CartesianGrid.renderLineItem(horizontal, props);
+      return renderLineItem(horizontal, props);
     });
 
     return <g className="recharts-cartesian-grid-horizontal">{items}</g>;
@@ -181,7 +181,7 @@ export class CartesianGrid extends PureComponent<Props> {
         index: i,
       };
 
-      return CartesianGrid.renderLineItem(vertical, props);
+      return renderLineItem(vertical, props);
     });
 
     return <g className="recharts-cartesian-grid-vertical">{items}</g>;

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -732,7 +732,7 @@ describe('<CartesianGrid />', () => {
     const emptyFillCases: { fill: string[] | undefined }[] = [{ fill: [] }, { fill: undefined }];
 
     describe('horizontal stripes', () => {
-      it('should render horizontal stripes', () => {
+      test.each([true, undefined])('should render horizontal stripes if horizontal prop = %s', horizontal => {
         const extraSpaceAtTheTopOfChart = 1;
         const { container } = render(
           <CartesianGrid
@@ -744,6 +744,7 @@ describe('<CartesianGrid />', () => {
             horizontalPoints={horizontalPoints}
             horizontalFill={['red', 'green']}
             fillOpacity="20%"
+            horizontal={horizontal}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
@@ -780,6 +781,60 @@ describe('<CartesianGrid />', () => {
         expect(allStripes[5]).toHaveAttribute('fill', 'green');
         expect(allStripes[5]).toHaveAttribute('y', '400');
         expect(allStripes[5]).toHaveAttribute('height', String(extraSpaceAtTheTopOfChart));
+      });
+
+      it('should render one big stripe if there are no horizontalPoints', () => {
+        const { container } = render(
+          <CartesianGrid x={0} y={0} width={500} height={500} horizontalFill={['red', 'green']} />,
+        );
+        const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
+        expect(allStripes).toHaveLength(1);
+        expect.soft(allStripes[0]).toHaveAttribute('width', '500');
+        expect.soft(allStripes[0]).toHaveAttribute('height', '500');
+        expect.soft(allStripes[0]).toHaveAttribute('x', '0');
+        expect.soft(allStripes[0]).toHaveAttribute('y', '0');
+        expect.soft(allStripes[0]).toHaveAttribute('fill', 'red');
+      });
+
+      it('should render stripes defined by horizontalCoordinatesGenerator', () => {
+        const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
+        const { container, debug } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
+              horizontalFill={['red', 'green']}
+            />
+          </Surface>,
+        );
+        debug();
+
+        expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
+
+        const allLines = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
+        expect(allLines).toHaveLength(3);
+      });
+
+      it('should not render anything if horizontal=false', () => {
+        const extraSpaceAtTheTopOfChart = 1;
+        const { container } = render(
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={Math.max(...horizontalPoints) + extraSpaceAtTheTopOfChart}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+            horizontalFill={['red', 'green']}
+            fillOpacity="20%"
+            horizontal={false}
+          />,
+        );
+        const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
+        expect(allStripes).toHaveLength(0);
       });
 
       test.each(emptyFillCases)('should render nothing if horizontalFill is $fill', ({ fill }) => {

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -38,10 +38,19 @@ describe('<CartesianGrid />', () => {
     expect(container.querySelectorAll('line')).toHaveLength(0);
   });
 
-  test("Don't render any lines when width or height is smaller than 0", () => {
+  test.each([0, -1, NaN, Infinity])("Don't render any lines when width is %s", w => {
     const { container } = render(
       <Surface width={500} height={500}>
-        <CartesianGrid width={0} height={500} />
+        <CartesianGrid width={w} height={500} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
+      </Surface>,
+    );
+    expect(container.querySelectorAll('line')).toHaveLength(0);
+  });
+
+  test.each([0, -1, NaN, Infinity])("Don't render any lines when height is %s", h => {
+    const { container } = render(
+      <Surface width={500} height={500}>
+        <CartesianGrid width={h} height={500} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
       </Surface>,
     );
     expect(container.querySelectorAll('line')).toHaveLength(0);
@@ -77,6 +86,94 @@ describe('<CartesianGrid />', () => {
           width={500}
           height={500}
           horizontal
+          verticalPoints={verticalPoints}
+          horizontalPoints={horizontalPoints}
+        />
+      </Surface>,
+    );
+    expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+    expect
+      .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+      .toHaveLength(horizontalPoints.length);
+    expect
+      .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+      .toHaveLength(verticalPoints.length);
+  });
+
+  it('should render all lines if horizontal is undefined', () => {
+    const { container } = render(
+      <Surface width={500} height={500}>
+        <CartesianGrid
+          x={0}
+          y={0}
+          width={500}
+          height={500}
+          verticalPoints={verticalPoints}
+          horizontalPoints={horizontalPoints}
+        />
+      </Surface>,
+    );
+    expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+    expect
+      .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+      .toHaveLength(horizontalPoints.length);
+    expect
+      .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+      .toHaveLength(verticalPoints.length);
+  });
+
+  it('should not render any lines if vertical=false', () => {
+    const { container } = render(
+      <Surface width={500} height={500}>
+        <CartesianGrid
+          x={0}
+          y={0}
+          width={500}
+          height={500}
+          vertical={false}
+          verticalPoints={verticalPoints}
+          horizontalPoints={horizontalPoints}
+        />
+      </Surface>,
+    );
+    expect.soft(container.querySelectorAll('line')).toHaveLength(horizontalPoints.length);
+    expect
+      .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+      .toHaveLength(horizontalPoints.length);
+    expect.soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line')).toHaveLength(0);
+  });
+
+  it('should render all lines if vertical=true', () => {
+    const { container } = render(
+      <Surface width={500} height={500}>
+        <CartesianGrid
+          x={0}
+          y={0}
+          width={500}
+          height={500}
+          vertical
+          verticalPoints={verticalPoints}
+          horizontalPoints={horizontalPoints}
+        />
+      </Surface>,
+    );
+    expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+    expect
+      .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+      .toHaveLength(horizontalPoints.length);
+    expect
+      .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+      .toHaveLength(verticalPoints.length);
+  });
+
+  it('should render all lines if vertical is undefined', () => {
+    const { container } = render(
+      <Surface width={500} height={500}>
+        <CartesianGrid
+          x={0}
+          y={0}
+          width={500}
+          height={500}
           verticalPoints={verticalPoints}
           horizontalPoints={horizontalPoints}
         />

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { describe, test, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { scaleLinear } from 'victory-vendor/d3-scale';
-import { Surface, CartesianGrid } from '../../src';
+import { Surface, CartesianGrid, LineChart } from '../../src';
 import { HorizontalCoordinatesGenerator, Props, VerticalCoordinatesGenerator } from '../../src/cartesian/CartesianGrid';
 
 describe('<CartesianGrid />', () => {
@@ -503,7 +503,7 @@ describe('<CartesianGrid />', () => {
         expect.soft(allLines[0]).toHaveAttribute('y1', '0');
         expect.soft(allLines[0]).toHaveAttribute('y2', '500');
         expect.soft(allLines[1]).toHaveAttribute('x', '0');
-        expect.soft(allLines[1]).toHaveAttribute('x2', '2');
+        expect.soft(allLines[1]).toHaveAttribute('x1', '2');
         expect.soft(allLines[1]).toHaveAttribute('x2', '2');
         expect.soft(allLines[1]).toHaveAttribute('y', '0');
         expect.soft(allLines[1]).toHaveAttribute('y1', '0');
@@ -724,7 +724,32 @@ describe('<CartesianGrid />', () => {
         },
       );
 
-      it.todo('should generate its own ticks if neither verticalPoints nor verticalCoordinatesGenerator are provided');
+      it('should generate its own ticks if neither verticalPoints nor verticalCoordinatesGenerator are provided', () => {
+        const xAxis: Props['xAxis'] = {
+          scale: scaleLinear(),
+          ticks: [10, 50, 100],
+        };
+        const { container } = render(
+          <LineChart width={500} height={500}>
+            <CartesianGrid x={0} y={0} width={500} height={500} xAxis={xAxis} />
+          </LineChart>,
+        );
+
+        const allLines = container.querySelectorAll('.recharts-cartesian-grid-vertical line');
+        expect(allLines).toHaveLength(2);
+        expect.soft(allLines[0]).toHaveAttribute('x', '0');
+        expect.soft(allLines[0]).toHaveAttribute('x1', '5');
+        expect.soft(allLines[0]).toHaveAttribute('x2', '5');
+        expect.soft(allLines[0]).toHaveAttribute('y', '0');
+        expect.soft(allLines[0]).toHaveAttribute('y1', '0');
+        expect.soft(allLines[0]).toHaveAttribute('y2', '500');
+        expect.soft(allLines[1]).toHaveAttribute('x', '0');
+        expect.soft(allLines[1]).toHaveAttribute('x1', '495');
+        expect.soft(allLines[1]).toHaveAttribute('x2', '495');
+        expect.soft(allLines[1]).toHaveAttribute('y', '0');
+        expect.soft(allLines[1]).toHaveAttribute('y1', '0');
+        expect.soft(allLines[1]).toHaveAttribute('y2', '500');
+      });
     });
   });
 
@@ -798,7 +823,7 @@ describe('<CartesianGrid />', () => {
 
       it('should render stripes defined by horizontalCoordinatesGenerator', () => {
         const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
-        const { container, debug } = render(
+        const { container } = render(
           <Surface width={500} height={500}>
             <CartesianGrid
               x={0}
@@ -810,7 +835,6 @@ describe('<CartesianGrid />', () => {
             />
           </Surface>,
         );
-        debug();
 
         expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
 

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -286,7 +286,6 @@ describe('<CartesianGrid />', () => {
           scale: scaleLinear(),
           ticks: ['x', 'y', 'x'],
         };
-        // @ts-expect-error Recharts offset type conflicts with SVG offset type
         const offset: Props['offset'] = {};
         render(
           <Surface width={500} height={500}>
@@ -323,7 +322,6 @@ describe('<CartesianGrid />', () => {
           scale: scaleLinear(),
           ticks: ['x', 'y', 'x'],
         };
-        // @ts-expect-error Recharts offset type conflicts with SVG offset type
         const offset: Props['offset'] = {};
         render(
           <Surface width={500} height={500}>
@@ -367,7 +365,6 @@ describe('<CartesianGrid />', () => {
           const yAxis: Props['yAxis'] = {
             scale: scaleLinear(),
           };
-          // @ts-expect-error Recharts offset type conflicts with SVG offset type
           const offset: Props['offset'] = {};
           render(
             <Surface width={500} height={500}>
@@ -412,7 +409,6 @@ describe('<CartesianGrid />', () => {
           const yAxis: Props['yAxis'] = {
             scale: scaleLinear(),
           };
-          // @ts-expect-error Recharts offset type conflicts with SVG offset type
           const offset: Props['offset'] = {};
           render(
             <Surface width={500} height={500}>
@@ -561,7 +557,6 @@ describe('<CartesianGrid />', () => {
           scale: scaleLinear(),
           ticks: ['x', 'y', 'x'],
         };
-        // @ts-expect-error Recharts offset type conflicts with SVG offset type
         const offset: Props['offset'] = {};
         render(
           <Surface width={500} height={500}>
@@ -598,7 +593,6 @@ describe('<CartesianGrid />', () => {
           scale: scaleLinear(),
           ticks: ['x', 'y', 'x'],
         };
-        // @ts-expect-error Recharts offset type conflicts with SVG offset type
         const offset: Props['offset'] = {};
         render(
           <Surface width={500} height={500}>
@@ -642,7 +636,6 @@ describe('<CartesianGrid />', () => {
           const xAxis: Props['xAxis'] = {
             scale: scaleLinear(),
           };
-          // @ts-expect-error Recharts offset type conflicts with SVG offset type
           const offset: Props['offset'] = {};
           render(
             <Surface width={500} height={500}>
@@ -687,7 +680,6 @@ describe('<CartesianGrid />', () => {
           const xAxis: Props['xAxis'] = {
             scale: scaleLinear(),
           };
-          // @ts-expect-error Recharts offset type conflicts with SVG offset type
           const offset: Props['offset'] = {};
           render(
             <Surface width={500} height={500}>
@@ -1268,6 +1260,41 @@ describe('<CartesianGrid />', () => {
         expect.soft(allStripes[2]).toHaveAttribute('x', '20');
         expect.soft(allStripes[2]).toHaveAttribute('y', '0');
       });
+    });
+  });
+
+  describe('offset prop', () => {
+    it('should not pass the offset prop anywhere', () => {
+      const offset: Props['offset'] = {
+        top: 1,
+        bottom: 2,
+        left: 3,
+        right: 4,
+        width: 5,
+        height: 6,
+        brushBottom: 7,
+      };
+      const { container } = render(
+        <Surface width={500} height={500}>
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={500}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+            offset={offset}
+          />
+        </Surface>,
+      );
+      // select everything
+      const allElements = container.querySelectorAll('*');
+      // check that the selector worked
+      expect(allElements).toHaveLength(15);
+      for (let i = 0; i < allElements.length; i++) {
+        const element = allElements[0];
+        expect(element).not.toHaveAttribute('offset');
+      }
     });
   });
 });

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -472,9 +472,32 @@ describe('<CartesianGrid />', () => {
         },
       );
 
-      it.todo(
-        'should generate its own ticks if neither horizontalPoints nor horizontalCoordinatesGenerator are provided',
-      );
+      it('should generate its own ticks if neither horizontalPoints nor horizontalCoordinatesGenerator are provided', () => {
+        const xAxis: Props['xAxis'] = {
+          scale: scaleLinear(),
+          ticks: [10, 50, 100],
+        };
+        const { container } = render(
+          <LineChart width={500} height={500}>
+            <CartesianGrid x={0} y={0} width={500} height={500} xAxis={xAxis} />
+          </LineChart>,
+        );
+
+        const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
+        expect(allLines).toHaveLength(2);
+        expect.soft(allLines[0]).toHaveAttribute('x', '0');
+        expect.soft(allLines[0]).toHaveAttribute('x1', '0');
+        expect.soft(allLines[0]).toHaveAttribute('x2', '500');
+        expect.soft(allLines[0]).toHaveAttribute('y', '0');
+        expect.soft(allLines[0]).toHaveAttribute('y1', '5');
+        expect.soft(allLines[0]).toHaveAttribute('y2', '5');
+        expect.soft(allLines[1]).toHaveAttribute('x', '0');
+        expect.soft(allLines[1]).toHaveAttribute('x1', '0');
+        expect.soft(allLines[1]).toHaveAttribute('x2', '500');
+        expect.soft(allLines[1]).toHaveAttribute('y', '0');
+        expect.soft(allLines[1]).toHaveAttribute('y1', '495');
+        expect.soft(allLines[1]).toHaveAttribute('y2', '495');
+      });
     });
 
     describe('verticalCoordinatesGenerator', () => {

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -7,184 +7,193 @@ describe('<CartesianGrid />', () => {
   const horizontalPoints = [10, 20, 30, 100, 400];
   const verticalPoints = [100, 200, 300, 400];
 
-  test('Render 5 horizontal lines and 4 vertical lines in simple CartesianGrid', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
-        <CartesianGrid
-          x={0}
-          y={0}
-          width={500}
-          height={500}
-          verticalPoints={verticalPoints}
-          horizontalPoints={horizontalPoints}
-        />
-      </Surface>,
-    );
-    expect.soft(container.querySelectorAll('line')).toHaveLength(9);
-    expect
-      .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-      .toHaveLength(horizontalPoints.length);
-    expect
-      .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-      .toHaveLength(verticalPoints.length);
+  describe('basic features', () => {
+    test('Render 5 horizontal lines and 4 vertical lines in simple CartesianGrid', () => {
+      const { container } = render(
+        <Surface width={500} height={500}>
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={500}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+          />
+        </Surface>,
+      );
+      expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+      expect
+        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+        .toHaveLength(horizontalPoints.length);
+      expect
+        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+        .toHaveLength(verticalPoints.length);
+    });
+
+    test("Don't render any lines when verticalPoints and horizontalPoints are empty", () => {
+      const { container } = render(
+        <Surface width={500} height={500}>
+          <CartesianGrid width={500} height={500} />
+        </Surface>,
+      );
+      expect(container.querySelectorAll('line')).toHaveLength(0);
+    });
+
+    test.each([0, -1, NaN, Infinity])("Don't render any lines when width is %s", w => {
+      const { container } = render(
+        <Surface width={500} height={500}>
+          <CartesianGrid width={w} height={500} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
+        </Surface>,
+      );
+      expect(container.querySelectorAll('line')).toHaveLength(0);
+    });
+
+    test.each([0, -1, NaN, Infinity])("Don't render any lines when height is %s", h => {
+      const { container } = render(
+        <Surface width={500} height={500}>
+          <CartesianGrid width={h} height={500} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
+        </Surface>,
+      );
+      expect(container.querySelectorAll('line')).toHaveLength(0);
+    });
   });
 
-  test("Don't render any lines when verticalPoints and horizontalPoints are empty", () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
-        <CartesianGrid width={500} height={500} />
-      </Surface>,
-    );
-    expect(container.querySelectorAll('line')).toHaveLength(0);
+  describe('horizontalPoints without generator', () => {
+    it('should not render any lines if horizontal=false', () => {
+      const { container } = render(
+        <Surface width={500} height={500}>
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={500}
+            horizontal={false}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+          />
+        </Surface>,
+      );
+      expect.soft(container.querySelectorAll('line')).toHaveLength(verticalPoints.length);
+      expect.soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line')).toHaveLength(0);
+      expect
+        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+        .toHaveLength(verticalPoints.length);
+    });
+
+    it('should render all lines if horizontal=true', () => {
+      const { container } = render(
+        <Surface width={500} height={500}>
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={500}
+            horizontal
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+          />
+        </Surface>,
+      );
+      expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+      expect
+        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+        .toHaveLength(horizontalPoints.length);
+      expect
+        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+        .toHaveLength(verticalPoints.length);
+    });
+
+    it('should render all lines if horizontal is undefined', () => {
+      const { container } = render(
+        <Surface width={500} height={500}>
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={500}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+          />
+        </Surface>,
+      );
+      expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+      expect
+        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+        .toHaveLength(horizontalPoints.length);
+      expect
+        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+        .toHaveLength(verticalPoints.length);
+    });
   });
 
-  test.each([0, -1, NaN, Infinity])("Don't render any lines when width is %s", w => {
-    const { container } = render(
-      <Surface width={500} height={500}>
-        <CartesianGrid width={w} height={500} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
-      </Surface>,
-    );
-    expect(container.querySelectorAll('line')).toHaveLength(0);
+  describe('verticalPoints without generator', () => {
+    it('should not render any lines if vertical=false', () => {
+      const { container } = render(
+        <Surface width={500} height={500}>
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={500}
+            vertical={false}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+          />
+        </Surface>,
+      );
+      expect.soft(container.querySelectorAll('line')).toHaveLength(horizontalPoints.length);
+      expect
+        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+        .toHaveLength(horizontalPoints.length);
+      expect.soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line')).toHaveLength(0);
+    });
+
+    it('should render all lines if vertical=true', () => {
+      const { container } = render(
+        <Surface width={500} height={500}>
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={500}
+            vertical
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+          />
+        </Surface>,
+      );
+      expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+      expect
+        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+        .toHaveLength(horizontalPoints.length);
+      expect
+        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+        .toHaveLength(verticalPoints.length);
+    });
+
+    it('should render all lines if vertical is undefined', () => {
+      const { container } = render(
+        <Surface width={500} height={500}>
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={500}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+          />
+        </Surface>,
+      );
+      expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+      expect
+        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+        .toHaveLength(horizontalPoints.length);
+      expect
+        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+        .toHaveLength(verticalPoints.length);
+    });
   });
 
-  test.each([0, -1, NaN, Infinity])("Don't render any lines when height is %s", h => {
-    const { container } = render(
-      <Surface width={500} height={500}>
-        <CartesianGrid width={h} height={500} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
-      </Surface>,
-    );
-    expect(container.querySelectorAll('line')).toHaveLength(0);
-  });
-
-  it('should not render any lines if horizontal=false', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
-        <CartesianGrid
-          x={0}
-          y={0}
-          width={500}
-          height={500}
-          horizontal={false}
-          verticalPoints={verticalPoints}
-          horizontalPoints={horizontalPoints}
-        />
-      </Surface>,
-    );
-    expect.soft(container.querySelectorAll('line')).toHaveLength(verticalPoints.length);
-    expect.soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line')).toHaveLength(0);
-    expect
-      .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-      .toHaveLength(verticalPoints.length);
-  });
-
-  it('should render all lines if horizontal=true', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
-        <CartesianGrid
-          x={0}
-          y={0}
-          width={500}
-          height={500}
-          horizontal
-          verticalPoints={verticalPoints}
-          horizontalPoints={horizontalPoints}
-        />
-      </Surface>,
-    );
-    expect.soft(container.querySelectorAll('line')).toHaveLength(9);
-    expect
-      .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-      .toHaveLength(horizontalPoints.length);
-    expect
-      .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-      .toHaveLength(verticalPoints.length);
-  });
-
-  it('should render all lines if horizontal is undefined', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
-        <CartesianGrid
-          x={0}
-          y={0}
-          width={500}
-          height={500}
-          verticalPoints={verticalPoints}
-          horizontalPoints={horizontalPoints}
-        />
-      </Surface>,
-    );
-    expect.soft(container.querySelectorAll('line')).toHaveLength(9);
-    expect
-      .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-      .toHaveLength(horizontalPoints.length);
-    expect
-      .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-      .toHaveLength(verticalPoints.length);
-  });
-
-  it('should not render any lines if vertical=false', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
-        <CartesianGrid
-          x={0}
-          y={0}
-          width={500}
-          height={500}
-          vertical={false}
-          verticalPoints={verticalPoints}
-          horizontalPoints={horizontalPoints}
-        />
-      </Surface>,
-    );
-    expect.soft(container.querySelectorAll('line')).toHaveLength(horizontalPoints.length);
-    expect
-      .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-      .toHaveLength(horizontalPoints.length);
-    expect.soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line')).toHaveLength(0);
-  });
-
-  it('should render all lines if vertical=true', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
-        <CartesianGrid
-          x={0}
-          y={0}
-          width={500}
-          height={500}
-          vertical
-          verticalPoints={verticalPoints}
-          horizontalPoints={horizontalPoints}
-        />
-      </Surface>,
-    );
-    expect.soft(container.querySelectorAll('line')).toHaveLength(9);
-    expect
-      .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-      .toHaveLength(horizontalPoints.length);
-    expect
-      .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-      .toHaveLength(verticalPoints.length);
-  });
-
-  it('should render all lines if vertical is undefined', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
-        <CartesianGrid
-          x={0}
-          y={0}
-          width={500}
-          height={500}
-          verticalPoints={verticalPoints}
-          horizontalPoints={horizontalPoints}
-        />
-      </Surface>,
-    );
-    expect.soft(container.querySelectorAll('line')).toHaveLength(9);
-    expect
-      .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-      .toHaveLength(horizontalPoints.length);
-    expect
-      .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-      .toHaveLength(verticalPoints.length);
-  });
+  describe.todo('horizontalCoordinatesGenerator');
+  describe.todo('verticalCoordinatesGenerator');
 });

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -7,443 +7,479 @@ import { HorizontalCoordinatesGenerator, Props, VerticalCoordinatesGenerator } f
 
 describe('<CartesianGrid />', () => {
   const horizontalPoints = [10, 20, 30, 100, 400];
+  /**
+   * JavaScript produces numbers like this when multiplying floats, for example:
+   * 1.1 * 1.1 * 100
+   * 1.1 * 2.1 * 100
+   */
+  const floatingPointPrecisionExamples = [121.00000000000002, 231.00000000000005];
   const verticalPoints = [100, 200, 300, 400];
 
-  describe('basic features', () => {
-    it('should render on its own, outside of Recharts', () => {
-      const { container } = render(
-        <CartesianGrid
-          x={0}
-          y={0}
-          width={500}
-          height={500}
-          verticalPoints={verticalPoints}
-          horizontalPoints={horizontalPoints}
-        />,
-      );
-      expect.soft(container.querySelectorAll('line')).toHaveLength(9);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-        .toHaveLength(horizontalPoints.length);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-        .toHaveLength(verticalPoints.length);
+  describe('grid', () => {
+    describe('basic features', () => {
+      it('should render on its own, outside of Recharts', () => {
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              verticalPoints={verticalPoints}
+              horizontalPoints={horizontalPoints}
+            />
+          </Surface>,
+        );
+        expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+          .toHaveLength(horizontalPoints.length);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+          .toHaveLength(verticalPoints.length);
+      });
+
+      test('Render 5 horizontal lines and 4 vertical lines in simple CartesianGrid', () => {
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              verticalPoints={verticalPoints}
+              horizontalPoints={horizontalPoints}
+            />
+          </Surface>,
+        );
+        expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+          .toHaveLength(horizontalPoints.length);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+          .toHaveLength(verticalPoints.length);
+      });
+
+      test("Don't render any lines when verticalPoints and horizontalPoints are empty", () => {
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid width={500} height={500} />
+          </Surface>,
+        );
+        expect(container.querySelectorAll('line')).toHaveLength(0);
+      });
+
+      test.each([0, -1, NaN, Infinity])("Don't render any lines when width is %s", w => {
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid width={w} height={500} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
+          </Surface>,
+        );
+        expect(container.querySelectorAll('line')).toHaveLength(0);
+      });
+
+      test.each([0, -1, NaN, Infinity])("Don't render any lines when height is %s", h => {
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid width={h} height={500} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
+          </Surface>,
+        );
+        expect(container.querySelectorAll('line')).toHaveLength(0);
+      });
     });
 
-    test('Render 5 horizontal lines and 4 vertical lines in simple CartesianGrid', () => {
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            verticalPoints={verticalPoints}
-            horizontalPoints={horizontalPoints}
-          />
-        </Surface>,
-      );
-      expect.soft(container.querySelectorAll('line')).toHaveLength(9);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-        .toHaveLength(horizontalPoints.length);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-        .toHaveLength(verticalPoints.length);
+    describe('horizontalPoints without generator', () => {
+      it('should not render any lines if horizontal=false', () => {
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              horizontal={false}
+              verticalPoints={verticalPoints}
+              horizontalPoints={horizontalPoints}
+            />
+          </Surface>,
+        );
+        expect.soft(container.querySelectorAll('line')).toHaveLength(verticalPoints.length);
+        expect.soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line')).toHaveLength(0);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+          .toHaveLength(verticalPoints.length);
+      });
+
+      it('should render all lines if horizontal=true', () => {
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              horizontal
+              verticalPoints={verticalPoints}
+              horizontalPoints={horizontalPoints}
+            />
+          </Surface>,
+        );
+        expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+          .toHaveLength(horizontalPoints.length);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+          .toHaveLength(verticalPoints.length);
+      });
+
+      it('should render all lines if horizontal is undefined', () => {
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              verticalPoints={verticalPoints}
+              horizontalPoints={horizontalPoints}
+            />
+          </Surface>,
+        );
+        expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+          .toHaveLength(horizontalPoints.length);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+          .toHaveLength(verticalPoints.length);
+      });
     });
 
-    test("Don't render any lines when verticalPoints and horizontalPoints are empty", () => {
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid width={500} height={500} />
-        </Surface>,
-      );
-      expect(container.querySelectorAll('line')).toHaveLength(0);
+    describe('verticalPoints without generator', () => {
+      it('should not render any lines if vertical=false', () => {
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              vertical={false}
+              verticalPoints={verticalPoints}
+              horizontalPoints={horizontalPoints}
+            />
+          </Surface>,
+        );
+        expect.soft(container.querySelectorAll('line')).toHaveLength(horizontalPoints.length);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+          .toHaveLength(horizontalPoints.length);
+        expect.soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line')).toHaveLength(0);
+      });
+
+      it('should render all lines if vertical=true', () => {
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              vertical
+              verticalPoints={verticalPoints}
+              horizontalPoints={horizontalPoints}
+            />
+          </Surface>,
+        );
+        expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+          .toHaveLength(horizontalPoints.length);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+          .toHaveLength(verticalPoints.length);
+      });
+
+      it('should render all lines if vertical is undefined', () => {
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              verticalPoints={verticalPoints}
+              horizontalPoints={horizontalPoints}
+            />
+          </Surface>,
+        );
+        expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+          .toHaveLength(horizontalPoints.length);
+        expect
+          .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+          .toHaveLength(verticalPoints.length);
+      });
     });
 
-    test.each([0, -1, NaN, Infinity])("Don't render any lines when width is %s", w => {
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid width={w} height={500} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
-        </Surface>,
-      );
-      expect(container.querySelectorAll('line')).toHaveLength(0);
-    });
+    describe('horizontalCoordinatesGenerator', () => {
+      it('should render lines that the generator returns', () => {
+        const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
+            />
+          </Surface>,
+        );
 
-    test.each([0, -1, NaN, Infinity])("Don't render any lines when height is %s", h => {
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid width={h} height={500} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
-        </Surface>,
-      );
-      expect(container.querySelectorAll('line')).toHaveLength(0);
-    });
-  });
+        expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
 
-  describe('horizontalPoints without generator', () => {
-    it('should not render any lines if horizontal=false', () => {
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            horizontal={false}
-            verticalPoints={verticalPoints}
-            horizontalPoints={horizontalPoints}
-          />
-        </Surface>,
-      );
-      expect.soft(container.querySelectorAll('line')).toHaveLength(verticalPoints.length);
-      expect.soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line')).toHaveLength(0);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-        .toHaveLength(verticalPoints.length);
-    });
+        const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
+        expect(allLines).toHaveLength(2);
+        expect.soft(allLines[0]).toHaveAttribute('x', '0');
+        expect.soft(allLines[0]).toHaveAttribute('x1', '0');
+        expect.soft(allLines[0]).toHaveAttribute('x2', '500');
+        expect.soft(allLines[0]).toHaveAttribute('y', '0');
+        expect.soft(allLines[0]).toHaveAttribute('y1', '1');
+        expect.soft(allLines[0]).toHaveAttribute('y2', '1');
+        expect.soft(allLines[1]).toHaveAttribute('x', '0');
+        expect.soft(allLines[1]).toHaveAttribute('x1', '0');
+        expect.soft(allLines[1]).toHaveAttribute('x2', '500');
+        expect.soft(allLines[1]).toHaveAttribute('y', '0');
+        expect.soft(allLines[1]).toHaveAttribute('y1', '2');
+        expect.soft(allLines[1]).toHaveAttribute('y2', '2');
+      });
 
-    it('should render all lines if horizontal=true', () => {
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            horizontal
-            verticalPoints={verticalPoints}
-            horizontalPoints={horizontalPoints}
-          />
-        </Surface>,
-      );
-      expect.soft(container.querySelectorAll('line')).toHaveLength(9);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-        .toHaveLength(horizontalPoints.length);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-        .toHaveLength(verticalPoints.length);
-    });
+      it('if both horizontalCoordinatesGenerator and horizontalPoints are present then horizontalPoints win', () => {
+        const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
+        expect(horizontalPoints.length).not.toBe(2);
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
+              horizontalPoints={horizontalPoints}
+            />
+          </Surface>,
+        );
 
-    it('should render all lines if horizontal is undefined', () => {
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            verticalPoints={verticalPoints}
-            horizontalPoints={horizontalPoints}
-          />
-        </Surface>,
-      );
-      expect.soft(container.querySelectorAll('line')).toHaveLength(9);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-        .toHaveLength(horizontalPoints.length);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-        .toHaveLength(verticalPoints.length);
-    });
-  });
+        expect(horizontalCoordinatesGenerator).not.toHaveBeenCalled();
 
-  describe('verticalPoints without generator', () => {
-    it('should not render any lines if vertical=false', () => {
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            vertical={false}
-            verticalPoints={verticalPoints}
-            horizontalPoints={horizontalPoints}
-          />
-        </Surface>,
-      );
-      expect.soft(container.querySelectorAll('line')).toHaveLength(horizontalPoints.length);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-        .toHaveLength(horizontalPoints.length);
-      expect.soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line')).toHaveLength(0);
-    });
+        const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
+        expect(allLines).toHaveLength(horizontalPoints.length);
+      });
 
-    it('should render all lines if vertical=true', () => {
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            vertical
-            verticalPoints={verticalPoints}
-            horizontalPoints={horizontalPoints}
-          />
-        </Surface>,
-      );
-      expect.soft(container.querySelectorAll('line')).toHaveLength(9);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-        .toHaveLength(horizontalPoints.length);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-        .toHaveLength(verticalPoints.length);
-    });
+      it('should pass props to the generator', () => {
+        const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([]);
+        const yAxis: Props['yAxis'] = {
+          scale: scaleLinear(),
+          ticks: ['x', 'y', 'x'],
+        };
+        // @ts-expect-error Recharts offset type conflicts with SVG offset type
+        const offset: Props['offset'] = {};
+        render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              yAxis={yAxis}
+              horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
+              chartWidth={300}
+              chartHeight={200}
+              offset={offset}
+            />
+          </Surface>,
+        );
 
-    it('should render all lines if vertical is undefined', () => {
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            verticalPoints={verticalPoints}
-            horizontalPoints={horizontalPoints}
-          />
-        </Surface>,
-      );
-      expect.soft(container.querySelectorAll('line')).toHaveLength(9);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
-        .toHaveLength(horizontalPoints.length);
-      expect
-        .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
-        .toHaveLength(verticalPoints.length);
-    });
-  });
+        expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
+        expect(horizontalCoordinatesGenerator).toHaveBeenCalledWith(
+          {
+            yAxis,
+            width: 300,
+            height: 200,
+            offset,
+          },
+          undefined,
+        );
+      });
 
-  describe('horizontalCoordinatesGenerator', () => {
-    it('should render lines that the generator returns', () => {
-      const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-          />
-        </Surface>,
-      );
-
-      expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
-
-      const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
-      expect(allLines).toHaveLength(2);
-      expect.soft(allLines[0]).toHaveAttribute('x', '0');
-      expect.soft(allLines[0]).toHaveAttribute('x1', '0');
-      expect.soft(allLines[0]).toHaveAttribute('x2', '500');
-      expect.soft(allLines[0]).toHaveAttribute('y', '0');
-      expect.soft(allLines[0]).toHaveAttribute('y1', '1');
-      expect.soft(allLines[0]).toHaveAttribute('y2', '1');
-      expect.soft(allLines[1]).toHaveAttribute('x', '0');
-      expect.soft(allLines[1]).toHaveAttribute('x1', '0');
-      expect.soft(allLines[1]).toHaveAttribute('x2', '500');
-      expect.soft(allLines[1]).toHaveAttribute('y', '0');
-      expect.soft(allLines[1]).toHaveAttribute('y1', '2');
-      expect.soft(allLines[1]).toHaveAttribute('y2', '2');
-    });
-
-    it('if both horizontalCoordinatesGenerator and horizontalPoints are present then horizontalPoints win', () => {
-      const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
-      expect(horizontalPoints.length).not.toBe(2);
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-            horizontalPoints={horizontalPoints}
-          />
-        </Surface>,
-      );
-
-      expect(horizontalCoordinatesGenerator).not.toHaveBeenCalled();
-
-      const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
-      expect(allLines).toHaveLength(horizontalPoints.length);
-    });
-
-    it('should pass props to the generator', () => {
-      const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([]);
-      const yAxis: Props['yAxis'] = {
-        scale: scaleLinear(),
-        ticks: ['x', 'y', 'x'],
-      };
-      // @ts-expect-error Recharts offset type conflicts with SVG offset type
-      const offset: Props['offset'] = {};
-      render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            yAxis={yAxis}
-            horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-            chartWidth={300}
-            chartHeight={200}
-            offset={offset}
-          />
-        </Surface>,
-      );
-
-      expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
-      expect(horizontalCoordinatesGenerator).toHaveBeenCalledWith(
-        {
-          yAxis,
-          width: 300,
-          height: 200,
-          offset,
-        },
-        undefined,
-      );
-    });
-
-    it(`should set syncWithTicks=true, and ticks=horizontalValues,
+      it(`should set syncWithTicks=true, and ticks=horizontalValues,
       when horizontalValues is provided, even if the explicit syncWithTicks is false`, () => {
-      const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([]);
-      const yAxis: Props['yAxis'] = {
-        scale: scaleLinear(),
-        ticks: ['x', 'y', 'x'],
-      };
-      // @ts-expect-error Recharts offset type conflicts with SVG offset type
-      const offset: Props['offset'] = {};
-      render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            yAxis={yAxis}
-            horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-            chartWidth={300}
-            chartHeight={200}
-            offset={offset}
-            syncWithTicks={false}
-            horizontalValues={['a', 'b']}
-          />
-        </Surface>,
+        const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([]);
+        const yAxis: Props['yAxis'] = {
+          scale: scaleLinear(),
+          ticks: ['x', 'y', 'x'],
+        };
+        // @ts-expect-error Recharts offset type conflicts with SVG offset type
+        const offset: Props['offset'] = {};
+        render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              yAxis={yAxis}
+              horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
+              chartWidth={300}
+              chartHeight={200}
+              offset={offset}
+              syncWithTicks={false}
+              horizontalValues={['a', 'b']}
+            />
+          </Surface>,
+        );
+
+        const yAxisExpected = {
+          ...yAxis,
+          ticks: ['a', 'b'],
+        };
+
+        expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
+        expect(horizontalCoordinatesGenerator).toHaveBeenCalledWith(
+          {
+            yAxis: yAxisExpected,
+            width: 300,
+            height: 200,
+            offset,
+          },
+          true,
+        );
+      });
+
+      test.each([true, false, undefined])(
+        'should set syncWithTicks as %s when horizontalValues is provided but is empty',
+        syncWithTicks => {
+          const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([]);
+          const yAxis: Props['yAxis'] = {
+            scale: scaleLinear(),
+          };
+          // @ts-expect-error Recharts offset type conflicts with SVG offset type
+          const offset: Props['offset'] = {};
+          render(
+            <Surface width={500} height={500}>
+              <CartesianGrid
+                x={0}
+                y={0}
+                width={500}
+                height={500}
+                yAxis={yAxis}
+                horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
+                chartWidth={300}
+                chartHeight={200}
+                offset={offset}
+                syncWithTicks={syncWithTicks}
+                horizontalValues={[]}
+              />
+            </Surface>,
+          );
+
+          const yAxisExpected = {
+            ...yAxis,
+            ticks: undefined,
+          };
+
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledWith(
+            {
+              yAxis: yAxisExpected,
+              width: 300,
+              height: 200,
+              offset,
+            },
+            syncWithTicks,
+          );
+        },
       );
 
-      const yAxisExpected = {
-        ...yAxis,
-        ticks: ['a', 'b'],
-      };
+      test.each([true, false, undefined])(
+        'should pass props to the generator when syncWithTicks is %s',
+        syncWithTicks => {
+          const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([]);
+          const yAxis: Props['yAxis'] = {
+            scale: scaleLinear(),
+          };
+          // @ts-expect-error Recharts offset type conflicts with SVG offset type
+          const offset: Props['offset'] = {};
+          render(
+            <Surface width={500} height={500}>
+              <CartesianGrid
+                x={0}
+                y={0}
+                width={500}
+                height={500}
+                yAxis={yAxis}
+                horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
+                chartWidth={300}
+                chartHeight={200}
+                offset={offset}
+                syncWithTicks={syncWithTicks}
+              />
+            </Surface>,
+          );
 
-      expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
-      expect(horizontalCoordinatesGenerator).toHaveBeenCalledWith(
-        {
-          yAxis: yAxisExpected,
-          width: 300,
-          height: 200,
-          offset,
+          const yAxisExpected = {
+            ...yAxis,
+            ticks: undefined,
+          };
+
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledWith(
+            {
+              yAxis: yAxisExpected,
+              width: 300,
+              height: 200,
+              offset,
+            },
+            syncWithTicks,
+          );
         },
-        true,
+      );
+
+      test.each([{ gen: [] }, { gen: null }, { gen: undefined }, { gen: 'some random string' }, { gen: NaN }])(
+        'should render nothing if the generator returns $gen',
+        ({ gen }) => {
+          const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue(gen);
+          const { container } = render(
+            <Surface width={500} height={500}>
+              <CartesianGrid
+                x={0}
+                y={0}
+                width={500}
+                height={500}
+                horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
+              />
+            </Surface>,
+          );
+
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
+
+          const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
+          expect(allLines).toHaveLength(0);
+        },
+      );
+
+      it.todo(
+        'should generate its own ticks if neither horizontalPoints nor horizontalCoordinatesGenerator are provided',
       );
     });
 
-    test.each([true, false, undefined])(
-      'should set syncWithTicks as %s when horizontalValues is provided but is empty',
-      syncWithTicks => {
-        const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([]);
-        const yAxis: Props['yAxis'] = {
-          scale: scaleLinear(),
-        };
-        // @ts-expect-error Recharts offset type conflicts with SVG offset type
-        const offset: Props['offset'] = {};
-        render(
-          <Surface width={500} height={500}>
-            <CartesianGrid
-              x={0}
-              y={0}
-              width={500}
-              height={500}
-              yAxis={yAxis}
-              horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-              chartWidth={300}
-              chartHeight={200}
-              offset={offset}
-              syncWithTicks={syncWithTicks}
-              horizontalValues={[]}
-            />
-          </Surface>,
-        );
-
-        const yAxisExpected = {
-          ...yAxis,
-          ticks: undefined,
-        };
-
-        expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
-        expect(horizontalCoordinatesGenerator).toHaveBeenCalledWith(
-          {
-            yAxis: yAxisExpected,
-            width: 300,
-            height: 200,
-            offset,
-          },
-          syncWithTicks,
-        );
-      },
-    );
-
-    test.each([true, false, undefined])(
-      'should pass props to the generator when syncWithTicks is %s',
-      syncWithTicks => {
-        const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([]);
-        const yAxis: Props['yAxis'] = {
-          scale: scaleLinear(),
-        };
-        // @ts-expect-error Recharts offset type conflicts with SVG offset type
-        const offset: Props['offset'] = {};
-        render(
-          <Surface width={500} height={500}>
-            <CartesianGrid
-              x={0}
-              y={0}
-              width={500}
-              height={500}
-              yAxis={yAxis}
-              horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-              chartWidth={300}
-              chartHeight={200}
-              offset={offset}
-              syncWithTicks={syncWithTicks}
-            />
-          </Surface>,
-        );
-
-        const yAxisExpected = {
-          ...yAxis,
-          ticks: undefined,
-        };
-
-        expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
-        expect(horizontalCoordinatesGenerator).toHaveBeenCalledWith(
-          {
-            yAxis: yAxisExpected,
-            width: 300,
-            height: 200,
-            offset,
-          },
-          syncWithTicks,
-        );
-      },
-    );
-
-    test.each([{ gen: [] }, { gen: null }, { gen: undefined }, { gen: 'some random string' }, { gen: NaN }])(
-      'should render nothing if the generator returns $gen',
-      ({ gen }) => {
-        const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue(gen);
+    describe('verticalCoordinatesGenerator', () => {
+      it('should render lines that the generator returns', () => {
+        const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
         const { container } = render(
           <Surface width={500} height={500}>
             <CartesianGrid
@@ -451,264 +487,441 @@ describe('<CartesianGrid />', () => {
               y={0}
               width={500}
               height={500}
-              horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
+              verticalCoordinatesGenerator={verticalCoordinatesGenerator}
             />
           </Surface>,
         );
 
-        expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
+        expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
 
-        const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
-        expect(allLines).toHaveLength(0);
-      },
-    );
+        const allLines = container.querySelectorAll('.recharts-cartesian-grid-vertical line');
+        expect(allLines).toHaveLength(2);
+        expect.soft(allLines[0]).toHaveAttribute('x', '0');
+        expect.soft(allLines[0]).toHaveAttribute('x1', '1');
+        expect.soft(allLines[0]).toHaveAttribute('x2', '1');
+        expect.soft(allLines[0]).toHaveAttribute('y', '0');
+        expect.soft(allLines[0]).toHaveAttribute('y1', '0');
+        expect.soft(allLines[0]).toHaveAttribute('y2', '500');
+        expect.soft(allLines[1]).toHaveAttribute('x', '0');
+        expect.soft(allLines[1]).toHaveAttribute('x2', '2');
+        expect.soft(allLines[1]).toHaveAttribute('x2', '2');
+        expect.soft(allLines[1]).toHaveAttribute('y', '0');
+        expect.soft(allLines[1]).toHaveAttribute('y1', '0');
+        expect.soft(allLines[1]).toHaveAttribute('y2', '500');
+      });
+
+      it('if both verticalCoordinatesGenerator and verticalPoints are present then verticalPoints wins', () => {
+        const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
+        expect(verticalPoints.length).not.toBe(2);
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              verticalCoordinatesGenerator={verticalCoordinatesGenerator}
+              verticalPoints={verticalPoints}
+            />
+          </Surface>,
+        );
+
+        expect(verticalCoordinatesGenerator).not.toHaveBeenCalled();
+
+        const allLines = container.querySelectorAll('.recharts-cartesian-grid-vertical line');
+        expect(allLines).toHaveLength(verticalPoints.length);
+      });
+
+      it('should pass props to the generator', () => {
+        const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([]);
+        const xAxis: Props['xAxis'] = {
+          scale: scaleLinear(),
+          ticks: ['x', 'y', 'x'],
+        };
+        // @ts-expect-error Recharts offset type conflicts with SVG offset type
+        const offset: Props['offset'] = {};
+        render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              xAxis={xAxis}
+              verticalCoordinatesGenerator={verticalCoordinatesGenerator}
+              chartWidth={300}
+              chartHeight={200}
+              offset={offset}
+            />
+          </Surface>,
+        );
+
+        expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
+        expect(verticalCoordinatesGenerator).toHaveBeenCalledWith(
+          {
+            xAxis,
+            width: 300,
+            height: 200,
+            offset,
+          },
+          undefined,
+        );
+      });
+
+      it(`should set syncWithTicks=true, and ticks=verticalValues,
+      when verticalValues is provided, even if the explicit syncWithTicks is false`, () => {
+        const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([]);
+        const xAxis: Props['xAxis'] = {
+          scale: scaleLinear(),
+          ticks: ['x', 'y', 'x'],
+        };
+        // @ts-expect-error Recharts offset type conflicts with SVG offset type
+        const offset: Props['offset'] = {};
+        render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              xAxis={xAxis}
+              verticalCoordinatesGenerator={verticalCoordinatesGenerator}
+              chartWidth={300}
+              chartHeight={200}
+              offset={offset}
+              syncWithTicks={false}
+              verticalValues={['a', 'b']}
+            />
+          </Surface>,
+        );
+
+        const xAxisExpected = {
+          ...xAxis,
+          ticks: ['a', 'b'],
+        };
+
+        expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
+        expect(verticalCoordinatesGenerator).toHaveBeenCalledWith(
+          {
+            xAxis: xAxisExpected,
+            width: 300,
+            height: 200,
+            offset,
+          },
+          true,
+        );
+      });
+
+      test.each([true, false, undefined])(
+        'should set syncWithTicks as %s when horizontalValues is provided but is empty',
+        syncWithTicks => {
+          const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([]);
+          const xAxis: Props['xAxis'] = {
+            scale: scaleLinear(),
+          };
+          // @ts-expect-error Recharts offset type conflicts with SVG offset type
+          const offset: Props['offset'] = {};
+          render(
+            <Surface width={500} height={500}>
+              <CartesianGrid
+                x={0}
+                y={0}
+                width={500}
+                height={500}
+                xAxis={xAxis}
+                verticalCoordinatesGenerator={verticalCoordinatesGenerator}
+                chartWidth={300}
+                chartHeight={200}
+                offset={offset}
+                syncWithTicks={syncWithTicks}
+                horizontalValues={[]}
+              />
+            </Surface>,
+          );
+
+          const xAxisExpected = {
+            ...xAxis,
+            ticks: undefined,
+          };
+
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledWith(
+            {
+              xAxis: xAxisExpected,
+              width: 300,
+              height: 200,
+              offset,
+            },
+            syncWithTicks,
+          );
+        },
+      );
+
+      test.each([true, false, undefined])(
+        'should pass props to the generator when syncWithTicks is %s',
+        syncWithTicks => {
+          const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([]);
+          const xAxis: Props['xAxis'] = {
+            scale: scaleLinear(),
+          };
+          // @ts-expect-error Recharts offset type conflicts with SVG offset type
+          const offset: Props['offset'] = {};
+          render(
+            <Surface width={500} height={500}>
+              <CartesianGrid
+                x={0}
+                y={0}
+                width={500}
+                height={500}
+                xAxis={xAxis}
+                verticalCoordinatesGenerator={verticalCoordinatesGenerator}
+                chartWidth={300}
+                chartHeight={200}
+                offset={offset}
+                syncWithTicks={syncWithTicks}
+              />
+            </Surface>,
+          );
+
+          const xAxisExpected = {
+            ...xAxis,
+            ticks: undefined,
+          };
+
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledWith(
+            {
+              xAxis: xAxisExpected,
+              width: 300,
+              height: 200,
+              offset,
+            },
+            syncWithTicks,
+          );
+        },
+      );
+
+      test.each([{ gen: [] }, { gen: null }, { gen: undefined }, { gen: 'some random string' }, { gen: NaN }])(
+        'should render nothing if the generator returns $gen',
+        ({ gen }) => {
+          const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue(gen);
+          const { container } = render(
+            <Surface width={500} height={500}>
+              <CartesianGrid
+                x={0}
+                y={0}
+                width={500}
+                height={500}
+                verticalCoordinatesGenerator={verticalCoordinatesGenerator}
+              />
+            </Surface>,
+          );
+
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
+
+          const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
+          expect(allLines).toHaveLength(0);
+        },
+      );
+
+      it.todo('should generate its own ticks if neither verticalPoints nor verticalCoordinatesGenerator are provided');
+    });
   });
 
-  describe('verticalCoordinatesGenerator', () => {
-    it('should render lines that the generator returns', () => {
-      const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-          />
-        </Surface>,
-      );
+  describe('stripes', () => {
+    const emptyFillCases: { fill: string[] | undefined }[] = [{ fill: [] }, { fill: undefined }];
 
-      expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
-
-      const allLines = container.querySelectorAll('.recharts-cartesian-grid-vertical line');
-      expect(allLines).toHaveLength(2);
-      expect.soft(allLines[0]).toHaveAttribute('x', '0');
-      expect.soft(allLines[0]).toHaveAttribute('x1', '1');
-      expect.soft(allLines[0]).toHaveAttribute('x2', '1');
-      expect.soft(allLines[0]).toHaveAttribute('y', '0');
-      expect.soft(allLines[0]).toHaveAttribute('y1', '0');
-      expect.soft(allLines[0]).toHaveAttribute('y2', '500');
-      expect.soft(allLines[1]).toHaveAttribute('x', '0');
-      expect.soft(allLines[1]).toHaveAttribute('x2', '2');
-      expect.soft(allLines[1]).toHaveAttribute('x2', '2');
-      expect.soft(allLines[1]).toHaveAttribute('y', '0');
-      expect.soft(allLines[1]).toHaveAttribute('y1', '0');
-      expect.soft(allLines[1]).toHaveAttribute('y2', '500');
-    });
-
-    it('if both verticalCoordinatesGenerator and verticalPoints are present then verticalPoints wins', () => {
-      const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
-      expect(verticalPoints.length).not.toBe(2);
-      const { container } = render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-            verticalPoints={verticalPoints}
-          />
-        </Surface>,
-      );
-
-      expect(verticalCoordinatesGenerator).not.toHaveBeenCalled();
-
-      const allLines = container.querySelectorAll('.recharts-cartesian-grid-vertical line');
-      expect(allLines).toHaveLength(verticalPoints.length);
-    });
-
-    it('should pass props to the generator', () => {
-      const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([]);
-      const xAxis: Props['xAxis'] = {
-        scale: scaleLinear(),
-        ticks: ['x', 'y', 'x'],
-      };
-      // @ts-expect-error Recharts offset type conflicts with SVG offset type
-      const offset: Props['offset'] = {};
-      render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            xAxis={xAxis}
-            verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-            chartWidth={300}
-            chartHeight={200}
-            offset={offset}
-          />
-        </Surface>,
-      );
-
-      expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
-      expect(verticalCoordinatesGenerator).toHaveBeenCalledWith(
-        {
-          xAxis,
-          width: 300,
-          height: 200,
-          offset,
-        },
-        undefined,
-      );
-    });
-
-    it(`should set syncWithTicks=true, and ticks=verticalValues,
-      when verticalValues is provided, even if the explicit syncWithTicks is false`, () => {
-      const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([]);
-      const xAxis: Props['xAxis'] = {
-        scale: scaleLinear(),
-        ticks: ['x', 'y', 'x'],
-      };
-      // @ts-expect-error Recharts offset type conflicts with SVG offset type
-      const offset: Props['offset'] = {};
-      render(
-        <Surface width={500} height={500}>
-          <CartesianGrid
-            x={0}
-            y={0}
-            width={500}
-            height={500}
-            xAxis={xAxis}
-            verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-            chartWidth={300}
-            chartHeight={200}
-            offset={offset}
-            syncWithTicks={false}
-            verticalValues={['a', 'b']}
-          />
-        </Surface>,
-      );
-
-      const xAxisExpected = {
-        ...xAxis,
-        ticks: ['a', 'b'],
-      };
-
-      expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
-      expect(verticalCoordinatesGenerator).toHaveBeenCalledWith(
-        {
-          xAxis: xAxisExpected,
-          width: 300,
-          height: 200,
-          offset,
-        },
-        true,
-      );
-    });
-
-    test.each([true, false, undefined])(
-      'should set syncWithTicks as %s when horizontalValues is provided but is empty',
-      syncWithTicks => {
-        const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([]);
-        const xAxis: Props['xAxis'] = {
-          scale: scaleLinear(),
-        };
-        // @ts-expect-error Recharts offset type conflicts with SVG offset type
-        const offset: Props['offset'] = {};
-        render(
-          <Surface width={500} height={500}>
-            <CartesianGrid
-              x={0}
-              y={0}
-              width={500}
-              height={500}
-              xAxis={xAxis}
-              verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-              chartWidth={300}
-              chartHeight={200}
-              offset={offset}
-              syncWithTicks={syncWithTicks}
-              horizontalValues={[]}
-            />
-          </Surface>,
-        );
-
-        const xAxisExpected = {
-          ...xAxis,
-          ticks: undefined,
-        };
-
-        expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
-        expect(verticalCoordinatesGenerator).toHaveBeenCalledWith(
-          {
-            xAxis: xAxisExpected,
-            width: 300,
-            height: 200,
-            offset,
-          },
-          syncWithTicks,
-        );
-      },
-    );
-
-    test.each([true, false, undefined])(
-      'should pass props to the generator when syncWithTicks is %s',
-      syncWithTicks => {
-        const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([]);
-        const xAxis: Props['xAxis'] = {
-          scale: scaleLinear(),
-        };
-        // @ts-expect-error Recharts offset type conflicts with SVG offset type
-        const offset: Props['offset'] = {};
-        render(
-          <Surface width={500} height={500}>
-            <CartesianGrid
-              x={0}
-              y={0}
-              width={500}
-              height={500}
-              xAxis={xAxis}
-              verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-              chartWidth={300}
-              chartHeight={200}
-              offset={offset}
-              syncWithTicks={syncWithTicks}
-            />
-          </Surface>,
-        );
-
-        const xAxisExpected = {
-          ...xAxis,
-          ticks: undefined,
-        };
-
-        expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
-        expect(verticalCoordinatesGenerator).toHaveBeenCalledWith(
-          {
-            xAxis: xAxisExpected,
-            width: 300,
-            height: 200,
-            offset,
-          },
-          syncWithTicks,
-        );
-      },
-    );
-
-    test.each([{ gen: [] }, { gen: null }, { gen: undefined }, { gen: 'some random string' }, { gen: NaN }])(
-      'should render nothing if the generator returns $gen',
-      ({ gen }) => {
-        const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue(gen);
+    describe('horizontal stripes', () => {
+      it('should render horizontal stripes', () => {
+        const extraSpaceAtTheTopOfChart = 1;
         const { container } = render(
-          <Surface width={500} height={500}>
-            <CartesianGrid
-              x={0}
-              y={0}
-              width={500}
-              height={500}
-              verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-            />
-          </Surface>,
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={Math.max(...horizontalPoints) + extraSpaceAtTheTopOfChart}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+            horizontalFill={['red', 'green']}
+            fillOpacity="20%"
+          />,
         );
+        const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
+        expect(allStripes).toHaveLength(horizontalPoints.length + 1);
 
-        expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
+        for (let i = 0; i < allStripes.length; i++) {
+          const element = allStripes[i];
+          expect.soft(element).toHaveAttribute('x', '0');
+          expect.soft(element).toHaveAttribute('stroke', 'none');
+          expect.soft(element).toHaveAttribute('fill-opacity', '20%');
+          expect.soft(element).toHaveClass('recharts-cartesian-grid-bg');
+        }
 
-        const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
-        expect(allLines).toHaveLength(0);
-      },
-    );
+        expect(allStripes[0]).toHaveAttribute('fill', 'red');
+        expect(allStripes[0]).toHaveAttribute('y', '0');
+        expect(allStripes[0]).toHaveAttribute('height', '10');
+
+        expect(allStripes[1]).toHaveAttribute('fill', 'green');
+        expect(allStripes[1]).toHaveAttribute('y', '10');
+        expect(allStripes[1]).toHaveAttribute('height', '10');
+
+        expect(allStripes[2]).toHaveAttribute('fill', 'red');
+        expect(allStripes[2]).toHaveAttribute('y', '20');
+        expect(allStripes[2]).toHaveAttribute('height', '10');
+
+        expect(allStripes[3]).toHaveAttribute('fill', 'green');
+        expect(allStripes[3]).toHaveAttribute('y', '30');
+        expect(allStripes[3]).toHaveAttribute('height', '70');
+
+        expect(allStripes[4]).toHaveAttribute('fill', 'red');
+        expect(allStripes[4]).toHaveAttribute('y', '100');
+        expect(allStripes[4]).toHaveAttribute('height', '300');
+
+        expect(allStripes[5]).toHaveAttribute('fill', 'green');
+        expect(allStripes[5]).toHaveAttribute('y', '400');
+        expect(allStripes[5]).toHaveAttribute('height', String(extraSpaceAtTheTopOfChart));
+      });
+
+      test.each(emptyFillCases)('should render nothing if horizontalFill is $fill', ({ fill }) => {
+        const { container } = render(
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={Math.max(...horizontalPoints) + 1}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+            horizontalFill={fill}
+          />,
+        );
+        const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
+        expect(allStripes).toHaveLength(0);
+      });
+
+      it('should leave out the stripe at the beginning if the smallest horizontalPoints happens to be exactly at position y', () => {
+        const { container } = render(
+          <CartesianGrid
+            x={0}
+            y={Math.min(...horizontalPoints)}
+            width={500}
+            height={Math.max(...horizontalPoints) + 1}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+            horizontalFill={['red', 'green']}
+          />,
+        );
+        const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
+        expect(allStripes).toHaveLength(horizontalPoints.length);
+      });
+
+      it('render the stripe at the beginning if the smallest horizontalPoints is smaller than position y', () => {
+        const { container } = render(
+          <CartesianGrid
+            x={0}
+            y={Math.min(...horizontalPoints) - 1}
+            width={500}
+            height={Math.max(...horizontalPoints) + 1}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+            horizontalFill={['red', 'green']}
+          />,
+        );
+        const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
+        /*
+         * This feels to me like a bug. This stripe is outside of the rendered Grid, why should it be visible?
+         */
+        expect(allStripes).toHaveLength(horizontalPoints.length + 1);
+      });
+
+      it('removes the one stripe at the end if it would render outside of the Grid', () => {
+        const { container } = render(
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={Math.max(...horizontalPoints) - 1}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+            horizontalFill={['red', 'green']}
+          />,
+        );
+        const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
+        expect(allStripes).toHaveLength(horizontalPoints.length);
+      });
+
+      it('removes still only one stripe even if all of them render outside of the grid', () => {
+        const { container } = render(
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={1}
+            verticalPoints={verticalPoints}
+            horizontalPoints={horizontalPoints}
+            horizontalFill={['red', 'green']}
+          />,
+        );
+        const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
+        /*
+         * Why remove only one? None of them are visible
+         */
+        expect(allStripes).toHaveLength(horizontalPoints.length);
+      });
+
+      it('should round horizontalPoints [https://github.com/recharts/recharts/pull/3075]', () => {
+        const { container } = render(
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={500}
+            verticalPoints={verticalPoints}
+            horizontalPoints={floatingPointPrecisionExamples}
+            horizontalFill={['red', 'green']}
+          />,
+        );
+        const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
+        /*
+         * This feels to me like a bug. This stripe is outside of the rendered Grid, why should it be visible?
+         */
+        expect(allStripes).toHaveLength(floatingPointPrecisionExamples.length + 1);
+
+        expect.soft(allStripes[0]).toHaveAttribute('height', '121');
+        expect.soft(allStripes[1]).toHaveAttribute('height', '110');
+        /*
+         * Without the rounding, these will have height of something like
+         * 268.99999999999994
+         * which makes the browser render a very thin line and it looks ugly.
+         */
+        expect.soft(allStripes[2]).toHaveAttribute('height', '269');
+      });
+
+      it('should ignore stripes that have computed height 0', () => {
+        const { container } = render(
+          <CartesianGrid
+            x={0}
+            y={0}
+            width={500}
+            height={500}
+            verticalPoints={verticalPoints}
+            horizontalPoints={[10, 20, 10, 500]}
+            horizontalFill={['red', 'green']}
+          />,
+        );
+        const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
+        expect(allStripes).toHaveLength(3);
+
+        expect.soft(allStripes[0]).toHaveAttribute('height', '10');
+        expect.soft(allStripes[0]).toHaveAttribute('y', '0');
+
+        // even though the horizontalPoints do define double 10, 10 ... the stripe is not rendered
+
+        expect.soft(allStripes[1]).toHaveAttribute('height', '10');
+        expect.soft(allStripes[1]).toHaveAttribute('y', '10');
+
+        expect.soft(allStripes[2]).toHaveAttribute('height', '480');
+        expect.soft(allStripes[2]).toHaveAttribute('y', '20');
+      });
+    });
   });
 });

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { describe, test, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
 import { Surface, CartesianGrid } from '../../src';
 
@@ -19,7 +20,13 @@ describe('<CartesianGrid />', () => {
         />
       </Surface>,
     );
-    expect(container.querySelectorAll('line')).toHaveLength(9);
+    expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+    expect
+      .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+      .toHaveLength(horizontalPoints.length);
+    expect
+      .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+      .toHaveLength(verticalPoints.length);
   });
 
   test("Don't render any lines when verticalPoints and horizontalPoints are empty", () => {
@@ -38,5 +45,49 @@ describe('<CartesianGrid />', () => {
       </Surface>,
     );
     expect(container.querySelectorAll('line')).toHaveLength(0);
+  });
+
+  it('should not render any lines if horizontal=false', () => {
+    const { container } = render(
+      <Surface width={500} height={500}>
+        <CartesianGrid
+          x={0}
+          y={0}
+          width={500}
+          height={500}
+          horizontal={false}
+          verticalPoints={verticalPoints}
+          horizontalPoints={horizontalPoints}
+        />
+      </Surface>,
+    );
+    expect.soft(container.querySelectorAll('line')).toHaveLength(verticalPoints.length);
+    expect.soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line')).toHaveLength(0);
+    expect
+      .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+      .toHaveLength(verticalPoints.length);
+  });
+
+  it('should render all lines if horizontal=true', () => {
+    const { container } = render(
+      <Surface width={500} height={500}>
+        <CartesianGrid
+          x={0}
+          y={0}
+          width={500}
+          height={500}
+          horizontal
+          verticalPoints={verticalPoints}
+          horizontalPoints={horizontalPoints}
+        />
+      </Surface>,
+    );
+    expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+    expect
+      .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
+      .toHaveLength(horizontalPoints.length);
+    expect
+      .soft(container.querySelectorAll('.recharts-cartesian-grid-vertical line'))
+      .toHaveLength(verticalPoints.length);
   });
 });


### PR DESCRIPTION
## Description

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

I want CartesianGrid to read data from context next, but first I wanted it to have tests and types.

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
