### PR TITLE
Fix legend size

### DIFF
--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -95,19 +95,18 @@ export class Legend extends PureComponent<Props, State> {
 
   public getBBox() {
     if (this.wrapperNode && this.wrapperNode.getBoundingClientRect) {
-      return this.wrapperNode.getBoundingClientRect();
+      const box = this.wrapperNode.getBoundingClientRect();
+      box.height = this.wrapperNode.offsetHeight;
+      box.width = this.wrapperNode.offsetWidth;
+      return box;
     }
-
     return null;
   }
 
   private updateBBox() {
     const { onBBoxUpdate } = this.props;
-
-    if (this.wrapperNode && this.wrapperNode.getBoundingClientRect) {
-      const box = this.wrapperNode.getBoundingClientRect();
-      box.height = this.wrapperNode.offsetHeight;
-      box.width = this.wrapperNode.offsetWidth;
+    const box = this.getBBox();
+    if (box) {
       if (
         Math.abs(box.width - this.lastBoundingBox.width) > EPS ||
         Math.abs(box.height - this.lastBoundingBox.height) > EPS

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -106,7 +106,8 @@ export class Legend extends PureComponent<Props, State> {
 
     if (this.wrapperNode && this.wrapperNode.getBoundingClientRect) {
       const box = this.wrapperNode.getBoundingClientRect();
-
+      box.height = this.wrapperNode.offsetHeight;
+      box.width = this.wrapperNode.offsetWidth;
       if (
         Math.abs(box.width - this.lastBoundingBox.width) > EPS ||
         Math.abs(box.height - this.lastBoundingBox.height) > EPS

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -2,8 +2,18 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import { Legend, LineChart, Line } from '../../src';
+import { mockGetBoundingClientRect, mockHTMLElementProperty } from '../helper/elementMockHelper';
 
 describe('<Legend />', () => {
+  const mockRect = {
+    width: 300,
+    height: 30,
+  };
+  const scale = 2;
+  beforeAll(() => mockGetBoundingClientRect(mockRect));
+  beforeAll(() => mockHTMLElementProperty('offsetHeight', mockRect.height * scale));
+  beforeAll(() => mockHTMLElementProperty('offsetWidth', mockRect.width * scale));
+
   const data = [
     { value: 'Apple', color: '#ff7300' },
     { value: 'Samsung', color: '#bb7300' },
@@ -110,5 +120,11 @@ describe('<Legend />', () => {
         "a function for the dataKey of a chart's cartesian components. " +
         'Ex: <Bar name="Name of my Data"/>',
     );
+  });
+  test('it should get the correct BBox when scale', () => {
+    const handleUpdate = vi.fn();
+    render(<Legend height={30} width={300} onBBoxUpdate={handleUpdate} />);
+    expect(handleUpdate.mock.calls[0][0].height).toEqual(mockRect.height * scale);
+    expect(handleUpdate.mock.calls[0][0].width).toEqual(mockRect.width * scale);
   });
 });

--- a/test/helper/elementMockHelper.ts
+++ b/test/helper/elementMockHelper.ts
@@ -1,0 +1,34 @@
+/**
+ * getBoundingClientRect always returns 0 in jsdom, we can't test for actual returned string size
+ * Execution order matters
+ * https://github.com/jsdom/jsdom/issues/1590#issuecomment-578350151
+ *
+ * @param rect overrides getBoundingClientRect return value in the mock. jsdom by design returns all zeroes
+ * @returns cleanup function, convenient for beforeAll or beforeEach
+ */
+export function mockGetBoundingClientRect(rect: Partial<DOMRect>) {
+  const original = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    toJSON: () => '{}',
+    ...rect,
+  });
+  return function cleanup() {
+    Element.prototype.getBoundingClientRect = original;
+  };
+}
+
+export function mockHTMLElementProperty(name: string, value: number) {
+  const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, name);
+  Object.defineProperty(HTMLElement.prototype, name, { configurable: true, value });
+  return function cleanup() {
+    Object.defineProperty(HTMLElement.prototype, name, original);
+  };
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The chart shrinks when I apply a scale on the chart container
<!--- Describe your changes in detail -->

## Related Issue
[The issue](https://github.com/recharts/recharts/issues/4246)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The [legend size(height and width)](https://github.com/okonet/react-container-dimensions/issues/5) provided by the `getBoundingClientRect` is changed if it's parent container is transformed using scale. If the container scale is 3x, then the legend height is significantly larger than usual, which makes the chart content visibly smaller than expected.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Firstly, I tested locally using the Recharts demo
Then I build a package and test in a third party application that facing the same problem
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
