### PR TITLE
Fix default parameters for setDetails()

### DIFF
--- a/src/chart/AccessibilityManager.ts
+++ b/src/chart/AccessibilityManager.ts
@@ -27,13 +27,13 @@ export class AccessibilityManager {
   private offset: InitiableOptions['offset'];
 
   public setDetails({
-    coordinateList = [],
+    coordinateList = null,
     container = null,
     layout = null,
     offset = null,
     mouseHandlerCallback = null,
   }: InitiableOptions) {
-    this.coordinateList = coordinateList ?? this.coordinateList;
+    this.coordinateList = coordinateList ?? this.coordinateList ?? [];
     this.container = container ?? this.container;
     this.layout = layout ?? this.layout;
     this.offset = offset ?? this.offset;


### PR DESCRIPTION
## Description

This PR is a small bug fix for how the default parameters are handled in `setDetails()` function. With the existing implementation, it is possible that `this.coordinateList` gets overridden with `[]` since it is not a nullish value.

## Related Issue

https://github.com/recharts/recharts/issues/4052

## Motivation and Context

This fix will make accessibility layer 

## How Has This Been Tested?

Unit tests are passing and Storybook story works as expected. Change is rather small so I'm not sure if a unit test for reproducing the issue is needed (it was a bit of a corner case anyways), but let me know if the tests should also be updated.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
