### PR TITLE
Make JSDoc types optional

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,10 @@
       }
     ],
     "import/extensions": "off",
-    "valid-jsdoc": "error",
+    "valid-jsdoc": ["error", {
+      "requireReturnType": false,
+      "requireParamType": false
+    }],
     "react/no-did-update-set-state": "warn",
     "react/sort-comp": "off",
     "react/jsx-uses-react": "error",


### PR DESCRIPTION
typescript types already include this information, let's focus on that.

Discussed here: https://recharts.slack.com/archives/C042Q5K5UDC/p1706230072017109
