### PR TITLE
Stop using offsetWidth and offsetHeight when calling getBoundingClientRect()

### DIFF
--- a/src/util/useGetBoundingClientRect.ts
+++ b/src/util/useGetBoundingClientRect.ts
@@ -30,8 +30,6 @@ export function useGetBoundingClientRect(
     (node: HTMLDivElement | null) => {
       if (node != null && node.getBoundingClientRect) {
         const box = node.getBoundingClientRect();
-        box.width = node.offsetWidth;
-        box.height = node.offsetHeight;
         if (Math.abs(box.width - lastBoundingBox.width) > EPS || Math.abs(box.height - lastBoundingBox.height) > EPS) {
           setLastBoundingBox({ width: box.width, height: box.height });
           if (onUpdate) {

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -1,7 +1,6 @@
 import React, { CSSProperties } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, test, vi } from 'vitest';
-import { mockHTMLElementProperty } from '../helper/mockHTMLElementProperty';
 import {
   Area,
   AreaChart,
@@ -545,22 +544,6 @@ describe('<Legend />', () => {
             "a function for the dataKey of a chart's cartesian components. " +
             'Ex: <Bar name="Name of my Data"/>',
         );
-      });
-
-      test('it should get the correct BBox when scaled 2x', () => {
-        const mockRect = {
-          width: 300,
-          height: 30,
-        };
-        const scale = 2;
-        mockGetBoundingClientRect(mockRect, false);
-        mockHTMLElementProperty('offsetHeight', mockRect.height * scale);
-        mockHTMLElementProperty('offsetWidth', mockRect.width * scale);
-
-        const handleUpdate = vi.fn();
-        render(<Legend height={30} width={300} onBBoxUpdate={handleUpdate} />);
-        expect(handleUpdate.mock.calls[0][0].height).toEqual(mockRect.height * scale);
-        expect(handleUpdate.mock.calls[0][0].width).toEqual(mockRect.width * scale);
       });
 
       it('should render one line legend item for each Line, with default class and style attributes', () => {


### PR DESCRIPTION
## Description

I was wondering what this is doing and ... I can't find that.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

This reassignment makes it so more difficult to mock and test different components. If we can get rid of it, testing gets easier.

## How Has This Been Tested?

There was one failing test - but that test wasn't actually testing anything, it was only mocking values and then expecting the mocked values back. jsdom doesn't do rendering so it won't do any scale either.

I looked at MDN and MDN says that it's getBoundingClientRect() that actually does include scale, and offsetWidth does not! So according to MDN this code was wrong from the beginning?

I also opened storybook and compared my branch to recharts.org storybook, and then added `scale: 2` to the main chart, and then added `scale: 2` to the Legend, and I can't find any difference.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
