### PR TITLE
Area, Bar, and Line set their legend payload even when hidden

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -577,7 +577,7 @@ export class Area extends PureComponent<Props, State> {
     const { hide, dot, points, className, top, left, xAxis, yAxis, width, height, isAnimationActive, id } = this.props;
 
     if (hide || !points || !points.length) {
-      return null;
+      return <SetAreaLegend {...this.props} />;
     }
 
     const { isAnimationFinished } = this.state;

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -496,7 +496,7 @@ export class Bar extends PureComponent<Props, State> {
     const { hide, data, className, xAxis, yAxis, left, top, width, height, isAnimationActive, background, id } =
       this.props;
     if (hide || !data || !data.length) {
-      return null;
+      return <SetBarLegend {...this.props} />;
     }
 
     const { isAnimationFinished } = this.state;

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -514,7 +514,7 @@ export class Line extends PureComponent<Props, State> {
     const { hide, dot, points, className, xAxis, yAxis, top, left, width, height, isAnimationActive, id } = this.props;
 
     if (hide || !points || !points.length) {
-      return null;
+      return <SetLineLegend {...this.props} />;
     }
 
     const { isAnimationFinished } = this.state;

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -2263,7 +2263,7 @@ describe('<Legend />', () => {
   });
 
   describe('as a child of ScatterChart', () => {
-    it('should render one legend item for each Radar', () => {
+    it('should render one legend item for each Scatter', () => {
       const { container, getByText } = render(
         <ScatterChart width={500} height={500} data={numericalData}>
           <Legend />

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -412,7 +412,6 @@ describe('<Legend />', () => {
     });
 
     it('should pass parameters to the function', () => {
-      // expect.assertions(1);
       const customContent = (params: unknown): null => {
         expect(params).toMatchSnapshot();
         return null;


### PR DESCRIPTION
## Description

Same as other components had before. Possibly an un-intuitive behaviour but let's refactor first.
