### PR TITLE
Add types to renderActivePoints

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Area
  */
-import React, { PureComponent, ReactElement, SVGProps } from 'react';
+import React, { PureComponent, SVGProps } from 'react';
 import clsx from 'clsx';
 import Animate from 'react-smooth';
 import isFunction from 'lodash/isFunction';
@@ -10,7 +10,7 @@ import isNil from 'lodash/isNil';
 import isNan from 'lodash/isNaN';
 import isEqual from 'lodash/isEqual';
 import { Curve, CurveType, Point as CurvePoint } from '../shape/Curve';
-import { Dot, Props as DotProps } from '../shape/Dot';
+import { Dot } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 import { LabelList } from '../component/LabelList';
 import { Global } from '../util/Global';
@@ -29,12 +29,12 @@ import {
   TickItem,
   AnimationDuration,
   LayoutType,
+  ActiveDotType,
 } from '../util/types';
 import { filterProps, isDotProps } from '../util/ReactUtils';
 import type { Payload as LegendPayload } from '../component/DefaultLegendContent';
 import { useLegendPayloadDispatch } from '../context/legendPayloadContext';
 
-export type AreaDot = ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | DotProps | boolean;
 interface AreaPointItem extends CurvePoint {
   value?: number | number[];
   payload?: any;
@@ -66,8 +66,8 @@ interface AreaProps extends InternalAreaProps {
   tooltipType?: TooltipType;
   connectNulls?: boolean;
   // whether have dot in line
-  activeDot?: AreaDot;
-  dot?: AreaDot;
+  activeDot?: ActiveDotType;
+  dot?: ActiveDotType;
 
   label?: any;
   layout?: 'horizontal' | 'vertical';
@@ -280,7 +280,7 @@ export class Area extends PureComponent<Props, State> {
     return { points, baseLine, layout, isRange, ...offset };
   };
 
-  static renderDotItem = (option: AreaDot, props: any) => {
+  static renderDotItem = (option: ActiveDotType, props: any) => {
     let dotItem;
 
     if (React.isValidElement(option)) {

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -265,6 +265,7 @@ export class Bar extends PureComponent<Props, State> {
         payload: entry,
         background,
         ...(cells && cells[index] && cells[index].props),
+        // @ts-expect-error missing types
         tooltipPayload: [getTooltipItem(item, entry)],
         tooltipPosition: { x: x + width / 2, y: y + height / 2 },
       };

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -9,7 +9,7 @@ import isEqual from 'lodash/isEqual';
 
 import clsx from 'clsx';
 import { Curve, CurveType, Props as CurveProps, Point as CurvePoint } from '../shape/Curve';
-import { Dot, Props as DotProps } from '../shape/Dot';
+import { Dot } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelType } from '../component/Label';
 import { LabelList } from '../component/LabelList';
@@ -29,13 +29,11 @@ import {
   DataKey,
   TickItem,
   AnimationDuration,
-  ActiveShape,
   LayoutType,
+  ActiveDotType,
 } from '../util/types';
 import type { Payload as LegendPayload } from '../component/DefaultLegendContent';
 import { useLegendPayloadDispatch } from '../context/legendPayloadContext';
-
-export type LineDot = ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | DotProps | boolean;
 
 export interface LinePointItem extends CurvePoint {
   value?: number;
@@ -67,9 +65,8 @@ interface LineProps extends InternalLineProps {
   connectNulls?: boolean;
   hide?: boolean;
 
-  // whether have dot in line
-  activeDot?: ActiveShape<DotProps> | DotProps;
-  dot?: LineDot;
+  activeDot?: ActiveDotType;
+  dot?: ActiveDotType;
 
   onAnimationStart?: () => void;
   onAnimationEnd?: () => void;
@@ -352,7 +349,7 @@ export class Line extends PureComponent<Props, State> {
     );
   }
 
-  static renderDotItem(option: LineDot, props: any) {
+  static renderDotItem(option: ActiveDotType, props: any) {
     let dotItem;
 
     if (React.isValidElement(option)) {

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -61,6 +61,7 @@ import { inRangeOfSector, polarToCartesian } from '../util/PolarUtils';
 import { shallowEqual } from '../util/ShallowEqual';
 import { eventCenter, SYNC_EVENT } from '../util/Events';
 import {
+  ActiveDotType,
   adaptEventHandlers,
   AxisType,
   BaseAxisProps,
@@ -262,6 +263,7 @@ const getTooltipContent = (
       return result;
     }
 
+    // @ts-expect-error missing types
     return [...result, getTooltipItem(child, payload)];
   }, []);
 };
@@ -1874,12 +1876,32 @@ export const generateCategoricalChart = ({
       );
     };
 
-    /*
-     * This method is used for rendering AreaChart, LineChart, and Tooltip
-     */
-    renderActivePoints = ({ item, activePoint, basePoint, childIndex, isRange }: any) => {
+    renderActivePoints = ({
+      item,
+      activePoint,
+      basePoint,
+      childIndex,
+      isRange,
+    }: {
+      // The graphical item, for example Area or Bar.
+      item: {
+        props: { key: string };
+        item: {
+          type: { displayName: string };
+          props: { activeDot: ActiveDotType; dataKey: DataKey<any>; stroke: string; fill: string };
+        };
+      };
+      // found in points array
+      activePoint: any;
+
+      basePoint: any;
+      childIndex: number;
+      isRange: boolean;
+    }) => {
       const result = [];
+      // item.props is whatever getComposedData returns
       const { key } = item.props;
+      // item.item.props are the original props on the DOM element
       const { activeDot, dataKey } = item.item.props;
       const dotProps = {
         index: childIndex,

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -244,6 +244,7 @@ export class RadialBar extends PureComponent<RadialBarProps, State> {
         startAngle,
         endAngle,
         ...(cells && cells[index] && cells[index].props),
+        // @ts-expect-error missing types
         tooltipPayload: [getTooltipItem(item, entry)],
         tooltipPosition: polarToCartesian(cx, cy, (innerRadius + outerRadius) / 2, (startAngle + endAngle) / 2),
       };

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -174,11 +174,15 @@ export const calculateActiveTickIndex = (
 };
 
 /**
+ * @deprecated render child components as children instead of reading DOM elements and passing them around
  * Get the main color of each graphic item
  * @param  {ReactElement} item A graphic item
  * @return {String}            Color
  */
-export const getMainColorOfGraphicItem = (item: ReactElement) => {
+export const getMainColorOfGraphicItem = (item: {
+  type: { displayName: string };
+  props: { stroke: string; fill: string };
+}) => {
   const {
     type: { displayName },
   } = item as any; // TODO: check if displayName is valid.
@@ -1319,7 +1323,23 @@ export const parseDomainOfCategoryAxis = <T>(
   return specifiedDomain;
 };
 
-export const getTooltipItem = (graphicalItem: ReactElement, payload: any) => {
+export const getTooltipItem = (
+  graphicalItem: {
+    type: { displayName: string };
+    props: {
+      stroke: string;
+      fill: string;
+      dataKey: DataKey<any>;
+      name: string;
+      unit: string;
+      formatter: any;
+      tooltipType: any;
+      chartType: any;
+      hide: boolean;
+    };
+  },
+  payload: any,
+) => {
   const { dataKey, name, unit, formatter, tooltipType, chartType, hide } = graphicalItem.props;
 
   return {

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -9,9 +9,7 @@ import { isFragment } from 'react-is';
 import { DotProps } from '..';
 import { isNumber } from './DataUtils';
 import { shallowEqual } from './ShallowEqual';
-import { FilteredSvgElementType, FilteredElementKeyMap, SVGElementPropKeys, EventKeys } from './types';
-import { AreaDot } from '../cartesian/Area';
-import { LineDot } from '../cartesian/Line';
+import { FilteredSvgElementType, FilteredElementKeyMap, SVGElementPropKeys, EventKeys, ActiveDotType } from './types';
 
 const REACT_BROWSER_EVENT_MAP: Record<string, string> = {
   click: 'onClick',
@@ -267,7 +265,7 @@ const SVG_TAGS: string[] = [
 
 const isSvgElement = (child: any) => child && child.type && isString(child.type) && SVG_TAGS.indexOf(child.type) >= 0;
 
-export const isDotProps = (dot: LineDot | AreaDot): dot is DotProps =>
+export const isDotProps = (dot: ActiveDotType): dot is DotProps =>
   dot && typeof dot === 'object' && 'cx' in dot && 'cy' in dot && 'r' in dot;
 
 /**

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -28,6 +28,7 @@ import { PolarAngleAxisProps } from '../polar/PolarAngleAxis';
 import { PolarRadiusAxisProps } from '../polar/PolarRadiusAxis';
 import type { Props as XAxisProps } from '../cartesian/XAxis';
 import type { Props as YAxisProps } from '../cartesian/YAxis';
+import type { Props as DotProps } from '../shape/Dot';
 
 /**
  * Determines how values are stacked:
@@ -1320,6 +1321,30 @@ export interface SankeyLink {
 }
 
 export type Size = { width: number; height: number };
+
+/**
+ * This is the type of `activeDot` prop on:
+ * - Area
+ * - Line
+ * - Radar
+ */
+export type ActiveDotType =
+  /**
+   * true | false will turn the default activeDot on and off, respectively
+   */
+  | boolean
+  /**
+   * activeDot can be a custom React Component
+   */
+  | ((props: DotProps) => ReactElement<SVGElement>)
+  /**
+   * activeDot can be an object; props from here will be appended to the default active dot
+   */
+  | DotProps
+  /**
+   * activeDot can be an element; it will get cloned and will receive new extra props.
+   */
+  | ReactElement<SVGElement>;
 
 export type ActiveShape<PropsType = Record<string, any>, ElementType = SVGElement> =
   | ReactElement<SVGProps<ElementType>>


### PR DESCRIPTION
No changes here, only types. I'm trying to make sense of how the active dots work.