### PR TITLE
Move bounding box to separate hook

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -9,6 +9,7 @@
   "es6/component",
   "es6/chart",
   "es6/cartesian",
+  "es6/util/useGetBoundingClientRect.js",
   "es6/util/types.js",
   "es6/util/tooltip",
   "es6/util/payload",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -9,6 +9,7 @@
   "lib/component",
   "lib/chart",
   "lib/cartesian",
+  "lib/util/useGetBoundingClientRect.js",
   "lib/util/types.js",
   "lib/util/tooltip",
   "lib/util/payload",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -9,6 +9,7 @@
   "types/component",
   "types/chart",
   "types/cartesian",
+  "types/util/useGetBoundingClientRect.d.ts",
   "types/util/types.d.ts",
   "types/util/tooltip",
   "types/util/payload",

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -94,6 +94,19 @@ interface State {
   boxHeight: number;
 }
 
+/**
+ * Use this to listen to bounding box changes.
+ * https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
+ *
+ * Very useful for reading actual sizes of DOM elements.
+ *
+ * Be aware that this is difficult to test for. jsdom, by design, returns all zeroes!
+ * If you want to write tests check out the utility function `mockGetBoundingClientRect`
+ *
+ * @param onUpdate this is extra callback that's called with the full DOMRect. Note that this receives different object than the return value.
+ * @param extraDependencies use this to trigger new DOM dimensions read when any of these change. Good for things like payload and label, that will re-render something down in the children array, but you want to read the bounding box of a parent.
+ * @returns [lastBoundingBox, updateBoundingBox] most recent value, and setter. Pass the setter to a DOM element ref like this: `<div ref={updateBoundingBox}>`
+ */
 function useGetBoundingClientRect(
   onUpdate: (domRect: DOMRect | null) => void,
   extraDependencies: ReadonlyArray<unknown>,

--- a/src/util/useGetBoundingClientRect.ts
+++ b/src/util/useGetBoundingClientRect.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from 'react';
+
+const EPS = 1;
+
+export type BoundingBox = {
+  width: number;
+  height: number;
+};
+type SetBoundingBox = (node: HTMLElement | null) => void;
+
+/**
+ * Use this to listen to bounding box changes.
+ * https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
+ *
+ * Very useful for reading actual sizes of DOM elements.
+ *
+ * Be aware that this is difficult to test for. jsdom, by design, returns all zeroes!
+ * If you want to write tests check out the utility function `mockGetBoundingClientRect`
+ *
+ * @param onUpdate this is extra callback that's called with the full DOMRect. Note that this receives different object than the return value.
+ * @param extraDependencies use this to trigger new DOM dimensions read when any of these change. Good for things like payload and label, that will re-render something down in the children array, but you want to read the bounding box of a parent.
+ * @returns [lastBoundingBox, updateBoundingBox] most recent value, and setter. Pass the setter to a DOM element ref like this: `<div ref={updateBoundingBox}>`
+ */
+export function useGetBoundingClientRect(
+  onUpdate: (domRect: DOMRect | null) => void,
+  extraDependencies: ReadonlyArray<unknown>,
+): [BoundingBox, SetBoundingBox] {
+  const [lastBoundingBox, setLastBoundingBox] = useState<BoundingBox>({ width: 0, height: 0 });
+  const updateBoundingBox = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node != null && node.getBoundingClientRect) {
+        const box = node.getBoundingClientRect();
+        box.width = node.offsetWidth;
+        box.height = node.offsetHeight;
+        if (Math.abs(box.width - lastBoundingBox.width) > EPS || Math.abs(box.height - lastBoundingBox.height) > EPS) {
+          setLastBoundingBox({ width: box.width, height: box.height });
+          if (onUpdate) {
+            onUpdate(box);
+          }
+        }
+      }
+    },
+    [lastBoundingBox.width, lastBoundingBox.height, onUpdate, ...extraDependencies],
+  );
+  return [lastBoundingBox, updateBoundingBox];
+}


### PR DESCRIPTION
## Description

Move hook from inside Legend to its own function and own file

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Tooltip is affected by the exact same problem as Legend was, and will reuse this hook too.

## How Has This Been Tested?

npm test
storybook

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
