### PR TITLE
Tooltip reads accessibilityLayer from context instead of props

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -63,6 +63,7 @@
   "es6/context/tooltipContext.js",
   "es6/context/legendPayloadContext.js",
   "es6/context/chartLayoutContext.js",
+  "es6/context/accessibilityContext.js",
   "es6/container/Surface.js",
   "es6/container/Layer.js",
   "es6/component/TooltipBoundingBox.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -63,6 +63,7 @@
   "lib/context/tooltipContext.js",
   "lib/context/legendPayloadContext.js",
   "lib/context/chartLayoutContext.js",
+  "lib/context/accessibilityContext.js",
   "lib/container/Surface.js",
   "lib/container/Layer.js",
   "lib/component/TooltipBoundingBox.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -63,6 +63,7 @@
   "types/context/tooltipContext.d.ts",
   "types/context/legendPayloadContext.d.ts",
   "types/context/chartLayoutContext.d.ts",
+  "types/context/accessibilityContext.d.ts",
   "types/container/Surface.d.ts",
   "types/container/Layer.d.ts",
   "types/component/TooltipBoundingBox.d.ts",

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -88,6 +88,7 @@ import { getActiveShapeIndexForTooltip, isFunnel, isPie, isScatter } from '../ut
 import { Cursor } from '../component/Cursor';
 import { ChartLayoutContextProvider } from '../context/chartLayoutContext';
 import { AxisMap, CategoricalChartState } from './types';
+import { AccessibilityContextProvider } from '../context/accessibilityContext';
 
 export interface MousePointer {
   pageX: number;
@@ -1869,16 +1870,10 @@ export const generateCategoricalChart = ({
      * @return {ReactElement}  The instance of Tooltip
      */
     renderTooltip = (): React.ReactElement => {
-      const { children, accessibilityLayer } = this.props;
+      const { children } = this.props;
       const tooltipItem = findChildByType(children, Tooltip);
 
-      if (!tooltipItem) {
-        return null;
-      }
-
-      return cloneElement(tooltipItem, {
-        accessibilityLayer,
-      });
+      return tooltipItem;
     };
 
     renderBrush = (element: React.ReactElement) => {
@@ -2193,29 +2188,31 @@ export const generateCategoricalChart = ({
 
       const events = this.parseEventsOfWrapper();
       return (
-        <ChartLayoutContextProvider
-          state={this.state}
-          width={this.props.width}
-          height={this.props.height}
-          clipPathId={this.clipPathId}
-        >
-          <div
-            className={clsx('recharts-wrapper', className)}
-            style={{ position: 'relative', cursor: 'default', width, height, ...style }}
-            {...events}
-            ref={(node: HTMLDivElement) => {
-              this.container = node;
-            }}
-            role={attrs.role ?? 'region'}
+        <AccessibilityContextProvider value={this.props.accessibilityLayer}>
+          <ChartLayoutContextProvider
+            state={this.state}
+            width={this.props.width}
+            height={this.props.height}
+            clipPathId={this.clipPathId}
           >
-            <Surface {...attrs} width={width} height={height} title={title} desc={desc} style={FULL_WIDTH_AND_HEIGHT}>
-              {this.renderClipPath()}
-              {renderByOrder(children, this.renderMap)}
-            </Surface>
-            {this.renderLegend()}
-            {this.renderTooltip()}
-          </div>
-        </ChartLayoutContextProvider>
+            <div
+              className={clsx('recharts-wrapper', className)}
+              style={{ position: 'relative', cursor: 'default', width, height, ...style }}
+              {...events}
+              ref={(node: HTMLDivElement) => {
+                this.container = node;
+              }}
+              role={attrs.role ?? 'region'}
+            >
+              <Surface {...attrs} width={width} height={height} title={title} desc={desc} style={FULL_WIDTH_AND_HEIGHT}>
+                {this.renderClipPath()}
+                {renderByOrder(children, this.renderMap)}
+              </Surface>
+              {this.renderLegend()}
+              {this.renderTooltip()}
+            </div>
+          </ChartLayoutContextProvider>
+        </AccessibilityContextProvider>
       );
     }
   };

--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -52,7 +52,7 @@ export interface Props<TValue extends ValueType, TName extends NameType> {
   label?: any;
   payload?: Array<Payload<TValue, TName>>;
   itemSorter?: (item: Payload<TValue, TName>) => number | string;
-  accessibilityLayer?: boolean;
+  accessibilityLayer: boolean;
 }
 
 export const DefaultTooltipContent = <TValue extends ValueType, TName extends NameType>(

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -17,14 +17,14 @@ import { useAccessibilityLayer } from '../context/accessibilityContext';
 
 export type ContentType<TValue extends ValueType, TName extends NameType> =
   | ReactElement
-  | ((props: TooltipProps<TValue, TName>) => ReactNode);
+  | ((props: TooltipContentProps<TValue, TName>) => ReactNode);
 
 function defaultUniqBy<TValue extends ValueType, TName extends NameType>(entry: Payload<TValue, TName>) {
   return entry.dataKey;
 }
 
 type TooltipContentProps<TValue extends ValueType, TName extends NameType> = TooltipProps<TValue, TName> &
-  TooltipContextValue;
+  TooltipContextValue & { accessibilityLayer: boolean };
 
 function renderContent<TValue extends ValueType, TName extends NameType>(
   content: ContentType<TValue, TName>,
@@ -40,7 +40,7 @@ function renderContent<TValue extends ValueType, TName extends NameType>(
   return <DefaultTooltipContent {...props} />;
 }
 
-type PropertiesReadFromContext = 'viewBox' | 'active' | 'payload' | 'coordinate' | 'label';
+type PropertiesReadFromContext = 'viewBox' | 'active' | 'payload' | 'coordinate' | 'label' | 'accessibilityLayer';
 
 export type TooltipProps<TValue extends ValueType, TName extends NameType> = Omit<
   DefaultTooltipContentProps<TValue, TName>,

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -13,6 +13,7 @@ import { getUniqPayload, UniqueOption } from '../util/payload/getUniqPayload';
 import { AllowInDimension, AnimationDuration, AnimationTiming, Coordinate } from '../util/types';
 import { useViewBox } from '../context/chartLayoutContext';
 import { TooltipContextValue, useTooltipContext } from '../context/tooltipContext';
+import { useAccessibilityLayer } from '../context/accessibilityContext';
 
 export type ContentType<TValue extends ValueType, TName extends NameType> =
   | ReactElement
@@ -39,11 +40,12 @@ function renderContent<TValue extends ValueType, TName extends NameType>(
   return <DefaultTooltipContent {...props} />;
 }
 
-export type TooltipProps<TValue extends ValueType, TName extends NameType> = DefaultTooltipContentProps<
-  TValue,
-  TName
+type PropertiesReadFromContext = 'viewBox' | 'active' | 'payload' | 'coordinate' | 'label';
+
+export type TooltipProps<TValue extends ValueType, TName extends NameType> = Omit<
+  DefaultTooltipContentProps<TValue, TName>,
+  PropertiesReadFromContext
 > & {
-  accessibilityLayer?: boolean;
   /**
    * If true, then Tooltip is always displayed, once an activeIndex is set by mouse over, or programmatically.
    * If false, then Tooltip is never displayed.
@@ -89,6 +91,7 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
     wrapperStyle,
   } = props;
   const viewBox = useViewBox();
+  const accessibilityLayer = useAccessibilityLayer();
   const { active: activeFromContext, payload, coordinate, label } = useTooltipContext();
 
   /*
@@ -129,7 +132,14 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
       viewBox={viewBox}
       wrapperStyle={wrapperStyle}
     >
-      {renderContent(content, { ...props, payload: finalPayload, label, active: finalIsActive, coordinate })}
+      {renderContent(content, {
+        ...props,
+        payload: finalPayload,
+        label,
+        active: finalIsActive,
+        coordinate,
+        accessibilityLayer,
+      })}
     </TooltipBoundingBox>
   );
 }
@@ -140,7 +150,6 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
   static displayName = 'Tooltip';
 
   static defaultProps = {
-    accessibilityLayer: false,
     allowEscapeViewBox: { x: false, y: false },
     animationDuration: 400,
     animationEasing: 'ease',

--- a/src/context/accessibilityContext.tsx
+++ b/src/context/accessibilityContext.tsx
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+const AccessibilityContext = createContext<boolean>(true);
+
+export const AccessibilityContextProvider = AccessibilityContext.Provider;
+
+export const useAccessibilityLayer = () => useContext(AccessibilityContext);

--- a/storybook/stories/Examples/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart.stories.tsx
@@ -18,7 +18,6 @@ import {
   Area,
   Brush,
   ReferenceArea,
-  DefaultTooltipContent,
 } from '../../../src';
 import { DataKey } from '../../../src/util/types';
 
@@ -915,7 +914,7 @@ export const ToggleChildrenComponentsExceptCartesianGrid: StoryObj = {
                 tickMargin={25}
               />
               {yAxisComponents}
-              <Tooltip content={<DefaultTooltipContent />} />
+              <Tooltip />
               <Line
                 name="PV"
                 type="monotone"

--- a/test/component/DefaultTooltipContent.spec.tsx
+++ b/test/component/DefaultTooltipContent.spec.tsx
@@ -4,6 +4,7 @@ import { DefaultTooltipContent } from '../../src/component/DefaultTooltipContent
 
 describe('DefaultTooltipContent', () => {
   const mockProps = {
+    accessibilityLayer: true,
     allowEscapeViewBox: { x: false, y: false },
     animationDuration: 400,
     animationEasing: 'ease',


### PR DESCRIPTION
## Description

Simple one this time, only boolean.

I switched the context default to `true` - but that will get overwritten by the defaultProps anyway.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Gets us one step closer to removing element cloning

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
