### PR TITLE
Add codecov config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Test
-        run: npm test
+        run: npm run test-coverage
       - name: Serve Storybook and run tests
         run: npm run test-storybook:ci
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: recharts/recharts
+          files: ./coverage/coverage-final.json


### PR DESCRIPTION
## Description

This will fail until we have the Secret installed as described here: https://app.codecov.io/gh/recharts/recharts/new.

I don't want to copy-paste the token here because it's not meant to be public.

## Motivation and Context

I hope that colorful dashboards will be a motivating force to add more tests. And Codecov is free for open-source projects.

## How Has This Been Tested?

I tried in my sandbox repository.