### PR TITLE
Legend getWidthOrHeight refresh

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1844,21 +1844,19 @@ export const generateCategoricalChart = ({
      */
     renderLegend = (): React.ReactElement => {
       const { children, width } = this.props;
+      const legendItem = findChildByType(children, Legend);
+      if (!legendItem) {
+        return null;
+      }
       const margin = this.props.margin || {};
       const legendWidth: number = width - (margin.left || 0) - (margin.right || 0);
       const props = getLegendProps({
-        children,
+        legendItem,
         legendWidth,
       });
 
-      if (!props) {
-        return null;
-      }
-
-      const { item, ...otherProps } = props;
-
-      return cloneElement(item, {
-        ...otherProps,
+      return cloneElement(legendItem, {
+        ...props,
         onBBoxUpdate: this.handleLegendBBoxUpdate,
       });
     };

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -136,7 +136,7 @@ export class Legend extends PureComponent<Props, State> {
     verticalAlign: 'bottom',
   };
 
-  static getWithHeight(
+  static getWidthOrHeight(
     item: { props: { layout?: LayoutType; height?: number; width?: number } },
     chartWidth: number,
   ): null | { height: number } | { width: number } {

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -137,19 +137,19 @@ export class Legend extends PureComponent<Props, State> {
   };
 
   static getWidthOrHeight(
-    item: { props: { layout?: LayoutType; height?: number; width?: number } },
-    chartWidth: number,
+    layout: LayoutType | undefined,
+    height: number | undefined,
+    width: number | undefined,
+    maxWidth: number,
   ): null | { height: number } | { width: number } {
-    const { layout } = item.props;
-
-    if (layout === 'vertical' && isNumber(item.props.height)) {
+    if (layout === 'vertical' && isNumber(height)) {
       return {
-        height: item.props.height,
+        height,
       };
     }
     if (layout === 'horizontal') {
       return {
-        width: item.props.width || chartWidth,
+        width: width || maxWidth,
       };
     }
 

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -25,7 +25,7 @@ import { getNiceTickValues, getTickValuesFixedDomain } from 'recharts-scale';
 
 import { ErrorBar } from '../cartesian/ErrorBar';
 import { findEntryInArray, getPercentValue, isNumber, isNumOrStr, mathSign, uniqueId } from './DataUtils';
-import { filterProps, findAllByType, getDisplayName } from './ReactUtils';
+import { filterProps, findAllByType, findChildByType, getDisplayName } from './ReactUtils';
 // TODO: Cause of circular dependency. Needs refactor.
 // import { RadiusAxisProps, AngleAxisProps } from '../polar/types';
 import {
@@ -44,6 +44,7 @@ import {
 } from './types';
 import { getLegendProps } from './getLegendProps';
 import { BoundingBox } from './useGetBoundingClientRect';
+import { Legend } from '../component/Legend';
 
 // Exported for backwards compatibility
 export { getLegendProps };
@@ -389,9 +390,10 @@ export const appendOffsetOfLegend = (
   legendBox: BoundingBox | null,
 ): ChartOffset => {
   const { children, width, margin } = props;
-  const legendWidth = width - (margin.left || 0) - (margin.right || 0);
-  const legendProps = getLegendProps({ children, legendWidth });
-  if (legendProps) {
+  const legendItem = findChildByType(children, Legend);
+  if (legendItem) {
+    const legendWidth = width - (margin.left || 0) - (margin.right || 0);
+    const legendProps = getLegendProps({ legendItem, legendWidth });
     const { width: boxWidth, height: boxHeight } = legendBox || {};
     const { align, verticalAlign, layout } = legendProps;
 

--- a/src/util/getLegendProps.ts
+++ b/src/util/getLegendProps.ts
@@ -1,6 +1,4 @@
-import { ReactElement, ReactNode } from 'react';
 import { Legend, Props as LegendProps } from '../component/Legend';
-import { findChildByType } from './ReactUtils';
 
 /**
  * @deprecated we are replacing this function with Context-based legend instead. See useLegendPayloadDispatch and useLegendPayload
@@ -9,19 +7,14 @@ import { findChildByType } from './ReactUtils';
  * @returns mix of everything, do not use
  */
 export const getLegendProps = ({
-  children,
+  legendItem,
   legendWidth,
 }: {
-  children: ReactNode[];
+  legendItem: { props: LegendProps };
   legendWidth: number;
-}): null | (LegendProps & { item: ReactElement }) => {
-  const legendItem = findChildByType(children, Legend);
-  if (!legendItem) {
-    return null;
-  }
+}): LegendProps => {
   return {
     ...legendItem.props,
     ...Legend.getWidthOrHeight(legendItem.props.layout, legendItem.props.height, legendItem.props.width, legendWidth),
-    item: legendItem,
   };
 };

--- a/src/util/getLegendProps.ts
+++ b/src/util/getLegendProps.ts
@@ -21,7 +21,7 @@ export const getLegendProps = ({
   }
   return {
     ...legendItem.props,
-    ...Legend.getWidthOrHeight(legendItem, legendWidth),
+    ...Legend.getWidthOrHeight(legendItem.props.layout, legendItem.props.height, legendItem.props.width, legendWidth),
     item: legendItem,
   };
 };

--- a/src/util/getLegendProps.ts
+++ b/src/util/getLegendProps.ts
@@ -21,7 +21,7 @@ export const getLegendProps = ({
   }
   return {
     ...legendItem.props,
-    ...Legend.getWithHeight(legendItem, legendWidth),
+    ...Legend.getWidthOrHeight(legendItem, legendWidth),
     item: legendItem,
   };
 };

--- a/test/util/ChartUtils/appendOffsetOfLegend.spec.tsx
+++ b/test/util/ChartUtils/appendOffsetOfLegend.spec.tsx
@@ -1,32 +1,39 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { vi } from 'vitest';
 import { appendOffsetOfLegend } from '../../../src/util/ChartUtils';
 import { ChartOffset } from '../../../src/util/types';
 import { getLegendProps } from '../../../src/util/getLegendProps';
+import { BoundingBox } from '../../../src/util/useGetBoundingClientRect';
+import { findChildByType } from '../../../src/util/ReactUtils';
 
-vi.mock('../../../src/util/getLegendProps');
+vi.mock('../../../src/util/ReactUtils');
 
-const spy = vi.mocked(getLegendProps);
+const spy = vi.mocked(findChildByType);
 
-function mockLegendProps(props: null | Omit<ReturnType<typeof getLegendProps>, 'item'>) {
-  spy.mockReturnValueOnce({ ...props, item: <p /> });
+function mockDomElement(item: ReactNode) {
+  // @ts-expect-error I cannot find a way to type DetailedReactHTMLElement properly
+  spy.mockReturnValueOnce(item);
 }
 
-function createMockDomRect(width: number, height: number): DOMRect {
-  // @ts-expect-error this is job for jsdom but jsdom does not implement DOMRect yet.
-  // See https://github.com/jsdom/jsdom/issues/2716
+function mockLegendProps(props: ReturnType<typeof getLegendProps>): ReactNode[] {
+  const mockLegendItem = { props };
+  mockDomElement(mockLegendItem);
+  return [mockLegendItem];
+}
+
+function createMockDomRect(width: number, height: number): BoundingBox {
   return { width, height };
 }
 
 describe('appendOffsetOfLegend', () => {
-  it('should return offset without changes if legendProps are not defined', () => {
+  it('should return offset without changes if Legend is not found in children', () => {
     const offset: ChartOffset = {
       bottom: 9,
       left: 5,
     };
-    mockLegendProps(null);
+    const children: ReactNode[] = [];
     const legendBox = createMockDomRect(100, 200);
-    const result = appendOffsetOfLegend(offset, { margin: {} }, legendBox);
+    const result = appendOffsetOfLegend(offset, { margin: {}, children }, legendBox);
     expect(result).toBe(offset);
     expect(result).toEqual({
       bottom: 9,
@@ -39,11 +46,11 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       left: 5,
     };
-    mockLegendProps({
+    const children = mockLegendProps({
       layout: 'vertical',
       align: 'left',
     });
-    const result = appendOffsetOfLegend(offset, { margin: {} }, null);
+    const result = appendOffsetOfLegend(offset, { margin: {}, children }, null);
     expect(result).toEqual({
       bottom: 9,
       left: 5,
@@ -55,12 +62,12 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       left: 5,
     };
-    mockLegendProps({
+    const children = mockLegendProps({
       layout: 'vertical',
       align: 'left',
     });
     const legendBox = createMockDomRect(100, 200);
-    const result = appendOffsetOfLegend(offset, { margin: {} }, legendBox);
+    const result = appendOffsetOfLegend(offset, { margin: {}, children }, legendBox);
     expect(result).toEqual({ bottom: 9, left: 105 });
   });
 
@@ -69,13 +76,13 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       left: 5,
     };
-    mockLegendProps({
+    const children = mockLegendProps({
       layout: 'horizontal',
       verticalAlign: 'middle',
       align: 'left',
     });
     const legendBox = createMockDomRect(100, 200);
-    const result = appendOffsetOfLegend(offset, { margin: {} }, legendBox);
+    const result = appendOffsetOfLegend(offset, { margin: {}, children }, legendBox);
     expect(result).toEqual({ bottom: 9, left: 105 });
   });
 
@@ -84,12 +91,12 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       left: 5,
     };
-    mockLegendProps({
+    const children = mockLegendProps({
       layout: 'horizontal',
       verticalAlign: 'middle',
     });
     const legendBox = createMockDomRect(100, 200);
-    const result = appendOffsetOfLegend(offset, { margin: {} }, legendBox);
+    const result = appendOffsetOfLegend(offset, { margin: {}, children }, legendBox);
     expect(result).toEqual({ bottom: 9, left: 5 });
   });
 
@@ -98,13 +105,13 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       left: 5,
     };
-    mockLegendProps({
+    const children = mockLegendProps({
       layout: 'horizontal',
       verticalAlign: 'middle',
       align: 'left',
     });
     const legendBox = createMockDomRect(100, 200);
-    appendOffsetOfLegend(offset, { margin: {} }, legendBox);
+    appendOffsetOfLegend(offset, { margin: {}, children }, legendBox);
     expect(offset).toEqual({ bottom: 9, left: 5 });
   });
 
@@ -113,12 +120,12 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       right: 14,
     };
-    mockLegendProps({
+    const children = mockLegendProps({
       layout: 'horizontal',
       verticalAlign: 'bottom',
     });
     const legendBox = createMockDomRect(100, 200);
-    const result = appendOffsetOfLegend(offset, { margin: {} }, legendBox);
+    const result = appendOffsetOfLegend(offset, { margin: {}, children }, legendBox);
     expect(result).toEqual({ bottom: 209, right: 14 });
   });
 
@@ -127,13 +134,13 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       right: 14,
     };
-    mockLegendProps({
+    const children = mockLegendProps({
       layout: 'vertical',
       align: 'center',
       verticalAlign: 'bottom',
     });
     const legendBox = createMockDomRect(100, 200);
-    const result = appendOffsetOfLegend(offset, { margin: {} }, legendBox);
+    const result = appendOffsetOfLegend(offset, { margin: {}, children }, legendBox);
     expect(result).toEqual({ bottom: 209, right: 14 });
   });
 
@@ -142,12 +149,12 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       right: 14,
     };
-    mockLegendProps({
+    const children = mockLegendProps({
       layout: 'vertical',
       align: 'center',
     });
     const legendBox = createMockDomRect(100, 200);
-    const result = appendOffsetOfLegend(offset, { margin: {} }, legendBox);
+    const result = appendOffsetOfLegend(offset, { margin: {}, children }, legendBox);
     expect(result).toEqual({ bottom: 9, right: 14 });
   });
 
@@ -156,20 +163,12 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       right: 14,
     };
-    mockLegendProps({
+    const children = mockLegendProps({
       layout: 'horizontal',
       verticalAlign: 'middle',
     });
     const legendBox = createMockDomRect(100, 200);
-    const result = appendOffsetOfLegend(offset, { margin: {} }, legendBox);
+    const result = appendOffsetOfLegend(offset, { margin: {}, children }, legendBox);
     expect(result).toEqual({ bottom: 9, right: 14 });
-  });
-
-  it('should pass margin to getLegendProps', () => {
-    const children: ReactNode[] = [];
-    spy.mockReset();
-    appendOffsetOfLegend({}, { margin: { left: 10, right: 20 }, children, width: 100 }, null);
-    expect(spy).toBeCalledTimes(1);
-    expect(spy).toBeCalledWith({ children, legendWidth: 70 });
   });
 });

--- a/test/util/ChartUtils/getLegendProps.spec.tsx
+++ b/test/util/ChartUtils/getLegendProps.spec.tsx
@@ -1,63 +1,27 @@
-import { ReactNode } from 'react';
-import { vi } from 'vitest';
 import { getLegendProps } from '../../../src/util/ChartUtils';
-import { findChildByType } from '../../../src/util/ReactUtils';
-import { Legend } from '../../../src/component/Legend';
 import { assertNotNull } from '../../helper/assertNotNull';
-
-vi.mock('../../../src/util/ReactUtils');
-
-const spy = vi.mocked(findChildByType);
-
-function mockDomElement(item: ReactNode) {
-  // @ts-expect-error I cannot find a way to type DetailedReactHTMLElement properly
-  spy.mockReturnValueOnce(item);
-}
-
-function createChildren(...nodes: ReactNode[]): ReactNode[] {
-  mockDomElement(nodes[0]);
-  return nodes;
-}
+import { LegendProps } from '../../../src';
 
 describe('getLegendProps', () => {
-  it('should call findChildByType to find Legend element', () => {
-    const children = createChildren();
-    getLegendProps({ children, legendWidth: 0 });
-    expect(findChildByType).toBeCalledTimes(1);
-    expect(findChildByType).toBeCalledWith(children, Legend);
-  });
-
-  it('should return null if there is no Legend in the DOM', () => {
-    const result = getLegendProps({ children: createChildren(), legendWidth: 0 });
-    expect(result).toBe(null);
-  });
-
-  it('if a Legend is defined then it returns it as `item`', () => {
-    const item = { props: {} };
-    const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
-    assertNotNull(result);
-    expect(result.item).toBe(item);
-  });
-
   it('should pass through all existing legendItem props', () => {
-    const item = { props: { align: 1, alphabetic: true } };
-    const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
+    const legendItem: { props: LegendProps } = { props: { align: 'center', alphabetic: '14px' } };
+    const result = getLegendProps({ legendItem, legendWidth: 0 });
     assertNotNull(result);
-    expect(result.align).toBe(1);
-    expect(result.alphabetic).toBe(true);
+    expect(result.align).toBe('center');
+    expect(result.alphabetic).toBe('14px');
   });
 
   describe('layout: undefined', () => {
     it('should not add height nor width', () => {
-      const item = { props: {} };
-      const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
+      const legendItem = { props: {} };
+      const result = getLegendProps({ legendItem, legendWidth: 0 });
       assertNotNull(result);
       expect(result.width).toBe(undefined);
       expect(result.height).toBe(undefined);
     });
     it('should pass through height and width', () => {
-      const item = { props: { width: 1, height: 2 } };
-      const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
+      const legendItem = { props: { width: 1, height: 2 } };
+      const result = getLegendProps({ legendItem, legendWidth: 0 });
       assertNotNull(result);
       expect(result.width).toBe(1);
       expect(result.height).toBe(2);
@@ -66,16 +30,16 @@ describe('getLegendProps', () => {
 
   describe('layout: vertical', () => {
     it('should pass through both width and height if layout is `vertical`', () => {
-      const item = { props: { layout: 'vertical', width: 1, height: 2 } };
-      const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
+      const legendItem: { props: LegendProps } = { props: { layout: 'vertical', width: 1, height: 2 } };
+      const result = getLegendProps({ legendItem, legendWidth: 0 });
       assertNotNull(result);
       expect(result.width).toBe(1);
       expect(result.height).toBe(2);
     });
 
     it('should return height: undefined if layout is `vertical` but height is not defined', () => {
-      const item = { props: { layout: 'vertical' } };
-      const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
+      const legendItem: { props: LegendProps } = { props: { layout: 'vertical' } };
+      const result = getLegendProps({ legendItem, legendWidth: 0 });
       assertNotNull(result);
       expect(result.width).toBe(undefined);
       expect(result.height).toBe(undefined);
@@ -84,24 +48,24 @@ describe('getLegendProps', () => {
 
   describe('layout: horizontal', () => {
     it('should default width to `legendWidth` if width is not defined', () => {
-      const item = { props: { layout: 'horizontal' } };
-      const result = getLegendProps({ children: createChildren(item), legendWidth: 10 });
+      const legendItem: { props: LegendProps } = { props: { layout: 'horizontal' } };
+      const result = getLegendProps({ legendItem, legendWidth: 10 });
       assertNotNull(result);
       expect(result.width).toBe(10);
       expect(result.height).toBe(undefined);
     });
 
     it('should default width to `legendWidth` if width is 0', () => {
-      const item = { props: { layout: 'horizontal', width: 0 } };
-      const result = getLegendProps({ children: createChildren(item), legendWidth: 10 });
+      const legendItem: { props: LegendProps } = { props: { layout: 'horizontal', width: 0 } };
+      const result = getLegendProps({ legendItem, legendWidth: 10 });
       assertNotNull(result);
       expect(result.width).toBe(10);
       expect(result.height).toBe(undefined);
     });
 
     it('should pass through both width and height', () => {
-      const item = { props: { layout: 'horizontal', width: 0 } };
-      const result = getLegendProps({ children: createChildren(item), legendWidth: 10 });
+      const legendItem: { props: LegendProps } = { props: { layout: 'horizontal', width: 0 } };
+      const result = getLegendProps({ legendItem, legendWidth: 10 });
       assertNotNull(result);
       expect(result.width).toBe(10);
       expect(result.height).toBe(undefined);
@@ -110,10 +74,10 @@ describe('getLegendProps', () => {
 
   describe('payload defined in props', () => {
     it('should pass it through unchanged', () => {
-      const item = { props: { payload: ['defined'] } };
-      const result = getLegendProps({ children: createChildren(item), legendWidth: 0 });
+      const legendItem: { props: LegendProps } = { props: { payload: [{ value: 'defined' }] } };
+      const result = getLegendProps({ legendItem, legendWidth: 0 });
       assertNotNull(result);
-      expect(result.payload).toBe(item.props.payload);
+      expect(result.payload).toBe(legendItem.props.payload);
     });
   });
 });


### PR DESCRIPTION
## Description

This function accepts and returns fewer things than before.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

I want to get rid of element cloning meaning the new code is not going to have a direct reference to the React Element in DOM meaning this function must not accept one nor return one.

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
