### PR TITLE
Legend bounding box update fix

### DIFF
--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -32,6 +32,41 @@ function LegendContent(props: Props) {
 
 const EPS = 1;
 
+type BoundingBox = {
+  width: number;
+  height: number;
+};
+
+function getDefaultPosition(style: React.CSSProperties, props: Props, box: BoundingBox) {
+  const { layout, align, verticalAlign, margin, chartWidth, chartHeight } = props;
+  let hPos, vPos;
+
+  if (
+    !style ||
+    ((style.left === undefined || style.left === null) && (style.right === undefined || style.right === null))
+  ) {
+    if (align === 'center' && layout === 'vertical') {
+      hPos = { left: ((chartWidth || 0) - box.width) / 2 };
+    } else {
+      hPos = align === 'right' ? { right: (margin && margin.right) || 0 } : { left: (margin && margin.left) || 0 };
+    }
+  }
+
+  if (
+    !style ||
+    ((style.top === undefined || style.top === null) && (style.bottom === undefined || style.bottom === null))
+  ) {
+    if (verticalAlign === 'middle') {
+      vPos = { top: ((chartHeight || 0) - box.height) / 2 };
+    } else {
+      vPos =
+        verticalAlign === 'bottom' ? { bottom: (margin && margin.bottom) || 0 } : { top: (margin && margin.top) || 0 };
+    }
+  }
+
+  return { ...hPos, ...vPos };
+}
+
 export type Props = DefaultProps & {
   wrapperStyle?: CSSProperties;
   chartWidth?: number;
@@ -85,7 +120,7 @@ export class Legend extends PureComponent<Props, State> {
     return null;
   }
 
-  lastBoundingBox = {
+  lastBoundingBox: BoundingBox = {
     width: -1,
     height: -1,
   };
@@ -123,46 +158,12 @@ export class Legend extends PureComponent<Props, State> {
     }
   }
 
-  private getBBoxSnapshot() {
+  private getBBoxSnapshot(): BoundingBox {
     if (this.lastBoundingBox.width >= 0 && this.lastBoundingBox.height >= 0) {
       return { ...this.lastBoundingBox };
     }
 
     return { width: 0, height: 0 };
-  }
-
-  private getDefaultPosition(style: CSSProperties) {
-    const { layout, align, verticalAlign, margin, chartWidth, chartHeight } = this.props;
-    let hPos, vPos;
-
-    if (
-      !style ||
-      ((style.left === undefined || style.left === null) && (style.right === undefined || style.right === null))
-    ) {
-      if (align === 'center' && layout === 'vertical') {
-        const box = this.getBBoxSnapshot();
-        hPos = { left: ((chartWidth || 0) - box.width) / 2 };
-      } else {
-        hPos = align === 'right' ? { right: (margin && margin.right) || 0 } : { left: (margin && margin.left) || 0 };
-      }
-    }
-
-    if (
-      !style ||
-      ((style.top === undefined || style.top === null) && (style.bottom === undefined || style.bottom === null))
-    ) {
-      if (verticalAlign === 'middle') {
-        const box = this.getBBoxSnapshot();
-        vPos = { top: ((chartHeight || 0) - box.height) / 2 };
-      } else {
-        vPos =
-          verticalAlign === 'bottom'
-            ? { bottom: (margin && margin.bottom) || 0 }
-            : { top: (margin && margin.top) || 0 };
-      }
-    }
-
-    return { ...hPos, ...vPos };
   }
 
   public render() {
@@ -171,7 +172,7 @@ export class Legend extends PureComponent<Props, State> {
       position: 'absolute',
       width: width || 'auto',
       height: height || 'auto',
-      ...this.getDefaultPosition(wrapperStyle),
+      ...getDefaultPosition(wrapperStyle, this.props, this.getBBoxSnapshot()),
       ...wrapperStyle,
     };
 

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -138,8 +138,6 @@ export class Legend extends PureComponent<Props, State> {
     verticalAlign: 'bottom',
   };
 
-  private wrapperNode: HTMLDivElement;
-
   static getWithHeight(
     item: { props: { layout?: LayoutType; height?: number; width?: number } },
     chartWidth: number,
@@ -158,44 +156,6 @@ export class Legend extends PureComponent<Props, State> {
     }
 
     return null;
-  }
-
-  lastBoundingBox: BoundingBox = {
-    width: -1,
-    height: -1,
-  };
-
-  public componentDidMount() {
-    this.updateBBox();
-  }
-
-  public componentDidUpdate() {
-    this.updateBBox();
-  }
-
-  private updateBBox() {
-    const { onBBoxUpdate } = this.props;
-
-    if (this.wrapperNode && this.wrapperNode.getBoundingClientRect) {
-      const box = this.wrapperNode.getBoundingClientRect();
-
-      if (
-        Math.abs(box.width - this.lastBoundingBox.width) > EPS ||
-        Math.abs(box.height - this.lastBoundingBox.height) > EPS
-      ) {
-        this.lastBoundingBox.width = box.width;
-        this.lastBoundingBox.height = box.height;
-        if (onBBoxUpdate) {
-          onBBoxUpdate(box);
-        }
-      }
-    } else if (this.lastBoundingBox.width !== -1 || this.lastBoundingBox.height !== -1) {
-      this.lastBoundingBox.width = -1;
-      this.lastBoundingBox.height = -1;
-      if (onBBoxUpdate) {
-        onBBoxUpdate(null);
-      }
-    }
   }
 
   public render() {

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -1426,7 +1426,6 @@ describe('<Legend />', () => {
         align: LegendProps['align'];
         verticalAlign: LegendProps['verticalAlign'];
         layout: LegendProps['layout'];
-        expectedStyle: string;
         expectedStyleOnSecondRender: string;
       };
 
@@ -1435,126 +1434,108 @@ describe('<Legend />', () => {
           align: 'center',
           verticalAlign: 'top',
           layout: 'horizontal',
-          expectedStyle: 'position: absolute; width: 470px; height: auto; left: 17px; top: 11px;',
           expectedStyleOnSecondRender: 'position: absolute; width: 470px; height: auto; left: 17px; top: 11px;',
         },
         {
           align: 'left',
           verticalAlign: 'top',
           layout: 'horizontal',
-          expectedStyle: 'position: absolute; width: 470px; height: auto; left: 17px; top: 11px;',
           expectedStyleOnSecondRender: 'position: absolute; width: 470px; height: auto; left: 17px; top: 11px;',
         },
         {
           align: 'right',
           verticalAlign: 'top',
           layout: 'horizontal',
-          expectedStyle: 'position: absolute; width: 470px; height: auto; right: 13px; top: 11px;',
           expectedStyleOnSecondRender: 'position: absolute; width: 470px; height: auto; right: 13px; top: 11px;',
         },
         {
           align: 'center',
           verticalAlign: 'bottom',
           layout: 'horizontal',
-          expectedStyle: 'position: absolute; width: 470px; height: auto; left: 17px; bottom: 19px;',
           expectedStyleOnSecondRender: 'position: absolute; width: 470px; height: auto; left: 17px; bottom: 19px;',
         },
         {
           align: 'left',
           verticalAlign: 'bottom',
           layout: 'horizontal',
-          expectedStyle: 'position: absolute; width: 470px; height: auto; left: 17px; bottom: 19px;',
           expectedStyleOnSecondRender: 'position: absolute; width: 470px; height: auto; left: 17px; bottom: 19px;',
         },
         {
           align: 'right',
           verticalAlign: 'bottom',
           layout: 'horizontal',
-          expectedStyle: 'position: absolute; width: 470px; height: auto; right: 13px; bottom: 19px;',
           expectedStyleOnSecondRender: 'position: absolute; width: 470px; height: auto; right: 13px; bottom: 19px;',
         },
         {
           align: 'center',
           verticalAlign: 'middle',
           layout: 'horizontal',
-          expectedStyle: 'position: absolute; width: 470px; height: auto; left: 17px; top: 350px;',
           expectedStyleOnSecondRender: 'position: absolute; width: 470px; height: auto; left: 17px; top: 335.5px;',
         },
         {
           align: 'left',
           verticalAlign: 'middle',
           layout: 'horizontal',
-          expectedStyle: 'position: absolute; width: 470px; height: auto; left: 17px; top: 350px;',
           expectedStyleOnSecondRender: 'position: absolute; width: 470px; height: auto; left: 17px; top: 335.5px;',
         },
         {
           align: 'right',
           verticalAlign: 'middle',
           layout: 'horizontal',
-          expectedStyle: 'position: absolute; width: 470px; height: auto; right: 13px; top: 350px;',
           expectedStyleOnSecondRender: 'position: absolute; width: 470px; height: auto; right: 13px; top: 335.5px;',
         },
         {
           align: 'center',
           verticalAlign: 'top',
           layout: 'vertical',
-          expectedStyle: 'position: absolute; width: auto; height: auto; left: 250px; top: 11px;',
           expectedStyleOnSecondRender: 'position: absolute; width: auto; height: auto; left: 238.5px; top: 11px;',
         },
         {
           align: 'left',
           verticalAlign: 'top',
           layout: 'vertical',
-          expectedStyle: 'position: absolute; width: auto; height: auto; left: 17px; top: 11px;',
           expectedStyleOnSecondRender: 'position: absolute; width: auto; height: auto; left: 17px; top: 11px;',
         },
         {
           align: 'right',
           verticalAlign: 'top',
           layout: 'vertical',
-          expectedStyle: 'position: absolute; width: auto; height: auto; right: 13px; top: 11px;',
           expectedStyleOnSecondRender: 'position: absolute; width: auto; height: auto; right: 13px; top: 11px;',
         },
         {
           align: 'center',
           verticalAlign: 'bottom',
           layout: 'vertical',
-          expectedStyle: 'position: absolute; width: auto; height: auto; left: 250px; bottom: 19px;',
           expectedStyleOnSecondRender: 'position: absolute; width: auto; height: auto; left: 238.5px; bottom: 19px;',
         },
         {
           align: 'left',
           verticalAlign: 'bottom',
           layout: 'vertical',
-          expectedStyle: 'position: absolute; width: auto; height: auto; left: 17px; bottom: 19px;',
           expectedStyleOnSecondRender: 'position: absolute; width: auto; height: auto; left: 17px; bottom: 19px;',
         },
         {
           align: 'right',
           verticalAlign: 'bottom',
           layout: 'vertical',
-          expectedStyle: 'position: absolute; width: auto; height: auto; right: 13px; bottom: 19px;',
           expectedStyleOnSecondRender: 'position: absolute; width: auto; height: auto; right: 13px; bottom: 19px;',
         },
         {
           align: 'center',
           verticalAlign: 'middle',
           layout: 'vertical',
-          expectedStyle: 'position: absolute; width: auto; height: auto; left: 250px; top: 350px;',
           expectedStyleOnSecondRender: 'position: absolute; width: auto; height: auto; left: 238.5px; top: 335.5px;',
         },
         {
           align: 'left',
           verticalAlign: 'middle',
           layout: 'vertical',
-          expectedStyle: 'position: absolute; width: auto; height: auto; left: 17px; top: 350px;',
           expectedStyleOnSecondRender: 'position: absolute; width: auto; height: auto; left: 17px; top: 335.5px;',
         },
         {
           align: 'right',
           verticalAlign: 'middle',
           layout: 'vertical',
-          expectedStyle: 'position: absolute; width: auto; height: auto; right: 13px; top: 350px;',
           expectedStyleOnSecondRender: 'position: absolute; width: auto; height: auto; right: 13px; top: 335.5px;',
         },
       ];
@@ -1573,7 +1554,7 @@ describe('<Legend />', () => {
 
       test.each(layoutPositionCartesianTests)(
         'should calculate position for align=$align, verticalAlign=$verticalAlign, layout=$layout',
-        ({ align, verticalAlign, layout, expectedStyle, expectedStyleOnSecondRender }) => {
+        ({ align, verticalAlign, layout, expectedStyleOnSecondRender }) => {
           mockGetBoundingClientRect({
             width: 23,
             height: 29,
@@ -1593,7 +1574,7 @@ describe('<Legend />', () => {
           expect(wrapper).toBeInTheDocument();
           expect.soft(wrapper.getAttributeNames()).toEqual(['class', 'style']);
           expect.soft(wrapper.getAttribute('class')).toBe('recharts-legend-wrapper');
-          expect.soft(wrapper.getAttribute('style')).toBe(expectedStyle);
+          expect.soft(wrapper.getAttribute('style')).toBe(expectedStyleOnSecondRender);
           /*
            * Because the bounding box is set as a class property instead of a state,
            * reading the legend width and height does not trigger re-render!

--- a/test/helper/MockLegendPayload.tsx
+++ b/test/helper/MockLegendPayload.tsx
@@ -1,0 +1,16 @@
+import { ReactElement, useCallback } from 'react';
+import { useLegendPayloadDispatch } from '../../src/context/legendPayloadContext';
+import { Payload as LegendPayload } from '../../src/component/DefaultLegendContent';
+
+export const exampleLegendPayload: LegendPayload[] = [
+  {
+    type: 'cross',
+    value: 'test',
+  },
+];
+
+export function MockLegendPayload({ payload }: { payload: LegendPayload[] }): ReactElement {
+  const computeLegendPayload = useCallback(() => payload, [payload]);
+  useLegendPayloadDispatch(computeLegendPayload, undefined);
+  return null;
+}

--- a/test/helper/mockGetBoundingClientRect.ts
+++ b/test/helper/mockGetBoundingClientRect.ts
@@ -1,3 +1,5 @@
+const original = Element.prototype.getBoundingClientRect;
+
 /**
  * getBoundingClientRect always returns 0 in jsdom, we can't test for actual returned string size
  * Execution order matters
@@ -7,8 +9,7 @@
  * @returns cleanup function, convenient for beforeAll or beforeEach
  */
 export function mockGetBoundingClientRect(rect: Partial<DOMRect>) {
-  const original = Element.prototype.getBoundingClientRect;
-  Element.prototype.getBoundingClientRect = () => ({
+  const mockDomRect = {
     x: 0,
     y: 0,
     width: 0,
@@ -17,10 +18,17 @@ export function mockGetBoundingClientRect(rect: Partial<DOMRect>) {
     right: 0,
     bottom: 0,
     left: 0,
-    toJSON: () => '{}',
     ...rect,
+  };
+  Element.prototype.getBoundingClientRect = () => ({
+    ...mockDomRect,
+    toJSON: () => JSON.stringify(mockDomRect),
   });
   return function cleanup() {
     Element.prototype.getBoundingClientRect = original;
   };
+}
+
+export function restoreGetBoundingClientRect() {
+  Element.prototype.getBoundingClientRect = original;
 }


### PR DESCRIPTION
## Description

Fixing the legend offset problem introduced in https://github.com/recharts/recharts/pull/4273

The problem is that after my changes, the component that reads and updates the `boundingClientRect` and the component that re-renders when payload changes, are no longer the same component.

In this PR I have moved both the bounding box, plus payload read, to the same component so that it can call `onBBoxUpdate` again.

In my opinion the `onBBoxUpdate` should not exist in the first place because all it does is it passes the width and height back to Legend as `width` and `height` props. But that's a refactor for another day.

## Related Issue

https://github.com/recharts/recharts/pull/4273

## Motivation and Context

Fixing 3.x regression

## How Has This Been Tested?

npm test
storybook

## Screenshots (if appropriate):
<img width="877" alt="image" src="https://github.com/recharts/recharts/assets/1100170/ba30120f-692f-4ca7-9578-37bf2e428291">
<img width="886" alt="image" src="https://github.com/recharts/recharts/assets/1100170/6d5d977f-888b-43e1-a68d-170c1c851005">

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
