### PR TITLE
CartesianGrid uses default props instead of generateCategoricalChart injection, also a functional component now

### DIFF
--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -11,6 +11,9 @@ import { ChartOffset, D3Scale } from '../util/types';
 import { Props as XAxisProps } from './XAxis';
 import { Props as YAxisProps } from './YAxis';
 import { filterProps } from '../util/ReactUtils';
+import { getCoordinatesOfGrid, getTicksOfAxis } from '../util/ChartUtils';
+import { getTicks } from './getTicks';
+import { CartesianAxis } from './CartesianAxis';
 
 type GridLineType =
   | SVGProps<SVGLineElement>
@@ -285,6 +288,22 @@ function VerticalStripes(props: Props) {
   return <g className="recharts-cartesian-gridstripes-vertical">{items}</g>;
 }
 
+const defaultVerticalCoordinatesGenerator: VerticalCoordinatesGenerator = (
+  { xAxis, width, height, offset },
+  syncWithTicks,
+) =>
+  getCoordinatesOfGrid(
+    getTicks({
+      ...CartesianAxis.defaultProps,
+      ...xAxis,
+      ticks: getTicksOfAxis(xAxis, true),
+      viewBox: { x: 0, y: 0, width, height },
+    }),
+    offset.left,
+    offset.left + offset.width,
+    syncWithTicks,
+  );
+
 export class CartesianGrid extends PureComponent<Props> {
   static displayName = 'CartesianGrid';
 
@@ -310,7 +329,6 @@ export class CartesianGrid extends PureComponent<Props> {
       width,
       height,
       horizontalCoordinatesGenerator,
-      verticalCoordinatesGenerator,
       xAxis,
       yAxis,
       offset,
@@ -333,6 +351,8 @@ export class CartesianGrid extends PureComponent<Props> {
     ) {
       return null;
     }
+
+    const verticalCoordinatesGenerator = this.props.verticalCoordinatesGenerator || defaultVerticalCoordinatesGenerator;
 
     let { horizontalPoints, verticalPoints } = this.props;
 
@@ -366,7 +386,6 @@ export class CartesianGrid extends PureComponent<Props> {
     // No vertical points are specified
     if ((!verticalPoints || !verticalPoints.length) && isFunction(verticalCoordinatesGenerator)) {
       const isVerticalValues = verticalValues && verticalValues.length;
-
       const generatorResult = verticalCoordinatesGenerator(
         {
           xAxis: xAxis

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -304,6 +304,22 @@ const defaultVerticalCoordinatesGenerator: VerticalCoordinatesGenerator = (
     syncWithTicks,
   );
 
+const defaultHorizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = (
+  { yAxis, width, height, offset },
+  syncWithTicks,
+) =>
+  getCoordinatesOfGrid(
+    getTicks({
+      ...CartesianAxis.defaultProps,
+      ...yAxis,
+      ticks: getTicksOfAxis(yAxis, true),
+      viewBox: { x: 0, y: 0, width, height },
+    }),
+    offset.top,
+    offset.top + offset.height,
+    syncWithTicks,
+  );
+
 export class CartesianGrid extends PureComponent<Props> {
   static displayName = 'CartesianGrid';
 
@@ -328,7 +344,6 @@ export class CartesianGrid extends PureComponent<Props> {
       y,
       width,
       height,
-      horizontalCoordinatesGenerator,
       xAxis,
       yAxis,
       offset,
@@ -353,6 +368,8 @@ export class CartesianGrid extends PureComponent<Props> {
     }
 
     const verticalCoordinatesGenerator = this.props.verticalCoordinatesGenerator || defaultVerticalCoordinatesGenerator;
+    const horizontalCoordinatesGenerator =
+      this.props.horizontalCoordinatesGenerator || defaultHorizontalCoordinatesGenerator;
 
     let { horizontalPoints, verticalPoints } = this.props;
 

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -15,10 +15,12 @@ import { getCoordinatesOfGrid, getTicksOfAxis } from '../util/ChartUtils';
 import { getTicks } from './getTicks';
 import { CartesianAxis } from './CartesianAxis';
 
+export type GridLineFunctionProps = Omit<LineItemProps, 'offset'>;
+
 type GridLineType =
   | SVGProps<SVGLineElement>
   | ReactElement<SVGElement>
-  | ((props: any) => ReactElement<SVGElement>)
+  | ((props: GridLineFunctionProps) => ReactElement<SVGElement>)
   | boolean;
 
 export type HorizontalCoordinatesGenerator = (

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1668,8 +1668,6 @@ export const generateCategoricalChart = ({
       }
     };
 
-    axesTicksGenerator = (axis?: any) => getTicksOfAxis(axis, true);
-
     filterFormatItem(item: any, displayName: any, childIndex: any) {
       const { formattedGraphicalItems } = this.state;
 

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1671,19 +1671,6 @@ export const generateCategoricalChart = ({
       }
     };
 
-    verticalCoordinatesGenerator = ({ xAxis, width, height, offset }: ChartCoordinate, syncWithTicks: Boolean) =>
-      getCoordinatesOfGrid(
-        getTicks({
-          ...CartesianAxis.defaultProps,
-          ...xAxis,
-          ticks: getTicksOfAxis(xAxis, true),
-          viewBox: { x: 0, y: 0, width, height },
-        }),
-        offset.left,
-        offset.left + offset.width,
-        syncWithTicks,
-      );
-
     horizontalCoordinatesGenerator = ({ yAxis, width, height, offset }: ChartCoordinate, syncWithTicks: Boolean) =>
       getCoordinatesOfGrid(
         getTicks({
@@ -1780,7 +1767,7 @@ export const generateCategoricalChart = ({
         offset,
         chartWidth: width,
         chartHeight: height,
-        verticalCoordinatesGenerator: props.verticalCoordinatesGenerator || this.verticalCoordinatesGenerator,
+        verticalCoordinatesGenerator: props.verticalCoordinatesGenerator,
         horizontalCoordinatesGenerator: props.horizontalCoordinatesGenerator || this.horizontalCoordinatesGenerator,
       });
     };

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -12,7 +12,6 @@ import clsx from 'clsx';
 // eslint-disable-next-line no-restricted-imports
 import type { DebouncedFunc } from 'lodash';
 import invariant from 'tiny-invariant';
-import { getTicks } from '../cartesian/getTicks';
 import { Surface } from '../container/Surface';
 import { Layer } from '../container/Layer';
 import { Tooltip } from '../component/Tooltip';
@@ -32,7 +31,6 @@ import {
   validateWidthHeight,
 } from '../util/ReactUtils';
 
-import { CartesianAxis } from '../cartesian/CartesianAxis';
 import { Brush } from '../cartesian/Brush';
 import { getOffset } from '../util/DOMUtils';
 import { findEntryInArray, getAnyElementOfObject, hasDuplicate, isNumber, uniqueId } from '../util/DataUtils';
@@ -45,7 +43,6 @@ import {
   getBandSizeOfAxis,
   getBarPosition,
   getBarSizeList,
-  getCoordinatesOfGrid,
   getDomainOfDataByKey,
   getDomainOfItemsWithSameAxis,
   getDomainOfStackGroups,
@@ -1671,19 +1668,6 @@ export const generateCategoricalChart = ({
       }
     };
 
-    horizontalCoordinatesGenerator = ({ yAxis, width, height, offset }: ChartCoordinate, syncWithTicks: Boolean) =>
-      getCoordinatesOfGrid(
-        getTicks({
-          ...CartesianAxis.defaultProps,
-          ...yAxis,
-          ticks: getTicksOfAxis(yAxis, true),
-          viewBox: { x: 0, y: 0, width, height },
-        }),
-        offset.top,
-        offset.top + offset.height,
-        syncWithTicks,
-      );
-
     axesTicksGenerator = (axis?: any) => getTicksOfAxis(axis, true);
 
     filterFormatItem(item: any, displayName: any, childIndex: any) {
@@ -1768,7 +1752,7 @@ export const generateCategoricalChart = ({
         chartWidth: width,
         chartHeight: height,
         verticalCoordinatesGenerator: props.verticalCoordinatesGenerator,
-        horizontalCoordinatesGenerator: props.horizontalCoordinatesGenerator || this.horizontalCoordinatesGenerator,
+        horizontalCoordinatesGenerator: props.horizontalCoordinatesGenerator,
       });
     };
 

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -880,8 +880,96 @@ describe('<CartesianGrid />', () => {
     });
 
     describe('vertical as a function', () => {
-      it.todo('should call once for each horizontal line, and render result');
-      it.todo('should pass through props, and add default stroke');
+      it('should pass props, add default stroke, and then render result of the function', () => {
+        const vertical = vi.fn().mockReturnValue(<g data-testid="my_mock_line" />);
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              verticalPoints={verticalPoints}
+              horizontalPoints={horizontalPoints}
+              vertical={vertical}
+            />
+          </Surface>,
+        );
+        expect(vertical).toHaveBeenCalledTimes(verticalPoints.length);
+
+        const expectedProps: GridLineFunctionProps = {
+          stroke: '#ccc',
+          fill: 'none',
+          height: 500,
+          width: 500,
+          horizontal: true,
+          horizontalFill: [],
+          horizontalPoints,
+          verticalFill: [],
+          verticalPoints,
+          vertical,
+          key: expect.stringMatching(/line-[0-9]/),
+          x: 0,
+          y: 0,
+          x1: expect.any(Number),
+          x2: expect.any(Number),
+          y1: 0,
+          y2: 500,
+          index: expect.any(Number),
+        };
+        expect(vertical).toHaveBeenCalledWith(expectedProps);
+
+        expect(container.querySelectorAll('[data-testid=my_mock_line]')).toHaveLength(verticalPoints.length);
+      });
+    });
+
+    describe('vertical as an element', () => {
+      it('should pass props, add default stroke, and then render result of the function', () => {
+        const spy = vi.fn();
+        const Vertical = (props: any) => {
+          spy(props);
+          return <g data-testid="my_mock_line" />;
+        };
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              verticalPoints={verticalPoints}
+              horizontalPoints={horizontalPoints}
+              vertical={<Vertical />}
+            />
+          </Surface>,
+        );
+        expect(spy).toHaveBeenCalledTimes(verticalPoints.length);
+
+        const expectedProps: GridLineFunctionProps = {
+          stroke: '#ccc',
+          fill: 'none',
+          height: 500,
+          width: 500,
+          horizontal: true,
+          horizontalFill: [],
+          horizontalPoints,
+          verticalFill: [],
+          verticalPoints,
+          vertical: <Vertical />,
+          // @ts-expect-error React does not pass the key through when calling cloneElement
+          key: undefined,
+          x: 0,
+          y: 0,
+          x1: expect.any(Number),
+          x2: expect.any(Number),
+          y1: 0,
+          y2: 500,
+          index: expect.any(Number),
+        };
+        expect(spy).toHaveBeenCalledWith(expectedProps);
+
+        expect(container.querySelectorAll('[data-testid=my_mock_line]')).toHaveLength(verticalPoints.length);
+      });
     });
   });
 

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react';
 import { scaleLinear } from 'victory-vendor/d3-scale';
 import { Surface, CartesianGrid, LineChart } from '../../src';
 import { HorizontalCoordinatesGenerator, Props, VerticalCoordinatesGenerator } from '../../src/cartesian/CartesianGrid';
+import { ChartOffset } from '../../src/util/types';
 
 describe('<CartesianGrid />', () => {
   const horizontalPoints = [10, 20, 30, 100, 400];
@@ -14,6 +15,15 @@ describe('<CartesianGrid />', () => {
    */
   const floatingPointPrecisionExamples = [121.00000000000002, 231.00000000000005];
   const verticalPoints = [100, 200, 300, 400];
+  const offset: ChartOffset = {
+    top: 1,
+    bottom: 2,
+    left: 3,
+    right: 4,
+    width: 5,
+    height: 6,
+    brushBottom: 7,
+  };
 
   describe('grid', () => {
     describe('basic features', () => {
@@ -236,6 +246,7 @@ describe('<CartesianGrid />', () => {
               width={500}
               height={500}
               horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
+              offset={{}}
             />
           </Surface>,
         );
@@ -270,6 +281,7 @@ describe('<CartesianGrid />', () => {
               height={500}
               horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
               horizontalPoints={horizontalPoints}
+              offset={offset}
             />
           </Surface>,
         );
@@ -286,7 +298,6 @@ describe('<CartesianGrid />', () => {
           scale: scaleLinear(),
           ticks: ['x', 'y', 'x'],
         };
-        const offset: Props['offset'] = {};
         render(
           <Surface width={500} height={500}>
             <CartesianGrid
@@ -322,7 +333,6 @@ describe('<CartesianGrid />', () => {
           scale: scaleLinear(),
           ticks: ['x', 'y', 'x'],
         };
-        const offset: Props['offset'] = {};
         render(
           <Surface width={500} height={500}>
             <CartesianGrid
@@ -365,7 +375,6 @@ describe('<CartesianGrid />', () => {
           const yAxis: Props['yAxis'] = {
             scale: scaleLinear(),
           };
-          const offset: Props['offset'] = {};
           render(
             <Surface width={500} height={500}>
               <CartesianGrid
@@ -409,7 +418,6 @@ describe('<CartesianGrid />', () => {
           const yAxis: Props['yAxis'] = {
             scale: scaleLinear(),
           };
-          const offset: Props['offset'] = {};
           render(
             <Surface width={500} height={500}>
               <CartesianGrid
@@ -457,6 +465,7 @@ describe('<CartesianGrid />', () => {
                 width={500}
                 height={500}
                 horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
+                offset={offset}
               />
             </Surface>,
           );
@@ -557,7 +566,6 @@ describe('<CartesianGrid />', () => {
           scale: scaleLinear(),
           ticks: ['x', 'y', 'x'],
         };
-        const offset: Props['offset'] = {};
         render(
           <Surface width={500} height={500}>
             <CartesianGrid
@@ -593,7 +601,6 @@ describe('<CartesianGrid />', () => {
           scale: scaleLinear(),
           ticks: ['x', 'y', 'x'],
         };
-        const offset: Props['offset'] = {};
         render(
           <Surface width={500} height={500}>
             <CartesianGrid
@@ -636,7 +643,6 @@ describe('<CartesianGrid />', () => {
           const xAxis: Props['xAxis'] = {
             scale: scaleLinear(),
           };
-          const offset: Props['offset'] = {};
           render(
             <Surface width={500} height={500}>
               <CartesianGrid
@@ -680,7 +686,6 @@ describe('<CartesianGrid />', () => {
           const xAxis: Props['xAxis'] = {
             scale: scaleLinear(),
           };
-          const offset: Props['offset'] = {};
           render(
             <Surface width={500} height={500}>
               <CartesianGrid
@@ -825,7 +830,7 @@ describe('<CartesianGrid />', () => {
 
       it('should render one big stripe if there are no horizontalPoints', () => {
         const { container } = render(
-          <CartesianGrid x={0} y={0} width={500} height={500} horizontalFill={['red', 'green']} />,
+          <CartesianGrid x={0} y={0} width={500} height={500} horizontalFill={['red', 'green']} offset={offset} />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
         expect(allStripes).toHaveLength(1);
@@ -847,6 +852,7 @@ describe('<CartesianGrid />', () => {
               height={500}
               horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
               horizontalFill={['red', 'green']}
+              offset={offset}
             />
           </Surface>,
         );
@@ -1065,19 +1071,6 @@ describe('<CartesianGrid />', () => {
         expect.soft(allStripes[4]).toHaveAttribute('width', String(extraSpaceAtTheEndOfChart));
       });
 
-      it('should render one big stripe if there are no verticalPoints', () => {
-        const { container } = render(
-          <CartesianGrid x={0} y={0} width={500} height={500} verticalFill={['red', 'green']} />,
-        );
-        const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
-        expect(allStripes).toHaveLength(1);
-        expect.soft(allStripes[0]).toHaveAttribute('width', '500');
-        expect.soft(allStripes[0]).toHaveAttribute('height', '500');
-        expect.soft(allStripes[0]).toHaveAttribute('x', '0');
-        expect.soft(allStripes[0]).toHaveAttribute('y', '0');
-        expect.soft(allStripes[0]).toHaveAttribute('fill', 'red');
-      });
-
       it('should render stripes defined by verticalCoordinatesGenerator', () => {
         const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
         const { container } = render(
@@ -1265,15 +1258,6 @@ describe('<CartesianGrid />', () => {
 
   describe('offset prop', () => {
     it('should not pass the offset prop anywhere', () => {
-      const offset: Props['offset'] = {
-        top: 1,
-        bottom: 2,
-        left: 3,
-        right: 4,
-        width: 5,
-        height: 6,
-        brushBottom: 7,
-      };
       const { container } = render(
         <Surface width={500} height={500}>
           <CartesianGrid

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -40,7 +40,13 @@ describe('<CartesianGrid />', () => {
             />
           </Surface>,
         );
-        expect.soft(container.querySelectorAll('line')).toHaveLength(9);
+        const allLines = container.querySelectorAll('line');
+        expect.soft(allLines).toHaveLength(9);
+        for (let i = 0; i < allLines.length; i++) {
+          const line = allLines[i];
+          expect.soft(line).toHaveAttribute('stroke', '#ccc');
+          expect.soft(line).toHaveAttribute('fill', 'none');
+        }
         expect
           .soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line'))
           .toHaveLength(horizontalPoints.length);

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -3,7 +3,12 @@ import { describe, test, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { scaleLinear } from 'victory-vendor/d3-scale';
 import { Surface, CartesianGrid, LineChart } from '../../src';
-import { HorizontalCoordinatesGenerator, Props, VerticalCoordinatesGenerator } from '../../src/cartesian/CartesianGrid';
+import {
+  GridLineFunctionProps,
+  HorizontalCoordinatesGenerator,
+  Props,
+  VerticalCoordinatesGenerator,
+} from '../../src/cartesian/CartesianGrid';
 import { ChartOffset } from '../../src/util/types';
 
 describe('<CartesianGrid />', () => {
@@ -779,6 +784,104 @@ describe('<CartesianGrid />', () => {
         expect.soft(allLines[1]).toHaveAttribute('y1', '0');
         expect.soft(allLines[1]).toHaveAttribute('y2', '500');
       });
+    });
+
+    describe('horizontal as a function', () => {
+      it('should pass props, add default stroke, and then render result of the function', () => {
+        const horizontal = vi.fn().mockReturnValue(<g data-testid="my_mock_line" />);
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              verticalPoints={verticalPoints}
+              horizontalPoints={horizontalPoints}
+              horizontal={horizontal}
+            />
+          </Surface>,
+        );
+        expect(horizontal).toHaveBeenCalledTimes(horizontalPoints.length);
+
+        const expectedProps: GridLineFunctionProps = {
+          stroke: '#ccc',
+          fill: 'none',
+          height: 500,
+          width: 500,
+          vertical: true,
+          horizontalFill: [],
+          horizontalPoints,
+          verticalFill: [],
+          verticalPoints,
+          horizontal,
+          key: expect.stringMatching(/line-[0-9]/),
+          x: 0,
+          y: 0,
+          x1: 0,
+          x2: 500,
+          y1: expect.any(Number),
+          y2: expect.any(Number),
+          index: expect.any(Number),
+        };
+        expect(horizontal).toHaveBeenCalledWith(expectedProps);
+
+        expect(container.querySelectorAll('[data-testid=my_mock_line]')).toHaveLength(horizontalPoints.length);
+      });
+    });
+
+    describe('horizontal as an element', () => {
+      it('should pass props, add default stroke, and then render result of the function', () => {
+        const spy = vi.fn();
+        const Horizontal = (props: any) => {
+          spy(props);
+          return <g data-testid="my_mock_line" />;
+        };
+        const { container } = render(
+          <Surface width={500} height={500}>
+            <CartesianGrid
+              x={0}
+              y={0}
+              width={500}
+              height={500}
+              verticalPoints={verticalPoints}
+              horizontalPoints={horizontalPoints}
+              horizontal={<Horizontal />}
+            />
+          </Surface>,
+        );
+        expect(spy).toHaveBeenCalledTimes(horizontalPoints.length);
+
+        const expectedProps: GridLineFunctionProps = {
+          stroke: '#ccc',
+          fill: 'none',
+          height: 500,
+          width: 500,
+          vertical: true,
+          horizontalFill: [],
+          horizontalPoints,
+          verticalFill: [],
+          verticalPoints,
+          horizontal: <Horizontal />,
+          // @ts-expect-error React does not pass the key through when calling cloneElement
+          key: undefined,
+          x: 0,
+          y: 0,
+          x1: 0,
+          x2: 500,
+          y1: expect.any(Number),
+          y2: expect.any(Number),
+          index: expect.any(Number),
+        };
+        expect(spy).toHaveBeenCalledWith(expectedProps);
+
+        expect(container.querySelectorAll('[data-testid=my_mock_line]')).toHaveLength(horizontalPoints.length);
+      });
+    });
+
+    describe('vertical as a function', () => {
+      it.todo('should call once for each horizontal line, and render result');
+      it.todo('should pass through props, and add default stroke');
     });
   });
 

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -516,6 +516,7 @@ describe('<CartesianGrid />', () => {
               width={500}
               height={500}
               verticalCoordinatesGenerator={verticalCoordinatesGenerator}
+              offset={offset}
             />
           </Surface>,
         );
@@ -550,6 +551,7 @@ describe('<CartesianGrid />', () => {
               height={500}
               verticalCoordinatesGenerator={verticalCoordinatesGenerator}
               verticalPoints={verticalPoints}
+              offset={offset}
             />
           </Surface>,
         );
@@ -733,13 +735,14 @@ describe('<CartesianGrid />', () => {
                 width={500}
                 height={500}
                 verticalCoordinatesGenerator={verticalCoordinatesGenerator}
+                offset={offset}
               />
             </Surface>,
           );
 
           expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
 
-          const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
+          const allLines = container.querySelectorAll('.recharts-cartesian-grid-vertical line');
           expect(allLines).toHaveLength(0);
         },
       );
@@ -826,19 +829,6 @@ describe('<CartesianGrid />', () => {
         expect(allStripes[5]).toHaveAttribute('fill', 'green');
         expect(allStripes[5]).toHaveAttribute('y', '400');
         expect(allStripes[5]).toHaveAttribute('height', String(extraSpaceAtTheTopOfChart));
-      });
-
-      it('should render one big stripe if there are no horizontalPoints', () => {
-        const { container } = render(
-          <CartesianGrid x={0} y={0} width={500} height={500} horizontalFill={['red', 'green']} offset={offset} />,
-        );
-        const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
-        expect(allStripes).toHaveLength(1);
-        expect.soft(allStripes[0]).toHaveAttribute('width', '500');
-        expect.soft(allStripes[0]).toHaveAttribute('height', '500');
-        expect.soft(allStripes[0]).toHaveAttribute('x', '0');
-        expect.soft(allStripes[0]).toHaveAttribute('y', '0');
-        expect.soft(allStripes[0]).toHaveAttribute('fill', 'red');
       });
 
       it('should render stripes defined by horizontalCoordinatesGenerator', () => {
@@ -1036,6 +1026,7 @@ describe('<CartesianGrid />', () => {
             verticalFill={['red', 'green']}
             fillOpacity="20%"
             vertical={vertical}
+            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1082,6 +1073,7 @@ describe('<CartesianGrid />', () => {
               height={500}
               verticalCoordinatesGenerator={verticalCoordinatesGenerator}
               verticalFill={['red', 'green']}
+              offset={offset}
             />
           </Surface>,
         );
@@ -1104,6 +1096,7 @@ describe('<CartesianGrid />', () => {
             verticalFill={['red', 'green']}
             fillOpacity="20%"
             vertical={false}
+            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1119,6 +1112,7 @@ describe('<CartesianGrid />', () => {
             width={Math.max(...verticalPoints) + 1}
             verticalPoints={verticalPoints}
             verticalFill={fill}
+            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1134,6 +1128,7 @@ describe('<CartesianGrid />', () => {
             width={Math.max(...verticalPoints) + 1}
             verticalPoints={verticalPoints}
             verticalFill={['red', 'green']}
+            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1149,6 +1144,7 @@ describe('<CartesianGrid />', () => {
             width={Math.max(...verticalPoints) + 1}
             verticalPoints={verticalPoints}
             verticalFill={['red', 'green']}
+            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1167,6 +1163,7 @@ describe('<CartesianGrid />', () => {
             width={Math.max(...verticalPoints) - 1}
             verticalPoints={verticalPoints}
             verticalFill={['red', 'green']}
+            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1182,6 +1179,7 @@ describe('<CartesianGrid />', () => {
             height={500}
             verticalPoints={verticalPoints}
             verticalFill={['red', 'green']}
+            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1200,6 +1198,7 @@ describe('<CartesianGrid />', () => {
             height={500}
             verticalPoints={floatingPointPrecisionExamples}
             verticalFill={['red', 'green']}
+            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1231,6 +1230,7 @@ describe('<CartesianGrid />', () => {
             height={500}
             verticalPoints={[10, 20, 10, 500]}
             verticalFill={['red', 'green']}
+            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');


### PR DESCRIPTION
## Description

I want the CartesianGrid to read data from context, and eventually completely remove `generateCategoricalChart.renderGrid` method. But before I do that, there's some opportunities for making things simpler that do not require the context even.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

No more element cloning

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
