### PR TITLE
Enable screen reader support with accessibilityLayer and default tooltip

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -2211,7 +2211,7 @@ export const generateCategoricalChart = ({
         // Set tabIndex to 0 by default (can be overwritten)
         attrs.tabIndex = this.props.tabIndex ?? 0;
         // Set role to img by default (can be overwritten)
-        attrs.role = this.props.role ?? 'img';
+        attrs.role = this.props.role ?? 'application';
         attrs.onKeyDown = (e: any) => {
           this.accessibilityManager.keyboardEvent(e);
           // 'onKeyDown' is not currently a supported prop that can be passed through
@@ -2239,7 +2239,7 @@ export const generateCategoricalChart = ({
             ref={(node: HTMLDivElement) => {
               this.container = node;
             }}
-            role={this.props.accessibilityLayer ? 'application' : 'region'}
+            role={attrs.role ?? 'region'}
           >
             <Surface {...attrs} width={width} height={height} title={title} desc={desc} style={FULL_WIDTH_AND_HEIGHT}>
               {this.renderClipPath()}

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1844,7 +1844,7 @@ export const generateCategoricalChart = ({
      * @return {ReactElement}  The instance of Tooltip
      */
     renderTooltip = (): React.ReactElement => {
-      const { children } = this.props;
+      const { children, accessibilityLayer } = this.props;
       const tooltipItem = findChildByType(children, Tooltip);
 
       if (!tooltipItem) {
@@ -1864,6 +1864,7 @@ export const generateCategoricalChart = ({
         label: activeLabel,
         payload: isActive ? activePayload : [],
         coordinate: activeCoordinate,
+        accessibilityLayer,
       });
     };
 
@@ -2238,7 +2239,7 @@ export const generateCategoricalChart = ({
             ref={(node: HTMLDivElement) => {
               this.container = node;
             }}
-            role="region"
+            role={this.props.accessibilityLayer ? 'application' : 'region'}
           >
             <Surface {...attrs} width={width} height={height} title={title} desc={desc} style={FULL_WIDTH_AND_HEIGHT}>
               {this.renderClipPath()}

--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Default Tooltip Content
  */
 
-import React, { CSSProperties, ReactNode } from 'react';
+import React, { CSSProperties, HTMLAttributes, ReactNode } from 'react';
 import sortBy from 'lodash/sortBy';
 import isNil from 'lodash/isNil';
 import clsx from 'clsx';
@@ -50,6 +50,7 @@ export interface Props<TValue extends ValueType, TName extends NameType> {
   label?: any;
   payload?: Array<Payload<TValue, TName>>;
   itemSorter?: (item: Payload<TValue, TName>) => number | string;
+  accessibilityLayer?: boolean;
 }
 
 export const DefaultTooltipContent = <TValue extends ValueType, TName extends NameType>(
@@ -67,6 +68,7 @@ export const DefaultTooltipContent = <TValue extends ValueType, TName extends Na
     labelClassName,
     label,
     labelFormatter,
+    accessibilityLayer = false,
   } = props;
 
   const renderContent = () => {
@@ -140,8 +142,15 @@ export const DefaultTooltipContent = <TValue extends ValueType, TName extends Na
     finalLabel = labelFormatter(label, payload);
   }
 
+  const accessibilityAttributes = accessibilityLayer
+    ? ({
+        role: 'status',
+        'aria-live': 'assertive',
+      } as HTMLAttributes<HTMLDivElement>)
+    : {};
+
   return (
-    <div className={wrapperCN} style={finalStyle}>
+    <div className={wrapperCN} style={finalStyle} {...accessibilityAttributes}>
       <p className={labelCN} style={finalLabelStyle}>
         {React.isValidElement(finalLabel) ? finalLabel : `${finalLabel}`}
       </p>

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -38,6 +38,7 @@ function renderContent<TValue extends ValueType, TName extends NameType>(
 }
 
 export type TooltipProps<TValue extends ValueType, TName extends NameType> = ToltipContentProps<TValue, TName> & {
+  accessibilityLayer?: boolean;
   /**
    * If true, then Tooltip is always displayed, once an activeIndex is set by mouse over, or programmatically.
    * If false, then Tooltip is never displayed.
@@ -69,6 +70,7 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
   static displayName = 'Tooltip';
 
   static defaultProps = {
+    accessibilityLayer: false,
     allowEscapeViewBox: { x: false, y: false },
     animationDuration: 400,
     animationEasing: 'ease',

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -145,7 +145,6 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
       // See https://github.com/recharts/recharts/pull/2925
       <div
         tabIndex={-1}
-        role="dialog"
         className={cssClasses}
         style={outerStyle}
         ref={node => {

--- a/storybook/stories/API/Accessibility.mdx
+++ b/storybook/stories/API/Accessibility.mdx
@@ -48,10 +48,17 @@ The accessibility layer is not currently available for all charts. The accessibi
 2. The chart must include a tooltip.
 3. The chart must have a horizontal layout.
 
+## Screen reader support
+The accessibility layer works with the tooltip to provide feedback to screen reader users.
+
+If you are using a default tooltip, it will work with the `accessibilityLayer` to support screen reader users. The default tooltip will turn into a "live region", which means that screen readers will read the contents of the region as it updates. This will give blind users access to the underlying data in a chart, alongside sighted users.
+
+If you are building your own custom tooltip, you can turn it into a live region by using the attributes `role="status" aria-live="assertive"`. Keep in mind that the full content of the tooltip will be read for every data point that the user interacts with, so it's best practices to keep the content in the tooltip to a minimum.
+
 ## Technical notes
 
 When you apply the `accessibilityLayer` to a chart, it will do a couple of things:
-1. By default, it will set the `role="img"`. This can be overwritten if you pass in your own `role` prop.
+1. By default, it will set the `role="application"`. This can be overwritten if you pass in your own `role` prop.
 2. By default, it will set the `tabIndex={0}`. This can be overwritten if you pass in your own `tabIndex` prop.
 
 The accessibility layer works by spoofing mouse movements. 

--- a/storybook/stories/API/props/ChartProps.ts
+++ b/storybook/stories/API/props/ChartProps.ts
@@ -79,7 +79,7 @@ toggling between multiple dataKey.`,
   data,
   margin,
   accessibilityLayer: {
-    description: 'Turn on keyboard accessibility',
+    description: 'Turn on accessibility support for keyboard-only and screen reader users.',
     table: {
       type: {
         summary: 'boolean',

--- a/test/chart/AccessibilityLayer.spec.tsx
+++ b/test/chart/AccessibilityLayer.spec.tsx
@@ -24,7 +24,7 @@ describe('AccessibilityLayer', () => {
     const svg = container.querySelector('svg');
     expect(svg).not.toBeNull();
     expect(svg).not.toBeUndefined();
-    expect(svg).toHaveAttribute('role', 'img');
+    expect(svg).toHaveAttribute('role', 'application');
     expect(svg).toHaveAttribute('tabindex', '0');
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Made the default tooltip renderer aware of the `accessibilityLayer`
- If the `accessibilityLayer` is set for a chart, and the default tooltip is being used, that tooltip becomes a "live region". This means that a screen reader will automatically read out the content of the tooltip as it updates.
- If the `accessibilityLayer` is set for a chart, it will have `role="application"`, which will tell the screen reader (and user) that the area is interactive.

If `accessibilityLayer` has been set, the experience for a screen reader user will be:
1. They encounter the chart, which is announced as an interactive area.
2. If the user presses arrow keys, the tooltip will move, and the screen reader will read out the changing tooltip to the user.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/3555

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This helps blind people have access to the same chart that sighted people can use.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested the interaction with Win11 + Chrome + NVDA. More combinations will be necessary before this PR goes in.
(NVDA is a windows-only open source screen reader).

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
