### PR TITLE
3.x Bugfix: Legend should prefer its own iconType prop, rather than individual legendType, if both are provided

### DIFF
--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -12,7 +12,6 @@ import {
   DataKey,
   LegendType,
   LayoutType,
-  SymbolType,
   adaptEventsOfChild,
   PresentationAttributesAdaptChildEvent,
 } from '../util/types';
@@ -70,16 +69,21 @@ export class DefaultLegendContent extends PureComponent<Props> {
   /**
    * Render the path of icon
    * @param data Data of each legend item
+   * @param iconType if defined, it will always render this icon. If undefined then it uses icon from data.type
    * @return Path element
    */
-  renderIcon(data: Payload) {
+  renderIcon(data: Payload, iconType: IconType | undefined) {
     const { inactiveColor } = this.props;
     const halfSize = SIZE / 2;
     const sixthSize = SIZE / 6;
     const thirdSize = SIZE / 3;
     const color = data.inactive ? inactiveColor : data.color;
+    const preferredIcon = iconType ?? data.type;
 
-    if (data.type === 'plainline') {
+    if (preferredIcon === 'none') {
+      return null;
+    }
+    if (preferredIcon === 'plainline') {
       return (
         <line
           strokeWidth={4}
@@ -94,7 +98,7 @@ export class DefaultLegendContent extends PureComponent<Props> {
         />
       );
     }
-    if (data.type === 'line') {
+    if (preferredIcon === 'line') {
       return (
         <path
           strokeWidth={4}
@@ -108,7 +112,7 @@ export class DefaultLegendContent extends PureComponent<Props> {
         />
       );
     }
-    if (data.type === 'rect') {
+    if (preferredIcon === 'rect') {
       return (
         <path
           stroke="none"
@@ -124,16 +128,7 @@ export class DefaultLegendContent extends PureComponent<Props> {
       return React.cloneElement(data.legendIcon, iconProps);
     }
 
-    return (
-      <Symbols
-        fill={color}
-        cx={halfSize}
-        cy={halfSize}
-        size={SIZE}
-        sizeType="diameter"
-        type={data.type as SymbolType}
-      />
-    );
+    return <Symbols fill={color} cx={halfSize} cy={halfSize} size={SIZE} sizeType="diameter" type={preferredIcon} />;
   }
 
   /**
@@ -141,7 +136,7 @@ export class DefaultLegendContent extends PureComponent<Props> {
    * @return Items
    */
   renderItems() {
-    const { payload, iconSize, layout, formatter, inactiveColor } = this.props;
+    const { payload, iconSize, layout, formatter, inactiveColor, iconType } = this.props;
     const viewBox = { x: 0, y: 0, width: SIZE, height: SIZE };
     const itemStyle = {
       display: layout === 'horizontal' ? 'inline-block' : 'block',
@@ -179,7 +174,7 @@ export class DefaultLegendContent extends PureComponent<Props> {
           {...adaptEventsOfChild(this.props, entry, i)}
         >
           <Surface width={iconSize} height={iconSize} viewBox={viewBox} style={svgStyle}>
-            {this.renderIcon(entry)}
+            {this.renderIcon(entry, iconType)}
           </Surface>
           <span className="recharts-legend-item-text" style={{ color }}>
             {finalFormatter ? finalFormatter(entryValue, entry, i) : entryValue}

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -163,6 +163,9 @@ type PiePayloadInputProps = {
 };
 
 const computeLegendPayloadFromPieData = ({ sectors, legendType }: PiePayloadInputProps): Array<LegendPayload> => {
+  if (sectors == null) {
+    return [];
+  }
   return sectors.map(
     (entry: PieSectorDataItem): LegendPayload => ({
       type: legendType,

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -712,25 +712,28 @@ describe('<Legend />', () => {
       test.each(expectedLegendTypeSymbolsWithColor('#3182bd'))(
         'should render element $selector for legendType $legendType',
         ({ legendType, selector, expectedAttributes }) => {
-          const { container, debug } = render(
+          const { container } = render(
             <LineChart width={500} height={500} data={categoricalData}>
               <Legend />
               <Line dataKey="value" legendType={legendType} />
             </LineChart>,
           );
-          const [legendItem] = assertHasLegend(container);
-          const symbol = legendItem.querySelector(selector);
-          if (symbol == null) {
-            debug();
-          }
-          expect(symbol).toBeInTheDocument();
-          const expectedAttributeNames = Object.keys(expectedAttributes);
-          expect.soft(symbol?.getAttributeNames().sort()).toEqual(expectedAttributeNames.sort());
-          expectedAttributeNames.forEach(attributeName => {
-            expect.soft(symbol).toHaveAttribute(attributeName, expectedAttributes[attributeName]);
-          });
+          assertExpectedAttributes(container, selector, expectedAttributes);
         },
       );
+    });
+
+    it('should prefer Legend.iconType over Line.legendType', () => {
+      const { container } = render(
+        <LineChart width={500} height={500} data={numericalData}>
+          <Legend iconType="circle" />
+          <Line dataKey="value" legendType="square" />
+        </LineChart>,
+      );
+      const { selector, expectedAttributes } = expectedLegendTypeSymbolsWithColor('#3182bd').find(
+        li => li.legendType === 'circle',
+      );
+      assertExpectedAttributes(container, selector, expectedAttributes);
     });
   });
 
@@ -926,6 +929,19 @@ describe('<Legend />', () => {
           assertExpectedAttributes(container, selector, expectedAttributes);
         },
       );
+
+      it('should prefer Legend.iconType over Bar.legendType', () => {
+        const { container } = render(
+          <BarChart width={500} height={500} data={numericalData}>
+            <Legend iconType="circle" />
+            <Bar dataKey="value" legendType="square" />
+          </BarChart>,
+        );
+        const { selector, expectedAttributes } = expectedLegendTypeSymbolsWithoutColor.find(
+          li => li.legendType === 'circle',
+        );
+        assertExpectedAttributes(container, selector, expectedAttributes);
+      });
     });
   });
 
@@ -1183,6 +1199,19 @@ describe('<Legend />', () => {
           },
         );
       });
+
+      it('should prefer Legend.iconType over Area.legendType', () => {
+        const { container } = render(
+          <AreaChart width={500} height={500} data={numericalData}>
+            <Legend iconType="circle" />
+            <Area dataKey="value" legendType="square" />
+          </AreaChart>,
+        );
+        const { selector, expectedAttributes } = expectedLegendTypeSymbolsWithColor('#3182bd').find(
+          li => li.legendType === 'circle',
+        );
+        assertExpectedAttributes(container, selector, expectedAttributes);
+      });
     });
   });
 
@@ -1268,6 +1297,19 @@ describe('<Legend />', () => {
           assertExpectedAttributes(container, selector, expectedAttributes);
         },
       );
+
+      it('should prefer Legend.iconType over Area.legendType', () => {
+        const { container } = render(
+          <ComposedChart width={500} height={500} data={numericalData}>
+            <Legend iconType="circle" />
+            <Area dataKey="value" legendType="square" />
+          </ComposedChart>,
+        );
+        const { selector, expectedAttributes } = expectedLegendTypeSymbolsWithColor('#3182bd').find(
+          li => li.legendType === 'circle',
+        );
+        assertExpectedAttributes(container, selector, expectedAttributes);
+      });
     });
 
     describe('legendType symbols for Bar', () => {
@@ -1283,6 +1325,19 @@ describe('<Legend />', () => {
           assertExpectedAttributes(container, selector, expectedAttributes);
         },
       );
+
+      it('should prefer Legend.iconType over Bar.legendType', () => {
+        const { container } = render(
+          <ComposedChart width={500} height={500} data={numericalData}>
+            <Legend iconType="circle" />
+            <Bar dataKey="value" legendType="square" />
+          </ComposedChart>,
+        );
+        const { selector, expectedAttributes } = expectedLegendTypeSymbolsWithoutColor.find(
+          li => li.legendType === 'circle',
+        );
+        assertExpectedAttributes(container, selector, expectedAttributes);
+      });
     });
 
     describe('legendType symbols for Line', () => {
@@ -1298,6 +1353,19 @@ describe('<Legend />', () => {
           assertExpectedAttributes(container, selector, expectedAttributes);
         },
       );
+
+      it('should prefer Legend.iconType over Line.legendType', () => {
+        const { container } = render(
+          <ComposedChart width={500} height={500} data={numericalData}>
+            <Legend iconType="circle" />
+            <Line dataKey="value" legendType="square" />
+          </ComposedChart>,
+        );
+        const { selector, expectedAttributes } = expectedLegendTypeSymbolsWithColor('#3182bd').find(
+          li => li.legendType === 'circle',
+        );
+        assertExpectedAttributes(container, selector, expectedAttributes);
+      });
     });
   });
 
@@ -1468,6 +1536,19 @@ describe('<Legend />', () => {
           assertExpectedAttributes(container, selector, expectedAttributes);
         },
       );
+
+      it('should prefer Legend.iconType over Pie.legendType', () => {
+        const { container } = render(
+          <PieChart width={500} height={500}>
+            <Legend iconType="circle" />
+            <Pie data={numericalData} dataKey="percent" legendType="square" />
+          </PieChart>,
+        );
+        const { selector, expectedAttributes } = expectedLegendTypeSymbolsWithColor('#808080').find(
+          li => li.legendType === 'circle',
+        );
+        assertExpectedAttributes(container, selector, expectedAttributes);
+      });
     });
   });
 
@@ -1663,6 +1744,19 @@ describe('<Legend />', () => {
           assertExpectedAttributes(container, selector, expectedAttributes);
         },
       );
+
+      it('should prefer Legend.iconType over Radar.legendType', () => {
+        const { container } = render(
+          <RadarChart width={500} height={500} data={numericalData}>
+            <Legend iconType="circle" />
+            <Radar dataKey="value" legendType="square" />
+          </RadarChart>,
+        );
+        const { selector, expectedAttributes } = expectedLegendTypeSymbolsWithoutColor.find(
+          li => li.legendType === 'circle',
+        );
+        assertExpectedAttributes(container, selector, expectedAttributes);
+      });
     });
 
     describe('legendType symbols with explicit fill', () => {
@@ -1858,6 +1952,19 @@ describe('<Legend />', () => {
         },
       );
     });
+
+    it('should prefer Legend.iconType over RadialBar.legendType', () => {
+      const { container } = render(
+        <RadialBarChart width={500} height={500} data={numericalData}>
+          <Legend iconType="circle" />
+          <RadialBar dataKey="value" legendType="square" />
+        </RadialBarChart>,
+      );
+      const { selector, expectedAttributes } = expectedLegendTypeSymbolsWithoutColor.find(
+        li => li.legendType === 'circle',
+      );
+      assertExpectedAttributes(container, selector, expectedAttributes);
+    });
   });
 
   describe('as a child of ScatterChart', () => {
@@ -1905,6 +2012,19 @@ describe('<Legend />', () => {
           assertExpectedAttributes(container, selector, expectedAttributes);
         },
       );
+
+      it('should prefer Legend.iconType over Scatter.legendType', () => {
+        const { container } = render(
+          <ScatterChart width={500} height={500} data={numericalData}>
+            <Legend iconType="circle" />
+            <Scatter dataKey="value" legendType="square" />
+          </ScatterChart>,
+        );
+        const { selector, expectedAttributes } = expectedLegendTypeSymbolsWithoutColor.find(
+          li => li.legendType === 'circle',
+        );
+        assertExpectedAttributes(container, selector, expectedAttributes);
+      });
     });
 
     describe('legendType symbols with explicit fill', () => {


### PR DESCRIPTION
## Description

I found a bug that my Legend context changes have caused, and fixed it.

The bug is only in 3.x branch so we don't need a release I think.
