### PR TITLE
Sankey renders Tooltip as a regular child, without special clone function

### DIFF
--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -14,7 +14,7 @@ import { Layer } from '../container/Layer';
 import { Tooltip } from '../component/Tooltip';
 import { Rectangle, Props as RectangleProps } from '../shape/Rectangle';
 import { shallowEqual } from '../util/ShallowEqual';
-import { filterSvgElements, validateWidthHeight, findChildByType, filterProps } from '../util/ReactUtils';
+import { validateWidthHeight, findChildByType, filterProps } from '../util/ReactUtils';
 import { getValueByDataKey } from '../util/ChartUtils';
 import { Margin, DataKey, SankeyLink, SankeyNode } from '../util/types';
 import { ViewBoxContext } from '../context/chartLayoutContext';
@@ -678,13 +678,6 @@ export class Sankey extends PureComponent<Props, State> {
     );
   }
 
-  renderTooltip(): ReactElement {
-    const { children } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip);
-
-    return tooltipItem;
-  }
-
   getTooltipContext(): TooltipContextValue {
     const { nameKey } = this.props;
     const { isTooltipActive, activeElement, activeElementType } = this.state;
@@ -720,11 +713,10 @@ export class Sankey extends PureComponent<Props, State> {
             role="region"
           >
             <Surface {...attrs} width={width} height={height}>
-              {filterSvgElements(children)}
+              {children}
               {this.renderLinks(links, nodes)}
               {this.renderNodes(nodes)}
             </Surface>
-            {this.renderTooltip()}
           </div>
         </TooltipContextProvider>
       </ViewBoxContext.Provider>

--- a/test/chart/Sankey.spec.tsx
+++ b/test/chart/Sankey.spec.tsx
@@ -68,21 +68,15 @@ describe('<Sankey />', () => {
       ),
     );
 
-    it(
-      'should provide axisMaps: undefined even if axes are specified',
-      testChartLayoutContext(
-        props => (
+    it('should throw if axes are provided - they are not an allowed child anyway', () => {
+      expect(() =>
+        render(
           <Sankey width={1000} height={500} data={SankeyData}>
             <XAxis dataKey="number" type="number" />
             <YAxis type="category" dataKey="name" />
-            {props.children}
-          </Sankey>
+          </Sankey>,
         ),
-        ({ xAxisMap, yAxisMap }) => {
-          expect(xAxisMap).toBe(undefined);
-          expect(yAxisMap).toBe(undefined);
-        },
-      ),
-    );
+      ).toThrowError('Invariant failed: Could not find Recharts context');
+    });
   });
 });


### PR DESCRIPTION
## Description

I have done this change in SunburstChart before: https://github.com/recharts/recharts/pull/4340, now is time for Sankey.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

No more element cloning, no more searching for elements in DOM

## How Has This Been Tested?

npm test
storybook

This one is interesting because the tooltip doesn't work for me on recharts.org storybooks - but it works on my localhost.

The Tooltip on my branch has a transparent background. Not quite sure if it was always there but we might want to fix that.

## Screenshots (if appropriate):
<img width="820" alt="image" src="https://github.com/recharts/recharts/assets/1100170/20c4de71-275e-4c3c-af42-d9a4d4fce00b">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
