### PR TITLE
Treemap renders Tooltip as a regular child, without special clone function

### DIFF
--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -16,7 +16,7 @@ import { COLOR_PANEL } from '../util/Constants';
 import { uniqueId } from '../util/DataUtils';
 import { getStringSize } from '../util/DOMUtils';
 import { Global } from '../util/Global';
-import { filterSvgElements, findChildByType, validateWidthHeight, filterProps } from '../util/ReactUtils';
+import { findChildByType, validateWidthHeight, filterProps } from '../util/ReactUtils';
 import { AnimationDuration, AnimationTiming, DataKey, TreemapNode } from '../util/types';
 import { ViewBoxContext } from '../context/chartLayoutContext';
 import { TooltipContextProvider, TooltipContextValue } from '../context/tooltipContext';
@@ -646,13 +646,6 @@ export class Treemap extends PureComponent<Props, State> {
     return this.renderNode(formatRoot, formatRoot);
   }
 
-  renderTooltip(): React.ReactElement {
-    const { children } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip);
-
-    return tooltipItem;
-  }
-
   // render nest treemap
   renderNestIndex(): React.ReactElement {
     const { nameKey, nestIndexContent } = this.props;
@@ -744,9 +737,8 @@ export class Treemap extends PureComponent<Props, State> {
           >
             <Surface {...attrs} width={width} height={type === 'nest' ? height - 30 : height}>
               {this.renderAllNodes()}
-              {filterSvgElements(children)}
+              {children}
             </Surface>
-            {this.renderTooltip()}
             {type === 'nest' && this.renderNestIndex()}
           </div>
         </TooltipContextProvider>

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -298,23 +298,6 @@ export const isValidSpreadableProp = (
   );
 };
 
-/**
- * Filter all the svg elements of children
- * @param  {Array} children The children of a react element
- * @return {Array}          All the svg elements
- */
-export const filterSvgElements = (children: React.ReactElement[]): React.ReactElement[] => {
-  const svgElements = [] as React.ReactElement[];
-
-  toArray(children).forEach((entry: React.ReactElement) => {
-    if (isSvgElement(entry)) {
-      svgElements.push(entry);
-    }
-  });
-
-  return svgElements;
-};
-
 export const filterProps = (
   props: Record<string, any> | Component | FunctionComponent | boolean | unknown,
   includeEvents: boolean,

--- a/test/chart/Treemap.spec.tsx
+++ b/test/chart/Treemap.spec.tsx
@@ -69,23 +69,15 @@ describe('<Treemap />', () => {
       ),
     );
 
-    it(
-      'should provide default empty context even if axes are specified',
-      testChartLayoutContext(
-        props => (
+    it('should throw if axes are provided - they are not an allowed child anyway', () => {
+      expect(() =>
+        render(
           <Treemap width={100} height={50}>
             <XAxis dataKey="number" type="number" />
             <YAxis type="category" dataKey="name" />
-            {props.children}
-          </Treemap>
+          </Treemap>,
         ),
-        ({ clipPathId, viewBox, xAxisMap, yAxisMap }) => {
-          expect(clipPathId).toBe(undefined);
-          expect(viewBox).toEqual({ x: 0, y: 0, width: 100, height: 50 });
-          expect(xAxisMap).toBe(undefined);
-          expect(yAxisMap).toBe(undefined);
-        },
-      ),
-    );
+      ).toThrowError('Invariant failed: Could not find Recharts context');
+    });
   });
 });

--- a/test/util/ReactUtils.spec.tsx
+++ b/test/util/ReactUtils.spec.tsx
@@ -5,7 +5,6 @@ import { vi } from 'vitest';
 import { Bar, Line, LineChart } from '../../src';
 import {
   filterProps,
-  filterSvgElements,
   findAllByType,
   getDisplayName,
   isChildrenEqual,
@@ -165,23 +164,6 @@ describe('ReactUtils untest tests', () => {
     test('validateWidthHeight return false when input is not a react element', () => {
       expect(validateWidthHeight({ a: 1 })).toEqual(false);
       expect(validateWidthHeight(vi.fn())).toEqual(false);
-    });
-  });
-
-  describe('filterSvgElements', () => {
-    test('filterSvgElements filter children which are svg elements', () => {
-      const children = [
-        <>
-          <Line dataKey="a" />
-          <Line dataKey="b" />
-          <rect x="0" y="0" width="20" height="20" />
-          <text x="0" y="0">
-            12
-          </text>
-        </>,
-      ];
-
-      expect(filterSvgElements(children)?.length).toEqual(2);
     });
   });
 


### PR DESCRIPTION
## Description

Last one of three. Previous PRs: https://github.com/recharts/recharts/pull/4348 https://github.com/recharts/recharts/pull/4340

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

No cloning, no DOM reading

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
