### PR TITLE
docs: add storybook example for line trailing icon in LineChart

### DIFF
--- a/storybook/stories/Examples/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart.stories.tsx
@@ -992,3 +992,33 @@ export const HideOnLegendClick: StoryObj = {
     );
   },
 };
+
+export const LineTrailingIcon: StoryObj = {
+  render: () => {
+    const lastDotKey = 'lastDot';
+    const data = pageData.map((entry, index) => ({
+      ...entry,
+      [lastDotKey]: index === pageData.length - 1 ? entry.pv : undefined,
+    }));
+
+    return (
+      <ResponsiveContainer>
+        <LineChart data={data}>
+          <XAxis dataKey="name" />
+          <YAxis />
+          <CartesianGrid strokeDasharray="3 3" />
+          <Tooltip />
+          <Legend />
+          <Line type="monotone" dataKey="pv" stroke="#8884d8" />
+          <Line
+            type="monotone"
+            dataKey={lastDotKey}
+            legendType="none"
+            tooltipType="none"
+            dot={{ stroke: 'red', strokeWidth: 1, r: 4 }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    );
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Adds a storybook example for adding a trailing icon to a Line in a LineChart.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#2824 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Example code is similar to the example outlined in the issue, with the main change being `legendType` and `tooltipType` set to `none` since the Line is just used for adding the icon.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
