### PR TITLE
Tooltip props are set through context instead of element cloning

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1876,18 +1876,7 @@ export const generateCategoricalChart = ({
         return null;
       }
 
-      const { isTooltipActive, activeCoordinate, activePayload, activeLabel } = this.state;
-
-      // The user can set isActive on the Tooltip,
-      // and we respect the user to enable customisation.
-      // The Tooltip is active if the user has set isActive, or if the tooltip is active due to a mouse event.
-      const isActive = tooltipItem.props.active ?? isTooltipActive;
-
       return cloneElement(tooltipItem, {
-        active: isActive,
-        label: activeLabel,
-        payload: isActive ? activePayload : [],
-        coordinate: activeCoordinate,
         accessibilityLayer,
       });
     };

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -9,6 +9,7 @@ import type { Props as YAxisProps } from '../cartesian/YAxis';
 import { calculateViewBox } from '../util/calculateViewBox';
 import { getAnyElementOfObject } from '../util/DataUtils';
 import { LegendPayloadProvider } from './legendPayloadContext';
+import { TooltipContextProvider, TooltipContextValue } from './tooltipContext';
 
 export const XAxisContext = createContext<XAxisMap | undefined>(undefined);
 export const YAxisContext = createContext<YAxisMap | undefined>(undefined);
@@ -36,7 +37,7 @@ export type ChartLayoutContextProviderProps = {
  */
 export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProps) => {
   const {
-    state: { xAxisMap, yAxisMap, offset },
+    state: { xAxisMap, yAxisMap, offset, activeLabel, activePayload, isTooltipActive, activeCoordinate },
     clipPathId,
     children,
     width,
@@ -47,6 +48,13 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
    * Perhaps we should compute this property when reading? Let's see what is more often used
    */
   const viewBox = calculateViewBox(offset);
+
+  const tooltipContextValue: TooltipContextValue = {
+    label: activeLabel,
+    payload: activePayload,
+    coordinate: activeCoordinate,
+    active: isTooltipActive,
+  };
 
   /*
    * This pretends to be a single context but actually is split into multiple smaller ones.
@@ -69,7 +77,9 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
             <ViewBoxContext.Provider value={viewBox}>
               <ClipPathIdContext.Provider value={clipPathId}>
                 <ChartHeightContext.Provider value={height}>
-                  <ChartWidthContext.Provider value={width}>{children}</ChartWidthContext.Provider>
+                  <ChartWidthContext.Provider value={width}>
+                    <TooltipContextProvider value={tooltipContextValue}>{children}</TooltipContextProvider>
+                  </ChartWidthContext.Provider>
                 </ChartHeightContext.Provider>
               </ClipPathIdContext.Provider>
             </ViewBoxContext.Provider>

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react';
+import { ChartCoordinate } from '../util/types';
+
+export type TooltipContextValue = {
+  label: string;
+  payload: any[];
+  coordinate: ChartCoordinate;
+  active: boolean;
+};
+
+export const doNotDisplayTooltip: TooltipContextValue = {
+  label: '',
+  payload: [],
+  coordinate: { x: 0, y: 0 },
+  active: false,
+};
+
+const TooltipContext = createContext<TooltipContextValue>(doNotDisplayTooltip);
+
+export const TooltipContextProvider = TooltipContext.Provider;
+
+export const useTooltipContext = () => useContext(TooltipContext);


### PR DESCRIPTION
## Description

All of these components still need a separate `renderTooltip()` function because the Tooltip itself doesn't react properly to change in payload and dimensions. Which is exactly the same problem as we found when refactoring Legend. I am working on that next.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

No more element cloning

## How Has This Been Tested?

npm test
storybook

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
