### PR TITLE
Sandwich Brush functional component between two class components

### DIFF
--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -1,6 +1,7 @@
-/**
- * @fileOverview Brush
+/*
+ * After we refactor classes to functional components, we can remove this eslint-disable
  */
+/* eslint-disable max-classes-per-file */
 import React, { Children, PureComponent, ReactElement, ReactText, SVGAttributes, SVGProps, TouchEvent } from 'react';
 import clsx from 'clsx';
 import { scalePoint, ScalePoint } from 'victory-vendor/d3-scale';
@@ -58,6 +59,8 @@ interface BrushProps extends InternalBrushProps {
 
 export type Props = Omit<SVGProps<SVGElement>, 'onChange'> & BrushProps;
 
+type PropertiesFromContext = {};
+
 type BrushTravellerId = 'startX' | 'endX';
 
 function DefaultTraveller(props: TravellerProps) {
@@ -100,7 +103,7 @@ function TravellerLayer({
 }: {
   id: BrushTravellerId;
   travellerX: number;
-  otherProps: Props;
+  otherProps: BrushWithStateProps;
   onMouseEnter: (e: MouseOrTouchEvent) => void;
   onMouseLeave: (e: MouseOrTouchEvent) => void;
   onMouseDown: (e: MouseOrTouchEvent) => void;
@@ -430,21 +433,10 @@ const isTouch = (e: TouchEvent<SVGElement> | React.MouseEvent<SVGElement>): e is
 
 type MouseOrTouchEvent = React.MouseEvent<SVGGElement> | TouchEvent<SVGGElement>;
 
-export class Brush extends PureComponent<Props, State> {
-  static displayName = 'Brush';
+type BrushWithStateProps = Props & PropertiesFromContext;
 
-  static defaultProps = {
-    height: 40,
-    travellerWidth: 5,
-    gap: 1,
-    fill: '#fff',
-    stroke: '#666',
-    padding: { top: 1, right: 1, bottom: 1, left: 1 },
-    leaveTimeOut: 1000,
-    alwaysShowText: false,
-  };
-
-  constructor(props: Props) {
+class BrushWithState extends PureComponent<BrushWithStateProps, State> {
+  constructor(props: BrushWithStateProps) {
     super(props);
 
     this.travellerDragStartHandlers = {
@@ -459,7 +451,7 @@ export class Brush extends PureComponent<Props, State> {
 
   travellerDragStartHandlers?: Record<BrushTravellerId, (event: MouseOrTouchEvent) => void>;
 
-  static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
+  static getDerivedStateFromProps(nextProps: BrushWithStateProps, prevState: State): State {
     const { data, width, x, travellerWidth, updateId, startIndex, endIndex } = nextProps;
 
     if (data !== prevState.prevData || updateId !== prevState.prevUpdateId) {
@@ -823,5 +815,29 @@ export class Brush extends PureComponent<Props, State> {
         )}
       </Layer>
     );
+  }
+}
+
+function BrushInternal(props: Props) {
+  // @ts-expect-error typescript complains about IntrinsicClassAttributes not matching
+  return <BrushWithState {...props} />;
+}
+
+export class Brush extends PureComponent<Props, State> {
+  static displayName = 'Brush';
+
+  static defaultProps = {
+    height: 40,
+    travellerWidth: 5,
+    gap: 1,
+    fill: '#fff',
+    stroke: '#666',
+    padding: { top: 1, right: 1, bottom: 1, left: 1 },
+    leaveTimeOut: 1000,
+    alwaysShowText: false,
+  };
+
+  render() {
+    return <BrushInternal {...this.props} />;
   }
 }


### PR DESCRIPTION
## Description

Small refactor.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

I want to have a functional components for hooks. Unfortunately there are two blockers:

1. the `defaultProps` and `displayName` properties that must be on the top `Brush` level component - because `generateCategoricalChart` is reading those and looking up this component in the DOM. So this has to be the parent of the functional component.
2. Tons of state that uses cloned props. I want these props to come from the context and the context comes via hooks which means this state has to be a child of the functional component.

So faced with these two blockers I changed Brush to be Class > Functional > Class.

A better solution would be to rewrite Brush to be a completely functional component but I think we have bigger fish to fry right now so I would prefer to spend time getting rid of the component cloning first.

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
