### PR TITLE
fix: legend size, use offset height and width

### DIFF
--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -100,6 +100,8 @@ function LegendWrapper(props: Props) {
     (node: HTMLDivElement | null) => {
       if (node != null && node.getBoundingClientRect) {
         const box = node.getBoundingClientRect();
+        box.width = node.offsetWidth;
+        box.height = node.offsetHeight;
         if (Math.abs(box.width - lastBoundingBox.width) > EPS || Math.abs(box.height - lastBoundingBox.height) > EPS) {
           setLastBoundingBox({ width: box.width, height: box.height });
           if (onBBoxUpdate) {

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, test, vi } from 'vitest';
+import { mockHTMLElementProperty } from '../helper/mockHTMLElementProperty';
 import {
   Area,
   AreaChart,
@@ -544,6 +545,26 @@ describe('<Legend />', () => {
             "a function for the dataKey of a chart's cartesian components. " +
             'Ex: <Bar name="Name of my Data"/>',
         );
+      });
+
+      test('it should get the correct BBox when scaled 2x', () => {
+        const mockRect = {
+          width: 300,
+          height: 30,
+        };
+        const scale = 2;
+        const cleanupRect = mockGetBoundingClientRect(mockRect, false);
+        const cleanupOffsetHeight = mockHTMLElementProperty('offsetHeight', mockRect.height * scale);
+        const cleanupOffsetWidth = mockHTMLElementProperty('offsetWidth', mockRect.width * scale);
+
+        const handleUpdate = vi.fn();
+        render(<Legend height={30} width={300} onBBoxUpdate={handleUpdate} />);
+        expect(handleUpdate.mock.calls[0][0].height).toEqual(mockRect.height * scale);
+        expect(handleUpdate.mock.calls[0][0].width).toEqual(mockRect.width * scale);
+
+        cleanupRect();
+        cleanupOffsetHeight();
+        cleanupOffsetWidth();
       });
 
       it('should render one line legend item for each Line, with default class and style attributes', () => {
@@ -1105,17 +1126,7 @@ describe('<Legend />', () => {
     });
 
     it('should push away Bars to make space', () => {
-      Element.prototype.getBoundingClientRect = () => ({
-        x: 0,
-        y: 0,
-        width: 0,
-        height: 10,
-        top: 0,
-        right: 0,
-        bottom: 0,
-        left: 0,
-        toJSON: () => '{}',
-      });
+      mockGetBoundingClientRect({ width: 0, height: 10 });
 
       const { container, rerender } = render(
         <BarChart width={500} height={500} data={numericalData}>

--- a/test/helper/mockHTMLElementProperty.ts
+++ b/test/helper/mockHTMLElementProperty.ts
@@ -1,0 +1,7 @@
+export function mockHTMLElementProperty(name: keyof HTMLElement, value: number) {
+  const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, name);
+  Object.defineProperty(HTMLElement.prototype, name, { configurable: true, value });
+  return function cleanup() {
+    Object.defineProperty(HTMLElement.prototype, name, original);
+  };
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Same PR as 
https://github.com/recharts/recharts/pull/4272
but for 3.x

- use offset height and width for legend bounding box to prevent scaling issues



## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/recharts/recharts/issues/4246

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
https://github.com/recharts/recharts/issues/4246

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- storybook visually
- uni test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
