### PR TITLE
fix: reference line should not render if its coord is NaN

### DIFF
--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -93,6 +93,8 @@ export const getEndPoints = (
   if (isFixedY) {
     const { y: yCoord } = props;
     const coord = scales.y.apply(yCoord, { position });
+    // don't render the line if the scale can't compute a result that makes sense
+    if (Number.isNaN(coord)) return null;
 
     if (props.ifOverflow === 'discard' && !scales.y.isInRange(coord)) {
       return null;
@@ -107,6 +109,8 @@ export const getEndPoints = (
   if (isFixedX) {
     const { x: xCoord } = props;
     const coord = scales.x.apply(xCoord, { position });
+    // don't render the line if the scale can't compute a result that makes sense
+    if (Number.isNaN(coord)) return null;
 
     if (props.ifOverflow === 'discard' && !scales.x.isInRange(coord)) {
       return null;

--- a/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
+++ b/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
@@ -246,9 +246,9 @@ describe('<ReferenceLine />', () => {
     const spy = vi.fn();
     const viewBox: CartesianViewBox = { x: 1, y: 2 };
     render(
-      <BarChart width={1100} height={250}>
-        <XAxis />
-        <YAxis />
+      <BarChart width={1100} height={250} data={data}>
+        <XAxis dataKey="name" />
+        <YAxis dataKey="uv" />
         <ReferenceLine y={20} ifOverflow="visible" shape={spy} viewBox={viewBox} />
       </BarChart>,
     );
@@ -262,8 +262,8 @@ describe('<ReferenceLine />', () => {
       x1: 65,
       x2: 1095,
       y: 20,
-      y1: NaN,
-      y2: NaN,
+      y1: -152.5,
+      y2: -152.5,
     });
   });
 
@@ -348,6 +348,20 @@ describe('<ReferenceLine />', () => {
         <p>
           <ReferenceLine y={20} ifOverflow="visible" />
         </p>
+      </BarChart>,
+    );
+    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);
+  });
+
+  test('does not return anything when there is a duplicated category', () => {
+    const firstDataItem = data[0];
+    const dataWithDupe = [...data, firstDataItem];
+    const { container } = render(
+      <BarChart width={1100} height={250} data={dataWithDupe}>
+        <XAxis dataKey="name" />
+        <YAxis />
+        {/* reference line is currently unable to differentiate between duplcates on categorical axes. Which one do I render on? The first? Both? */}
+        <ReferenceLine y={firstDataItem.name} ifOverflow="extendDomain" />
       </BarChart>,
     );
     expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);

--- a/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
+++ b/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
@@ -360,7 +360,7 @@ describe('<ReferenceLine />', () => {
       <BarChart width={1100} height={250} data={dataWithDupe}>
         <XAxis dataKey="name" />
         <YAxis />
-        {/* reference line is currently unable to differentiate between duplcates on categorical axes. Which one do I render on? The first? Both? */}
+        {/* reference line is currently unable to differentiate between duplicates on categorical axes. Which one do I render on? The first? Both? */}
         <ReferenceLine y={firstDataItem.name} ifOverflow="extendDomain" />
       </BarChart>,
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Currently when a ReferenceLine is created and the scale generates `NaN` as a coordinate of the line (X or Y), the line still renders. It renders with a value of `NaN` which is invalid and should never be in the DOM. This gets treated as 0 and is rendered on the far edge of the chart.
![image](https://github.com/recharts/recharts/assets/25180830/d3d19f2e-6a83-4b6e-9ffe-92a1bca8393e)

If the main coord of the ReferenceLine is `NaN` we should prefer to discard it (at least for now) rather than rendering something that shouldn't be in the DOM.

As a follow up we could warn when this happens or for the case of duplicated categories, we could attempt to render lines at both categories somehow.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4239

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Attempts to mitigate some confusing behavior

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit tests
- manual tests

## Screenshots (if appropriate):
see above

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
  -  technically breaking in terms of current functionality

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. --> the documentation currently states that it is discarded but it is not
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
