### PR TITLE
Chore: reintroduce index on scatter layer component

### DIFF
--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -278,7 +278,8 @@ export class Scatter extends PureComponent<Props, State> {
         <Layer
           className="recharts-scatter-symbol"
           {...adaptEventsOfChild(this.props, entry, i)}
-          key={`symbol-${entry?.cx}-${entry?.cy}-${entry?.size}`}
+          // eslint-disable-next-line react/no-array-index-key
+          key={`symbol-${entry?.cx}-${entry?.cy}-${entry?.size}-${i}`}
           role="img"
         >
           <ScatterSymbol option={option} isActive={isActive} {...props} />


### PR DESCRIPTION
## Description
include the `index` in the key of rendered `Layer` components to remove duplicate-key logged errors

## Related Issue
https://github.com/recharts/recharts/issues/4060


## Motivation and Context
This removes a logged error due to duplicate-keys

## How Has This Been Tested?
_manually_  

## Types of changes

- [x] "Bug fix" (non-breaking change which fixes an issue) 

## Checklist: -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
