### PR TITLE
Add Cell story

### DIFF
--- a/storybook/stories/API/component/Cell.mdx
+++ b/storybook/stories/API/component/Cell.mdx
@@ -1,0 +1,21 @@
+import { Meta, Story, Canvas, Controls } from '@storybook/blocks';
+import * as ComponentStories from './Cell.stories';
+
+# Cell
+
+Cell can be wrapped by Pie, Bar, or RadialBar to specify attributes of each child. 
+In Pie, for example, we can specify the attributes of each child node through data,
+but the props of Cell have higher priority.
+
+<Meta of={ComponentStories} />
+
+<Canvas>
+  <Story name="API" of={ComponentStories} />
+</Canvas>
+
+## Parent Components
+The Legend can be used within a `<Bar />`, `<Scatter />`, `<Pie />`, `<RadialBar />` or a `<Funnel />`
+
+## Properties
+
+<Controls of={ComponentStories.API} />

--- a/storybook/stories/API/component/Cell.stories.tsx
+++ b/storybook/stories/API/component/Cell.stories.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Cell, Pie, PieChart, ResponsiveContainer } from '../../../../src';
+import { GeneralStyle } from '../props/Styles';
+import { EventHandlers } from '../props/EventHandlers';
+import { getStoryArgsFromArgsTypesObject } from '../props/utils';
+import { pageData } from '../../data';
+
+export default {
+  argTypes: {
+    ...GeneralStyle,
+    ...EventHandlers,
+    // Deprecated
+    dangerouslySetInnerHTML: { table: { category: 'Deprecated', disable: true } },
+  },
+  component: Cell,
+};
+
+const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', 'red', 'pink', 'url(#pattern-checkers)'];
+
+export const API = {
+  render: (args: Record<string, any>) => {
+    const surfaceDimension = 400;
+    return (
+      <ResponsiveContainer width="100%" height={surfaceDimension}>
+        <PieChart>
+          <defs>
+            <pattern id="pattern-checkers" x="0" y="0" width="10" height="10" patternUnits="userSpaceOnUse">
+              <rect x="0" width="5" height="5" y="0" />
+              <rect x="100" width="5" height="5" y="100" />
+            </pattern>
+          </defs>
+          <Pie data={pageData} dataKey="uv" label>
+            {pageData.map((entry, index) => (
+              <Cell key={`cell-pie-${entry.pv}-${entry.uv}`} fill={COLORS[index]} {...args} />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(GeneralStyle),
+    ...getStoryArgsFromArgsTypesObject(EventHandlers),
+  },
+};


### PR DESCRIPTION
## Description

Added cell story with props imported from `GeneralStyle` and `EventHandlers`. Two events (`onPointerEnterCapture` and `onPointerLeaveCapture` generate a console error (in screenshots) but appear to be valid events for the `Cell` component. I'm open to more information/advice on this from people who know more than me!

The Story is otherwise built to match the overall structure of other components in the Storybook (one "API" story per component), which differs slightly from the previous docs which had two demos (using `<PieChart />` and `<BarChart />`)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[#3736](https://github.com/recharts/recharts/issues/3736)

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

* Cell story
![image](https://github.com/recharts/recharts/assets/58190350/c049eadf-c564-4196-9e56-1654d42271cd)

* Event Handler error
![image](https://github.com/recharts/recharts/assets/58190350/7989db56-f9a6-45b9-a8f0-31baa1b0cbfb)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
