### PR TITLE
Legend payload context

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -59,6 +59,7 @@
   "es6/polar/PolarAngleAxis.js",
   "es6/polar/Pie.js",
   "es6/numberAxis/Funnel.js",
+  "es6/context/legendPayloadContext.js",
   "es6/context/chartLayoutContext.js",
   "es6/container/Surface.js",
   "es6/container/Layer.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -59,6 +59,7 @@
   "lib/polar/PolarAngleAxis.js",
   "lib/polar/Pie.js",
   "lib/numberAxis/Funnel.js",
+  "lib/context/legendPayloadContext.js",
   "lib/context/chartLayoutContext.js",
   "lib/container/Surface.js",
   "lib/container/Layer.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -59,6 +59,7 @@
   "types/polar/PolarAngleAxis.d.ts",
   "types/polar/Pie.d.ts",
   "types/numberAxis/Funnel.d.ts",
+  "types/context/legendPayloadContext.d.ts",
   "types/context/chartLayoutContext.d.ts",
   "types/container/Surface.d.ts",
   "types/container/Layer.d.ts",

--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -22,20 +22,7 @@ export type ContentType = ReactElement | ((props: Props) => ReactNode);
 export type IconType = Exclude<LegendType, 'none'>;
 export type HorizontalAlignmentType = 'center' | 'left' | 'right';
 export type VerticalAlignmentType = 'top' | 'bottom' | 'middle';
-export type Formatter = (
-  value: any,
-  entry: {
-    value: any;
-    id?: string;
-    type?: LegendType;
-    color?: string;
-    payload?: {
-      strokeDasharray: ReactText;
-      value?: any;
-    };
-  },
-  index: number,
-) => ReactNode;
+export type Formatter = (value: any, entry: Payload, index: number) => ReactNode;
 
 export interface Payload {
   value: any;
@@ -43,7 +30,7 @@ export interface Payload {
   type?: LegendType;
   color?: string;
   payload?: {
-    strokeDasharray: ReactText;
+    strokeDasharray?: ReactText;
     value?: any;
   };
   formatter?: Formatter;
@@ -82,8 +69,8 @@ export class DefaultLegendContent extends PureComponent<Props> {
 
   /**
    * Render the path of icon
-   * @param {Object} data Data of each legend item
-   * @return {String} Path element
+   * @param data Data of each legend item
+   * @return Path element
    */
   renderIcon(data: Payload) {
     const { inactiveColor } = this.props;
@@ -151,7 +138,7 @@ export class DefaultLegendContent extends PureComponent<Props> {
 
   /**
    * Draw items of legend
-   * @return {ReactElement} Items
+   * @return Items
    */
   renderItems() {
     const { payload, iconSize, layout, formatter, inactiveColor } = this.props;

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -4,13 +4,17 @@ import { DefaultLegendContent, Payload, Props as DefaultProps } from './DefaultL
 import { isNumber } from '../util/DataUtils';
 import { LayoutType } from '../util/types';
 import { UniqueOption, getUniqPayload } from '../util/payload/getUniqPayload';
+import { useLegendPayload } from '../context/legendPayloadContext';
 
 function defaultUniqBy(entry: Payload) {
   return entry.value;
 }
 
 function LegendContent(props: Props) {
-  const finalPayload = getUniqPayload(props.payload, props.payloadUniqBy, defaultUniqBy);
+  const contextPayload = useLegendPayload();
+  // We are in the process of refactoring all charts to Context; once that's done we can get rid of props.payload.
+  const preferredPayload = contextPayload.length > 0 ? contextPayload : props.payload;
+  const finalPayload = getUniqPayload(preferredPayload, props.payloadUniqBy, defaultUniqBy);
   const contentProps = {
     ...props,
     payload: finalPayload,

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, createContext, useContext } from 'react';
+import React, { createContext, ReactNode, useContext } from 'react';
 import invariant from 'tiny-invariant';
 import find from 'lodash/find';
 import every from 'lodash/every';
@@ -8,6 +8,7 @@ import type { Props as XAxisProps } from '../cartesian/XAxis';
 import type { Props as YAxisProps } from '../cartesian/YAxis';
 import { calculateViewBox } from '../util/calculateViewBox';
 import { getAnyElementOfObject } from '../util/DataUtils';
+import { LegendPayloadProvider } from './legendPayloadContext';
 
 export const XAxisContext = createContext<XAxisMap | undefined>(undefined);
 export const YAxisContext = createContext<YAxisMap | undefined>(undefined);
@@ -31,7 +32,7 @@ export type ChartLayoutContextProviderProps = {
  * If you want to read these properties, see the collection of hooks exported from this file.
  *
  * @param {object} props CategoricalChartState, plus children
- * @returns {ReactElement} React Context Provider
+ * @returns React Context Provider
  */
 export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProps) => {
   const {
@@ -61,19 +62,21 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
    * See the test file for details.
    */
   return (
-    <XAxisContext.Provider value={xAxisMap}>
-      <YAxisContext.Provider value={yAxisMap}>
-        <OffsetContext.Provider value={offset}>
-          <ViewBoxContext.Provider value={viewBox}>
-            <ClipPathIdContext.Provider value={clipPathId}>
-              <ChartHeightContext.Provider value={height}>
-                <ChartWidthContext.Provider value={width}>{children}</ChartWidthContext.Provider>
-              </ChartHeightContext.Provider>
-            </ClipPathIdContext.Provider>
-          </ViewBoxContext.Provider>
-        </OffsetContext.Provider>
-      </YAxisContext.Provider>
-    </XAxisContext.Provider>
+    <LegendPayloadProvider>
+      <XAxisContext.Provider value={xAxisMap}>
+        <YAxisContext.Provider value={yAxisMap}>
+          <OffsetContext.Provider value={offset}>
+            <ViewBoxContext.Provider value={viewBox}>
+              <ClipPathIdContext.Provider value={clipPathId}>
+                <ChartHeightContext.Provider value={height}>
+                  <ChartWidthContext.Provider value={width}>{children}</ChartWidthContext.Provider>
+                </ChartHeightContext.Provider>
+              </ClipPathIdContext.Provider>
+            </ViewBoxContext.Provider>
+          </OffsetContext.Provider>
+        </YAxisContext.Provider>
+      </XAxisContext.Provider>
+    </LegendPayloadProvider>
   );
 };
 
@@ -196,8 +199,7 @@ export const useMaybeYAxis = (yAxisId: string | number): YAxisProps | undefined 
 };
 
 export const useViewBox = (): CartesianViewBox => {
-  const viewBox = useContext(ViewBoxContext);
-  return viewBox;
+  return useContext(ViewBoxContext);
 };
 
 export const useOffset = (): ChartOffset => {

--- a/src/context/legendPayloadContext.tsx
+++ b/src/context/legendPayloadContext.tsx
@@ -8,12 +8,17 @@ type DispatchPayload = {
   removeSupplier: (supplier: PayloadSupplier) => void;
 };
 
-export const LegendPayloadContext = createContext<Array<PayloadSupplier>>([]);
-export const LegendPayloadDispatchContext = createContext<DispatchPayload>({
+const LegendPayloadContext = createContext<Array<PayloadSupplier>>([]);
+const LegendPayloadDispatchContext = createContext<DispatchPayload>({
   addSupplier: () => {},
   removeSupplier: () => {},
 });
 
+/**
+ * Use this at the root of a chart where you want to have Legend
+ * @param children all of the chart goes here
+ * @returns ReactNode
+ */
 export const LegendPayloadProvider = ({ children }: { children: React.ReactNode }) => {
   const [payload, setPayload] = useState<Array<PayloadSupplier>>([]);
   const addSupplier = useCallback(
@@ -31,15 +36,40 @@ export const LegendPayloadProvider = ({ children }: { children: React.ReactNode 
   );
 };
 
-export function useLegendPayload(): LegendPayload[] {
+/**
+ * Use this hook in Legend, or anywhere else where you want to read the current Legend items.
+ * @return all Legend items ready to be rendered
+ */
+export function useLegendPayload(): Array<LegendPayload> {
   const allSuppliers = useContext(LegendPayloadContext);
   return allSuppliers.flatMap((supplier: PayloadSupplier) => supplier());
 }
 
+/**
+ * Use this inside every component that is adding items to the legend.
+ * This is a little bit convoluted because it needs to do caching and has to avoid re-renders so instead of just the array of items,
+ * it accepts a function to compute the items and the input in it.
+ *
+ * @param computeLegendPayload function that accepts input and returns Legend payload array
+ * @param input input to computeLegendPayload function
+ * @returns void - this does not return anything, only use it to write legend items
+ */
 export function useLegendPayloadDispatch<Input>(
-  computeLegendPayload: (input1: Input) => LegendPayload[],
+  computeLegendPayload: (input1: Input) => Array<LegendPayload>,
   input: Input,
 ): void {
+  /*
+   * So this is a bit convoluted. If you are better at React than me (many are) then please refactor.
+   *
+   * I tried setting the array of LegendPayload directly, but then if there are multiple Pies they will overwrite each other's legends;
+   * I tried concatenating arrays of other payload with the current payload, but that leads to an infinite loop;
+   * finally this approach worked.
+   *
+   * Each Pie (or Area, or Bar) will register a function that returns payload items,
+   * and then the reading hook (presumably used in Legend) can call them.
+   * That way the Pie does not have access to other Pie's Legend items,
+   * which means we avoid the infinite re-render loop.
+   */
   const { addSupplier, removeSupplier } = useContext(LegendPayloadDispatchContext);
   useEffect(() => {
     const supplier = () => computeLegendPayload(input);

--- a/src/context/legendPayloadContext.tsx
+++ b/src/context/legendPayloadContext.tsx
@@ -1,0 +1,52 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { Payload as LegendPayload } from '../component/DefaultLegendContent';
+
+type PayloadSupplier = () => Array<LegendPayload>;
+
+type DispatchPayload = {
+  addSupplier: (supplier: PayloadSupplier) => void;
+  removeSupplier: (supplier: PayloadSupplier) => void;
+};
+
+export const LegendPayloadContext = createContext<Array<PayloadSupplier>>([]);
+export const LegendPayloadDispatchContext = createContext<DispatchPayload>({
+  addSupplier: () => {},
+  removeSupplier: () => {},
+});
+
+export const LegendPayloadProvider = ({ children }: { children: React.ReactNode }) => {
+  const [payload, setPayload] = useState<Array<PayloadSupplier>>([]);
+  const addSupplier = useCallback(
+    (payloadSupplier: PayloadSupplier) => setPayload(prev => [...prev, payloadSupplier]),
+    [],
+  );
+  const removeSupplier = useCallback(
+    (payloadSupplier: PayloadSupplier) => setPayload(prev => prev.filter(p => p !== payloadSupplier)),
+    [],
+  );
+  return (
+    <LegendPayloadDispatchContext.Provider value={{ addSupplier, removeSupplier }}>
+      <LegendPayloadContext.Provider value={payload}>{children}</LegendPayloadContext.Provider>
+    </LegendPayloadDispatchContext.Provider>
+  );
+};
+
+export function useLegendPayload(): LegendPayload[] {
+  const allSuppliers = useContext(LegendPayloadContext);
+  return allSuppliers.flatMap((supplier: PayloadSupplier) => supplier());
+}
+
+export function useLegendPayloadDispatch<Input>(
+  computeLegendPayload: (input1: Input) => LegendPayload[],
+  input: Input,
+): void {
+  const { addSupplier, removeSupplier } = useContext(LegendPayloadDispatchContext);
+  useEffect(() => {
+    const supplier = () => computeLegendPayload(input);
+    addSupplier(supplier);
+    return () => {
+      removeSupplier(supplier);
+    };
+  }, [input, addSupplier, removeSupplier, computeLegendPayload]);
+  return null;
+}

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -20,6 +20,7 @@ import { Global } from '../util/Global';
 import { polarToCartesian, getMaxRadius } from '../util/PolarUtils';
 import { isNumber, getPercentValue, mathSign, interpolateNumber, uniqueId } from '../util/DataUtils';
 import { getValueByDataKey } from '../util/ChartUtils';
+import { Payload as LegendPayload } from '../component/DefaultLegendContent';
 import {
   LegendType,
   TooltipType,
@@ -34,6 +35,7 @@ import {
   GeometrySector,
 } from '../util/types';
 import { Shape } from '../util/ActiveShapeUtils';
+import { useLegendPayloadDispatch } from '../context/legendPayloadContext';
 
 interface PieDef {
   /** The abscissa of pole in polar coordinate  */
@@ -155,6 +157,26 @@ type PieComposedData = PieCoordinate & {
   sectors: PieSectorDataItem[];
   data: RealPieData[];
 };
+type PiePayloadInputProps = {
+  sectors: PieSectorDataItem[];
+  legendType?: LegendType;
+};
+
+const computeLegendPayloadFromPieData = ({ sectors, legendType }: PiePayloadInputProps): Array<LegendPayload> => {
+  return sectors.map(
+    (entry: PieSectorDataItem): LegendPayload => ({
+      type: legendType,
+      value: entry.name,
+      color: entry.fill,
+      payload: entry,
+    }),
+  );
+};
+
+function SetPiePayloadLegend(props: PiePayloadInputProps): null {
+  useLegendPayloadDispatch(computeLegendPayloadFromPieData, props);
+  return null;
+}
 
 export class Pie extends PureComponent<Props, State> {
   pieRef: HTMLElement = null;
@@ -642,6 +664,7 @@ export class Pie extends PureComponent<Props, State> {
         {label && this.renderLabels(sectors)}
         {Label.renderCallByParent(this.props, null, false)}
         {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, sectors, false)}
+        <SetPiePayloadLegend sectors={this.props.sectors} legendType={this.props.legendType} />
       </Layer>
     );
   }

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -795,7 +795,22 @@ describe('<Legend />', () => {
         </PieChart>,
       );
       const legendItems1 = assertHasLegend(container);
-      expect(legendItems1).toHaveLength(numericalData.length + numericalData2.length);
+      expect.soft(legendItems1).toHaveLength(numericalData.length + numericalData2.length);
+      expect
+        .soft(Array.from(legendItems1).map(i => i.textContent))
+        .toEqual([
+          '0',
+          '1',
+          '2',
+          '3',
+          '4',
+          '5',
+          'Luftbaloons',
+          'Miles I would walk',
+          'Days a week',
+          'Mambo number',
+          'Seas of Rhye',
+        ]);
       rerender(
         <PieChart width={500} height={500}>
           <Legend />
@@ -803,7 +818,10 @@ describe('<Legend />', () => {
         </PieChart>,
       );
       const legendItems2 = container.querySelectorAll('.recharts-default-legend .recharts-legend-item');
-      expect(legendItems2).toHaveLength(numericalData2.length);
+      expect.soft(legendItems2).toHaveLength(numericalData2.length);
+      expect
+        .soft(Array.from(legendItems2).map(i => i.textContent))
+        .toEqual(['Luftbaloons', 'Miles I would walk', 'Days a week', 'Mambo number', 'Seas of Rhye']);
     });
 
     it('should update legend if Pie data changes', () => {


### PR DESCRIPTION
## Description

Okay this is how all legend payload pushing can work. No more going through formattedGraphicalItems - this should be a step towards removing formattedGraphicalItems completely!

## Related Issue

https://github.com/recharts/recharts/pull/4229/files

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

1. Once we get rid of formattedGraphicalItems we can also stop reading all graphical elements (Bar, Area, Pie, ...) from the DOM and stop reading their props and their defaultProps.
2. This is also a step towards removing cloning of Pie, Bar, and other graphical elements

## How Has This Been Tested?

tests + storybooks

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
