### PR TITLE
CartesianGrid reads offset from context instead of props

### DIFF
--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -16,7 +16,10 @@ import { getTicks } from './getTicks';
 import { CartesianAxis } from './CartesianAxis';
 import { useChartHeight, useChartWidth } from '../context/chartLayoutContext';
 
-export type GridLineFunctionProps = Omit<LineItemProps, 'offset'>;
+export type GridLineFunctionProps = Omit<LineItemProps, 'key'> & {
+  // React does not pass the key through when calling cloneElement - so it might be undefined when cloning
+  key: LineItemProps['key'] | undefined;
+};
 
 type GridLineType =
   | SVGProps<SVGLineElement>
@@ -49,8 +52,8 @@ interface InternalCartesianGridProps {
   height?: number;
   horizontalCoordinatesGenerator?: HorizontalCoordinatesGenerator;
   verticalCoordinatesGenerator?: VerticalCoordinatesGenerator;
-  xAxis?: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> };
-  yAxis?: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> };
+  xAxis?: null | (Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> });
+  yAxis?: null | (Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> });
   offset?: ChartOffset;
 }
 

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -16,15 +16,17 @@ import { getTicks } from './getTicks';
 import { CartesianAxis } from './CartesianAxis';
 import { useChartHeight, useChartWidth, useOffset } from '../context/chartLayoutContext';
 
-export type GridLineFunctionProps = Omit<LineItemProps, 'key'> & {
+export type GridLineTypeFunctionProps = Omit<LineItemProps, 'key'> & {
   // React does not pass the key through when calling cloneElement - so it might be undefined when cloning
   key: LineItemProps['key'] | undefined;
+  // offset is not present in LineItemProps but it is read from context and then passed to the GridLineType function and element
+  offset: ChartOffset;
 };
 
 type GridLineType =
   | SVGProps<SVGLineElement>
   | ReactElement<SVGElement>
-  | ((props: GridLineFunctionProps) => ReactElement<SVGElement>)
+  | ((props: GridLineTypeFunctionProps) => ReactElement<SVGElement>)
   | boolean;
 
 export type HorizontalCoordinatesGenerator = (
@@ -54,7 +56,6 @@ interface InternalCartesianGridProps {
   verticalCoordinatesGenerator?: VerticalCoordinatesGenerator;
   xAxis?: null | (Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> });
   yAxis?: null | (Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> });
-  offset?: ChartOffset;
 }
 
 interface CartesianGridProps extends InternalCartesianGridProps {
@@ -150,6 +151,7 @@ const Background = (props: Pick<AcceptedSvgProps, 'fill' | 'fillOpacity' | 'x' |
 };
 
 type LineItemProps = Props & {
+  offset: ChartOffset;
   x1: number;
   y1: number;
   x2: number;
@@ -175,7 +177,11 @@ function renderLineItem(option: GridLineType, props: LineItemProps) {
   return lineItem;
 }
 
-function HorizontalGridLines(props: Props) {
+type GridLinesProps = Props & {
+  offset: ChartOffset;
+};
+
+function HorizontalGridLines(props: GridLinesProps) {
   const { x, width, horizontal = true, horizontalPoints } = props;
 
   if (!horizontal || !horizontalPoints || !horizontalPoints.length) {
@@ -199,7 +205,7 @@ function HorizontalGridLines(props: Props) {
   return <g className="recharts-cartesian-grid-horizontal">{items}</g>;
 }
 
-function VerticalGridLines(props: Props) {
+function VerticalGridLines(props: GridLinesProps) {
   const { y, height, vertical = true, verticalPoints } = props;
 
   if (!vertical || !verticalPoints || !verticalPoints.length) {
@@ -453,9 +459,9 @@ export function CartesianGrid(props: Props) {
         width={propsIncludingDefaults.width}
         height={propsIncludingDefaults.height}
       />
-      <HorizontalGridLines {...propsIncludingDefaults} horizontalPoints={horizontalPoints} />
+      <HorizontalGridLines {...propsIncludingDefaults} offset={offset} horizontalPoints={horizontalPoints} />
 
-      <VerticalGridLines {...propsIncludingDefaults} verticalPoints={verticalPoints} />
+      <VerticalGridLines {...propsIncludingDefaults} offset={offset} verticalPoints={verticalPoints} />
 
       <HorizontalStripes {...propsIncludingDefaults} horizontalPoints={horizontalPoints} />
 

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -14,7 +14,7 @@ import { filterProps } from '../util/ReactUtils';
 import { getCoordinatesOfGrid, getTicksOfAxis } from '../util/ChartUtils';
 import { getTicks } from './getTicks';
 import { CartesianAxis } from './CartesianAxis';
-import { useChartHeight, useChartWidth } from '../context/chartLayoutContext';
+import { useChartHeight, useChartWidth, useOffset } from '../context/chartLayoutContext';
 
 export type GridLineFunctionProps = Omit<LineItemProps, 'key'> & {
   // React does not pass the key through when calling cloneElement - so it might be undefined when cloning
@@ -350,6 +350,7 @@ const defaultProps: Partial<Props> = {
 export function CartesianGrid(props: Props) {
   const chartWidth = useChartWidth();
   const chartHeight = useChartHeight();
+  const offset = useOffset();
   const propsIncludingDefaults: Props = {
     ...props,
     stroke: props.stroke ?? defaultProps.stroke,
@@ -360,8 +361,7 @@ export function CartesianGrid(props: Props) {
     verticalFill: props.verticalFill ?? defaultProps.verticalFill,
   };
 
-  const { x, y, width, height, xAxis, yAxis, offset, syncWithTicks, horizontalValues, verticalValues } =
-    propsIncludingDefaults;
+  const { x, y, width, height, xAxis, yAxis, syncWithTicks, horizontalValues, verticalValues } = propsIncludingDefaults;
 
   if (
     !isNumber(width) ||

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1818,7 +1818,6 @@ export const generateCategoricalChart = ({
         height: isNumber(props.height) ? props.height : offset.height,
         xAxis,
         yAxis,
-        offset,
         verticalCoordinatesGenerator: props.verticalCoordinatesGenerator,
         horizontalCoordinatesGenerator: props.horizontalCoordinatesGenerator,
       });

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -9,7 +9,7 @@ import { calculateViewBox } from '../util/calculateViewBox';
 export const XAxisContext = createContext<XAxisMap | undefined>(undefined);
 export const YAxisContext = createContext<YAxisMap | undefined>(undefined);
 export const ViewBoxContext = createContext<CartesianViewBox | undefined>(undefined);
-export const OffsetContext = createContext<ChartOffset | null>(null);
+export const OffsetContext = createContext<ChartOffset>({});
 export const ClipPathIdContext = createContext<string | undefined>(undefined);
 export const ChartHeightContext = createContext<number>(0);
 export const ChartWidthContext = createContext<number>(0);

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, createContext, useContext } from 'react';
 import invariant from 'tiny-invariant';
-import { CartesianViewBox, XAxisMap, YAxisMap } from '../util/types';
+import { CartesianViewBox, ChartOffset, XAxisMap, YAxisMap } from '../util/types';
 import type { CategoricalChartState } from '../chart/types';
 import type { Props as XAxisProps } from '../cartesian/XAxis';
 import type { Props as YAxisProps } from '../cartesian/YAxis';
@@ -9,6 +9,7 @@ import { calculateViewBox } from '../util/calculateViewBox';
 export const XAxisContext = createContext<XAxisMap | undefined>(undefined);
 export const YAxisContext = createContext<YAxisMap | undefined>(undefined);
 export const ViewBoxContext = createContext<CartesianViewBox | undefined>(undefined);
+export const OffsetContext = createContext<ChartOffset | null>(null);
 export const ClipPathIdContext = createContext<string | undefined>(undefined);
 export const ChartHeightContext = createContext<number>(0);
 export const ChartWidthContext = createContext<number>(0);
@@ -36,6 +37,9 @@ export const ChartLayoutContextProvider = (props: {
     height,
   } = props;
 
+  /**
+   * Perhaps we should compute this property when reading? Let's see what is more often used
+   */
   const viewBox = calculateViewBox(offset);
 
   /*
@@ -54,13 +58,15 @@ export const ChartLayoutContextProvider = (props: {
   return (
     <XAxisContext.Provider value={xAxisMap}>
       <YAxisContext.Provider value={yAxisMap}>
-        <ViewBoxContext.Provider value={viewBox}>
-          <ClipPathIdContext.Provider value={clipPathId}>
-            <ChartHeightContext.Provider value={height}>
-              <ChartWidthContext.Provider value={width}>{children}</ChartWidthContext.Provider>
-            </ChartHeightContext.Provider>
-          </ClipPathIdContext.Provider>
-        </ViewBoxContext.Provider>
+        <OffsetContext.Provider value={offset}>
+          <ViewBoxContext.Provider value={viewBox}>
+            <ClipPathIdContext.Provider value={clipPathId}>
+              <ChartHeightContext.Provider value={height}>
+                <ChartWidthContext.Provider value={width}>{children}</ChartWidthContext.Provider>
+              </ChartHeightContext.Provider>
+            </ClipPathIdContext.Provider>
+          </ViewBoxContext.Provider>
+        </OffsetContext.Provider>
       </YAxisContext.Provider>
     </XAxisContext.Provider>
   );
@@ -111,6 +117,10 @@ export const useYAxisOrThrow = (yAxisId: string | number): YAxisProps => {
 export const useViewBox = (): CartesianViewBox => {
   const viewBox = useContext(ViewBoxContext);
   return viewBox;
+};
+
+export const useOffset = (): ChartOffset => {
+  return useContext(OffsetContext);
 };
 
 export const useChartWidth = (): number => {

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import { scaleLinear } from 'victory-vendor/d3-scale';
 import { CartesianGrid, LineChart, ComposedChart, BarChart, ScatterChart, AreaChart, Surface } from '../../src';
 import {
-  GridLineFunctionProps,
+  GridLineTypeFunctionProps,
   HorizontalCoordinatesGenerator,
   Props,
   VerticalCoordinatesGenerator,
@@ -28,15 +28,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
    */
   const floatingPointPrecisionExamples = [121.00000000000002, 231.00000000000005];
   const verticalPoints = [100, 200, 300, 400];
-  const offset: ChartOffset = {
-    top: 1,
-    bottom: 2,
-    left: 3,
-    right: 4,
-    width: 5,
-    height: 6,
-    brushBottom: 7,
-  };
 
   const chartMargin: Margin = {
     bottom: 11,
@@ -401,7 +392,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-              offset={{}}
             />
           </ChartElement>,
         );
@@ -433,7 +423,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               {...exampleCartesianGridDimensions}
               horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
               horizontalPoints={horizontalPoints}
-              offset={offset}
             />
           </ChartElement>,
         );
@@ -456,7 +445,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               {...exampleCartesianGridDimensions}
               yAxis={yAxis}
               horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-              offset={offset}
             />
           </ChartElement>,
         );
@@ -486,7 +474,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               {...exampleCartesianGridDimensions}
               yAxis={yAxis}
               horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-              offset={offset}
               syncWithTicks={false}
               horizontalValues={['a', 'b']}
             />
@@ -518,7 +505,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
                 {...exampleCartesianGridDimensions}
                 yAxis={yAxis}
                 horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-                offset={offset}
                 syncWithTicks={syncWithTicks}
                 horizontalValues={[]}
               />
@@ -551,7 +537,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
                 {...exampleCartesianGridDimensions}
                 yAxis={yAxis}
                 horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-                offset={offset}
                 syncWithTicks={syncWithTicks}
               />
             </ChartElement>,
@@ -579,7 +564,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               <CartesianGrid
                 {...exampleCartesianGridDimensions}
                 horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
-                offset={offset}
               />
             </ChartElement>,
           );
@@ -627,7 +611,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-              offset={offset}
             />
           </ChartElement>,
         );
@@ -659,7 +642,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               {...exampleCartesianGridDimensions}
               verticalCoordinatesGenerator={verticalCoordinatesGenerator}
               verticalPoints={verticalPoints}
-              offset={offset}
             />
           </ChartElement>,
         );
@@ -682,7 +664,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               {...exampleCartesianGridDimensions}
               xAxis={xAxis}
               verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-              offset={offset}
             />
           </ChartElement>,
         );
@@ -712,7 +693,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               {...exampleCartesianGridDimensions}
               xAxis={xAxis}
               verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-              offset={offset}
               syncWithTicks={false}
               verticalValues={['a', 'b']}
             />
@@ -744,7 +724,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
                 {...exampleCartesianGridDimensions}
                 xAxis={xAxis}
                 verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-                offset={offset}
                 syncWithTicks={syncWithTicks}
                 horizontalValues={[]}
               />
@@ -777,7 +756,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
                 {...exampleCartesianGridDimensions}
                 xAxis={xAxis}
                 verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-                offset={offset}
                 syncWithTicks={syncWithTicks}
               />
             </ChartElement>,
@@ -805,7 +783,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               <CartesianGrid
                 {...exampleCartesianGridDimensions}
                 verticalCoordinatesGenerator={verticalCoordinatesGenerator}
-                offset={offset}
               />
             </ChartElement>,
           );
@@ -860,7 +837,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
         );
         expect(horizontal).toHaveBeenCalledTimes(horizontalPoints.length);
 
-        const expectedProps: GridLineFunctionProps = {
+        const expectedProps: GridLineTypeFunctionProps = {
           stroke: '#ccc',
           fill: 'none',
           height: 200,
@@ -918,7 +895,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
         );
         expect(spy).toHaveBeenCalledTimes(horizontalPoints.length);
 
-        const expectedProps: GridLineFunctionProps = {
+        const expectedProps: GridLineTypeFunctionProps = {
           stroke: '#ccc',
           fill: 'none',
           height: 200,
@@ -972,7 +949,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
         );
         expect(vertical).toHaveBeenCalledTimes(verticalPoints.length);
 
-        const expectedProps: GridLineFunctionProps = {
+        const expectedProps: GridLineTypeFunctionProps = {
           stroke: '#ccc',
           fill: 'none',
           height: 200,
@@ -1030,7 +1007,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
         );
         expect(spy).toHaveBeenCalledTimes(verticalPoints.length);
 
-        const expectedProps: GridLineFunctionProps = {
+        const expectedProps: GridLineTypeFunctionProps = {
           stroke: '#ccc',
           fill: 'none',
           height: 200,
@@ -1134,7 +1111,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               {...exampleCartesianGridDimensions}
               horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
               horizontalFill={['red', 'green']}
-              offset={offset}
             />
           </ChartElement>,
         );
@@ -1304,7 +1280,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             verticalFill={['red', 'green']}
             fillOpacity="20%"
             vertical={vertical}
-            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1353,7 +1328,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               height={500}
               verticalCoordinatesGenerator={verticalCoordinatesGenerator}
               verticalFill={['red', 'green']}
-              offset={offset}
             />
           </ChartElement>,
         );
@@ -1374,7 +1348,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             verticalFill={['red', 'green']}
             fillOpacity="20%"
             vertical={false}
-            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1388,7 +1361,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             width={Math.max(...verticalPoints) + 1}
             verticalPoints={verticalPoints}
             verticalFill={fill}
-            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1403,7 +1375,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             width={Math.max(...verticalPoints) + 1}
             verticalPoints={verticalPoints}
             verticalFill={['red', 'green']}
-            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1418,7 +1389,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             width={Math.max(...verticalPoints) + 1}
             verticalPoints={verticalPoints}
             verticalFill={['red', 'green']}
-            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1435,7 +1405,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             width={Math.max(...verticalPoints) - 1}
             verticalPoints={verticalPoints}
             verticalFill={['red', 'green']}
-            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1449,7 +1418,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             width={1}
             verticalPoints={verticalPoints}
             verticalFill={['red', 'green']}
-            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1468,7 +1436,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             height={500}
             verticalPoints={floatingPointPrecisionExamples}
             verticalFill={['red', 'green']}
-            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1497,7 +1464,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             {...exampleCartesianGridDimensions}
             verticalPoints={[10, 20, 10, 500]}
             verticalFill={['red', 'green']}
-            offset={offset}
           />,
         );
         const allStripes = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
@@ -1531,7 +1497,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             {...exampleCartesianGridDimensions}
             verticalPoints={verticalPoints}
             horizontalPoints={horizontalPoints}
-            offset={offset}
           />
         </ChartElement>,
       );

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { describe, test, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { scaleLinear } from 'victory-vendor/d3-scale';
-import { Surface, CartesianGrid, LineChart, ComposedChart, BarChart, ScatterChart, AreaChart } from '../../src';
+import { CartesianGrid, LineChart, ComposedChart, BarChart, ScatterChart, AreaChart, Surface } from '../../src';
 import {
   GridLineFunctionProps,
   HorizontalCoordinatesGenerator,
@@ -205,13 +205,13 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
     describe('basic features', () => {
       it('should render on its own, outside of Recharts', () => {
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
             />
-          </Surface>,
+          </ChartElement>,
         );
         const allLines = container.querySelectorAll('line');
         expect.soft(allLines).toHaveLength(9);
@@ -230,13 +230,13 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
 
       test('Render 5 horizontal lines and 4 vertical lines in simple CartesianGrid', () => {
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
             />
-          </Surface>,
+          </ChartElement>,
         );
         expect.soft(container.querySelectorAll('line')).toHaveLength(9);
         expect
@@ -256,20 +256,20 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
         expect(container.querySelectorAll('line')).toHaveLength(0);
       });
 
-      test.each([0, -1, NaN, Infinity])("Don't render any lines when width is %s", w => {
+      test.each([0, -1, NaN, -Infinity])("Don't render any lines when width is %s", w => {
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={w} height={500}>
             <CartesianGrid width={w} height={500} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
-          </Surface>,
+          </ChartElement>,
         );
         expect(container.querySelectorAll('line')).toHaveLength(0);
       });
 
-      test.each([0, -1, NaN, Infinity])("Don't render any lines when height is %s", h => {
+      test.each([0, -1, NaN, -Infinity])("Don't render any lines when height is %s", h => {
         const { container } = render(
-          <Surface width={500} height={500}>
-            <CartesianGrid width={h} height={500} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
-          </Surface>,
+          <ChartElement width={500} height={h}>
+            <CartesianGrid width={500} height={h} verticalPoints={verticalPoints} horizontalPoints={horizontalPoints} />
+          </ChartElement>,
         );
         expect(container.querySelectorAll('line')).toHaveLength(0);
       });
@@ -278,14 +278,14 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
     describe('horizontalPoints without generator', () => {
       it('should not render any lines if horizontal=false', () => {
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               horizontal={false}
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
             />
-          </Surface>,
+          </ChartElement>,
         );
         expect.soft(container.querySelectorAll('line')).toHaveLength(verticalPoints.length);
         expect.soft(container.querySelectorAll('.recharts-cartesian-grid-horizontal line')).toHaveLength(0);
@@ -296,14 +296,14 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
 
       it('should render all lines if horizontal=true', () => {
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               horizontal
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
             />
-          </Surface>,
+          </ChartElement>,
         );
         expect.soft(container.querySelectorAll('line')).toHaveLength(9);
         expect
@@ -316,13 +316,13 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
 
       it('should render all lines if horizontal is undefined', () => {
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
             />
-          </Surface>,
+          </ChartElement>,
         );
         expect.soft(container.querySelectorAll('line')).toHaveLength(9);
         expect
@@ -337,14 +337,14 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
     describe('verticalPoints without generator', () => {
       it('should not render any lines if vertical=false', () => {
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               vertical={false}
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
             />
-          </Surface>,
+          </ChartElement>,
         );
         expect.soft(container.querySelectorAll('line')).toHaveLength(horizontalPoints.length);
         expect
@@ -355,14 +355,14 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
 
       it('should render all lines if vertical=true', () => {
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               vertical
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
             />
-          </Surface>,
+          </ChartElement>,
         );
         expect.soft(container.querySelectorAll('line')).toHaveLength(9);
         expect
@@ -375,13 +375,13 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
 
       it('should render all lines if vertical is undefined', () => {
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
             />
-          </Surface>,
+          </ChartElement>,
         );
         expect.soft(container.querySelectorAll('line')).toHaveLength(9);
         expect
@@ -397,13 +397,13 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
       it('should render lines that the generator returns', () => {
         const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([3, 4]);
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
               offset={{}}
             />
-          </Surface>,
+          </ChartElement>,
         );
 
         expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
@@ -428,14 +428,14 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
         const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
         expect(horizontalPoints.length).not.toBe(2);
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
               horizontalPoints={horizontalPoints}
               offset={offset}
             />
-          </Surface>,
+          </ChartElement>,
         );
 
         expect(horizontalCoordinatesGenerator).not.toHaveBeenCalled();
@@ -575,13 +575,13 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
         ({ gen }) => {
           const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue(gen);
           const { container } = render(
-            <Surface width={500} height={500}>
+            <ChartElement width={500} height={500}>
               <CartesianGrid
                 {...exampleCartesianGridDimensions}
                 horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
                 offset={offset}
               />
-            </Surface>,
+            </ChartElement>,
           );
 
           expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
@@ -597,9 +597,9 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
           ticks: [10, 50, 100],
         };
         const { container } = render(
-          <LineChart width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid x={0} y={0} width={500} height={500} xAxis={xAxis} />
-          </LineChart>,
+          </ChartElement>,
         );
 
         const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
@@ -623,13 +623,13 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
       it('should render lines that the generator returns', () => {
         const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([3, 4]);
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               verticalCoordinatesGenerator={verticalCoordinatesGenerator}
               offset={offset}
             />
-          </Surface>,
+          </ChartElement>,
         );
 
         expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
@@ -654,14 +654,14 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
         const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
         expect(verticalPoints.length).not.toBe(2);
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               verticalCoordinatesGenerator={verticalCoordinatesGenerator}
               verticalPoints={verticalPoints}
               offset={offset}
             />
-          </Surface>,
+          </ChartElement>,
         );
 
         expect(verticalCoordinatesGenerator).not.toHaveBeenCalled();
@@ -801,13 +801,13 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
         ({ gen }) => {
           const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue(gen);
           const { container } = render(
-            <Surface width={500} height={500}>
+            <ChartElement width={500} height={500}>
               <CartesianGrid
                 {...exampleCartesianGridDimensions}
                 verticalCoordinatesGenerator={verticalCoordinatesGenerator}
                 offset={offset}
               />
-            </Surface>,
+            </ChartElement>,
           );
 
           expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
@@ -849,14 +849,14 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
       it('should pass props, add default stroke, and then render result of the function', () => {
         const horizontal = vi.fn().mockReturnValue(<g data-testid="my_mock_line" />);
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
               horizontal={horizontal}
             />
-          </Surface>,
+          </ChartElement>,
         );
         expect(horizontal).toHaveBeenCalledTimes(horizontalPoints.length);
 
@@ -879,6 +879,19 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
           y1: expect.any(Number),
           y2: expect.any(Number),
           index: expect.any(Number),
+          horizontalCoordinatesGenerator: undefined,
+          verticalCoordinatesGenerator: undefined,
+          offset: {
+            bottom: 5,
+            brushBottom: 5,
+            height: 490,
+            left: 5,
+            right: 5,
+            top: 5,
+            width: 490,
+          },
+          xAxis: null,
+          yAxis: null,
         };
         expect(horizontal).toHaveBeenCalledWith(expectedProps);
 
@@ -889,19 +902,19 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
     describe('horizontal as an element', () => {
       it('should pass props, add default stroke, and then render result of the function', () => {
         const spy = vi.fn();
-        const Horizontal = (props: any) => {
+        const Horizontal = (props: unknown) => {
           spy(props);
           return <g data-testid="my_mock_line" />;
         };
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
               horizontal={<Horizontal />}
             />
-          </Surface>,
+          </ChartElement>,
         );
         expect(spy).toHaveBeenCalledTimes(horizontalPoints.length);
 
@@ -916,7 +929,6 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
           verticalFill: [],
           verticalPoints,
           horizontal: <Horizontal />,
-          // @ts-expect-error React does not pass the key through when calling cloneElement
           key: undefined,
           x: 1,
           y: 2,
@@ -925,6 +937,19 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
           y1: expect.any(Number),
           y2: expect.any(Number),
           index: expect.any(Number),
+          horizontalCoordinatesGenerator: undefined,
+          verticalCoordinatesGenerator: undefined,
+          offset: {
+            bottom: 5,
+            brushBottom: 5,
+            height: 490,
+            left: 5,
+            right: 5,
+            top: 5,
+            width: 490,
+          },
+          xAxis: null,
+          yAxis: null,
         };
         expect(spy).toHaveBeenCalledWith(expectedProps);
 
@@ -936,14 +961,14 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
       it('should pass props, add default stroke, and then render result of the function', () => {
         const vertical = vi.fn().mockReturnValue(<g data-testid="my_mock_line" />);
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
               vertical={vertical}
             />
-          </Surface>,
+          </ChartElement>,
         );
         expect(vertical).toHaveBeenCalledTimes(verticalPoints.length);
 
@@ -966,6 +991,19 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
           y1: 2,
           y2: 202,
           index: expect.any(Number),
+          horizontalCoordinatesGenerator: undefined,
+          verticalCoordinatesGenerator: undefined,
+          offset: {
+            bottom: 5,
+            brushBottom: 5,
+            height: 490,
+            left: 5,
+            right: 5,
+            top: 5,
+            width: 490,
+          },
+          xAxis: null,
+          yAxis: null,
         };
         expect(vertical).toHaveBeenCalledWith(expectedProps);
 
@@ -976,19 +1014,19 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
     describe('vertical as an element', () => {
       it('should pass props, add default stroke, and then render result of the function', () => {
         const spy = vi.fn();
-        const Vertical = (props: any) => {
+        const Vertical = (props: unknown) => {
           spy(props);
           return <g data-testid="my_mock_line" />;
         };
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
               vertical={<Vertical />}
             />
-          </Surface>,
+          </ChartElement>,
         );
         expect(spy).toHaveBeenCalledTimes(verticalPoints.length);
 
@@ -1003,7 +1041,19 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
           verticalFill: [],
           verticalPoints,
           vertical: <Vertical />,
-          // @ts-expect-error React does not pass the key through when calling cloneElement
+          horizontalCoordinatesGenerator: undefined,
+          verticalCoordinatesGenerator: undefined,
+          offset: {
+            bottom: 5,
+            brushBottom: 5,
+            height: 490,
+            left: 5,
+            right: 5,
+            top: 5,
+            width: 490,
+          },
+          xAxis: null,
+          yAxis: null,
           key: undefined,
           x: 1,
           y: 2,
@@ -1079,14 +1129,14 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
       it('should render stripes defined by horizontalCoordinatesGenerator', () => {
         const horizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               horizontalCoordinatesGenerator={horizontalCoordinatesGenerator}
               horizontalFill={['red', 'green']}
               offset={offset}
             />
-          </Surface>,
+          </ChartElement>,
         );
 
         expect(horizontalCoordinatesGenerator).toHaveBeenCalledOnce();
@@ -1295,7 +1345,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
       it('should render stripes defined by verticalCoordinatesGenerator', () => {
         const verticalCoordinatesGenerator: VerticalCoordinatesGenerator = vi.fn().mockReturnValue([1, 2]);
         const { container } = render(
-          <Surface width={500} height={500}>
+          <ChartElement width={500} height={500}>
             <CartesianGrid
               x={0}
               y={0}
@@ -1305,7 +1355,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               verticalFill={['red', 'green']}
               offset={offset}
             />
-          </Surface>,
+          </ChartElement>,
         );
 
         expect(verticalCoordinatesGenerator).toHaveBeenCalledOnce();
@@ -1476,19 +1526,19 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
   describe('offset prop', () => {
     it('should not pass the offset prop anywhere', () => {
       const { container } = render(
-        <Surface width={500} height={500}>
+        <ChartElement width={500} height={500}>
           <CartesianGrid
             {...exampleCartesianGridDimensions}
             verticalPoints={verticalPoints}
             horizontalPoints={horizontalPoints}
             offset={offset}
           />
-        </Surface>,
+        </ChartElement>,
       );
       // select everything
       const allElements = container.querySelectorAll('*');
       // check that the selector worked
-      expect(allElements).toHaveLength(15);
+      expect(allElements).toHaveLength(19);
       for (let i = 0; i < allElements.length; i++) {
         const element = allElements[0];
         expect(element).not.toHaveAttribute('offset');

--- a/test/chart/AreaChart.spec.tsx
+++ b/test/chart/AreaChart.spec.tsx
@@ -241,18 +241,27 @@ describe('AreaChart', () => {
 
   describe('AreaChart layout context', () => {
     it(
-      'should provide viewBox and clipPathId if there are no axes',
+      'should provide viewBox and offset and clipPathId if there are no axes',
       testChartLayoutContext(
         props => (
           <AreaChart width={100} height={50} barSize={20}>
             {props.children}
           </AreaChart>
         ),
-        ({ clipPathId, viewBox, xAxisMap, yAxisMap }) => {
+        ({ clipPathId, viewBox, xAxisMap, yAxisMap, offset }) => {
           expect(clipPathId).toMatch(/recharts\d+-clip/);
           expect(viewBox).toEqual({ height: 40, width: 90, x: 5, y: 5 });
           expect(xAxisMap).toEqual({});
           expect(yAxisMap).toEqual({});
+          expect(offset).toEqual({
+            bottom: 5,
+            brushBottom: 5,
+            height: 40,
+            left: 5,
+            right: 5,
+            top: 5,
+            width: 90,
+          });
         },
       ),
     );

--- a/test/util/context.tsx
+++ b/test/util/context.tsx
@@ -6,10 +6,11 @@ import {
   useChartHeight,
   useChartWidth,
   useClipPathId,
+  useOffset,
   useViewBox,
 } from '../../src/context/chartLayoutContext';
 import { Tooltip } from '../../src/component/Tooltip';
-import { CartesianViewBox, XAxisMap, YAxisMap } from '../../src/util/types';
+import { CartesianViewBox, ChartOffset, XAxisMap, YAxisMap } from '../../src/util/types';
 
 type AllContextPropertiesMixed = {
   clipPathId: string | undefined;
@@ -18,6 +19,7 @@ type AllContextPropertiesMixed = {
   viewBox: CartesianViewBox | undefined;
   width: number;
   height: number;
+  offset: ChartOffset | null;
 };
 
 export function testChartLayoutContext(
@@ -47,7 +49,8 @@ export function testChartLayoutContext(
       const yAxisMap = useContext(YAxisContext);
       const width = useChartWidth();
       const height = useChartHeight();
-      const context: AllContextPropertiesMixed = { clipPathId, viewBox, xAxisMap, yAxisMap, width, height };
+      const offset = useOffset();
+      const context: AllContextPropertiesMixed = { clipPathId, viewBox, xAxisMap, yAxisMap, width, height, offset };
       assertions(context);
       return <></>;
     }


### PR DESCRIPTION
## Description

One more PR, one less cloned prop

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

no more cloning

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
