### PR TITLE
Add compact variant to parameterized test cases

### DIFF
--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -1,22 +1,15 @@
 import React, { ComponentType, FC, ReactNode } from 'react';
 import { describe, test, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import {
-  Area,
-  AreaChart,
-  BarChart,
-  ComposedChart,
-  FunnelChart,
-  LineChart,
-  PieChart,
-  RadarChart,
-  RadialBarChart,
-  ScatterChart,
-  XAxis,
-  YAxis,
-} from '../../src';
+import { Area, XAxis, YAxis } from '../../src';
 import type { Props } from '../../src/cartesian/Area';
 import { LayoutType } from '../../src/util/types';
+import {
+  AreaChartCase,
+  ComposedChartCase,
+  allCategoricalsChartsExcept,
+  includingCompact,
+} from '../helper/parameterizedTestCases';
 
 type TestCase = {
   ChartElement: ComponentType<{
@@ -29,24 +22,11 @@ type TestCase = {
   testName: string;
 };
 
-const chartsThatSupportArea: ReadonlyArray<TestCase> = [
-  { ChartElement: ComposedChart, testName: 'ComposedChart' },
-  { ChartElement: AreaChart, testName: 'AreaElement' },
-];
+const chartsThatSupportArea: ReadonlyArray<TestCase> = includingCompact([ComposedChartCase, AreaChartCase]);
 
-const chartsThatDoNotSupportArea: ReadonlyArray<TestCase> = [
-  { ChartElement: BarChart, testName: 'BarChart' },
-  { ChartElement: LineChart, testName: 'LineChart' },
-  { ChartElement: ScatterChart, testName: 'ScatterChart' },
-  { ChartElement: PieChart, testName: 'PieChart' },
-  { ChartElement: RadarChart, testName: 'RadarChart' },
-  { ChartElement: RadialBarChart, testName: 'RadialBarChart' },
-  { ChartElement: ScatterChart, testName: 'ScatterChart' },
-  { ChartElement: FunnelChart, testName: 'FunnelChart' },
-  // Treemap and Sankey do not accept children
-  // { ChartElement: Treemap, testName: 'Treemap' },
-  // { ChartElement: Sankey, testName: 'Sankey' },
-];
+const chartsThatDoNotSupportArea: ReadonlyArray<TestCase> = includingCompact(
+  allCategoricalsChartsExcept(chartsThatSupportArea),
+);
 
 const data = [
   { x: 10, y: 50, value: 100 },

--- a/test/cartesian/Bar.spec.tsx
+++ b/test/cartesian/Bar.spec.tsx
@@ -2,46 +2,24 @@ import React, { ComponentType, ReactNode } from 'react';
 import { describe, expect, test, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import uniqueId from 'lodash/uniqueId';
+import { Bar, Legend, LegendType, XAxis, YAxis } from '../../src';
 import {
-  AreaChart,
-  Bar,
-  BarChart,
-  ComposedChart,
-  FunnelChart,
-  Legend,
-  LegendType,
-  LineChart,
-  PieChart,
-  RadarChart,
-  RadialBarChart,
-  ScatterChart,
-  XAxis,
-  YAxis,
-} from '../../src';
+  BarChartCase,
+  ComposedChartCase,
+  allCategoricalsChartsExcept,
+  includingCompact,
+} from '../helper/parameterizedTestCases';
 
 type TestCase = {
   ChartElement: ComponentType<{ children?: ReactNode; width?: number; height?: number; data?: any[] }>;
   testName: string;
 };
 
-const chartsThatSupportBar: ReadonlyArray<TestCase> = [
-  { ChartElement: ComposedChart, testName: 'ComposedChart' },
-  { ChartElement: BarChart, testName: 'BarChart' },
-];
+const chartsThatSupportBar: ReadonlyArray<TestCase> = [ComposedChartCase, BarChartCase];
 
-const chartsThatDoNotSupportBar: ReadonlyArray<TestCase> = [
-  { ChartElement: AreaChart, testName: 'AreaElement' },
-  { ChartElement: LineChart, testName: 'LineChart' },
-  { ChartElement: ScatterChart, testName: 'ScatterChart' },
-  { ChartElement: PieChart, testName: 'PieChart' },
-  { ChartElement: RadarChart, testName: 'RadarChart' },
-  { ChartElement: RadialBarChart, testName: 'RadialBarChart' },
-  { ChartElement: ScatterChart, testName: 'ScatterChart' },
-  { ChartElement: FunnelChart, testName: 'FunnelChart' },
-  // Treemap and Sankey do not accept children
-  // { ChartElement: Treemap, testName: 'Treemap' },
-  // { ChartElement: Sankey, testName: 'Sankey' },
-];
+const chartsThatDoNotSupportBar: ReadonlyArray<TestCase> = includingCompact(
+  allCategoricalsChartsExcept(chartsThatSupportBar),
+);
 
 const data = [
   { x: 10, y: 50, width: 20, height: 50, value: 100, label: 'test1' },
@@ -51,7 +29,7 @@ const data = [
   { x: 170, y: 50, width: 20, height: 50, value: 500, label: 'test5' },
 ];
 
-describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartElement }) => {
+describe.each(includingCompact(chartsThatSupportBar))('<Bar /> as a child of $testName', ({ ChartElement }) => {
   it(`Render ${data.length} rectangles in horizontal Bar`, () => {
     const { container } = render(
       <ChartElement width={500} height={500}>
@@ -363,7 +341,12 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
       });
     });
   });
+});
 
+describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartElement }) => {
+  /**
+   * legend does not render in the compact chart so that's why this excludes the compact cases
+   */
   describe('legendType', () => {
     const allLegendTypesExceptNone: ReadonlyArray<LegendType> = [
       'circle',

--- a/test/helper/parameterizedTestCases.tsx
+++ b/test/helper/parameterizedTestCases.tsx
@@ -1,0 +1,137 @@
+import React, { ComponentType, ReactNode } from 'react';
+import { LayoutType } from '../../src/util/types';
+import {
+  AreaChart,
+  BarChart,
+  ComposedChart,
+  FunnelChart,
+  LineChart,
+  PieChart,
+  RadarChart,
+  RadialBarChart,
+  ScatterChart,
+} from '../../src';
+
+/**
+ * This is for parameterized tests - for when you have a bunch of tests and you want to run the same tests
+ * with different kinds of charts.
+ */
+export type ChartTestCase = {
+  ChartElement: ComponentType<{
+    children?: ReactNode;
+    width?: number;
+    height?: number;
+    data?: any[];
+    layout?: LayoutType;
+    compact?: boolean;
+  }>;
+  testName: string;
+};
+
+function makeCompact({ ChartElement, testName }: ChartTestCase) {
+  const compactTestCase: ChartTestCase = {
+    ChartElement: props => <ChartElement {...props} compact />,
+    testName: `compact ${testName}`,
+  };
+  return compactTestCase;
+}
+
+/**
+ * Duplicates each test case into two, one regular one compact.
+ *
+ * Recharts has two rendering modes, one "regular" another one "compact".
+ * The compact one is used when rendering a Brush - Recharts has the feature
+ * to return small "baby" chart inside there, for overview.
+ * There are some differences - for example, the compact version does not include Legend.
+ * And it does not listen to mouse events.
+ *
+ * For the cases when the behaviour is the same - for example, Area, or Bar rendering -
+ * this method can be useful to generate the test cases with both modes.
+ *
+ * @param testCases - array of test cases
+ * @returns array of test cases twice the size
+ */
+export function includingCompact(testCases: ReadonlyArray<ChartTestCase>): ReadonlyArray<ChartTestCase> {
+  const result: ChartTestCase[] = [];
+  testCases.forEach(testCase => {
+    result.push(testCase);
+    result.push(makeCompact(testCase));
+  });
+  return result;
+}
+
+export const ComposedChartCase: ChartTestCase = {
+  ChartElement: ComposedChart,
+  testName: 'ComposedChart',
+};
+
+export const AreaChartCase: ChartTestCase = {
+  ChartElement: AreaChart,
+  testName: 'AreaChart',
+};
+
+export const BarChartCase: ChartTestCase = {
+  ChartElement: BarChart,
+  testName: 'BarChart',
+};
+
+export const LineChartCase: ChartTestCase = {
+  ChartElement: LineChart,
+  testName: 'LineChart',
+};
+
+export const ScatterChartCase: ChartTestCase = {
+  ChartElement: ScatterChart,
+  testName: 'ScatterChart',
+};
+
+export const PieChartCase: ChartTestCase = {
+  ChartElement: PieChart,
+  testName: 'PieChart',
+};
+
+export const RadarChartCase: ChartTestCase = {
+  ChartElement: RadarChart,
+  testName: 'RadarChart',
+};
+
+export const RadialBarChartCase: ChartTestCase = {
+  ChartElement: RadialBarChart,
+  testName: 'RadialBarChart',
+};
+
+export const FunnelChartCase: ChartTestCase = {
+  ChartElement: FunnelChart,
+  testName: 'FunnelChart',
+};
+
+/**
+ * All charts coming out of generateCategoricalChart.
+ * Treemap and Sankey are left out because they do not
+ * use generateCategoricalChart - write tests for those separately.
+ */
+export const allCategoricalChartCases: ReadonlyArray<ChartTestCase> = [
+  ComposedChartCase,
+  AreaChartCase,
+  BarChartCase,
+  LineChartCase,
+  ScatterChartCase,
+  PieChartCase,
+  RadarChartCase,
+  RadialBarChartCase,
+  FunnelChartCase,
+];
+
+/**
+ * For when you want to exclude certain charts from the test suite.
+ * Useful for testing two sets of behaviour: my component behaves like this in these charts,
+ * and behaves like this in all other charts.
+ *
+ * This function uses allCategoricalChartCases as the base, and removes the given exceptions.
+ *
+ * @param exceptions charts that will be excluded from allCategoricalChartCases
+ * @returns chart test cases that are left
+ */
+export function allCategoricalsChartsExcept(exceptions: ReadonlyArray<ChartTestCase>): ReadonlyArray<ChartTestCase> {
+  return allCategoricalChartCases.filter(testCase => !exceptions.includes(testCase));
+}


### PR DESCRIPTION
## Description

Okay so I thought my parameterized tests are testing everything but apparently I missed the compact mode. So here's new test cases.

I also moved it to a new file to avoid repeating all the time. I will reuse these in other files too.

Since this effectively doubles the amount of tests it's running, I was interested in the time it takes. On my computer I can't tell the difference though - before, the test suite took between 30 and 50 seconds, after it takes between 30 and 50 seconds.

## Related Issue

https://github.com/recharts/recharts/issues/4193

## Motivation and Context

tests!

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
