### PR TITLE
Add mockGetBoundingClientRect helper function

### DIFF
--- a/test/component/Text.spec.tsx
+++ b/test/component/Text.spec.tsx
@@ -1,21 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { vi } from 'vitest';
 import { Surface, Text } from '../../src';
+import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 
 describe('<Text />', () => {
-  const mock = {
-    x: 200,
-    y: 100,
+  const mockRect = {
     width: 25,
     height: 17,
-    top: 10,
-    right: 10,
-    bottom: 10,
-    left: 10,
-    toJSON: vi.fn(),
   };
-  Element.prototype.getBoundingClientRect = vi.fn(() => mock);
+  beforeAll(() => mockGetBoundingClientRect(mockRect));
 
   test('Does not wrap long text if enough width', () => {
     render(
@@ -47,7 +40,7 @@ describe('<Text />', () => {
   });
 
   test('Wraps long text if styled but would have had enough room', () => {
-    Element.prototype.getBoundingClientRect = vi.fn(() => ({ ...mock, width: 40 }));
+    mockGetBoundingClientRect({ ...mockRect, width: 40 });
     render(
       <Surface width={300} height={200}>
         <Text role="img" width={300} style={{ fontSize: '2em', fontFamily: 'Courier' }}>

--- a/test/helper/mockGetBoundingClientRect.ts
+++ b/test/helper/mockGetBoundingClientRect.ts
@@ -1,0 +1,26 @@
+/**
+ * getBoundingClientRect always returns 0 in jsdom, we can't test for actual returned string size
+ * Execution order matters
+ * https://github.com/jsdom/jsdom/issues/1590#issuecomment-578350151
+ *
+ * @param rect overrides getBoundingClientRect return value in the mock. jsdom by design returns all zeroes
+ * @returns cleanup function, convenient for beforeAll or beforeEach
+ */
+export function mockGetBoundingClientRect(rect: Partial<DOMRect>) {
+  const original = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    toJSON: () => '{}',
+    ...rect,
+  });
+  return function cleanup() {
+    Element.prototype.getBoundingClientRect = original;
+  };
+}

--- a/test/util/DomUtils.spec.tsx
+++ b/test/util/DomUtils.spec.tsx
@@ -1,13 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
-import { vi } from 'vitest';
 import { getStringSize } from '../../src/util/DOMUtils';
+import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 
-/**
- * getBoundingClientRect always returns 0 in jsdom, we can't test for actual returned string size
- * Execution order matters
- * https://github.com/jsdom/jsdom/issues/1590#issuecomment-578350151
- * */
 describe('DOMUtils', () => {
   test('getStringSize() returns 0', () => {
     expect(getStringSize(undefined)).toEqual({ width: 0, height: 0 });
@@ -15,8 +10,7 @@ describe('DOMUtils', () => {
 
   test('getStringSize() with value returns mocked getBoundingClientRect values', () => {
     render(<span id="recharts_measurement_span">test</span>);
-    const span = screen.getByText('test');
-    span.getBoundingClientRect = vi.fn(() => ({
+    mockGetBoundingClientRect({
       x: 200,
       y: 100,
       width: 25,
@@ -25,8 +19,7 @@ describe('DOMUtils', () => {
       right: 10,
       bottom: 10,
       left: 10,
-      toJSON: vi.fn(),
-    }));
+    });
 
     expect(getStringSize('test')).toEqual({
       width: 25,


### PR DESCRIPTION
Small test util to unify mocking the DOMRect in various tests. I am planning to write more tests of the same.