### PR TITLE
fix: radial bar chart cx cy parsing

### DIFF
--- a/src/util/RadialBarUtils.tsx
+++ b/src/util/RadialBarUtils.tsx
@@ -17,9 +17,9 @@ export function parseCornerRadius(cornerRadius: string | number): number {
 // This function will return the passed in props along with cx, cy as numbers.
 export function typeGuardSectorProps(option: SVGProps<SVGPathElement>, props: SectorProps): SectorProps {
   const cxValue = `${props.cx || option.cx}`;
-  const cx = parseInt(cxValue, 10);
+  const cx = Number(cxValue);
   const cyValue = `${props.cy || option.cy}`;
-  const cy = parseInt(cyValue, 10);
+  const cy = Number(cyValue);
   return {
     ...props,
     ...option,

--- a/test/chart/RadialBarChart.spec.tsx
+++ b/test/chart/RadialBarChart.spec.tsx
@@ -387,6 +387,29 @@ describe('<RadialBarChart />', () => {
       ),
     );
 
+    test('renders background in the exact same position as foreground', () => {
+      const preparedData = [{ value: 42, fill: '#241084' }];
+      const emptyBackgroundColor = '#D8BDF3';
+
+      const { container } = render(
+        <RadialBarChart data={preparedData} height={280} width={340} cx="47%" startAngle={180} endAngle={0}>
+          <RadialBar
+            background={{
+              fill: emptyBackgroundColor,
+            }}
+            dataKey="value"
+            isAnimationActive={false}
+          />
+        </RadialBarChart>,
+      );
+      const background = container.querySelector('.recharts-radial-bar-background-sector');
+      expect(background).toBeInTheDocument();
+      const foreground = container.querySelector('.recharts-radial-bar-sector');
+      expect(foreground).not.toBeNull();
+      expect(foreground).toBeInTheDocument();
+      expect(foreground!.getAttribute('d')).toEqual(background!.getAttribute('d'));
+    });
+
     /**
      * This test is skipped because generateCategoricalChart throws an error if axes are provided to FunnelChart.
      * TODO un-skip this level if fixing the exception.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix issue where background and foreground of radial bar were not the same because parsing of strings to numbers were not the same. If we want to use `parseInt` we have to use it everywhere. Call to `Number` works the same as no cast as it retains the values without messing with a radix or actually "parsing"

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4264

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
fix bug https://github.com/recharts/recharts/issues/4264

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit test red green

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All new and existing tests passed.
