### PR TITLE
Add tests for Tooltip in Treemap chart

### DIFF
--- a/test/_data.ts
+++ b/test/_data.ts
@@ -132,7 +132,7 @@ export const SankeyData = {
   ],
 };
 
-export const TreemapData = [
+export const exampleTreemapData = [
   {
     rank: '1',
     name: 'A',

--- a/test/chart/AccessibilityScans.spec.tsx
+++ b/test/chart/AccessibilityScans.spec.tsx
@@ -28,7 +28,7 @@ import {
   XAxis,
   YAxis,
 } from '../../src';
-import { PageData as data, SankeyData, TreemapData, exampleSunburstData } from '../_data';
+import { PageData as data, SankeyData, exampleTreemapData, exampleSunburstData } from '../_data';
 
 describe('Static scanning for accessibility markup issues', () => {
   test('Area chart', async () => {
@@ -154,7 +154,14 @@ describe('Static scanning for accessibility markup issues', () => {
 
   test.skip('Treemap', async () => {
     const { container } = render(
-      <Treemap width={500} height={250} data={TreemapData} isAnimationActive={false} nameKey="name" dataKey="value" />,
+      <Treemap
+        width={500}
+        height={250}
+        data={exampleTreemapData}
+        isAnimationActive={false}
+        nameKey="name"
+        dataKey="value"
+      />,
     );
 
     expect((await axe(container)).violations).toHaveLength(0);

--- a/test/chart/Treemap.spec.tsx
+++ b/test/chart/Treemap.spec.tsx
@@ -2,12 +2,19 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { Treemap, XAxis, YAxis } from '../../src';
 import { testChartLayoutContext } from '../util/context';
-import { TreemapData as data } from '../_data';
+import { exampleTreemapData } from '../_data';
 
 describe('<Treemap />', () => {
   test('renders 20 rectangles in simple TreemapChart', () => {
     const { container } = render(
-      <Treemap width={500} height={250} data={data} isAnimationActive={false} nameKey="name" dataKey="value" />,
+      <Treemap
+        width={500}
+        height={250}
+        data={exampleTreemapData}
+        isAnimationActive={false}
+        nameKey="name"
+        dataKey="value"
+      />,
     );
 
     expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(24);
@@ -18,7 +25,7 @@ describe('<Treemap />', () => {
       <Treemap
         width={500}
         height={250}
-        data={data}
+        data={exampleTreemapData}
         isAnimationActive={false}
         nameKey="name"
         dataKey="value"

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -23,12 +23,13 @@ import {
   ScatterChart,
   SunburstChart,
   Tooltip,
+  Treemap,
   XAxis,
   YAxis,
 } from '../../../src';
 import { restoreGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
 import { getTooltip, showTooltip } from './tooltipTestHelpers';
-import { PageData, SankeyData, exampleSunburstData } from '../../_data';
+import { PageData, SankeyData, exampleSunburstData, exampleTreemapData } from '../../_data';
 import {
   areaChartMouseHoverTooltipSelector,
   barChartMouseHoverTooltipSelector,
@@ -41,6 +42,7 @@ import {
   sankeyChartMouseHoverTooltipSelector,
   sankeyNodeChartMouseHoverTooltipSelector,
   sunburstChartMouseHoverTooltipSelector,
+  treemapNodeChartMouseHoverTooltipSelector,
 } from './tooltipMouseHoverSelectors';
 
 type TooltipPayloadTestCase = {
@@ -285,6 +287,26 @@ const SunburstChartTestCase: TooltipPayloadTestCase = {
   expectedTooltipContent: ['Agricultural waste : 124.729'],
 };
 
+const TreemapTestCase: TooltipPayloadTestCase = {
+  name: 'Treemap',
+  Wrapper: ({ children }) => (
+    <Treemap
+      width={400}
+      height={400}
+      data={exampleTreemapData}
+      dataKey="value"
+      nameKey="name"
+      stroke="#fff"
+      fill="#8884d8"
+    >
+      {children}
+    </Treemap>
+  ),
+  mouseHoverSelector: treemapNodeChartMouseHoverTooltipSelector,
+  expectedTooltipTitle: '',
+  expectedTooltipContent: ['U : 12490887132'],
+};
+
 const testCases: ReadonlyArray<TooltipPayloadTestCase> = [
   AreaChartTestCase,
   AreaChartWithXAxisTestCase,
@@ -302,6 +324,7 @@ const testCases: ReadonlyArray<TooltipPayloadTestCase> = [
   ScatterChartTestCase,
   // Sunburst is excluded because it renders tooltip multiple times and all tests fail :( TODO fix and re-enable
   // SunburstChartTestCase,
+  TreemapTestCase,
 ];
 
 function expectTooltipPayload(

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -27,11 +27,12 @@ import {
   ScatterChart,
   SunburstChart,
   Tooltip,
+  Treemap,
   XAxis,
   YAxis,
 } from '../../../src';
 import { mockGetBoundingClientRect, restoreGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
-import { PageData, SankeyData, exampleSunburstData } from '../../_data';
+import { PageData, SankeyData, exampleSunburstData, exampleTreemapData } from '../../_data';
 import { getTooltip, showTooltip } from './tooltipTestHelpers';
 import {
   areaChartMouseHoverTooltipSelector,
@@ -45,6 +46,7 @@ import {
   sankeyNodeChartMouseHoverTooltipSelector,
   scatterChartMouseHoverTooltipSelector,
   sunburstChartMouseHoverTooltipSelector,
+  treemapNodeChartMouseHoverTooltipSelector,
 } from './tooltipMouseHoverSelectors';
 
 type TooltipVisibilityTestCase = {
@@ -226,11 +228,27 @@ const SunburstChartTestCase: TooltipVisibilityTestCase = {
   name: 'SunburstChart',
   Wrapper: ({ children }) => (
     <SunburstChart width={400} height={400} data={exampleSunburstData}>
-      <Tooltip />
       {children}
     </SunburstChart>
   ),
   mouseHoverSelector: sunburstChartMouseHoverTooltipSelector,
+};
+
+const TreemapTestCase: TooltipVisibilityTestCase = {
+  name: 'Treemap',
+  Wrapper: ({ children }) => (
+    <Treemap
+      width={400}
+      height={400}
+      data={exampleTreemapData}
+      isAnimationActive={false}
+      nameKey="name"
+      dataKey="value"
+    >
+      {children}
+    </Treemap>
+  ),
+  mouseHoverSelector: treemapNodeChartMouseHoverTooltipSelector,
 };
 
 const testCases: ReadonlyArray<TooltipVisibilityTestCase> = [
@@ -249,6 +267,7 @@ const testCases: ReadonlyArray<TooltipVisibilityTestCase> = [
   // Sunburst is excluded because it renders tooltip multiple times and all tests fail :( TODO fix and re-enable
   // SunburstChartTestCase,
   // FunnelChart is excluded because FunnelChart does not support Tooltip
+  TreemapTestCase,
 ];
 
 describe('Tooltip visibility', () => {
@@ -288,6 +307,9 @@ describe('Tooltip visibility', () => {
       );
 
       showTooltip(container, mouseHoverSelector, debug);
+
+      const tooltip = getTooltip(container);
+      expect(tooltip).toBeVisible();
 
       // After the mouse over event over the chart, the tooltip wrapper still is not set to visible,
       // but the content is already created based on the nearest data point.
@@ -341,6 +363,12 @@ describe('Tooltip visibility', () => {
            */
           context.skip();
         }
+        if (name === 'Treemap') {
+          /*
+           * Treemap chart for some reason ignores active property on Tooltip
+           */
+          context.skip();
+        }
         const { container } = render(
           <Wrapper>
             <Tooltip active />
@@ -364,6 +392,12 @@ describe('Tooltip visibility', () => {
         if (name === 'Sankey') {
           /*
            * Sankey chart for some reason ignores active property on Tooltip
+           */
+          context.skip();
+        }
+        if (name === 'Treemap') {
+          /*
+           * Treemap chart for some reason ignores active property on Tooltip
            */
           context.skip();
         }
@@ -419,6 +453,12 @@ describe('Tooltip visibility', () => {
         if (name === 'Sankey') {
           /*
            * Sankey chart for some reason ignores defaultIndex property on Tooltip
+           */
+          context.skip();
+        }
+        if (name === 'Treemap') {
+          /*
+           * Treemap chart for some reason ignores defaultIndex property on Tooltip
            */
           context.skip();
         }
@@ -622,6 +662,7 @@ describe('Active element visibility', () => {
     SankeyTestCase,
     ScatterChartTestCase,
     SunburstChartTestCase,
+    TreemapTestCase,
   ])('as a child of $name', ({ Wrapper, mouseHoverSelector }) => {
     it('should not display activeDot', () => {
       const { container, debug } = render(

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -54,6 +54,7 @@ type TooltipVisibilityTestCase = {
   name: string;
   mouseHoverSelector: MouseHoverTooltipTriggerSelector;
   Wrapper: ComponentType<{ children: ReactNode }>;
+  expectedTransform: string;
 };
 
 const commonChartProps = {
@@ -71,6 +72,7 @@ const AreaChartTestCase: TooltipVisibilityTestCase = {
     </AreaChart>
   ),
   mouseHoverSelector: areaChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(10px, 10px);',
 };
 
 const BarChartTestCase: TooltipVisibilityTestCase = {
@@ -82,6 +84,7 @@ const BarChartTestCase: TooltipVisibilityTestCase = {
     </BarChart>
   ),
   mouseHoverSelector: barChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(10px, 10px);',
 };
 
 const LineChartHorizontalTestCase: TooltipVisibilityTestCase = {
@@ -97,6 +100,7 @@ const LineChartHorizontalTestCase: TooltipVisibilityTestCase = {
     </LineChart>
   ),
   mouseHoverSelector: lineChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(65px, 10px);',
 };
 
 const LineChartVerticalTestCase: TooltipVisibilityTestCase = {
@@ -121,6 +125,7 @@ const LineChartVerticalTestCase: TooltipVisibilityTestCase = {
     </LineChart>
   ),
   mouseHoverSelector: lineChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(80px, 20px);',
 };
 
 const ComposedChartWithAreaTestCase: TooltipVisibilityTestCase = {
@@ -134,6 +139,7 @@ const ComposedChartWithAreaTestCase: TooltipVisibilityTestCase = {
     </ComposedChart>
   ),
   mouseHoverSelector: composedChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(65px, 10px);',
 };
 
 const ComposedChartWithBarTestCase: TooltipVisibilityTestCase = {
@@ -147,6 +153,7 @@ const ComposedChartWithBarTestCase: TooltipVisibilityTestCase = {
     </ComposedChart>
   ),
   mouseHoverSelector: composedChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(65px, 10px);',
 };
 
 const ComposedChartWithLineTestCase: TooltipVisibilityTestCase = {
@@ -160,6 +167,7 @@ const ComposedChartWithLineTestCase: TooltipVisibilityTestCase = {
     </ComposedChart>
   ),
   mouseHoverSelector: composedChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(65px, 10px);',
 };
 
 const PieChartTestCase: TooltipVisibilityTestCase = {
@@ -171,6 +179,7 @@ const PieChartTestCase: TooltipVisibilityTestCase = {
     </PieChart>
   ),
   mouseHoverSelector: pieChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(271.8676024097812px, 161.6138988484545px);',
 };
 
 const RadarChartTestCase: TooltipVisibilityTestCase = {
@@ -185,6 +194,7 @@ const RadarChartTestCase: TooltipVisibilityTestCase = {
     </RadarChart>
   ),
   mouseHoverSelector: radarChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(10px, 10px);',
 };
 
 const RadialBarChartTestCase: TooltipVisibilityTestCase = {
@@ -199,6 +209,7 @@ const RadialBarChartTestCase: TooltipVisibilityTestCase = {
     </RadialBarChart>
   ),
   mouseHoverSelector: radialBarChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(10px, 10px);',
 };
 
 const SankeyTestCase: TooltipVisibilityTestCase = {
@@ -209,6 +220,7 @@ const SankeyTestCase: TooltipVisibilityTestCase = {
     </Sankey>
   ),
   mouseHoverSelector: sankeyNodeChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(35px, 114.89236115144739px);',
 };
 
 const ScatterChartTestCase: TooltipVisibilityTestCase = {
@@ -222,6 +234,7 @@ const ScatterChartTestCase: TooltipVisibilityTestCase = {
     </ScatterChart>
   ),
   mouseHoverSelector: scatterChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(115px, 280.8px);',
 };
 
 const SunburstChartTestCase: TooltipVisibilityTestCase = {
@@ -232,6 +245,7 @@ const SunburstChartTestCase: TooltipVisibilityTestCase = {
     </SunburstChart>
   ),
   mouseHoverSelector: sunburstChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(10px, 10px);',
 };
 
 const TreemapTestCase: TooltipVisibilityTestCase = {
@@ -249,6 +263,7 @@ const TreemapTestCase: TooltipVisibilityTestCase = {
     </Treemap>
   ),
   mouseHoverSelector: treemapNodeChartMouseHoverTooltipSelector,
+  expectedTransform: 'transform: translate(94.5px, 58.5px);',
 };
 
 const testCases: ReadonlyArray<TooltipVisibilityTestCase> = [
@@ -273,7 +288,7 @@ const testCases: ReadonlyArray<TooltipVisibilityTestCase> = [
 describe('Tooltip visibility', () => {
   afterEach(restoreGetBoundingClientRect);
 
-  describe.each(testCases)('as a child of $name', ({ name, Wrapper, mouseHoverSelector }) => {
+  describe.each(testCases)('as a child of $name', ({ name, Wrapper, mouseHoverSelector, expectedTransform }) => {
     test('Without an event, the tooltip wrapper is rendered but not visible', () => {
       const { container } = render(
         <Wrapper>
@@ -326,17 +341,24 @@ describe('Tooltip visibility', () => {
         width: 10,
         height: 10,
       });
-      const { container, debug } = render(
+      const { container } = render(
         <Wrapper>
           <Tooltip />
         </Wrapper>,
       );
 
       const tooltipTriggerElement = showTooltip(container, mouseHoverSelector);
+
+      const tooltip1 = getTooltip(container);
+      expect(tooltip1.getAttribute('style')).toContain('position: absolute;');
+      expect(tooltip1.getAttribute('style')).toContain('top: 0px');
+      expect(tooltip1.getAttribute('style')).toContain('left: 0px');
+
       fireEvent.mouseMove(tooltipTriggerElement, { clientX: 201, clientY: 201 });
-      debug();
-      const tooltip = getTooltip(container);
-      expect(tooltip.getAttribute('style')).toContain('translate');
+
+      const tooltip2 = getTooltip(container);
+
+      expect(tooltip2.getAttribute('style')).toContain(expectedTransform);
     });
 
     it('should render customized tooltip when content is set to be a react element', () => {

--- a/test/component/Tooltip/tooltipMouseHoverSelectors.ts
+++ b/test/component/Tooltip/tooltipMouseHoverSelectors.ts
@@ -24,3 +24,5 @@ export const scatterChartMouseHoverTooltipSelector: MouseHoverTooltipTriggerSele
 export const sankeyChartMouseHoverTooltipSelector: MouseHoverTooltipTriggerSelector =
   '.recharts-sankey-links .recharts-sankey-link';
 export const sunburstChartMouseHoverTooltipSelector: MouseHoverTooltipTriggerSelector = '.recharts-sector';
+export const treemapNodeChartMouseHoverTooltipSelector: MouseHoverTooltipTriggerSelector =
+  '.recharts-treemap-depth-2 .recharts-rectangle';


### PR DESCRIPTION
## Description

So Treemap does support Tooltip after all. I found out and added tests.

And while I'm changing the Tooltip tests again I also added assertions for expected position. I will be changing the viewBox and boundingClientRect and I don't want to break anything.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Tests for everything

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
