### PR TITLE
Legend renders from Context

### DIFF
--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,4 +1,5 @@
 {
+  "storybookConfigDir": "storybook",
   "projectId": "Project:63da8268a0da9970db6992aa",
   "zip": true
 }

--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -62,6 +62,7 @@
   "es6/numberAxis/Funnel.js",
   "es6/context/tooltipContext.js",
   "es6/context/legendPayloadContext.js",
+  "es6/context/legendBoundingBoxContext.js",
   "es6/context/chartLayoutContext.js",
   "es6/context/accessibilityContext.js",
   "es6/container/Surface.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -62,6 +62,7 @@
   "lib/numberAxis/Funnel.js",
   "lib/context/tooltipContext.js",
   "lib/context/legendPayloadContext.js",
+  "lib/context/legendBoundingBoxContext.js",
   "lib/context/chartLayoutContext.js",
   "lib/context/accessibilityContext.js",
   "lib/container/Surface.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -62,6 +62,7 @@
   "types/numberAxis/Funnel.d.ts",
   "types/context/tooltipContext.d.ts",
   "types/context/legendPayloadContext.d.ts",
+  "types/context/legendBoundingBoxContext.d.ts",
   "types/context/chartLayoutContext.d.ts",
   "types/context/accessibilityContext.d.ts",
   "types/container/Surface.d.ts",

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -44,7 +44,6 @@ import {
   getDomainOfDataByKey,
   getDomainOfItemsWithSameAxis,
   getDomainOfStackGroups,
-  getLegendProps,
   getMainColorOfGraphicItem,
   getStackedDataOfItem,
   getStackGroupsByAxisId,
@@ -1808,22 +1807,13 @@ export const generateCategoricalChart = ({
      * @return {ReactElement}            The instance of Legend
      */
     renderLegend = (): React.ReactElement => {
-      const { children, width } = this.props;
+      const { children } = this.props;
       const legendItem = findChildByType(children, Legend);
       if (!legendItem) {
         return null;
       }
-      const margin = this.props.margin || {};
-      const legendWidth: number = width - (margin.left || 0) - (margin.right || 0);
-      const props = getLegendProps({
-        legendItem,
-        legendWidth,
-      });
 
-      return cloneElement(legendItem, {
-        ...props,
-        onBBoxUpdate: this.handleLegendBBoxUpdate,
-      });
+      return legendItem;
     };
 
     /**

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -90,6 +90,7 @@ import { ChartLayoutContextProvider } from '../context/chartLayoutContext';
 import { AxisMap, CategoricalChartState } from './types';
 import { AccessibilityContextProvider } from '../context/accessibilityContext';
 import { BoundingBox } from '../util/useGetBoundingClientRect';
+import { LegendBoundingBoxContext } from '../context/legendBoundingBoxContext';
 
 export interface MousePointer {
   pageX: number;
@@ -2149,32 +2150,41 @@ export const generateCategoricalChart = ({
 
       const events = this.parseEventsOfWrapper();
       return (
-        <AccessibilityContextProvider value={this.props.accessibilityLayer}>
-          <ChartLayoutContextProvider
-            state={this.state}
-            width={this.props.width}
-            height={this.props.height}
-            clipPathId={this.clipPathId}
-            margin={this.props.margin}
-          >
-            <div
-              className={clsx('recharts-wrapper', className)}
-              style={{ position: 'relative', cursor: 'default', width, height, ...style }}
-              {...events}
-              ref={(node: HTMLDivElement) => {
-                this.container = node;
-              }}
-              role={attrs.role ?? 'region'}
+        <LegendBoundingBoxContext.Provider value={this.handleLegendBBoxUpdate}>
+          <AccessibilityContextProvider value={this.props.accessibilityLayer}>
+            <ChartLayoutContextProvider
+              state={this.state}
+              width={this.props.width}
+              height={this.props.height}
+              clipPathId={this.clipPathId}
+              margin={this.props.margin}
             >
-              <Surface {...attrs} width={width} height={height} title={title} desc={desc} style={FULL_WIDTH_AND_HEIGHT}>
-                {this.renderClipPath()}
-                {renderByOrder(children, this.renderMap)}
-              </Surface>
-              {this.renderLegend()}
-              {this.renderTooltip()}
-            </div>
-          </ChartLayoutContextProvider>
-        </AccessibilityContextProvider>
+              <div
+                className={clsx('recharts-wrapper', className)}
+                style={{ position: 'relative', cursor: 'default', width, height, ...style }}
+                {...events}
+                ref={(node: HTMLDivElement) => {
+                  this.container = node;
+                }}
+                role={attrs.role ?? 'region'}
+              >
+                <Surface
+                  {...attrs}
+                  width={width}
+                  height={height}
+                  title={title}
+                  desc={desc}
+                  style={FULL_WIDTH_AND_HEIGHT}
+                >
+                  {this.renderClipPath()}
+                  {renderByOrder(children, this.renderMap)}
+                </Surface>
+                {this.renderLegend()}
+                {this.renderTooltip()}
+              </div>
+            </ChartLayoutContextProvider>
+          </AccessibilityContextProvider>
+        </LegendBoundingBoxContext.Provider>
       );
     }
   };

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1803,20 +1803,6 @@ export const generateCategoricalChart = ({
     };
 
     /**
-     * Draw legend
-     * @return {ReactElement}            The instance of Legend
-     */
-    renderLegend = (): React.ReactElement => {
-      const { children } = this.props;
-      const legendItem = findChildByType(children, Legend);
-      if (!legendItem) {
-        return null;
-      }
-
-      return legendItem;
-    };
-
-    /**
      * Draw Tooltip
      * @return {ReactElement}  The instance of Tooltip
      */
@@ -2093,6 +2079,7 @@ export const generateCategoricalChart = ({
       PolarAngleAxis: { handler: renderAsIs },
       PolarRadiusAxis: { handler: renderAsIs },
       Customized: { handler: this.renderCustomized },
+      Legend: { handler: renderAsIs },
     };
 
     render() {
@@ -2169,7 +2156,6 @@ export const generateCategoricalChart = ({
                   {this.renderClipPath()}
                   {renderByOrder(children, this.renderMap)}
                 </Surface>
-                {this.renderLegend()}
                 {this.renderTooltip()}
               </div>
             </ChartLayoutContextProvider>

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -99,18 +99,20 @@ interface State {
 function LegendWrapper(props: Props) {
   const contextPayload = useLegendPayload();
   const margin = useMargin();
-  const { width, height, wrapperStyle } = props;
+  const { width: widthFromProps, height: heightFromProps, wrapperStyle } = props;
   const onBBoxUpdate = useContext(LegendBoundingBoxContext);
   // The contextPayload is not used directly inside the hook, but we need the onBBoxUpdate call
   // when the payload changes, therefore it's here as a dependency.
   const [lastBoundingBox, updateBoundingBox] = useGetBoundingClientRect(onBBoxUpdate, [contextPayload]);
   const chartWidth = useChartWidth();
   const chartHeight = useChartHeight();
-
+  const maxWidth = chartWidth - (margin.left || 0) - (margin.right || 0);
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  const widthOrHeight = Legend.getWidthOrHeight(props.layout, heightFromProps, widthFromProps, maxWidth);
   const outerStyle: CSSProperties = {
     position: 'absolute',
-    width: width || 'auto',
-    height: height || 'auto',
+    width: widthOrHeight?.width || 'auto',
+    height: widthOrHeight?.height || 'auto',
     ...getDefaultPosition(wrapperStyle, props, margin, chartWidth, chartHeight, lastBoundingBox),
     ...wrapperStyle,
   };
@@ -119,7 +121,10 @@ function LegendWrapper(props: Props) {
     <div className="recharts-legend-wrapper" style={outerStyle} ref={updateBoundingBox}>
       <LegendContent
         {...props}
+        {...widthOrHeight}
         margin={margin}
+        // This doesn't need the bboxupdate callback at all - I pass it for the sake of not changing anything in the API
+        onBBoxUpdate={onBBoxUpdate}
         chartWidth={chartWidth}
         chartHeight={chartHeight}
         contextPayload={contextPayload}
@@ -143,7 +148,7 @@ export class Legend extends PureComponent<Props, State> {
     height: number | undefined,
     width: number | undefined,
     maxWidth: number,
-  ): null | { height: number } | { width: number } {
+  ): null | { height?: number; width?: number } {
     if (layout === 'vertical' && isNumber(height)) {
       return {
         height,

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -164,6 +164,12 @@ export class Legend extends PureComponent<Props, State> {
   }
 
   public render() {
-    return <LegendWrapper {...this.props} />;
+    return (
+      <g>
+        <foreignObject x="0" y="0" width="100%" height="100%" style={{ pointerEvents: 'none' }}>
+          <LegendWrapper {...this.props} />
+        </foreignObject>
+      </g>
+    );
   }
 }

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, PureComponent } from 'react';
+import React, { CSSProperties, PureComponent, useContext } from 'react';
 import { DefaultLegendContent, Payload, Props as DefaultProps } from './DefaultLegendContent';
 
 import { isNumber } from '../util/DataUtils';
@@ -7,6 +7,7 @@ import { getUniqPayload, UniqueOption } from '../util/payload/getUniqPayload';
 import { useLegendPayload } from '../context/legendPayloadContext';
 import { BoundingBox, useGetBoundingClientRect } from '../util/useGetBoundingClientRect';
 import { useChartHeight, useChartWidth, useMargin } from '../context/chartLayoutContext';
+import { LegendBoundingBoxContext } from '../context/legendBoundingBoxContext';
 
 function defaultUniqBy(entry: Payload) {
   return entry.value;
@@ -98,7 +99,8 @@ interface State {
 function LegendWrapper(props: Props) {
   const contextPayload = useLegendPayload();
   const margin = useMargin();
-  const { width, height, wrapperStyle, onBBoxUpdate } = props;
+  const { width, height, wrapperStyle } = props;
+  const onBBoxUpdate = useContext(LegendBoundingBoxContext);
   // The contextPayload is not used directly inside the hook, but we need the onBBoxUpdate call
   // when the payload changes, therefore it's here as a dependency.
   const [lastBoundingBox, updateBoundingBox] = useGetBoundingClientRect(onBBoxUpdate, [contextPayload]);

--- a/src/context/legendBoundingBoxContext.tsx
+++ b/src/context/legendBoundingBoxContext.tsx
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+import { BoundingBox } from '../util/useGetBoundingClientRect';
+
+type OnLegendBoundingBoxUpdate = (legendBoundingBox: BoundingBox) => void;
+
+export const LegendBoundingBoxContext = createContext<OnLegendBoundingBoxUpdate>(() => {});

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -26,6 +26,7 @@ import { testChartLayoutContext } from '../util/context';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 import { LegendPayloadProvider } from '../../src/context/legendPayloadContext';
 import { exampleLegendPayload, MockLegendPayload } from '../helper/MockLegendPayload';
+import { LegendBoundingBoxContext } from '../../src/context/legendBoundingBoxContext';
 
 function assertHasLegend(container: HTMLElement) {
   expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(1);
@@ -358,7 +359,11 @@ describe('<Legend />', () => {
     it('should call onBBoxUpdate once on mount', () => {
       const onBBoxUpdate = vi.fn();
       mockGetBoundingClientRect({ width: 50, height: 15 });
-      render(<Legend onBBoxUpdate={onBBoxUpdate} />);
+      render(
+        <LegendBoundingBoxContext.Provider value={onBBoxUpdate}>
+          <Legend />
+        </LegendBoundingBoxContext.Provider>,
+      );
       expect(onBBoxUpdate).toHaveBeenCalledTimes(1);
       expect(onBBoxUpdate).toHaveBeenCalledWith(expect.objectContaining({ width: 50, height: 15 }));
     });
@@ -367,27 +372,33 @@ describe('<Legend />', () => {
       const onBBoxUpdate = vi.fn();
       mockGetBoundingClientRect({ width: 50, height: 15 });
       const { rerender } = render(
-        <LegendPayloadProvider>
-          <Legend onBBoxUpdate={onBBoxUpdate} />
-        </LegendPayloadProvider>,
+        <LegendBoundingBoxContext.Provider value={onBBoxUpdate}>
+          <LegendPayloadProvider>
+            <Legend />
+          </LegendPayloadProvider>
+        </LegendBoundingBoxContext.Provider>,
       );
 
       expect(onBBoxUpdate).toHaveBeenCalledTimes(1);
       expect(onBBoxUpdate).toHaveBeenCalledWith(expect.objectContaining({ width: 50, height: 15 }));
       mockGetBoundingClientRect({ width: 50, height: 25 });
       rerender(
-        <LegendPayloadProvider>
-          <MockLegendPayload payload={exampleLegendPayload} />
-          <Legend onBBoxUpdate={onBBoxUpdate} />
-        </LegendPayloadProvider>,
+        <LegendBoundingBoxContext.Provider value={onBBoxUpdate}>
+          <LegendPayloadProvider>
+            <MockLegendPayload payload={exampleLegendPayload} />
+            <Legend />
+          </LegendPayloadProvider>
+        </LegendBoundingBoxContext.Provider>,
       );
       expect(onBBoxUpdate).toHaveBeenCalledTimes(2);
       mockGetBoundingClientRect({ width: 50, height: 0 });
       rerender(
-        <LegendPayloadProvider>
-          <MockLegendPayload payload={[]} />
-          <Legend onBBoxUpdate={onBBoxUpdate} />
-        </LegendPayloadProvider>,
+        <LegendBoundingBoxContext.Provider value={onBBoxUpdate}>
+          <LegendPayloadProvider>
+            <MockLegendPayload payload={[]} />
+            <Legend />
+          </LegendPayloadProvider>
+        </LegendBoundingBoxContext.Provider>,
       );
       expect(onBBoxUpdate).toHaveBeenCalledTimes(3);
       expect(onBBoxUpdate).toHaveBeenCalledWith(expect.objectContaining({ width: 50, height: 0 }));
@@ -558,7 +569,11 @@ describe('<Legend />', () => {
         mockHTMLElementProperty('offsetWidth', mockRect.width * scale);
 
         const handleUpdate = vi.fn();
-        render(<Legend height={30} width={300} onBBoxUpdate={handleUpdate} />);
+        render(
+          <LegendBoundingBoxContext.Provider value={handleUpdate}>
+            <Legend height={30} width={300} />
+          </LegendBoundingBoxContext.Provider>,
+        );
         expect(handleUpdate.mock.calls[0][0].height).toEqual(mockRect.height * scale);
         expect(handleUpdate.mock.calls[0][0].width).toEqual(mockRect.width * scale);
       });


### PR DESCRIPTION
## Description

No more Legend cloning

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Let's get rid of element cloning

## How Has This Been Tested?

npm test
storybook

There are differences in every Legend - I can't see it but chromatic insists there is. I suspect it's because text antialiasing in SVG and HTML are different? Or something. See here: https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=796

## Screenshots (if appropriate):
<img width="1666" alt="image" src="https://github.com/recharts/recharts/assets/1100170/674bacb2-566e-4268-bb85-e787babc34c0">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
