### PR TITLE
Types only: change DOMRect to BoundingBox

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -89,6 +89,7 @@ import { Cursor } from '../component/Cursor';
 import { ChartLayoutContextProvider } from '../context/chartLayoutContext';
 import { AxisMap, CategoricalChartState } from './types';
 import { AccessibilityContextProvider } from '../context/accessibilityContext';
+import { BoundingBox } from '../util/useGetBoundingClientRect';
 
 export interface MousePointer {
   pageX: number;
@@ -730,7 +731,7 @@ const calculateOffset = (
     xAxisMap?: XAxisMap;
     yAxisMap?: YAxisMap;
   },
-  prevLegendBBox?: DOMRect | null,
+  prevLegendBBox?: BoundingBox | null,
 ): ChartOffset => {
   const { width, height, children } = props;
   const margin = props.margin || {};
@@ -1469,7 +1470,7 @@ export const generateCategoricalChart = ({
       eventCenter.removeListener(SYNC_EVENT, this.handleReceiveSyncEvent);
     }
 
-    handleLegendBBoxUpdate = (box: DOMRect | null) => {
+    handleLegendBBoxUpdate = (box: BoundingBox | null) => {
       if (box) {
         const { dataStartIndex, dataEndIndex, updateId } = this.state;
 

--- a/src/chart/types.ts
+++ b/src/chart/types.ts
@@ -10,6 +10,7 @@ import {
   TickItem,
 } from '../util/types';
 import { AxisStackGroups } from '../util/ChartUtils';
+import { BoundingBox } from '../util/useGetBoundingClientRect';
 
 export type AxisMap = {
   [axisId: string]: BaseAxisProps;
@@ -71,7 +72,7 @@ export interface CategoricalChartState {
 
   yValue?: number;
 
-  legendBBox?: DOMRect | null;
+  legendBBox?: BoundingBox | null;
 
   prevDataKey?: DataKey<any>;
   prevData?: any[];

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -78,7 +78,7 @@ export type Props = DefaultProps & {
     right?: number;
   };
   payloadUniqBy?: UniqueOption<Payload>;
-  onBBoxUpdate?: (box: DOMRect | null) => void;
+  onBBoxUpdate?: (box: BoundingBox | null) => void;
 };
 
 interface State {

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -43,6 +43,7 @@ import {
   XAxisMap,
 } from './types';
 import { getLegendProps } from './getLegendProps';
+import { BoundingBox } from './useGetBoundingClientRect';
 
 // Exported for backwards compatibility
 export { getLegendProps };
@@ -385,7 +386,7 @@ export const getBarPosition = ({
 export const appendOffsetOfLegend = (
   offset: ChartOffset,
   props: { width?: number; margin: Margin; children?: ReactNode[] },
-  legendBox: DOMRect | null,
+  legendBox: BoundingBox | null,
 ): ChartOffset => {
   const { children, width, margin } = props;
   const legendWidth = width - (margin.left || 0) - (margin.right || 0);

--- a/src/util/useGetBoundingClientRect.ts
+++ b/src/util/useGetBoundingClientRect.ts
@@ -22,7 +22,7 @@ type SetBoundingBox = (node: HTMLElement | null) => void;
  * @returns [lastBoundingBox, updateBoundingBox] most recent value, and setter. Pass the setter to a DOM element ref like this: `<div ref={updateBoundingBox}>`
  */
 export function useGetBoundingClientRect(
-  onUpdate: (domRect: DOMRect | null) => void,
+  onUpdate: (domRect: BoundingBox | null) => void,
   extraDependencies: ReadonlyArray<unknown>,
 ): [BoundingBox, SetBoundingBox] {
   const [lastBoundingBox, setLastBoundingBox] = useState<BoundingBox>({ width: 0, height: 0 });


### PR DESCRIPTION
## Description

This change is type only - it is my assessment that no code in recharts actually reads what the `getBoundingClientRect` returns, instead it always reads only `width` and `height` which are read from `offsetWidth` and `offsetHeight`, respectively.

Not sure why is it this way but my next step will be to remove the `getBoundingClientRect` call completely - it's useless.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

The whole bounding rect reading code is very suspicious.

## How Has This Been Tested?

npm run check-types

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
