### PR TITLE
useGetBoundingClientRect never actually uses results of getBoundingClientRect

### DIFF
--- a/src/util/useGetBoundingClientRect.ts
+++ b/src/util/useGetBoundingClientRect.ts
@@ -28,10 +28,11 @@ export function useGetBoundingClientRect(
   const [lastBoundingBox, setLastBoundingBox] = useState<BoundingBox>({ width: 0, height: 0 });
   const updateBoundingBox = useCallback(
     (node: HTMLDivElement | null) => {
-      if (node != null && node.getBoundingClientRect) {
-        const box = node.getBoundingClientRect();
-        box.width = node.offsetWidth;
-        box.height = node.offsetHeight;
+      if (node != null) {
+        const box = {
+          width: node.offsetWidth,
+          height: node.offsetHeight,
+        };
         if (Math.abs(box.width - lastBoundingBox.width) > EPS || Math.abs(box.height - lastBoundingBox.height) > EPS) {
           setLastBoundingBox({ width: box.width, height: box.height });
           if (onUpdate) {


### PR DESCRIPTION
so I removed it.

## Motivation and Context

The return value of the function was never used so why call it.

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
