### PR TITLE
refactor: cleanup unused/old references to valueKey prop

### DIFF
--- a/demo/component/BarChart.tsx
+++ b/demo/component/BarChart.tsx
@@ -279,7 +279,7 @@ const initialState = {
 };
 
 const NoDataBar = (props: any) => {
-  const { x, width, value, valueKey, fill, y } = props;
+  const { x, width, value, dataKey, fill, y } = props;
 
   const noDataYVal = 5 + y / 2;
   const noDataHeight = y / 2 - 5;
@@ -288,7 +288,7 @@ const NoDataBar = (props: any) => {
     <svg className="NoDataLabel">
       <defs>
         <pattern
-          id={`hatch_${valueKey}`}
+          id={`hatch_${dataKey}`}
           patternUnits="userSpaceOnUse"
           width="35"
           height="10"
@@ -311,8 +311,8 @@ const NoDataBar = (props: any) => {
           fill="#ffffff"
           rx="3"
         />
-        <rect x={x} y={noDataYVal} width={width} height={noDataHeight} fill={`url(#hatch_${valueKey})`} />
-        <p>{value && value[valueKey] ? value[valueKey] : 'No Data'}</p>
+        <rect x={x} y={noDataYVal} width={width} height={noDataHeight} fill={`url(#hatch_${dataKey})`} />
+        <p>{value && value[dataKey] ? value[dataKey] : 'No Data'}</p>
       </g>
     </svg>
   );

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -28,19 +28,19 @@ const computeNode = ({
   depth,
   node,
   index,
-  valueKey,
+  dataKey,
 }: {
   depth: number;
   node: TreemapNode;
   index: number;
-  valueKey: DataKey<any>;
+  dataKey: DataKey<any>;
 }) => {
   const { children } = node;
   const childDepth = depth + 1;
   const computedChildren =
     children && children.length
       ? children.map((child: TreemapNode, i: number) =>
-          computeNode({ depth: childDepth, node: child, index: i, valueKey }),
+          computeNode({ depth: childDepth, node: child, index: i, dataKey }),
         )
       : null;
   let nodeValue;
@@ -48,8 +48,8 @@ const computeNode = ({
   if (children && children.length) {
     nodeValue = computedChildren.reduce((result: any, child: TreemapNode) => result + child[NODE_VALUE_KEY], 0);
   } else {
-    // TODO need to verify valueKey
-    nodeValue = isNan(node[valueKey as string]) || node[valueKey as string] <= 0 ? 0 : node[valueKey as string];
+    // TODO need to verify dataKey
+    nodeValue = isNan(node[dataKey as string]) || node[dataKey as string] <= 0 ? 0 : node[dataKey as string];
   }
 
   return {
@@ -335,7 +335,7 @@ export class Treemap extends PureComponent<Props, State> {
         depth: 0,
         node: { children: nextProps.data, x: 0, y: 0, width: nextProps.width, height: nextProps.height } as TreemapNode,
         index: 0,
-        valueKey: nextProps.dataKey,
+        dataKey: nextProps.dataKey,
       });
       const formatRoot = squarify(root, nextProps.aspectRatio);
 
@@ -426,7 +426,7 @@ export class Treemap extends PureComponent<Props, State> {
         depth: 0,
         node: { ...node, x: 0, y: 0, width, height },
         index: 0,
-        valueKey: dataKey,
+        dataKey,
       });
 
       const formatRoot = squarify(root, aspectRatio);
@@ -452,7 +452,7 @@ export class Treemap extends PureComponent<Props, State> {
       depth: 0,
       node: { ...node, x: 0, y: 0, width, height },
       index: 0,
-      valueKey: dataKey,
+      dataKey,
     });
 
     const formatRoot = squarify(root, aspectRatio);

--- a/storybook/stories/API/polar/Pie.stories.tsx
+++ b/storybook/stories/API/polar/Pie.stories.tsx
@@ -8,7 +8,7 @@ import { ActiveShapeProps } from '../props/ActiveShapeProps';
 
 const GeneralProps: Args = {
   cx: {
-    description: `The x-coordinate of center. If set a percentage, 
+    description: `The x-coordinate of center. If set a percentage,
       the final value is obtained by multiplying the percentage of container width.`,
     table: {
       type: { summary: 'percentage | number', defaultValue: '50%' },
@@ -16,7 +16,7 @@ const GeneralProps: Args = {
     },
   },
   cy: {
-    description: `The y-coordinate of center. If set a percentage, 
+    description: `The y-coordinate of center. If set a percentage,
       the final value is obtained by multiplying the percentage of container height.`,
     table: {
       type: { summary: 'percentage | number', defaultValue: '50%' },
@@ -24,7 +24,7 @@ const GeneralProps: Args = {
     },
   },
   innerRadius: {
-    description: `The inner radius of all the sectors. If set a percentage, the final value is 
+    description: `The inner radius of all the sectors. If set a percentage, the final value is
       obtained by multiplying the percentage of maxRadius which is calculated by the width, height, cx, cy.`,
     table: {
       type: { summary: 'percentage | number', defaultValue: 0 },
@@ -32,7 +32,7 @@ const GeneralProps: Args = {
     },
   },
   outerRadius: {
-    description: `The outer radius of all the sectors. If set a percentage, the final value is 
+    description: `The outer radius of all the sectors. If set a percentage, the final value is
       obtained by multiplying the percentage of maxRadius which is calculated by the width, height, cx, cy.`,
     table: {
       type: { summary: 'percentage | number', defaultValue: '80%' },
@@ -80,7 +80,7 @@ const GeneralProps: Args = {
     description: 'The type of icon in legend. If set to "none", no legend item will be rendered.',
     table: {
       type: {
-        summary: `'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' 
+        summary: `'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square'
           | 'star' | 'triangle' | 'wye' | 'none'`,
         defaultValue: 'rect',
       },
@@ -88,10 +88,10 @@ const GeneralProps: Args = {
     },
   },
   label: {
-    description: `If false set, labels will not be drawn. If true set, labels will be drawn which have 
-      the props calculated internally. If object set, labels will be drawn which have the props 
-      merged by the internal calculated props and the option. If ReactElement set, the option 
-      can be the custom label element. If set a function, the function will be called to render 
+    description: `If false set, labels will not be drawn. If true set, labels will be drawn which have
+      the props calculated internally. If object set, labels will be drawn which have the props
+      merged by the internal calculated props and the option. If ReactElement set, the option
+      can be the custom label element. If set a function, the function will be called to render
       customized label.`,
     table: {
       type: { summary: 'Boolean | Object | ReactElement | Function', defaultValue: false },
@@ -99,10 +99,10 @@ const GeneralProps: Args = {
     },
   },
   labelLine: {
-    description: `If false set, label lines will not be drawn. If true set, label lines will be drawn which 
-      have the props calculated internally. If object set, label lines will be drawn which have 
-      the props merged by the internal calculated props and the option. If ReactElement set, 
-      the option can be the custom label line element. If set a function, the function will be 
+    description: `If false set, label lines will not be drawn. If true set, label lines will be drawn which
+      have the props calculated internally. If object set, label lines will be drawn which have
+      the props merged by the internal calculated props and the option. If ReactElement set,
+      the option can be the custom label line element. If set a function, the function will be
       called to render customized label line.`,
     table: {
       type: { summary: 'Boolean | Object | ReactElement | Function', defaultValue: false },
@@ -135,12 +135,6 @@ export default {
     ...AnimationProps,
     // Deprecated
     dangerouslySetInnerHTML: { table: { category: 'Deprecated' }, hide: true, disable: true },
-    valueKey: {
-      description: "Use 'dataKey' alternatively, The key of each sector's value.",
-      table: { type: { summary: 'string', defaultValue: 'value' }, category: 'Deprecated' },
-      hide: true,
-      disable: true,
-    },
   },
   component: Pie,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Breaking change to remove old prop

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A - I should've made one but I'm too lazy

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- removes unneeded lines of code
- follows up on a removal that was slated for 1.1.0?

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

build succeeds

## Screenshots (if appropriate):

N?A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
