### PR TITLE
Add stories to show tooltip, and active dot

### DIFF
--- a/storybook/stories/Examples/AreaChart.stories.tsx
+++ b/storybook/stories/Examples/AreaChart.stories.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { curveCardinal } from 'd3-shape';
-import { pageData } from '../data';
+import { pageData, rangeData } from '../data';
 import { AreaChart, ResponsiveContainer, CartesianGrid, XAxis, YAxis, Tooltip, Area } from '../../../src';
 
 export default {
@@ -56,7 +56,7 @@ export const StackedAreaChart = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
+          <Tooltip active defaultIndex={2} />
           <Area type="monotone" dataKey="uv" stackId="1" stroke="#8884d8" fill="#8884d8" />
           <Area type="monotone" dataKey="pv" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
           <Area type="monotone" dataKey="amt" stackId="1" stroke="#ffc658" fill="#ffc658" />
@@ -133,7 +133,7 @@ export const PercentAreaChart = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="month" />
           <YAxis tickFormatter={toPercent} />
-          <Tooltip content={renderTooltipContent} />
+          <Tooltip content={renderTooltipContent} defaultIndex={3} active />
           <Area type="monotone" dataKey="uv" stackId="1" stroke="#8884d8" fill="#8884d8" />
           <Area type="monotone" dataKey="pv" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
           <Area type="monotone" dataKey="amt" stackId="1" stroke="#ffc658" fill="#ffc658" />
@@ -402,6 +402,31 @@ export const AreaChartFillByValue = {
             </linearGradient>
           </defs>
           <Area type="monotone" dataKey="uv" stroke="#000" fill="url(#splitColor)" />
+        </AreaChart>
+      </ResponsiveContainer>
+    );
+  },
+};
+
+export const AreaChartRange = {
+  render: () => {
+    return (
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart
+          width={500}
+          height={400}
+          data={rangeData}
+          margin={{
+            top: 10,
+            right: 30,
+            left: 0,
+            bottom: 0,
+          }}
+        >
+          <XAxis dataKey="day" />
+          <YAxis />
+          <Tooltip defaultIndex={4} active />
+          <Area dataKey="temperature" stroke="#d82428" fill="#8884d8" />
         </AreaChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart.stories.tsx
@@ -85,7 +85,7 @@ export const Dashed = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
+          <Tooltip defaultIndex={3} active />
           <Legend />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" strokeDasharray="5 5" />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" strokeDasharray="3 4 5 2" />
@@ -114,7 +114,7 @@ export const Vertical = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis type="number" />
           <YAxis dataKey="name" type="category" />
-          <Tooltip />
+          <Tooltip defaultIndex={4} active />
           <Legend />
           <Line dataKey="pv" stroke="#8884d8" />
           <Line dataKey="uv" stroke="#82ca9d" />

--- a/storybook/stories/Examples/RadarChart.stories.tsx
+++ b/storybook/stories/Examples/RadarChart.stories.tsx
@@ -91,7 +91,7 @@ export const RadarWithLegend: StoryObj = {
       <RadarChart data={data} width={360} height={360}>
         <PolarGrid gridType="circle" />
         <Legend />
-        <Tooltip />
+        <Tooltip defaultIndex={2} />
         <PolarRadiusAxis type="number" dataKey="r" />
 
         <PolarAngleAxis dataKey="angle" axisLineType="circle" type="number" domain={[0, 360]} />

--- a/storybook/stories/data/Page.ts
+++ b/storybook/stories/data/Page.ts
@@ -5,6 +5,45 @@ export type PageDataType = {
   amt: number;
 };
 
+export const rangeData = [
+  {
+    day: '05-01',
+    temperature: [-1, 10],
+  },
+  {
+    day: '05-02',
+    temperature: [2, 15],
+  },
+  {
+    day: '05-03',
+    temperature: [3, 12],
+  },
+  {
+    day: '05-04',
+    temperature: [4, 12],
+  },
+  {
+    day: '05-05',
+    temperature: [12, 16],
+  },
+  {
+    day: '05-06',
+    temperature: [5, 16],
+  },
+  {
+    day: '05-07',
+    temperature: [3, 12],
+  },
+  {
+    day: '05-08',
+    temperature: [0, 8],
+  },
+  {
+    day: '05-09',
+    temperature: [-3, 5],
+  },
+];
+
 const pageData: PageDataType[] = [
   {
     name: 'Page A',


### PR DESCRIPTION
## Description

Only storybooks.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

I want to have some baseline screenshots before refactoring the active dots.

## How Has This Been Tested?

storybook

## Screenshots (if appropriate):

You will notice that the "Vertical" example renders cursor in a wrong position; this is only present when using `defaultIndex`. When mouse-hovering the cursor shows correct. I don't have ambitions of fixing that in this PR 😬 

<img width="709" alt="image" src="https://github.com/recharts/recharts/assets/1100170/bfab2fdf-d50d-492e-ba7a-3679a329dc65">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
