### PR TITLE
Move Clip path to a component

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -69,6 +69,7 @@
   "es6/context/accessibilityContext.js",
   "es6/container/Surface.js",
   "es6/container/Layer.js",
+  "es6/container/ClipPath.js",
   "es6/component/TooltipBoundingBox.js",
   "es6/component/Tooltip.js",
   "es6/component/Text.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -69,6 +69,7 @@
   "lib/context/accessibilityContext.js",
   "lib/container/Surface.js",
   "lib/container/Layer.js",
+  "lib/container/ClipPath.js",
   "lib/component/TooltipBoundingBox.js",
   "lib/component/Tooltip.js",
   "lib/component/Text.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -69,6 +69,7 @@
   "types/context/accessibilityContext.d.ts",
   "types/container/Surface.d.ts",
   "types/container/Layer.d.ts",
+  "types/container/ClipPath.d.ts",
   "types/component/TooltipBoundingBox.d.ts",
   "types/component/Tooltip.d.ts",
   "types/component/Text.d.ts",

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -93,6 +93,7 @@ import { BoundingBox } from '../util/useGetBoundingClientRect';
 import { LegendBoundingBoxContext } from '../context/legendBoundingBoxContext';
 import { ChartDataContextProvider } from '../context/chartDataContext';
 import { BrushStartEndIndex, BrushUpdateDispatchContext } from '../context/brushUpdateContext';
+import { ClipPath } from '../container/ClipPath';
 
 export interface MousePointer {
   pageX: number;
@@ -1995,21 +1996,6 @@ export const generateCategoricalChart = ({
         ...this.state,
       });
 
-    renderClipPath() {
-      const { clipPathId } = this;
-      const {
-        offset: { left, top, height, width },
-      } = this.state;
-
-      return (
-        <defs>
-          <clipPath id={clipPathId}>
-            <rect x={left} y={top} height={height} width={width} />
-          </clipPath>
-        </defs>
-      );
-    }
-
     public getItemByXY(chartXY: { x: number; y: number }) {
       const { formattedGraphicalItems, activeItem } = this.state;
       if (formattedGraphicalItems && formattedGraphicalItems.length) {
@@ -2105,7 +2091,7 @@ export const generateCategoricalChart = ({
             margin={this.props.margin}
           >
             <Surface {...attrs} width={width} height={height} title={title} desc={desc}>
-              {this.renderClipPath()}
+              <ClipPath clipPathId={this.clipPathId} offset={this.state.offset} />
               {renderByOrder(children, this.renderMap)}
             </Surface>
           </ChartLayoutContextProvider>
@@ -2158,7 +2144,7 @@ export const generateCategoricalChart = ({
                       desc={desc}
                       style={FULL_WIDTH_AND_HEIGHT}
                     >
-                      {this.renderClipPath()}
+                      <ClipPath clipPathId={this.clipPathId} offset={this.state.offset} />
                       {renderByOrder(children, this.renderMap)}
                     </Surface>
                     {this.renderTooltip()}

--- a/src/container/ClipPath.tsx
+++ b/src/container/ClipPath.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ChartOffset } from '../util/types';
+
+type ClipPathProps = {
+  clipPathId: string;
+  offset: ChartOffset;
+};
+
+export function ClipPath({ clipPathId, offset }: ClipPathProps) {
+  const { left, top, height, width } = offset;
+
+  return (
+    <defs>
+      <clipPath id={clipPathId}>
+        <rect x={left} y={top} height={height} width={width} />
+      </clipPath>
+    </defs>
+  );
+}


### PR DESCRIPTION
## Description

Use Component instead of an instance method

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

This wasn't blocking anything tbh. But it makes `generateCategoricalChart` a bit smaller.

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
