### PR TITLE
re-introduce "index" to pie slice keys

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -499,7 +499,8 @@ export class Pie extends PureComponent<Props, State> {
           tabIndex={-1}
           className="recharts-pie-sector"
           {...adaptEventsOfChild(this.props, entry, i)}
-          key={`sector-${entry?.startAngle}-${entry?.endAngle}-${entry.midAngle}`}
+          // eslint-disable-next-line react/no-array-index-key
+          key={`sector-${entry?.startAngle}-${entry?.endAngle}-${entry.midAngle}-${i}`}
         >
           <Shape option={sectorOptions} isActive={isActive} shapeType="sector" {...sectorProps} />
         </Layer>


### PR DESCRIPTION
## Description
Re-introduces the `index` to the `key` of pie sector rendered items

## Related Issue
[#4004](https://github.com/recharts/recharts/issues/4004)

## Motivation and Context
Remove a console.log error when iterating over pie slices that contain the same values and are bot equal to 0.

## How Has This Been Tested?
_manually_  

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- _remove error log_

## Checklist:
- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
- [ ] ~~I have added tests to cover my changes.~~
- [ ] ~~I have added a storybook story or extended an existing story to show my changes~~
- [x] All new and existing tests passed.
