### PR TITLE
Cursor reads context instead of cloned props

### DIFF
--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -691,6 +691,7 @@ export class Sankey extends PureComponent<Props, State> {
       payload,
       coordinate,
       active: isTooltipActive,
+      index: 0,
     };
   }
 

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -715,6 +715,7 @@ export class Treemap extends PureComponent<Props, State> {
       coordinate,
       label: '',
       payload,
+      index: 0,
     };
   }
 

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1781,25 +1781,18 @@ export const generateCategoricalChart = ({
     }
 
     renderCursor = (element: ReactElement) => {
-      const { isTooltipActive, activeCoordinate, activePayload, offset, activeTooltipIndex, tooltipAxisBandSize } =
-        this.state;
+      const { tooltipAxisBandSize } = this.state;
       const tooltipEventType = this.getTooltipEventType();
-      // The cursor is a part of the Tooltip, and it should be shown (by default) when the Tooltip is active.
-      const isActive: boolean = element.props.active ?? isTooltipActive;
+
       const { layout } = this.props;
       const key = element.key || '_recharts-cursor';
 
       return (
         <Cursor
           key={key}
-          activeCoordinate={activeCoordinate}
-          activePayload={activePayload}
-          activeTooltipIndex={activeTooltipIndex}
           chartName={chartName}
           element={element}
-          isActive={isActive}
           layout={layout}
-          offset={offset}
           tooltipAxisBandSize={tooltipAxisBandSize}
           tooltipEventType={tooltipEventType}
         />

--- a/src/component/Cursor.tsx
+++ b/src/component/Cursor.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, cloneElement, createElement, isValidElement } from 'react';
 import clsx from 'clsx';
-import { ChartCoordinate, ChartOffset, LayoutType, TooltipEventType } from '../util/types';
+import { LayoutType, TooltipEventType } from '../util/types';
 import { Curve } from '../shape/Curve';
 import { Cross } from '../shape/Cross';
 import { getCursorRectangle } from '../util/cursor/getCursorRectangle';
@@ -9,16 +9,13 @@ import { getRadialCursorPoints } from '../util/cursor/getRadialCursorPoints';
 import { Sector } from '../shape/Sector';
 import { getCursorPoints } from '../util/cursor/getCursorPoints';
 import { filterProps } from '../util/ReactUtils';
+import { useTooltipContext } from '../context/tooltipContext';
+import { useOffset } from '../context/chartLayoutContext';
 
 export type CursorProps = {
-  activeCoordinate: ChartCoordinate;
-  activePayload: any[];
-  activeTooltipIndex: number;
   chartName: string;
   element: ReactElement;
-  isActive: boolean;
   layout: LayoutType;
-  offset: ChartOffset;
   tooltipAxisBandSize: number;
   tooltipEventType: TooltipEventType;
 };
@@ -32,18 +29,14 @@ export type CursorProps = {
  * to emphasise which part of the chart does the tooltip refer to.
  */
 export function Cursor(props: CursorProps) {
-  const {
-    element,
-    tooltipEventType,
-    isActive,
-    activeCoordinate,
-    activePayload,
-    offset,
-    activeTooltipIndex,
-    tooltipAxisBandSize,
-    layout,
-    chartName,
-  } = props;
+  const { element, tooltipEventType, tooltipAxisBandSize, layout, chartName } = props;
+  const { active, coordinate, payload, index } = useTooltipContext();
+  const offset = useOffset();
+  // The cursor is a part of the Tooltip, and it should be shown (by default) when the Tooltip is active.
+  const isActive: boolean = element.props.active ?? active;
+  const activeCoordinate = coordinate;
+  const activePayload = payload;
+  const activeTooltipIndex = index;
   if (
     !element ||
     !element.props.cursor ||

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -25,7 +25,7 @@ function defaultUniqBy<TValue extends ValueType, TName extends NameType>(entry: 
 }
 
 type TooltipContentProps<TValue extends ValueType, TName extends NameType> = TooltipProps<TValue, TName> &
-  TooltipContextValue & { accessibilityLayer: boolean };
+  Pick<TooltipContextValue, 'label' | 'payload' | 'coordinate' | 'active'> & { accessibilityLayer: boolean };
 
 function renderContent<TValue extends ValueType, TName extends NameType>(
   content: ContentType<TValue, TName>,

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -68,6 +68,7 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
       dataStartIndex,
       dataEndIndex,
       updateId,
+      activeTooltipIndex,
     },
     clipPathId,
     children,
@@ -86,6 +87,7 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
     payload: activePayload,
     coordinate: activeCoordinate,
     active: isTooltipActive,
+    index: activeTooltipIndex,
   };
 
   /*

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -6,6 +6,7 @@ export type TooltipContextValue = {
   payload: any[];
   coordinate: ChartCoordinate;
   active: boolean;
+  index: number;
 };
 
 export const doNotDisplayTooltip: TooltipContextValue = {
@@ -13,6 +14,7 @@ export const doNotDisplayTooltip: TooltipContextValue = {
   payload: [],
   coordinate: { x: 0, y: 0 },
   active: false,
+  index: 0,
 };
 
 const TooltipContext = createContext<TooltipContextValue>(doNotDisplayTooltip);

--- a/test/component/Cursor.spec.tsx
+++ b/test/component/Cursor.spec.tsx
@@ -4,33 +4,40 @@ import { render } from '@testing-library/react';
 import { Cursor, CursorProps } from '../../src/component/Cursor';
 import { Tooltip, TooltipProps } from '../../src/component/Tooltip';
 import { assertNotNull } from '../helper/assertNotNull';
+import { TooltipContextProvider, TooltipContextValue } from '../../src/context/tooltipContext';
+import { OffsetContext } from '../../src/context/chartLayoutContext';
 
 function getTooltipElement(props: TooltipProps<any, any>) {
   return <Tooltip {...props} />;
 }
 
 const defaultProps: CursorProps = {
-  activeCoordinate: {
+  chartName: '',
+  element: getTooltipElement({}),
+  layout: 'horizontal',
+  tooltipAxisBandSize: 0,
+  tooltipEventType: 'axis',
+};
+
+const tooltipContext: TooltipContextValue = {
+  label: '',
+  payload: [],
+  coordinate: {
     x: 0,
     y: 0,
   },
-  activePayload: [],
-  activeTooltipIndex: 0,
-  chartName: '',
-  element: getTooltipElement({}),
-  isActive: true,
-  layout: 'horizontal',
-  offset: {},
-  tooltipAxisBandSize: 0,
-  tooltipEventType: 'axis',
+  active: true,
+  index: 0,
 };
 
 describe('Cursor', () => {
   it('should render curve cursor by default', () => {
     const { container } = render(
-      <svg width={100} height={100}>
-        <Cursor {...defaultProps} />
-      </svg>,
+      <TooltipContextProvider value={tooltipContext}>
+        <svg width={100} height={100}>
+          <Cursor {...defaultProps} />
+        </svg>
+      </TooltipContextProvider>,
     );
     const cursor = container.querySelector('.recharts-curve');
     assertNotNull(cursor);
@@ -46,9 +53,11 @@ describe('Cursor', () => {
       element: getTooltipElement({ cursor: <MyCustomCursor /> }),
     };
     const { getByText } = render(
-      <svg width={100} height={100}>
-        <Cursor {...props} />
-      </svg>,
+      <TooltipContextProvider value={tooltipContext}>
+        <svg width={100} height={100}>
+          <Cursor {...props} />
+        </svg>
+      </TooltipContextProvider>,
     );
     expect(getByText('I am a cursor.')).toBeVisible();
   });
@@ -59,9 +68,11 @@ describe('Cursor', () => {
       chartName: 'ScatterChart',
     };
     const { container } = render(
-      <svg width={100} height={100}>
-        <Cursor {...props} />
-      </svg>,
+      <TooltipContextProvider value={tooltipContext}>
+        <svg width={100} height={100}>
+          <Cursor {...props} />
+        </svg>
+      </TooltipContextProvider>,
     );
     const cursor = container.querySelector('.recharts-cross');
     assertNotNull(cursor);
@@ -71,17 +82,17 @@ describe('Cursor', () => {
   it('should render rectangle cursor for bar chart', () => {
     const props: CursorProps = {
       ...defaultProps,
-      offset: {
-        top: 0,
-        height: 2,
-      },
       tooltipAxisBandSize: 1,
       chartName: 'BarChart',
     };
     const { container } = render(
-      <svg width={100} height={100}>
-        <Cursor {...props} />
-      </svg>,
+      <OffsetContext.Provider value={{ top: 0, height: 0 }}>
+        <TooltipContextProvider value={tooltipContext}>
+          <svg width={100} height={100}>
+            <Cursor {...props} />
+          </svg>
+        </TooltipContextProvider>
+      </OffsetContext.Provider>,
     );
     const cursor = container.querySelector('.recharts-rectangle');
     assertNotNull(cursor);
@@ -91,19 +102,24 @@ describe('Cursor', () => {
   it('should render sector cursor for radial layout charts', () => {
     const props: CursorProps = {
       ...defaultProps,
-      activeCoordinate: {
+      layout: 'radial',
+    };
+    const radialTooltipContext: TooltipContextValue = {
+      ...tooltipContext,
+      coordinate: {
         endAngle: 2,
         radius: 1,
         startAngle: 1,
         x: 0,
         y: 0,
       },
-      layout: 'radial',
     };
     const { container } = render(
-      <svg width={100} height={100}>
-        <Cursor {...props} />
-      </svg>,
+      <TooltipContextProvider value={radialTooltipContext}>
+        <svg width={100} height={100}>
+          <Cursor {...props} />
+        </svg>
+      </TooltipContextProvider>,
     );
     const cursor = container.querySelector('.recharts-sector');
     assertNotNull(cursor);


### PR DESCRIPTION
## Description

Not quite all props yet. More to come later.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Less element cloning.

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
