### PR TITLE
fix: compact render should read from context, fixes brush panorama

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -2206,10 +2206,17 @@ export const generateCategoricalChart = ({
       // The "compact" mode is mainly used as the panorama within Brush
       if (compact) {
         return (
-          <Surface {...attrs} width={width} height={height} title={title} desc={desc}>
-            {this.renderClipPath()}
-            {renderByOrder(children, this.renderMap)}
-          </Surface>
+          <ChartLayoutContextProvider
+            state={this.state}
+            width={this.props.width}
+            height={this.props.height}
+            clipPathId={this.clipPathId}
+          >
+            <Surface {...attrs} width={width} height={height} title={title} desc={desc}>
+              {this.renderClipPath()}
+              {renderByOrder(children, this.renderMap)}
+            </Surface>
+          </ChartLayoutContextProvider>
         );
       }
 

--- a/storybook/stories/Examples/cartesian/Brush/Brush.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Brush/Brush.stories.tsx
@@ -1,7 +1,19 @@
 import { expect } from '@storybook/jest';
 import React, { useState } from 'react';
 import { within, userEvent } from '@storybook/testing-library';
-import { ComposedChart, ResponsiveContainer, Line, Brush } from '../../../../../src';
+import {
+  ComposedChart,
+  ResponsiveContainer,
+  Line,
+  Brush,
+  CartesianGrid,
+  Legend,
+  LineChart,
+  ReferenceLine,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from '../../../../../src';
 import { pageData } from '../../../data';
 
 export default {
@@ -67,5 +79,30 @@ export const ControlledBrush = {
 
     expect(brushTexts.item(0).textContent).toContain('2');
     expect(brushTexts.item(1).textContent).toContain('5');
+  },
+};
+
+export const PanoramicBrush = {
+  render: () => {
+    return (
+      <ComposedChart width={600} height={300} data={pageData} margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>
+        <XAxis dataKey="name" />
+        <YAxis />
+        <CartesianGrid strokeDasharray="3 3" />
+        <Tooltip />
+        <Legend />
+        <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
+        <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+        <ReferenceLine stroke="red" strokeOpacity="red" strokeWidth={3} strokeLinecap="round" y={1000} />
+        <Brush dataKey="name">
+          <LineChart>
+            <ReferenceLine key="test" stroke="red" strokeOpacity="red" strokeWidth={3} strokeLinecap="round" y={1000} />
+            <CartesianGrid strokeDasharray="1 1" verticalPoints={[10, 20, 30]} horizontalPoints={[10, 20, 30]} />
+            <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
+            <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+          </LineChart>
+        </Brush>
+      </ComposedChart>
+    );
   },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Moving to context broke `compact` charts (aka, Brush panorama) for components that have moved to context (Grid, ReferenceLine) because the rendered compact chart was not wrapped in its own chart context as it was returned


- Wrap return in chart context
- New story adding panorama
- Unit test

Will release this as 2.12.1 and then backport to 3.x

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
https://github.com/recharts/recharts/issues/4193

<!--- Why is this change required? What problem does it solve? -->
Bug in 2.x and 3.x

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- storybook story
- unit test

## Screenshots (if appropriate):

![image](https://github.com/recharts/recharts/assets/25180830/8efcb71b-c9b6-4e9f-ba08-b92d56623d6c)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
