### PR TITLE
Reading Legend payload from context: proof of concept

### DIFF
--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -4,22 +4,30 @@ import { DefaultLegendContent, Payload, Props as DefaultProps, ContentType } fro
 import { isNumber } from '../util/DataUtils';
 import { LayoutType } from '../util/types';
 import { UniqueOption, getUniqPayload } from '../util/payload/getUniqPayload';
+import { useLegendPayload } from '../context/LegendPayloadContext';
 
 function defaultUniqBy(entry: Payload) {
   return entry.value;
 }
 
-function renderContent(content: ContentType, props: Props) {
+type PieContentProps = {
+  content: ContentType;
+  props: Props;
+};
+
+function PieContent({ content, props }: PieContentProps) {
+  const contextPayload = useLegendPayload();
+  const uniqPayload = getUniqPayload(contextPayload, props.payloadUniqBy, defaultUniqBy);
   if (React.isValidElement(content)) {
-    return React.cloneElement(content, props);
+    return React.cloneElement(content, { ...props, payload: uniqPayload });
   }
   if (typeof content === 'function') {
-    return React.createElement(content as any, props);
+    return React.createElement(content as any, { ...props, payload: uniqPayload });
   }
 
   const { ref, ...otherProps } = props;
 
-  return <DefaultLegendContent {...otherProps} />;
+  return <DefaultLegendContent {...otherProps} payload={uniqPayload} />;
 }
 
 const EPS = 1;
@@ -166,7 +174,7 @@ export class Legend extends PureComponent<Props, State> {
   }
 
   public render() {
-    const { content, width, height, wrapperStyle, payloadUniqBy, payload } = this.props;
+    const { content, width, height, wrapperStyle } = this.props;
     const outerStyle: CSSProperties = {
       position: 'absolute',
       width: width || 'auto',
@@ -183,7 +191,7 @@ export class Legend extends PureComponent<Props, State> {
           this.wrapperNode = node;
         }}
       >
-        {renderContent(content, { ...this.props, payload: getUniqPayload(payload, payloadUniqBy, defaultUniqBy) })}
+        <PieContent content={content} props={this.props} />
       </div>
     );
   }

--- a/src/context/LegendPayloadContext.tsx
+++ b/src/context/LegendPayloadContext.tsx
@@ -1,0 +1,21 @@
+import React, { createContext, useContext, useState } from 'react';
+import { Payload as LegendPayload } from '../component/DefaultLegendContent';
+
+export type LegendPayloadContextType = {
+  payload: ReadonlyArray<LegendPayload>;
+  setPayload: (payload: ReadonlyArray<LegendPayload>) => void;
+};
+
+export const LegendPayloadContext = createContext<LegendPayloadContextType>({
+  payload: [],
+  setPayload: () => undefined,
+});
+
+export const LegendPayloadProvider = ({ children }: { children: React.ReactNode }) => {
+  const [payload, setPayload] = useState<ReadonlyArray<LegendPayload>>([]);
+  return <LegendPayloadContext.Provider value={{ payload, setPayload }}>{children}</LegendPayloadContext.Provider>;
+};
+
+export function useLegendPayload() {
+  return useContext(LegendPayloadContext).payload;
+}

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -8,6 +8,7 @@ import type { Props as XAxisProps } from '../cartesian/XAxis';
 import type { Props as YAxisProps } from '../cartesian/YAxis';
 import { calculateViewBox } from '../util/calculateViewBox';
 import { getAnyElementOfObject } from '../util/DataUtils';
+import { LegendPayloadProvider } from './LegendPayloadContext';
 
 export const XAxisContext = createContext<XAxisMap | undefined>(undefined);
 export const YAxisContext = createContext<YAxisMap | undefined>(undefined);
@@ -31,7 +32,7 @@ export type ChartLayoutContextProviderProps = {
  * If you want to read these properties, see the collection of hooks exported from this file.
  *
  * @param {object} props CategoricalChartState, plus children
- * @returns {ReactElement} React Context Provider
+ * @returns React Context Provider
  */
 export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProps) => {
   const {
@@ -61,19 +62,21 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
    * See the test file for details.
    */
   return (
-    <XAxisContext.Provider value={xAxisMap}>
-      <YAxisContext.Provider value={yAxisMap}>
-        <OffsetContext.Provider value={offset}>
-          <ViewBoxContext.Provider value={viewBox}>
-            <ClipPathIdContext.Provider value={clipPathId}>
-              <ChartHeightContext.Provider value={height}>
-                <ChartWidthContext.Provider value={width}>{children}</ChartWidthContext.Provider>
-              </ChartHeightContext.Provider>
-            </ClipPathIdContext.Provider>
-          </ViewBoxContext.Provider>
-        </OffsetContext.Provider>
-      </YAxisContext.Provider>
-    </XAxisContext.Provider>
+    <LegendPayloadProvider>
+      <XAxisContext.Provider value={xAxisMap}>
+        <YAxisContext.Provider value={yAxisMap}>
+          <OffsetContext.Provider value={offset}>
+            <ViewBoxContext.Provider value={viewBox}>
+              <ClipPathIdContext.Provider value={clipPathId}>
+                <ChartHeightContext.Provider value={height}>
+                  <ChartWidthContext.Provider value={width}>{children}</ChartWidthContext.Provider>
+                </ChartHeightContext.Provider>
+              </ClipPathIdContext.Provider>
+            </ViewBoxContext.Provider>
+          </OffsetContext.Provider>
+        </YAxisContext.Provider>
+      </XAxisContext.Provider>
+    </LegendPayloadProvider>
   );
 };
 

--- a/src/util/getLegendProps.ts
+++ b/src/util/getLegendProps.ts
@@ -40,18 +40,6 @@ export const getLegendProps = ({
     legendData = legendItem.props && legendItem.props.payload;
   } else if (legendContent === 'children') {
     // This branch is true for: PieChart, RadialBarChart; false for every other chart
-    legendData = (formattedGraphicalItems || []).reduce((result, { item, props }) => {
-      const data: ReadonlyArray<SectorOrDataEntry> = props.sectors || props.data || [];
-
-      return result.concat(
-        data.map((entry: SectorOrDataEntry) => ({
-          type: legendItem.props.iconType || item.props.legendType,
-          value: entry.name,
-          color: entry.fill,
-          payload: entry,
-        })),
-      );
-    }, []);
   } else {
     legendData = (formattedGraphicalItems || []).map(({ item }): LegendPayload => {
       const { dataKey, name, legendType, hide } = item.props;
@@ -71,7 +59,6 @@ export const getLegendProps = ({
   return {
     ...legendItem.props,
     ...Legend.getWithHeight(legendItem, legendWidth),
-    payload: legendData,
     item: legendItem,
   };
 };


### PR DESCRIPTION
## Description

Okay I am thinking how to unwrap Legend.

The trouble now is that generateCategoricalChart goes and reads all "GraphicalChildren" from the DOM, then reads their props, gathers all "data|sectors|points", and squishes it into getLegendProps and then clones and renders the Legend.

I propose, instead of the DOM element searching and cloning, let's have each graphical child push their legend items into a context, and the Legend can read it from there directly. `generateCategoricalChart` will have nothing left to do.

This PR will fail all tests and all storybooks - I broke everything except Pie I'm sure.

Let me know what you think - if this is acceptable, I will add tests, iron things out and get a real PR going.

If we do decide to go this path I have to solve:
- [ ] Multiple Pie segments each pushing their own legend payload
- [ ] Re-rendering Pie should overwrite payload, not append
- [ ] Removing Pie segment should remove the legend items from context

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

no more cloning and DOM searching

## How Has This Been Tested?

Pie storybook works - tests will fail, POC only

## Screenshots (if appropriate):

<img width="1470" alt="image" src="https://github.com/recharts/recharts/assets/1100170/a22f13e0-06a0-4360-ac70-bde3064479c8">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [ ] All new and existing tests passed.
