### PR TITLE
chore: group babel and storybook dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,11 @@ updates:
     # request maintainers to review
     reviewers:
       - 'recharts/maintainers'
+    groups:
+      storybook:
+        patterns:
+          - '@storybook*'
+          - 'storybook'
+      babel:
+        patterns:
+          - '@babel*'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- group related dependencies (with the same/similar versions) into depbot groups to prevent 1000000000 PRs