### PR TITLE
Fix axis padding calculation for 0 or 1 data point. Fixes #4313

### DIFF
--- a/src/util/CartesianUtils.ts
+++ b/src/util/CartesianUtils.ts
@@ -50,17 +50,19 @@ export const formatAxisMap = (props: any, axisMap: any, offset: any, axisType: A
           );
         }
       });
-      const smallestDistanceInPercent = smallestDistanceBetweenValues / diff;
-      const rangeWidth = axis.layout === 'vertical' ? offset.height : offset.width;
+      if (Number.isFinite(smallestDistanceBetweenValues)) {
+        const smallestDistanceInPercent = smallestDistanceBetweenValues / diff;
+        const rangeWidth = axis.layout === 'vertical' ? offset.height : offset.width;
 
-      if (axis.padding === 'gap') {
-        calculatedPadding = (smallestDistanceInPercent * rangeWidth) / 2;
-      }
+        if (axis.padding === 'gap') {
+          calculatedPadding = (smallestDistanceInPercent * rangeWidth) / 2;
+        }
 
-      if (axis.padding === 'no-gap') {
-        const gap = getPercentValue(props.barCategoryGap, smallestDistanceInPercent * rangeWidth);
-        const halfBand = (smallestDistanceInPercent * rangeWidth) / 2;
-        calculatedPadding = halfBand - gap - ((halfBand - gap) / rangeWidth) * gap;
+        if (axis.padding === 'no-gap') {
+          const gap = getPercentValue(props.barCategoryGap, smallestDistanceInPercent * rangeWidth);
+          const halfBand = (smallestDistanceInPercent * rangeWidth) / 2;
+          calculatedPadding = halfBand - gap - ((halfBand - gap) / rangeWidth) * gap;
+        }
       }
     }
 

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -1,4 +1,4 @@
-import { prettyDOM, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { ScatterChart, Scatter, LineChart, Line, XAxis, YAxis, BarChart, Bar } from '../../src';
 
@@ -165,8 +165,6 @@ describe('<XAxis />', () => {
         <YAxis dataKey="y" />
       </BarChart>,
     );
-
-    console.log(prettyDOM(container));
 
     const tick = container.querySelector('.xAxis .recharts-cartesian-axis-tick-value');
     expect(parseInt(tick?.getAttribute('x') as string, 10)).toEqual(180);

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -167,7 +167,8 @@ describe('<XAxis />', () => {
     );
 
     const tick = container.querySelector('.xAxis .recharts-cartesian-axis-tick-value');
-    expect(parseInt(tick?.getAttribute('x') as string, 10)).toEqual(180);
+    expect(tick).toBeInTheDocument();
+    expect(tick?.getAttribute('x')).toEqual('180');
   });
 
   test('Render no ticks if type is category and data is empty', () => {

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { prettyDOM, render } from '@testing-library/react';
 import React from 'react';
 import { ScatterChart, Scatter, LineChart, Line, XAxis, YAxis, BarChart, Bar } from '../../src';
 
@@ -155,6 +155,21 @@ describe('<XAxis />', () => {
 
     const bar = container.querySelector('.recharts-rectangle');
     expect(parseInt(bar?.getAttribute('x') as string, 10)).toEqual(66);
+  });
+
+  it('Render Bars with gap for a single data point', () => {
+    const { container } = render(
+      <BarChart width={300} height={300} data={data.slice(0, 1)}>
+        <Bar dataKey="y" isAnimationActive={false} />
+        <XAxis dataKey="x" type="number" domain={['dataMin', 'dataMax']} padding="gap" />
+        <YAxis dataKey="y" />
+      </BarChart>,
+    );
+
+    console.log(prettyDOM(container));
+
+    const tick = container.querySelector('.xAxis .recharts-cartesian-axis-tick-value');
+    expect(parseInt(tick?.getAttribute('x') as string, 10)).toEqual(180);
   });
 
   test('Render no ticks if type is category and data is empty', () => {


### PR DESCRIPTION
The padding calculation did not take into account the case when there is only 0 or 1 data point, in which case the calculatedPadding is Infinite, resulting in `range()` to be set to Infinite, resulting in the ticks not being drawn properly.

I have fixed this by checking for Infinite before setting calculatedPadding.

This results in at least something being drawn – behaving as if padding was undefined. An even better fix would be to calculate padding without relying on the distance between values, but that would require a big refactor.

## Related Issue
#4313

## How Has This Been Tested?

I added a test case. It is failing without my fix, showing that the x-axis is not drawn at all.

N.B. the same test case can also show the bug in #3640 if we look at the rendered .recharts-rectangle (it is empty even though there should be one bar).


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
