### PR TITLE
Independent tooltip

### DIFF
--- a/src/chart/SunburstChart.tsx
+++ b/src/chart/SunburstChart.tsx
@@ -1,13 +1,11 @@
 import React, { useState } from 'react';
 import { scaleLinear } from 'victory-vendor/d3-scale';
 import clsx from 'clsx';
-import { findChildByType } from '../util/ReactUtils';
 import { Surface } from '../container/Surface';
 import { Layer } from '../container/Layer';
 import { Sector } from '../shape/Sector';
 import { Text } from '../component/Text';
 import { polarToCartesian } from '../util/PolarUtils';
-import { Tooltip } from '../component/Tooltip';
 import { ViewBoxContext } from '../context/chartLayoutContext';
 import { doNotDisplayTooltip, TooltipContextProvider, TooltipContextValue } from '../context/tooltipContext';
 
@@ -190,11 +188,6 @@ export const SunburstChart = ({
 
   const layerClass = clsx('recharts-sunburst', className);
 
-  function renderTooltip() {
-    const tooltipComponent = findChildByType([children], Tooltip);
-
-    return tooltipComponent;
-  }
   function getTooltipContext(): TooltipContextValue {
     if (activeNode == null) {
       return doNotDisplayTooltip;
@@ -221,7 +214,6 @@ export const SunburstChart = ({
             {children}
             <Layer className={layerClass}>{sectors}</Layer>
           </Surface>
-          {renderTooltip()}
         </div>
       </TooltipContextProvider>
     </ViewBoxContext.Provider>

--- a/src/chart/SunburstChart.tsx
+++ b/src/chart/SunburstChart.tsx
@@ -211,8 +211,8 @@ export const SunburstChart = ({
           role="region"
         >
           <Surface width={width} height={height}>
-            {children}
             <Layer className={layerClass}>{sectors}</Layer>
+            {children}
           </Surface>
         </div>
       </TooltipContextProvider>

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -14,6 +14,7 @@ import { AllowInDimension, AnimationDuration, AnimationTiming, Coordinate } from
 import { useViewBox } from '../context/chartLayoutContext';
 import { TooltipContextValue, useTooltipContext } from '../context/tooltipContext';
 import { useAccessibilityLayer } from '../context/accessibilityContext';
+import { useGetBoundingClientRect } from '../util/useGetBoundingClientRect';
 
 export type ContentType<TValue extends ValueType, TName extends NameType> =
   | ReactElement
@@ -93,7 +94,6 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
   const viewBox = useViewBox();
   const accessibilityLayer = useAccessibilityLayer();
   const { active: activeFromContext, payload, coordinate, label } = useTooltipContext();
-
   /*
    * The user can set `active=true` on the Tooltip in which case the Tooltip will stay always active,
    * or `active=false` in which case the Tooltip never shows.
@@ -101,6 +101,7 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
    * If the `active` prop is not defined then it will show and hide based on mouse or keyboard activity.
    */
   const finalIsActive = activeFromProps ?? activeFromContext;
+  const [lastBoundingBox, updateBoundingBox] = useGetBoundingClientRect(undefined, [payload, finalIsActive]);
   let finalPayload: Payload<TValue, TName>[] = payload ?? [];
   if (!finalIsActive) {
     finalPayload = [];
@@ -131,6 +132,8 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
       useTranslate3d={useTranslate3d}
       viewBox={viewBox}
       wrapperStyle={wrapperStyle}
+      lastBoundingBox={lastBoundingBox}
+      innerRef={updateBoundingBox}
     >
       {renderContent(content, {
         ...props,

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -111,12 +111,25 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
       ...wrapperStyle,
     };
 
+    /*
+     * So Tooltip is a specialty in Recharts - it is a HTML element rendered inside SVG container.
+     * This does not work just like that (HTML is not a subset of SVG) but there is a special tag for it
+     * - <foreignObject>. This tag allows including extra stuff inside the SVG - such as HTML.
+     * See https://developer.mozilla.org/en-US/docs/Web/SVG/Element/foreignObject
+     *
+     * The x and 0 and width and height are static and cover the whole SVG document, because
+     * the tooltip itself is positioned via context.
+     *
+     * pointer-events: none is necessary because this foreignObject covers the whole chart,
+     * and if it was catching mouse events it would steal them all before they reach the chart
+     * and tooltip would never open.
+     */
     return (
       <g>
         <foreignObject x="0" y="0" width="100%" height="100%" style={{ pointerEvents: 'none' }}>
           {/* This element allow listening to the `Escape` key. // See https://github.com/recharts/recharts/pull/2925 */}
           <div
-            // @ts-expect-error typescript library does not recognize xmlns attribute
+            // @ts-expect-error typescript library does not recognize xmlns attribute, but it's required for an HTML chunk inside SVG.
             xmlns="http://www.w3.org/1999/xhtml"
             tabIndex={-1}
             className={cssClasses}

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -113,7 +113,7 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
 
     return (
       <g>
-        <foreignObject>
+        <foreignObject x="0" y="0" width="100%" height="100%" style={{ pointerEvents: 'none' }}>
           {/* This element allow listening to the `Escape` key. // See https://github.com/recharts/recharts/pull/2925 */}
           <div
             // @ts-expect-error typescript library does not recognize xmlns attribute

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -27,41 +27,16 @@ type State = {
   dismissedAtCoordinate: Coordinate;
 };
 
-const EPSILON = 1;
-
 export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, State> {
   state = {
     dismissed: false,
     dismissedAtCoordinate: { x: 0, y: 0 },
   };
 
-  lastBoundingBox = {
-    width: -1,
-    height: -1,
-  };
-
   private wrapperNode: HTMLDivElement;
-
-  updateBBox() {
-    if (this.wrapperNode && this.wrapperNode.getBoundingClientRect) {
-      const box = this.wrapperNode.getBoundingClientRect();
-
-      if (
-        Math.abs(box.width - this.lastBoundingBox.width) > EPSILON ||
-        Math.abs(box.height - this.lastBoundingBox.height) > EPSILON
-      ) {
-        this.lastBoundingBox.width = box.width;
-        this.lastBoundingBox.height = box.height;
-      }
-    } else if (this.lastBoundingBox.width !== -1 || this.lastBoundingBox.height !== -1) {
-      this.lastBoundingBox.width = -1;
-      this.lastBoundingBox.height = -1;
-    }
-  }
 
   componentDidMount() {
     document.addEventListener('keydown', this.handleKeyDown);
-    this.updateBBox();
   }
 
   componentWillUnmount() {
@@ -69,10 +44,6 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
   }
 
   componentDidUpdate() {
-    if (this.props.active) {
-      this.updateBBox();
-    }
-
     if (!this.state.dismissed) {
       return;
     }

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, PureComponent, ReactNode } from 'react';
 import { AllowInDimension, AnimationDuration, AnimationTiming, CartesianViewBox, Coordinate } from '../util/types';
 import { getTooltipTranslate } from '../util/tooltip/translate';
+import { BoundingBox, SetBoundingBox } from '../util/useGetBoundingClientRect';
 
 export type TooltipBoundingBoxProps = {
   active: boolean;
@@ -17,6 +18,8 @@ export type TooltipBoundingBoxProps = {
   useTranslate3d: boolean;
   viewBox: CartesianViewBox;
   wrapperStyle: CSSProperties;
+  lastBoundingBox: BoundingBox;
+  innerRef: SetBoundingBox;
 };
 
 type State = {
@@ -110,6 +113,8 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
       useTranslate3d,
       viewBox,
       wrapperStyle,
+      lastBoundingBox,
+      innerRef,
     } = this.props;
 
     const { cssClasses, cssProperties } = getTooltipTranslate({
@@ -119,8 +124,8 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
       position,
       reverseDirection,
       tooltipBox: {
-        height: this.lastBoundingBox.height,
-        width: this.lastBoundingBox.width,
+        height: lastBoundingBox.height,
+        width: lastBoundingBox.width,
       },
       useTranslate3d,
       viewBox,
@@ -146,6 +151,7 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
         style={outerStyle}
         ref={node => {
           this.wrapperNode = node;
+          innerRef(node);
         }}
       >
         {children}

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -112,11 +112,21 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
     };
 
     return (
-      // This element allow listening to the `Escape` key.
-      // See https://github.com/recharts/recharts/pull/2925
-      <div tabIndex={-1} className={cssClasses} style={outerStyle} ref={innerRef}>
-        {children}
-      </div>
+      <g>
+        <foreignObject>
+          {/* This element allow listening to the `Escape` key. // See https://github.com/recharts/recharts/pull/2925 */}
+          <div
+            // @ts-expect-error typescript library does not recognize xmlns attribute
+            xmlns="http://www.w3.org/1999/xhtml"
+            tabIndex={-1}
+            className={cssClasses}
+            style={outerStyle}
+            ref={innerRef}
+          >
+            {children}
+          </div>
+        </foreignObject>
+      </g>
     );
   }
 }

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -33,8 +33,6 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
     dismissedAtCoordinate: { x: 0, y: 0 },
   };
 
-  private wrapperNode: HTMLDivElement;
-
   componentDidMount() {
     document.addEventListener('keydown', this.handleKeyDown);
   }
@@ -116,15 +114,7 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
     return (
       // This element allow listening to the `Escape` key.
       // See https://github.com/recharts/recharts/pull/2925
-      <div
-        tabIndex={-1}
-        className={cssClasses}
-        style={outerStyle}
-        ref={node => {
-          this.wrapperNode = node;
-          innerRef(node);
-        }}
-      >
+      <div tabIndex={-1} className={cssClasses} style={outerStyle} ref={innerRef}>
         {children}
       </div>
     );

--- a/src/util/useGetBoundingClientRect.ts
+++ b/src/util/useGetBoundingClientRect.ts
@@ -6,7 +6,7 @@ export type BoundingBox = {
   width: number;
   height: number;
 };
-type SetBoundingBox = (node: HTMLElement | null) => void;
+export type SetBoundingBox = (node: HTMLElement | null) => void;
 
 /**
  * Use this to listen to bounding box changes.
@@ -22,7 +22,7 @@ type SetBoundingBox = (node: HTMLElement | null) => void;
  * @returns [lastBoundingBox, updateBoundingBox] most recent value, and setter. Pass the setter to a DOM element ref like this: `<div ref={updateBoundingBox}>`
  */
 export function useGetBoundingClientRect(
-  onUpdate: (domRect: BoundingBox | null) => void,
+  onUpdate: undefined | ((boundingBox: BoundingBox | null) => void),
   extraDependencies: ReadonlyArray<unknown>,
 ): [BoundingBox, SetBoundingBox] {
   const [lastBoundingBox, setLastBoundingBox] = useState<BoundingBox>({ width: 0, height: 0 });

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -260,7 +260,7 @@ const SunburstChartTestCase: TooltipVisibilityTestCase = {
     </SunburstChart>
   ),
   mouseHoverSelector: sunburstChartMouseHoverTooltipSelector,
-  expectedTransform: 'transform: translate(10px, 10px);',
+  expectedTransform: 'transform: translate(285px, 210px);',
 };
 
 const TreemapTestCase: TooltipVisibilityTestCase = {
@@ -296,7 +296,7 @@ const testCases: ReadonlyArray<TooltipVisibilityTestCase> = [
   SankeyTestCase,
   ScatterChartTestCase,
   // Sunburst is excluded because it renders tooltip multiple times and all tests fail :( TODO fix and re-enable
-  // SunburstChartTestCase,
+  SunburstChartTestCase,
   TreemapTestCase,
 ];
 
@@ -404,6 +404,12 @@ describe('Tooltip visibility', () => {
            */
           context.skip();
         }
+        if (name === 'SunburstChart') {
+          /*
+           * SunburstChart for some reason ignores active property on Tooltip
+           */
+          context.skip();
+        }
         const { container } = render(
           <Wrapper>
             <Tooltip active />
@@ -498,6 +504,12 @@ describe('Tooltip visibility', () => {
         if (name === 'Treemap') {
           /*
            * Treemap chart for some reason ignores defaultIndex property on Tooltip
+           */
+          context.skip();
+        }
+        if (name === 'SunburstChart') {
+          /*
+           * SunburstChart for some reason ignores active property on Tooltip
            */
           context.skip();
         }
@@ -668,7 +680,7 @@ describe('Tooltip visibility', () => {
     fireEvent.click(container.querySelector('#goRight') as HTMLButtonElement);
 
     // Data should be displayed in the Tooltip payload
-    expect(tooltip?.textContent).toBe('120stature : 120cmweight : 100kg');
+    expect(tooltip.textContent).toBe('120stature : 120cmweight : 100kg');
   });
 });
 

--- a/test/component/TooltipBoundingBox.spec.tsx
+++ b/test/component/TooltipBoundingBox.spec.tsx
@@ -6,6 +6,8 @@ import { TooltipBoundingBox, TooltipBoundingBoxProps } from '../../src/component
 
 describe('TooltipBoundingBox', () => {
   const defaultProps: TooltipBoundingBoxProps = {
+    innerRef(): void {},
+    lastBoundingBox: { width: 0, height: 0 },
     active: true,
     hasPayload: true,
     children: 'Hello world!',


### PR DESCRIPTION
## Description

Tooltip no longer requires its own specialized method, instead can be rendered together with rest of children.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

I don't want Tooltip to be special cloned element, I want Tooltip to be just another child element so that it can be deeply nested and wrapped in other custom elements.

## How Has This Been Tested?

npm test
storybook

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
