### PR TITLE
Add tsconfig and npm script for running typescript in test folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,11 @@ jobs:
         run: npm ci
       - name: Run build
         run: npm run build --if-present
+      - name: Typecheck
+        run: npm run check-types
+      - name: Lint
+        run: npm run lint
       - name: Test
-        run: |
-          tsc --noEmit
-          npm run lint
-          npm test
+        run: npm test
       - name: Serve Storybook and run tests
         run: npm run test-storybook:ci

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build-es6": "rimraf es6 && cross-env NODE_ENV=es6 babel ./src -d es6 --extensions '.js,.ts,.tsx'",
     "build-umd": "rimraf umd && cross-env NODE_ENV=production webpack --entry ./src/index.ts -o umd",
     "build-types": "rimraf types && npm run tsc",
+    "check-types-test": "tsc --project test/tsconfig.json",
     "demo": "webpack serve --config demo/webpack.config.js --port 3000 --host 127.0.0.1 --progress --profile --static demo/",
     "test": "vitest run --config vitest.config.ts",
     "test-coverage": "vitest run --config vitest.config.ts --coverage",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build-es6": "rimraf es6 && cross-env NODE_ENV=es6 babel ./src -d es6 --extensions '.js,.ts,.tsx'",
     "build-umd": "rimraf umd && cross-env NODE_ENV=production webpack --entry ./src/index.ts -o umd",
     "build-types": "rimraf types && npm run tsc",
+    "check-types": "tsc --noEmit && npm run check-types-test",
     "check-types-test": "tsc --project test/tsconfig.json",
     "demo": "webpack serve --config demo/webpack.config.js --port 3000 --host 127.0.0.1 --progress --profile --static demo/",
     "test": "vitest run --config vitest.config.ts",

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -132,7 +132,7 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
       const { container } = render(
         <ChartElement width={500} height={500} data={data}>
           {/* Test that the error Cannot read properties of null (reading 'clipDot') does not appear in JS projects */}
-          {/* @ts-expect-error TypeScript correctly flags this as an error, but we want to have a test for it regardless */}
+          {/* TypeScript should flag this as an error, but we have strict null checks disabled in config */}
           <Area dataKey="value" dot={null} />
         </ChartElement>,
       );

--- a/test/cartesian/Bar.spec.tsx
+++ b/test/cartesian/Bar.spec.tsx
@@ -122,7 +122,7 @@ describe.each(includingCompact(chartsThatSupportBar))('<Bar /> as a child of $te
         x: expect.any(Number),
         y: 50,
       };
-      const backgroundComponent = props => {
+      const backgroundComponent = (props: unknown) => {
         expect.soft(props).toEqual(expectedProps);
         return <></>;
       };

--- a/test/context/chartLayoutContext.spec.tsx
+++ b/test/context/chartLayoutContext.spec.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { ComponentType, memo } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import {
@@ -29,7 +29,7 @@ describe('ChartLayoutContextProvider', () => {
   describe('ClipPathIdContext', () => {
     it('should add clipPathId to context', () => {
       expect.assertions(1);
-      const MockConsumer = () => {
+      const MockConsumer: ComponentType = () => {
         const clipPathId = useClipPathId();
         expect(clipPathId).toBe('my mock ID');
         return null;
@@ -43,7 +43,7 @@ describe('ChartLayoutContextProvider', () => {
 
     it('should return undefined when using the hook outside of context', () => {
       expect.assertions(1);
-      const MockComponent = () => {
+      const MockComponent: ComponentType = () => {
         const clipPathId = useClipPathId();
         expect(clipPathId).toBe(undefined);
         return null;
@@ -54,7 +54,7 @@ describe('ChartLayoutContextProvider', () => {
     describe('vanilla children', () => {
       it('should re-render children every time even when nothing changes', () => {
         let renderCount = 0;
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           renderCount++;
           return null;
         };
@@ -215,7 +215,7 @@ describe('ChartLayoutContextProvider', () => {
     };
 
     describe('useXAxisOrThrow', () => {
-      let originalConsoleError;
+      let originalConsoleError: typeof console.error;
       beforeAll(() => {
         originalConsoleError = console.error;
         console.error = vi.fn();
@@ -227,7 +227,7 @@ describe('ChartLayoutContextProvider', () => {
       });
 
       it('should throw when reading axis but the xAxisMap is undefined', () => {
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           useXAxisOrThrow('a');
           return null;
         };
@@ -243,7 +243,7 @@ describe('ChartLayoutContextProvider', () => {
       });
 
       it('should throw when reading axis outside of Recharts context', () => {
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           useXAxisOrThrow('a');
           return null;
         };
@@ -253,7 +253,7 @@ describe('ChartLayoutContextProvider', () => {
       });
 
       it('should throw when reading axis but the xAxisMap is empty object', () => {
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           useXAxisOrThrow('a');
           return null;
         };
@@ -269,7 +269,7 @@ describe('ChartLayoutContextProvider', () => {
       });
 
       it('should throw when axes are set but the ID is wrong', () => {
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           useXAxisOrThrow('wrong ID');
           return null;
         };
@@ -284,7 +284,7 @@ describe('ChartLayoutContextProvider', () => {
 
       it('should read xAxis from context', () => {
         expect.assertions(2);
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           const xAxis = useXAxisOrThrow('a');
           expect(xAxis).toEqual({
             width: 200,
@@ -302,7 +302,7 @@ describe('ChartLayoutContextProvider', () => {
     });
 
     describe('useMaybeXAxis', () => {
-      let originalConsoleError;
+      let originalConsoleError: typeof console.error;
       beforeAll(() => {
         originalConsoleError = console.error;
         console.error = vi.fn();
@@ -315,7 +315,7 @@ describe('ChartLayoutContextProvider', () => {
 
       it('should return undefined when reading axis but the xAxisMap is undefined', () => {
         expect.assertions(1);
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           const xAxis = useMaybeXAxis('wrong ID');
           expect(xAxis).toBe(undefined);
           return null;
@@ -330,7 +330,7 @@ describe('ChartLayoutContextProvider', () => {
 
       it('should return undefined when reading axis outside of Recharts context', () => {
         expect.assertions(1);
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           const xAxis = useMaybeXAxis('wrong ID');
           expect(xAxis).toBe(undefined);
           return null;
@@ -340,7 +340,7 @@ describe('ChartLayoutContextProvider', () => {
 
       it('should return undefined when reading axis but the xAxisMap is empty object', () => {
         expect.assertions(1);
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           const xAxis = useMaybeXAxis('wrong ID');
           expect(xAxis).toBe(undefined);
           return null;
@@ -356,7 +356,7 @@ describe('ChartLayoutContextProvider', () => {
 
       it('should return undefined when axes are set but the ID is wrong', () => {
         expect.assertions(1);
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           const xAxis = useMaybeXAxis('wrong ID');
           expect(xAxis).toBe(undefined);
           return null;
@@ -370,7 +370,7 @@ describe('ChartLayoutContextProvider', () => {
 
       it('should read xAxis from context', () => {
         expect.assertions(2);
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           const xAxis = useMaybeXAxis('a');
           expect(xAxis).toEqual({
             width: 200,
@@ -390,7 +390,7 @@ describe('ChartLayoutContextProvider', () => {
     describe('vanilla children', () => {
       it('should re-render children every time even when nothing changes', () => {
         let renderCount = 0;
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           renderCount++;
           return null;
         };
@@ -588,7 +588,7 @@ describe('ChartLayoutContextProvider', () => {
     };
 
     describe('useYAxisOrThrow', () => {
-      let originalConsoleError;
+      let originalConsoleError: typeof console.error;
       beforeAll(() => {
         originalConsoleError = console.error;
         console.error = vi.fn();
@@ -600,7 +600,7 @@ describe('ChartLayoutContextProvider', () => {
       });
 
       it('should throw when reading axis but the yAxisMap is undefined', () => {
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           useYAxisOrThrow('a');
           return null;
         };
@@ -616,7 +616,7 @@ describe('ChartLayoutContextProvider', () => {
       });
 
       it('should throw when reading axis outside of Recharts context', () => {
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           useYAxisOrThrow('a');
           return null;
         };
@@ -626,7 +626,7 @@ describe('ChartLayoutContextProvider', () => {
       });
 
       it('should throw when reading axis but the xAxisMap is empty object', () => {
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           useYAxisOrThrow('a');
           return null;
         };
@@ -642,7 +642,7 @@ describe('ChartLayoutContextProvider', () => {
       });
 
       it('should throw when axes are set but the ID is wrong', () => {
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           useYAxisOrThrow('wrong ID');
           return null;
         };
@@ -657,7 +657,7 @@ describe('ChartLayoutContextProvider', () => {
 
       it('should read yAxis from context', () => {
         expect.assertions(2);
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           const yAxis = useYAxisOrThrow('m');
           expect(yAxis).toEqual({
             width: 200,
@@ -675,7 +675,7 @@ describe('ChartLayoutContextProvider', () => {
     });
 
     describe('useMaybeYAxis', () => {
-      let originalConsoleError;
+      let originalConsoleError: typeof console.error;
       beforeAll(() => {
         originalConsoleError = console.error;
         console.error = vi.fn();
@@ -688,7 +688,7 @@ describe('ChartLayoutContextProvider', () => {
 
       it('should return undefined when reading axis but the yAxisMap is undefined', () => {
         expect.assertions(1);
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           const yAxis = useMaybeYAxis('a');
           expect(yAxis).toBe(undefined);
           return null;
@@ -703,7 +703,7 @@ describe('ChartLayoutContextProvider', () => {
 
       it('should return undefined when reading axis outside of Recharts context', () => {
         expect.assertions(1);
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           const yAxis = useMaybeYAxis('a');
           expect(yAxis).toBe(undefined);
           return null;
@@ -714,7 +714,7 @@ describe('ChartLayoutContextProvider', () => {
 
       it('should return undefined when reading axis but the xAxisMap is empty object', () => {
         expect.assertions(1);
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           const yAxis = useMaybeYAxis('a');
           expect(yAxis).toBe(undefined);
           return null;
@@ -730,7 +730,7 @@ describe('ChartLayoutContextProvider', () => {
 
       it('should return undefined when axes are set but the ID is wrong', () => {
         expect.assertions(1);
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           const yAxis = useMaybeYAxis('wrong ID');
           expect(yAxis).toBe(undefined);
           return null;
@@ -744,7 +744,7 @@ describe('ChartLayoutContextProvider', () => {
 
       it('should read yAxis from context', () => {
         expect.assertions(2);
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           const yAxis = useMaybeYAxis('m');
           expect(yAxis).toEqual({
             width: 200,
@@ -764,7 +764,7 @@ describe('ChartLayoutContextProvider', () => {
     describe('vanilla children', () => {
       it('should re-render children every time even when nothing changes', () => {
         let renderCount = 0;
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           renderCount++;
           return null;
         };
@@ -969,7 +969,7 @@ describe('ChartLayoutContextProvider', () => {
 
     it('should set viewBox to all undefined properties if there is offset but it is missing properties', () => {
       expect.assertions(1);
-      const MockConsumer = () => {
+      const MockConsumer: ComponentType = () => {
         const viewBox = useViewBox();
         expect(viewBox).toEqual({
           x: undefined,
@@ -988,7 +988,7 @@ describe('ChartLayoutContextProvider', () => {
 
     it('should add viewBox to context', () => {
       expect.assertions(1);
-      const MockConsumer = () => {
+      const MockConsumer: ComponentType = () => {
         const viewBox = useViewBox();
         expect(viewBox).toEqual({
           y: 10,
@@ -1008,7 +1008,7 @@ describe('ChartLayoutContextProvider', () => {
     describe('vanilla children', () => {
       it('should re-render children every time even when nothing changes', () => {
         let renderCount = 0;
-        const MockConsumer = () => {
+        const MockConsumer: ComponentType = () => {
           renderCount++;
           return null;
         };

--- a/test/shape/Curve.spec.tsx
+++ b/test/shape/Curve.spec.tsx
@@ -137,7 +137,7 @@ describe('getPath', () => {
     const actual = getPath({
       type: 'linear',
       layout: 'horizontal',
-      // @ts-expect-error type says not-null but when I try in sandbox I can see nulls coming here
+      // typescript type says not-null but when I try in sandbox I can see nulls coming here
       points: [{ x: 5, y: null }],
       baseLine: undefined,
     });

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "esModuleInterop": true,
+        "jsx": "react",
+        "module": "commonjs",
+        "noEmit": true,
+        "noImplicitAny": true,
+        "skipLibCheck": true,
+        "target": "es6"
+    },
+    "include": [
+        "../src/**/*",
+        "./**/*",
+        "../types.d.ts"
+    ]
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -10,7 +10,6 @@
         "target": "es6"
     },
     "include": [
-        "../src/**/*",
         "./**/*",
         "../types.d.ts"
     ]

--- a/test/util/ChartUtils.spec.tsx
+++ b/test/util/ChartUtils.spec.tsx
@@ -623,7 +623,7 @@ describe('getDomainOfErrorBars', () => {
     );
 
     it('should ignore null values for domain with direction y in yAxis domain', () => {
-      const valueNull = {
+      const valueNull: Record<string, unknown> = {
         x: 3,
         y: null,
         error: 30,
@@ -631,7 +631,7 @@ describe('getDomainOfErrorBars', () => {
       };
       expect(getDomainOfErrorBars([...data, valueNull], scatter, 'y', undefined, 'yAxis')).toEqual([90, 220]);
 
-      const valueAndErrorNull = {
+      const valueAndErrorNull: Record<string, unknown> = {
         x: 3,
         y: null,
         error: null,
@@ -639,7 +639,7 @@ describe('getDomainOfErrorBars', () => {
       };
       expect(getDomainOfErrorBars([...data, valueAndErrorNull], scatter, 'y', undefined, 'yAxis')).toEqual([90, 220]);
 
-      const errorNull = {
+      const errorNull: Record<string, unknown> = {
         x: 3,
         y: 300,
         error: null,
@@ -649,7 +649,7 @@ describe('getDomainOfErrorBars', () => {
     });
 
     it('should ignore null values for domain with direction x in xAxis domain', () => {
-      const valueNull = {
+      const valueNull: Record<string, unknown> = {
         x: null,
         y: 300,
         error: 30,
@@ -658,7 +658,7 @@ describe('getDomainOfErrorBars', () => {
 
       expect(getDomainOfErrorBars([...data, valueNull], scatter, 'x', undefined, 'xAxis')).toEqual([-14, 17]);
 
-      const valueAndErrorNull = {
+      const valueAndErrorNull: Record<string, unknown> = {
         x: null,
         y: 300,
         error: 30,
@@ -666,7 +666,7 @@ describe('getDomainOfErrorBars', () => {
       };
       expect(getDomainOfErrorBars([...data, valueAndErrorNull], scatter, 'x', undefined, 'xAxis')).toEqual([-14, 17]);
 
-      const errorNull = {
+      const errorNull: Record<string, unknown> = {
         x: 3,
         y: 300,
         error: 30,

--- a/test/util/calculateViewBox.spec.ts
+++ b/test/util/calculateViewBox.spec.ts
@@ -4,7 +4,8 @@ import { calculateViewBox } from '../../src/util/calculateViewBox';
 
 describe('calculateViewBox', () => {
   test('should throw if offset is undefined', () => {
-    // @ts-expect-error this should show an error - the function will not accept undefined, so typescript should highlight that too
+    // this should show an error - the function will not accept undefined, so typescript should highlight that too.
+    // but recharts has strict mode off so this is allowed!
     expect(() => calculateViewBox(undefined)).toThrow();
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,25 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    "declarationDir": "./types" /* Output directory for generated declaration files. */,
+    "esModuleInterop": true,
     "jsx": "react",
     "module": "commonjs",
     "noImplicitAny": true,
     "outDir": "./build/",
-    "declarationDir": "./types" /* Output directory for generated declaration files. */,
     "preserveConstEnums": true,
     "removeComments": true,
-    "esModuleInterop": true,
-    "sourceMap": true,
     "skipLibCheck": true,
-    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    "sourceMap": true,
     "target": "es6",
-    "allowSyntheticDefaultImports": true,
-    "types": ["vitest/globals"],
-    "baseUrl": "."
+    "types": [
+      "vitest/globals"
+    ]
   },
-  "include": ["./src/**/*", "types.d.ts"]
+  "include": [
+    "./src/**/*",
+    "types.d.ts"
+  ]
 }


### PR DESCRIPTION
## Description

Separate tsconfig to prevent exposing test types to npm + fixed ts errors in test folder + added tsc check to CI script.

## Related Issue

## Motivation and Context

If there's a typescript error in tests we want to know when merging.

## How Has This Been Tested?

npm scripts

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
