### PR TITLE
RadialBar sets legend through Context

### DIFF
--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -35,6 +35,8 @@ import {
   LayoutType,
 } from '../util/types';
 import { polarToCartesian } from '../util/PolarUtils';
+import type { Payload as LegendPayload } from '../component/DefaultLegendContent';
+import { useLegendPayloadDispatch } from '../context/legendPayloadContext';
 // TODO: Cause of circular dependency. Needs refactoring of functions that need them.
 // import { AngleAxisProps, RadiusAxisProps } from './types';
 
@@ -90,6 +92,27 @@ type RadialBarComposedData = {
   data: RadialBarDataItem[];
   layout: LayoutType;
 };
+
+type RadialBarPayloadInputProps = {
+  data: RadialBarDataItem[];
+  legendType?: LegendType;
+};
+
+const computeLegendPayloadFromRadarData = ({ data, legendType }: RadialBarPayloadInputProps): Array<LegendPayload> => {
+  return data.map(
+    (entry: RadialBarDataItem): LegendPayload => ({
+      type: legendType,
+      value: entry.name,
+      color: entry.fill,
+      payload: entry,
+    }),
+  );
+};
+
+function SetRadialBarPayloadLegend(props: RadialBarPayloadInputProps): null {
+  useLegendPayloadDispatch(computeLegendPayloadFromRadarData, props);
+  return null;
+}
 
 export class RadialBar extends PureComponent<RadialBarProps, State> {
   static displayName = 'RadialBar';
@@ -394,6 +417,7 @@ export class RadialBar extends PureComponent<RadialBarProps, State> {
 
     return (
       <Layer className={layerClass}>
+        <SetRadialBarPayloadLegend data={this.props.data} legendType={this.props.legendType} />
         {background && <Layer className="recharts-radial-bar-background">{this.renderBackground(data)}</Layer>}
 
         <Layer className="recharts-radial-bar-sectors">{this.renderSectors()}</Layer>

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -1203,6 +1203,23 @@ describe('<Legend />', () => {
       });
     });
 
+    it('should use special `name` and `fill` properties from data as legend labels and colors, even if the dataKey does not match', () => {
+      const { container, getByText } = render(
+        <RadialBarChart width={500} height={500} data={dataWithSpecialNameAndFillProperties}>
+          <Legend />
+          <RadialBar dataKey="unknown" />
+        </RadialBarChart>,
+      );
+      const legendItems = assertHasLegend(container);
+      expect(legendItems).toHaveLength(dataWithSpecialNameAndFillProperties.length);
+      // I think this is the only way to set legend labels for RadialBarChart?
+      dataWithSpecialNameAndFillProperties.forEach(({ name }) => expect.soft(getByText(name)).toBeInTheDocument());
+      legendItems.forEach((legendItem, index) => {
+        const icon = legendItem.querySelector('.recharts-legend-icon');
+        expect.soft(icon).toHaveAttribute('fill', dataWithSpecialNameAndFillProperties[index].fill);
+      });
+    });
+
     it('should disappear after RadialBar itself is removed', () => {
       const { container, rerender } = render(
         <RadialBarChart width={500} height={500} data={numericalData}>


### PR DESCRIPTION
## Description

More legend in context, this time in RadialBar

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Element cloning, DOM browsing

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
