### PR TITLE
fix(Area): fixed a bug where className was not assigned to areaDot

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -288,7 +288,8 @@ export class Area extends PureComponent<Props, State> {
     } else if (isFunction(option)) {
       dotItem = option(props);
     } else {
-      dotItem = <Dot {...props} className="recharts-area-dot" />;
+      const className = clsx('recharts-area-dot', option ? (option as DotProps).className : '');
+      dotItem = <Dot {...props} className={className} />;
     }
 
     return dotItem;

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -288,7 +288,7 @@ export class Area extends PureComponent<Props, State> {
     } else if (isFunction(option)) {
       dotItem = option(props);
     } else {
-      const className = clsx('recharts-area-dot', option ? (option as DotProps).className : '');
+      const className = clsx('recharts-area-dot', typeof option !== 'boolean' ? option.className : '');
       dotItem = <Dot {...props} className={className} />;
     }
 

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -360,7 +360,7 @@ export class Line extends PureComponent<Props, State> {
     } else if (isFunction(option)) {
       dotItem = option(props);
     } else {
-      const className = clsx('recharts-line-dot', option ? (option as DotProps).className : '');
+      const className = clsx('recharts-line-dot', typeof option !== 'boolean' ? option.className : '');
       dotItem = <Dot {...props} className={className} />;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixed a bug where classname was not assigned when passed to areachart dot as follows.
```tsx
          <Area
            type="monotone"
            dot={{ className： 'custom-dot-className' }}
            dataKey="uv"
            stroke="#8884d8"
            fill="#8884d8"
          />
```
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4290 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Required if you want to assign a className to dot in areachart.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked in storybook and passed existing tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
