### PR TITLE
Radar sets legend through context

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -20,7 +20,7 @@ import { Global } from '../util/Global';
 import { polarToCartesian, getMaxRadius } from '../util/PolarUtils';
 import { isNumber, getPercentValue, mathSign, interpolateNumber, uniqueId } from '../util/DataUtils';
 import { getValueByDataKey } from '../util/ChartUtils';
-import { Payload as LegendPayload } from '../component/DefaultLegendContent';
+import type { Payload as LegendPayload } from '../component/DefaultLegendContent';
 import {
   LegendType,
   TooltipType,
@@ -647,7 +647,14 @@ export class Pie extends PureComponent<Props, State> {
       !isNumber(innerRadius as number) ||
       !isNumber(outerRadius as number)
     ) {
-      return null;
+      /*
+       * This used to render `null`, but it should still set the legend because:
+       * 1. Hidden pie still renders a legend item (albeit with inactive color)
+       * 2. if a dataKey does not match anything from props.data, then props.sectors are not defined.
+       * Legend still renders though! Behaviour (2) is arguably a bug - and we should be fixing it perhaps?
+       * But for now I will keep it as-is.
+       */
+      return <SetPiePayloadLegend sectors={this.props.sectors || this.props.data} legendType={this.props.legendType} />;
     }
 
     const layerClass = clsx('recharts-pie', className);

--- a/src/util/getLegendProps.ts
+++ b/src/util/getLegendProps.ts
@@ -19,6 +19,14 @@ export interface LegendPropsGraphicalItemInput {
   item: ReactElement<{ legendType?: LegendType; hide: boolean; name?: string; dataKey: DataKey<any> }>;
 }
 
+/**
+ * @deprecated we are replacing this function with Context-based legend instead. See useLegendPayloadDispatch and useLegendPayload
+ * @param children do not use
+ * @param formattedGraphicalItems do not use
+ * @param legendWidth do not use
+ * @param legendContent do not use
+ * @returns mix of everything, do not use
+ */
 export const getLegendProps = ({
   children,
   formattedGraphicalItems,

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -916,6 +916,50 @@ describe('<Legend />', () => {
       assertExpectedAttributes(container, selector, expectedAttributes);
     });
 
+    it('should change color and className of hidden Radar', () => {
+      const { container, getByText } = render(
+        <RadarChart width={500} height={500} data={numericalData}>
+          <Legend inactiveColor="yellow" />
+          {/* this will ignore the stroke and use inactive color on legend */}
+          <Radar dataKey="percent" stroke="red" hide />
+        </RadarChart>,
+      );
+      expect(getByText('percent')).toBeInTheDocument();
+      const legendItems = assertHasLegend(container);
+
+      expect.soft(legendItems[0].getAttributeNames()).toEqual(['class', 'style']);
+      expect.soft(legendItems[0].getAttribute('class')).toBe('recharts-legend-item legend-item-0 inactive');
+      expect.soft(legendItems[0].getAttribute('style')).toBe('display: inline-block; margin-right: 10px;');
+
+      // in absence of explicit `legendType`, Radar should default to rect
+      const { selector, expectedAttributes } = expectedLegendTypeSymbolsWithColor('yellow')
+        .filter(tc => tc.legendType === 'rect')
+        .pop();
+      assertExpectedAttributes(container, selector, expectedAttributes);
+    });
+
+    it('should have a default inactive Radar legend color', () => {
+      const { container, getByText } = render(
+        <RadarChart width={500} height={500} data={numericalData}>
+          <Legend />
+          {/* this will ignore the stroke and use inactive color on legend */}
+          <Radar dataKey="percent" stroke="red" hide />
+        </RadarChart>,
+      );
+      expect(getByText('percent')).toBeInTheDocument();
+      const legendItems = assertHasLegend(container);
+
+      expect.soft(legendItems[0].getAttributeNames()).toEqual(['class', 'style']);
+      expect.soft(legendItems[0].getAttribute('class')).toBe('recharts-legend-item legend-item-0 inactive');
+      expect.soft(legendItems[0].getAttribute('style')).toBe('display: inline-block; margin-right: 10px;');
+
+      // in absence of explicit `legendType`, Radar should default to rect
+      const { selector, expectedAttributes } = expectedLegendTypeSymbolsWithColor('#ccc')
+        .filter(tc => tc.legendType === 'rect')
+        .pop();
+      assertExpectedAttributes(container, selector, expectedAttributes);
+    });
+
     it('should render one empty legend item if Radar has no dataKey', () => {
       const { container } = render(
         <RadarChart width={500} height={500} data={numericalData}>

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -743,6 +743,17 @@ describe('<Legend />', () => {
       numericalData.forEach(({ value }) => expect(getByText(value)).toBeInTheDocument());
     });
 
+    it('should render a legend item even if the dataKey does not match anything from the data', () => {
+      const { container } = render(
+        <PieChart width={500} height={500}>
+          <Legend />
+          <Pie data={numericalData} dataKey="unknown" />
+        </PieChart>,
+      );
+      const legendItems = assertHasLegend(container);
+      expect(legendItems).toHaveLength(numericalData.length);
+    });
+
     it('should implicitly use special `name` and `fill` properties from data as legend labels and colors', () => {
       const { container, getByText } = render(
         <PieChart width={500} height={500}>
@@ -914,6 +925,18 @@ describe('<Legend />', () => {
         .filter(tc => tc.legendType === 'rect')
         .pop();
       assertExpectedAttributes(container, selector, expectedAttributes);
+    });
+
+    it('should render a legend item even if the dataKey does not match anything from the data', () => {
+      const { container, getByText } = render(
+        <RadarChart width={500} height={500} data={numericalData}>
+          <Legend />
+          <Radar dataKey="unknown" />
+        </RadarChart>,
+      );
+      expect(getByText('unknown')).toBeInTheDocument();
+      const legendItems = assertHasLegend(container);
+      expect(legendItems).toHaveLength(1);
     });
 
     it('should change color and className of hidden Radar', () => {

--- a/test/component/__snapshots__/Legend.spec.tsx.snap
+++ b/test/component/__snapshots__/Legend.spec.tsx.snap
@@ -81,6 +81,27 @@ exports[`<Legend /> > content as a React Component > should pass parameters to t
 }
 `;
 
+exports[`<Legend /> > content as a React Component > should pass parameters to the Component 2`] = `
+{
+  "align": "center",
+  "chartHeight": 300,
+  "chartWidth": 600,
+  "content": [Function],
+  "iconSize": 14,
+  "layout": "horizontal",
+  "margin": {
+    "bottom": 5,
+    "left": 20,
+    "right": 30,
+    "top": 5,
+  },
+  "onBBoxUpdate": [Function],
+  "payload": [],
+  "verticalAlign": "bottom",
+  "width": 550,
+}
+`;
+
 exports[`<Legend /> > content as a function > should pass parameters to the function 1`] = `
 {
   "align": "center",
@@ -157,6 +178,27 @@ exports[`<Legend /> > content as a function > should pass parameters to the func
       "value": "uv",
     },
   ],
+  "verticalAlign": "bottom",
+  "width": 550,
+}
+`;
+
+exports[`<Legend /> > content as a function > should pass parameters to the function 2`] = `
+{
+  "align": "center",
+  "chartHeight": 300,
+  "chartWidth": 600,
+  "content": [Function],
+  "iconSize": 14,
+  "layout": "horizontal",
+  "margin": {
+    "bottom": 5,
+    "left": 20,
+    "right": 30,
+    "top": 5,
+  },
+  "onBBoxUpdate": [Function],
+  "payload": [],
   "verticalAlign": "bottom",
   "width": 550,
 }


### PR DESCRIPTION
## Description

Also I found an edge case with how Pie was implemented. It all still works in 3.x branch anyway because the Legend component has a fallback to props.payload

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

No more cloning, no more reading DOM

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
