### PR TITLE
ReferenceArea does not use element cloning anymore

### DIFF
--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -11,16 +11,12 @@ import { IfOverflow, ifOverflowMatches } from '../util/IfOverflowMatches';
 import { isNumOrStr } from '../util/DataUtils';
 import { warn } from '../util/LogUtils';
 import { Rectangle, Props as RectangleProps } from '../shape/Rectangle';
-import { CartesianViewBox, D3Scale } from '../util/types';
+import { D3Scale } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 
 import { useClipPathId, useMaybeXAxis, useMaybeYAxis } from '../context/chartLayoutContext';
 
-interface InternalReferenceAreaProps {
-  viewBox?: CartesianViewBox;
-}
-
-interface ReferenceAreaProps extends InternalReferenceAreaProps {
+interface ReferenceAreaProps {
   isFront?: boolean;
   /** @deprecated use ifOverflow="extendDomain"  */
   alwaysShow?: boolean;

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -2177,7 +2177,7 @@ export const generateCategoricalChart = ({
 
     renderMap = {
       CartesianGrid: { handler: renderAsIs, once: true },
-      ReferenceArea: { handler: this.renderReferenceElement },
+      ReferenceArea: { handler: renderAsIs },
       ReferenceLine: { handler: renderAsIs },
       ReferenceDot: { handler: this.renderReferenceElement },
       XAxis: { handler: renderAsIs },

--- a/storybook/stories/API/cartesian/ReferenceArea.stories.tsx
+++ b/storybook/stories/API/cartesian/ReferenceArea.stories.tsx
@@ -15,11 +15,7 @@ import {
 } from '../props/EventHandlers';
 import { animationBegin, animationDuration, animationEasing, isAnimationActive } from '../props/AnimationProps';
 import { GeneralStyle } from '../props/Styles';
-import {
-  ReferenceComponentGeneralArgs,
-  ReferenceComponentInternalArgs,
-  ReferenceComponentStyle,
-} from '../props/ReferenceComponentShared';
+import { ReferenceComponentGeneralArgs, ReferenceComponentStyle } from '../props/ReferenceComponentShared';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 
 const StyleProps: Args = {
@@ -84,23 +80,9 @@ const GeneralProps: Args = {
   },
 };
 
-const InternalProps: Args = {
-  ...ReferenceComponentInternalArgs,
-  viewBox: {
-    description: 'The box of the viewing area, usually calculated internally.',
-    table: {
-      type: {
-        summary: '{x: number, y: number, width: number, height: number}',
-      },
-      category: 'Internal',
-    },
-  },
-};
-
 const referenceAreaArgTypes = {
   ...StyleProps,
   ...GeneralProps,
-  ...InternalProps,
   // Rectangle
   radius,
   // Deprecated


### PR DESCRIPTION
## Description

Turns out it never used viewBox at all.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

no more cloning

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
