### PR TITLE
Active points render separately

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -82,6 +82,7 @@
   "es6/component/Customized.js",
   "es6/component/Cursor.js",
   "es6/component/Cell.js",
+  "es6/component/ActivePoints.js",
   "es6/chart/types.js",
   "es6/chart/generateCategoricalChart.js",
   "es6/chart/Treemap.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -82,6 +82,7 @@
   "lib/component/Customized.js",
   "lib/component/Cursor.js",
   "lib/component/Cell.js",
+  "lib/component/ActivePoints.js",
   "lib/chart/types.js",
   "lib/chart/generateCategoricalChart.js",
   "lib/chart/Treemap.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -82,6 +82,7 @@
   "types/component/Customized.d.ts",
   "types/component/Cursor.d.ts",
   "types/component/Cell.d.ts",
+  "types/component/ActivePoints.d.ts",
   "types/chart/types.d.ts",
   "types/chart/generateCategoricalChart.d.ts",
   "types/chart/Treemap.d.ts",

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -624,6 +624,7 @@ export class Area extends PureComponent<Props, State> {
           {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
         </Layer>
         <ActivePoints
+          hide={hide}
           points={points}
           isRange={this.props.isRange}
           baseLine={this.props.baseLine}

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -624,7 +624,6 @@ export class Area extends PureComponent<Props, State> {
           {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
         </Layer>
         <ActivePoints
-          hide={hide}
           points={points}
           isRange={this.props.isRange}
           baseLine={this.props.baseLine}

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -34,6 +34,7 @@ import {
 import { filterProps, isDotProps } from '../util/ReactUtils';
 import type { Payload as LegendPayload } from '../component/DefaultLegendContent';
 import { useLegendPayloadDispatch } from '../context/legendPayloadContext';
+import { ActivePoints } from '../component/ActivePoints';
 
 interface AreaPointItem extends CurvePoint {
   value?: number | number[];
@@ -47,7 +48,7 @@ interface InternalAreaProps {
   left?: number;
   width?: number;
   height?: number;
-  points?: AreaPointItem[];
+  points?: ReadonlyArray<AreaPointItem>;
   baseLine?: number | Coordinate[];
 }
 
@@ -593,29 +594,44 @@ export class Area extends PureComponent<Props, State> {
     const dotSize = r * 2 + strokeWidth;
 
     return (
-      <Layer className={layerClass}>
-        <SetAreaLegend {...this.props} />
-        {needClipX || needClipY ? (
-          <defs>
-            <clipPath id={`clipPath-${clipPathId}`}>
-              <rect
-                x={needClipX ? left : left - width / 2}
-                y={needClipY ? top : top - height / 2}
-                width={needClipX ? width : width * 2}
-                height={needClipY ? height : height * 2}
-              />
-            </clipPath>
-            {!clipDot && (
-              <clipPath id={`clipPath-dots-${clipPathId}`}>
-                <rect x={left - dotSize / 2} y={top - dotSize / 2} width={width + dotSize} height={height + dotSize} />
+      <>
+        <Layer className={layerClass}>
+          <SetAreaLegend {...this.props} />
+          {needClipX || needClipY ? (
+            <defs>
+              <clipPath id={`clipPath-${clipPathId}`}>
+                <rect
+                  x={needClipX ? left : left - width / 2}
+                  y={needClipY ? top : top - height / 2}
+                  width={needClipX ? width : width * 2}
+                  height={needClipY ? height : height * 2}
+                />
               </clipPath>
-            )}
-          </defs>
-        ) : null}
-        {!hasSinglePoint ? this.renderArea(needClip, clipPathId) : null}
-        {(dot || hasSinglePoint) && this.renderDots(needClip, clipDot, clipPathId)}
-        {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
-      </Layer>
+              {!clipDot && (
+                <clipPath id={`clipPath-dots-${clipPathId}`}>
+                  <rect
+                    x={left - dotSize / 2}
+                    y={top - dotSize / 2}
+                    width={width + dotSize}
+                    height={height + dotSize}
+                  />
+                </clipPath>
+              )}
+            </defs>
+          ) : null}
+          {!hasSinglePoint ? this.renderArea(needClip, clipPathId) : null}
+          {(dot || hasSinglePoint) && this.renderDots(needClip, clipDot, clipPathId)}
+          {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
+        </Layer>
+        <ActivePoints
+          points={points}
+          isRange={this.props.isRange}
+          baseLine={this.props.baseLine}
+          mainColor={getLegendItemColor(this.props.stroke, this.props.fill)}
+          itemDataKey={this.props.dataKey}
+          activeDot={this.props.activeDot}
+        />
+      </>
     );
   }
 }

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -48,7 +48,7 @@ interface InternalAreaProps {
   left?: number;
   width?: number;
   height?: number;
-  points?: ReadonlyArray<AreaPointItem>;
+  points?: AreaPointItem[];
   baseLine?: number | Coordinate[];
 }
 
@@ -505,7 +505,7 @@ export class Area extends PureComponent<Props, State> {
         {({ t }: { t: number }) => {
           if (prevPoints) {
             const prevPointsDiffFactor = prevPoints.length / points.length;
-            // update animtaion
+            // update animation
             const stepPoints = points.map((entry, index) => {
               const prevPointIndex = Math.floor(index * prevPointsDiffFactor);
               if (prevPoints[prevPointIndex]) {
@@ -576,7 +576,8 @@ export class Area extends PureComponent<Props, State> {
   }
 
   render() {
-    const { hide, dot, points, className, top, left, xAxis, yAxis, width, height, isAnimationActive, id } = this.props;
+    const { hide, dot, points, className, top, left, xAxis, yAxis, width, height, isAnimationActive, id, baseLine } =
+      this.props;
 
     if (hide || !points || !points.length) {
       return <SetAreaLegend {...this.props} />;
@@ -625,12 +626,18 @@ export class Area extends PureComponent<Props, State> {
         </Layer>
         <ActivePoints
           points={points}
-          isRange={this.props.isRange}
-          baseLine={this.props.baseLine}
           mainColor={getLegendItemColor(this.props.stroke, this.props.fill)}
           itemDataKey={this.props.dataKey}
           activeDot={this.props.activeDot}
         />
+        {this.props.isRange && Array.isArray(baseLine) && (
+          <ActivePoints
+            points={baseLine}
+            mainColor={getLegendItemColor(this.props.stroke, this.props.fill)}
+            itemDataKey={this.props.dataKey}
+            activeDot={this.props.activeDot}
+          />
+        )}
       </>
     );
   }

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -558,7 +558,6 @@ export class Line extends PureComponent<Props, State> {
           {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
         </Layer>
         <ActivePoints
-          hide={hide}
           activeDot={this.props.activeDot}
           points={points}
           isRange={false}

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -34,6 +34,7 @@ import {
 } from '../util/types';
 import type { Payload as LegendPayload } from '../component/DefaultLegendContent';
 import { useLegendPayloadDispatch } from '../context/legendPayloadContext';
+import { ActivePoints } from '../component/ActivePoints';
 
 export interface LinePointItem extends CurvePoint {
   value?: number;
@@ -45,7 +46,7 @@ interface InternalLineProps {
   left?: number;
   width?: number;
   height?: number;
-  points?: LinePointItem[];
+  points?: ReadonlyArray<LinePointItem>;
   xAxis?: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> };
   yAxis?: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> };
 }
@@ -526,30 +527,45 @@ export class Line extends PureComponent<Props, State> {
     const dotSize = r * 2 + strokeWidth;
 
     return (
-      <Layer className={layerClass}>
-        <SetLineLegend {...this.props} />
-        {needClipX || needClipY ? (
-          <defs>
-            <clipPath id={`clipPath-${clipPathId}`}>
-              <rect
-                x={needClipX ? left : left - width / 2}
-                y={needClipY ? top : top - height / 2}
-                width={needClipX ? width : width * 2}
-                height={needClipY ? height : height * 2}
-              />
-            </clipPath>
-            {!clipDot && (
-              <clipPath id={`clipPath-dots-${clipPathId}`}>
-                <rect x={left - dotSize / 2} y={top - dotSize / 2} width={width + dotSize} height={height + dotSize} />
+      <>
+        <Layer className={layerClass}>
+          <SetLineLegend {...this.props} />
+          {needClipX || needClipY ? (
+            <defs>
+              <clipPath id={`clipPath-${clipPathId}`}>
+                <rect
+                  x={needClipX ? left : left - width / 2}
+                  y={needClipY ? top : top - height / 2}
+                  width={needClipX ? width : width * 2}
+                  height={needClipY ? height : height * 2}
+                />
               </clipPath>
-            )}
-          </defs>
-        ) : null}
-        {!hasSinglePoint && this.renderCurve(needClip, clipPathId)}
-        {this.renderErrorBar(needClip, clipPathId)}
-        {(hasSinglePoint || dot) && this.renderDots(needClip, clipDot, clipPathId)}
-        {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
-      </Layer>
+              {!clipDot && (
+                <clipPath id={`clipPath-dots-${clipPathId}`}>
+                  <rect
+                    x={left - dotSize / 2}
+                    y={top - dotSize / 2}
+                    width={width + dotSize}
+                    height={height + dotSize}
+                  />
+                </clipPath>
+              )}
+            </defs>
+          ) : null}
+          {!hasSinglePoint && this.renderCurve(needClip, clipPathId)}
+          {this.renderErrorBar(needClip, clipPathId)}
+          {(hasSinglePoint || dot) && this.renderDots(needClip, clipDot, clipPathId)}
+          {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
+        </Layer>
+        <ActivePoints
+          activeDot={this.props.activeDot}
+          points={points}
+          isRange={false}
+          baseLine={0}
+          mainColor={this.props.stroke}
+          itemDataKey={this.props.dataKey}
+        />
+      </>
     );
   }
 }

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -46,7 +46,7 @@ interface InternalLineProps {
   left?: number;
   width?: number;
   height?: number;
-  points?: ReadonlyArray<LinePointItem>;
+  points?: LinePointItem[];
   xAxis?: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> };
   yAxis?: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> };
 }
@@ -560,8 +560,6 @@ export class Line extends PureComponent<Props, State> {
         <ActivePoints
           activeDot={this.props.activeDot}
           points={points}
-          isRange={false}
-          baseLine={0}
           mainColor={this.props.stroke}
           itemDataKey={this.props.dataKey}
         />

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -558,6 +558,7 @@ export class Line extends PureComponent<Props, State> {
           {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
         </Layer>
         <ActivePoints
+          hide={hide}
           activeDot={this.props.activeDot}
           points={points}
           isRange={false}

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1872,7 +1872,6 @@ export const generateCategoricalChart = ({
                 activePoint,
                 basePoint,
                 childIndex: activeTooltipIndex,
-                isRange,
                 mainColor: getMainColorOfGraphicItem(item.item),
               }),
             ];

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1868,7 +1868,9 @@ export const generateCategoricalChart = ({
             return [
               graphicalItem,
               renderActivePoints({
-                item,
+                keyPrefix: item.props.key,
+                activeDot: item.item.props.activeDot,
+                dataKey: item.item.props.dataKey,
                 activePoint,
                 basePoint,
                 childIndex: activeTooltipIndex,
@@ -2039,6 +2041,7 @@ export const generateCategoricalChart = ({
                   height={this.props.height}
                   clipPathId={this.clipPathId}
                   margin={this.props.margin}
+                  layout={this.props.layout}
                 >
                   <div
                     className={clsx('recharts-wrapper', className)}

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -42,7 +42,6 @@ import {
   getDomainOfDataByKey,
   getDomainOfItemsWithSameAxis,
   getDomainOfStackGroups,
-  getMainColorOfGraphicItem,
   getStackedDataOfItem,
   getStackGroupsByAxisId,
   getTicksOfAxis,
@@ -1814,7 +1813,7 @@ export const generateCategoricalChart = ({
         return null;
       }
       const tooltipEventType = this.getTooltipEventType();
-      const { isTooltipActive, tooltipAxis, activeTooltipIndex, activeLabel } = this.state;
+      const { isTooltipActive, activeTooltipIndex } = this.state;
       const { children } = this.props;
       const tooltipItem = findChildByType(children, Tooltip);
       const { isRange } = item.props;

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -42,6 +42,7 @@ import {
   getDomainOfDataByKey,
   getDomainOfItemsWithSameAxis,
   getDomainOfStackGroups,
+  getMainColorOfGraphicItem,
   getStackedDataOfItem,
   getStackGroupsByAxisId,
   getTicksOfAxis,
@@ -1872,6 +1873,7 @@ export const generateCategoricalChart = ({
                 basePoint,
                 childIndex: activeTooltipIndex,
                 isRange,
+                mainColor: getMainColorOfGraphicItem(item.item),
               }),
             ];
           }

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1867,15 +1867,15 @@ export const generateCategoricalChart = ({
           if (!isNil(activePoint)) {
             return [
               graphicalItem,
-              renderActivePoints({
-                keyPrefix: item.props.key,
-                activeDot: item.item.props.activeDot,
-                dataKey: item.item.props.dataKey,
-                activePoint,
-                basePoint,
-                childIndex: activeTooltipIndex,
-                mainColor: getMainColorOfGraphicItem(item.item),
-              }),
+              // renderActivePoints({
+              //   keyPrefix: item.props.key,
+              //   activeDot: item.item.props.activeDot,
+              //   dataKey: item.item.props.dataKey,
+              //   activePoint,
+              //   basePoint,
+              //   childIndex: activeTooltipIndex,
+              //   mainColor: getMainColorOfGraphicItem(item.item),
+              // }),
             ];
           }
         } else {
@@ -2003,6 +2003,7 @@ export const generateCategoricalChart = ({
             height={this.props.height}
             clipPathId={this.clipPathId}
             margin={this.props.margin}
+            layout={this.props.layout}
           >
             <Surface {...attrs} width={width} height={height} title={title} desc={desc}>
               <ClipPath clipPathId={this.clipPathId} offset={this.state.offset} />

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -92,7 +92,6 @@ const renderActivePoints = ({
 };
 
 type ActivePointsProps = {
-  hide: boolean;
   points: ReadonlyArray<PointType>;
   isRange: boolean;
   baseLine: number | Coordinate[];
@@ -105,18 +104,10 @@ type ActivePointsProps = {
   activeDot: ActiveDotType;
 };
 
-export function ActivePoints({
-  hide,
-  points,
-  isRange,
-  baseLine,
-  mainColor,
-  activeDot,
-  itemDataKey,
-}: ActivePointsProps) {
+export function ActivePoints({ points, isRange, baseLine, mainColor, activeDot, itemDataKey }: ActivePointsProps) {
   const tooltipAxis = useTooltipAxis();
   const { active: isTooltipActive, index: activeTooltipIndex, label: activeLabel } = useTooltipContext();
-  const hasActive = Boolean(!hide && isTooltipActive);
+  const hasActive = Boolean(isTooltipActive);
 
   if (!hasActive) {
     return null;

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -4,7 +4,7 @@ import { ActiveDotType, adaptEventHandlers, Coordinate, DataKey } from '../util/
 import { filterProps } from '../util/ReactUtils';
 import { Dot, Props as DotProps } from '../shape/Dot';
 import { Layer } from '../container/Layer';
-import { useCartesianTooltipAxis } from '../context/chartLayoutContext';
+import { useTooltipAxis } from '../context/chartLayoutContext';
 import { useTooltipContext } from '../context/tooltipContext';
 import { findEntryInArray } from '../util/DataUtils';
 import isNil from 'lodash/isNil';
@@ -92,7 +92,7 @@ export const renderActivePoints = ({
 };
 
 type ActivePointsProps = {
-  hide?: boolean;
+  hide: boolean;
   points: ReadonlyArray<PointType>;
   isRange: boolean;
   baseLine: number | Coordinate[];
@@ -114,7 +114,7 @@ export function ActivePoints({
   activeDot,
   itemDataKey,
 }: ActivePointsProps) {
-  const tooltipAxis = useCartesianTooltipAxis();
+  const tooltipAxis = useTooltipAxis();
   const { active: isTooltipActive, index: activeTooltipIndex, label: activeLabel } = useTooltipContext();
   const hasActive = Boolean(!hide && isTooltipActive);
 

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -1,9 +1,13 @@
 import React, { cloneElement, isValidElement } from 'react';
 import isFunction from 'lodash/isFunction';
-import { ActiveDotType, adaptEventHandlers, DataKey } from '../util/types';
+import { ActiveDotType, adaptEventHandlers, Coordinate, DataKey } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { Dot, Props as DotProps } from '../shape/Dot';
 import { Layer } from '../container/Layer';
+import { useCartesianTooltipAxis } from '../context/chartLayoutContext';
+import { useTooltipContext } from '../context/tooltipContext';
+import { findEntryInArray } from '../util/DataUtils';
+import isNil from 'lodash/isNil';
 
 const renderActiveDot = (option: ActiveDotType, props: DotProps): React.ReactElement => {
   let dot;
@@ -86,3 +90,66 @@ export const renderActivePoints = ({
 
   return result;
 };
+
+type ActivePointsProps = {
+  hide?: boolean;
+  points: ReadonlyArray<PointType>;
+  isRange: boolean;
+  baseLine: number | Coordinate[];
+  /**
+   * Different graphical elements have different opinion on what is their main color.
+   * Sometimes stroke, sometimes fill, sometimes combination.
+   */
+  mainColor: string;
+  itemDataKey: DataKey<any>;
+  activeDot: ActiveDotType;
+};
+
+export function ActivePoints({
+  hide,
+  points,
+  isRange,
+  baseLine,
+  mainColor,
+  activeDot,
+  itemDataKey,
+}: ActivePointsProps) {
+  const tooltipAxis = useCartesianTooltipAxis();
+  const { active: isTooltipActive, index: activeTooltipIndex, label: activeLabel } = useTooltipContext();
+  const hasActive = Boolean(!hide && isTooltipActive);
+
+  if (!hasActive) {
+    return null;
+  }
+
+  let activePoint: PointType, basePoint: PointType;
+
+  const tooltipAxisDataKey = tooltipAxis.dataKey;
+  if (tooltipAxisDataKey && !tooltipAxis.allowDuplicatedCategory) {
+    const specifiedKey =
+      typeof tooltipAxisDataKey === 'function'
+        ? (point: PointType) => tooltipAxisDataKey(point.payload)
+        : `payload.${tooltipAxisDataKey}`;
+    activePoint = findEntryInArray(points, specifiedKey, activeLabel);
+    // @ts-expect-error doesn't handle the case where baseLine is number
+    basePoint = isRange && baseLine && findEntryInArray(baseLine, specifiedKey, activeLabel);
+  } else {
+    activePoint = points?.[activeTooltipIndex];
+    // @ts-expect-error doesn't handle the case where baseLine is number
+    basePoint = isRange && baseLine && baseLine[activeTooltipIndex];
+  }
+
+  if (!isNil(activePoint)) {
+    return renderActivePoints({
+      activePoint,
+      basePoint,
+      childIndex: activeTooltipIndex,
+      mainColor,
+      dataKey: itemDataKey,
+      activeDot,
+      keyPrefix: '',
+    });
+  }
+
+  return null;
+}

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -1,6 +1,6 @@
 import React, { cloneElement, isValidElement } from 'react';
 import isFunction from 'lodash/isFunction';
-import { ActiveDotType, adaptEventHandlers, Coordinate, DataKey } from '../util/types';
+import { ActiveDotType, adaptEventHandlers, DataKey } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { Dot, Props as DotProps } from '../shape/Dot';
 import { Layer } from '../container/Layer';
@@ -53,7 +53,6 @@ const renderActivePoints = ({
    */
   mainColor: string;
 }) => {
-  const result = [];
   const dotProps: DotProps = {
     // @ts-expect-error Dot does not expect the 'index' prop
     index: childIndex,
@@ -70,9 +69,7 @@ const renderActivePoints = ({
     ...adaptEventHandlers(activeDot),
   };
 
-  result.push(renderActiveDot(activeDot, dotProps));
-
-  return result;
+  return <>{renderActiveDot(activeDot, dotProps)}</>;
 };
 
 type ActivePointsProps = {
@@ -95,7 +92,7 @@ export function ActivePoints({ points, mainColor, activeDot, itemDataKey }: Acti
     return null;
   }
 
-  let activePoint: PointType, basePoint: PointType;
+  let activePoint: PointType;
 
   const tooltipAxisDataKey = tooltipAxis.dataKey;
   if (tooltipAxisDataKey && !tooltipAxis.allowDuplicatedCategory) {

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -1,15 +1,15 @@
 import React, { cloneElement, isValidElement } from 'react';
 import isFunction from 'lodash/isFunction';
 import { ActiveDotType, adaptEventHandlers, DataKey } from '../util/types';
-import { getMainColorOfGraphicItem } from '../util/ChartUtils';
 import { filterProps } from '../util/ReactUtils';
-import { Dot } from '../shape/Dot';
+import { Dot, Props as DotProps } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 
-const renderActiveDot = (option: any, props: any): React.ReactElement => {
+const renderActiveDot = (option: ActiveDotType, props: DotProps): React.ReactElement => {
   let dot;
 
   if (isValidElement(option)) {
+    // @ts-expect-error element cloning does not have types
     dot = cloneElement(option, props);
   } else if (isFunction(option)) {
     dot = option(props);
@@ -30,13 +30,13 @@ export const renderActivePoints = ({
   basePoint,
   childIndex,
   isRange,
+  mainColor,
 }: {
   // The graphical item, for example Area or Bar.
   item: {
     props: { key: string };
     item: {
-      type: { displayName: string };
-      props: { hide: boolean; activeDot: ActiveDotType; dataKey: DataKey<any>; stroke: string; fill: string };
+      props: { hide: boolean; activeDot: ActiveDotType; dataKey: DataKey<any> };
     };
   };
   // found in points array
@@ -45,6 +45,11 @@ export const renderActivePoints = ({
   basePoint: any;
   childIndex: number;
   isRange: boolean;
+  /**
+   * Different graphical elements have different opinion on what is their main color.
+   * Sometimes stroke, sometimes fill, sometimes combination.
+   */
+  mainColor: string;
 }) => {
   const { activeDot, dataKey } = item.item.props;
   const result = [];
@@ -57,7 +62,7 @@ export const renderActivePoints = ({
     cx: activePoint.x,
     cy: activePoint.y,
     r: 4,
-    fill: getMainColorOfGraphicItem(item.item),
+    fill: mainColor,
     strokeWidth: 2,
     stroke: '#fff',
     payload: activePoint.payload,

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -29,7 +29,6 @@ export const renderActivePoints = ({
   activePoint,
   basePoint,
   childIndex,
-  isRange,
   mainColor,
 }: {
   // The graphical item, for example Area or Bar.
@@ -44,7 +43,6 @@ export const renderActivePoints = ({
 
   basePoint: any;
   childIndex: number;
-  isRange: boolean;
   /**
    * Different graphical elements have different opinion on what is their main color.
    * Sometimes stroke, sometimes fill, sometimes combination.
@@ -83,8 +81,6 @@ export const renderActivePoints = ({
         key: `${key}-basePoint-${childIndex}`,
       }),
     );
-  } else if (isRange) {
-    result.push(null);
   }
 
   return result;

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -24,37 +24,38 @@ const renderActiveDot = (option: ActiveDotType, props: DotProps): React.ReactEle
   );
 };
 
+export interface PointType {
+  x: number;
+  y: number;
+  value: any;
+  payload: any;
+}
+
 export const renderActivePoints = ({
-  item,
   activePoint,
   basePoint,
   childIndex,
   mainColor,
+  activeDot,
+  dataKey,
+  keyPrefix,
 }: {
-  // The graphical item, for example Area or Bar.
-  item: {
-    props: { key: string };
-    item: {
-      props: { hide: boolean; activeDot: ActiveDotType; dataKey: DataKey<any> };
-    };
-  };
   // found in points array
-  activePoint: any;
-
-  basePoint: any;
+  activePoint: PointType;
+  activeDot: ActiveDotType;
+  basePoint: PointType;
   childIndex: number;
+  dataKey: DataKey<any>;
   /**
    * Different graphical elements have different opinion on what is their main color.
    * Sometimes stroke, sometimes fill, sometimes combination.
    */
   mainColor: string;
+  keyPrefix: string;
 }) => {
-  const { activeDot, dataKey } = item.item.props;
   const result = [];
-  // item.props is whatever getComposedData returns
-  const { key } = item.props;
-  // item.item.props are the original props on the DOM element
-  const dotProps = {
+  const dotProps: DotProps = {
+    // @ts-expect-error Dot does not expect the 'index' prop
     index: childIndex,
     dataKey,
     cx: activePoint.x,
@@ -65,7 +66,7 @@ export const renderActivePoints = ({
     stroke: '#fff',
     payload: activePoint.payload,
     value: activePoint.value,
-    key: `${key}-activePoint-${childIndex}`,
+    key: `${keyPrefix}-activePoint-${childIndex}`,
     ...filterProps(activeDot, false),
     ...adaptEventHandlers(activeDot),
   };
@@ -78,7 +79,7 @@ export const renderActivePoints = ({
         ...dotProps,
         cx: basePoint.x,
         cy: basePoint.y,
-        key: `${key}-basePoint-${childIndex}`,
+        key: `${keyPrefix}-basePoint-${childIndex}`,
       }),
     );
   }

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -35,7 +35,7 @@ export interface PointType {
   readonly payload?: any;
 }
 
-export const renderActivePoints = ({
+const renderActivePoints = ({
   activePoint,
   basePoint,
   childIndex,

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -1,0 +1,86 @@
+import React, { cloneElement, isValidElement } from 'react';
+import isFunction from 'lodash/isFunction';
+import { ActiveDotType, adaptEventHandlers, DataKey } from '../util/types';
+import { getMainColorOfGraphicItem } from '../util/ChartUtils';
+import { filterProps } from '../util/ReactUtils';
+import { Dot } from '../shape/Dot';
+import { Layer } from '../container/Layer';
+
+const renderActiveDot = (option: any, props: any): React.ReactElement => {
+  let dot;
+
+  if (isValidElement(option)) {
+    dot = cloneElement(option, props);
+  } else if (isFunction(option)) {
+    dot = option(props);
+  } else {
+    dot = <Dot {...props} />;
+  }
+
+  return (
+    <Layer className="recharts-active-dot" key={props.key}>
+      {dot}
+    </Layer>
+  );
+};
+
+export const renderActivePoints = ({
+  item,
+  activePoint,
+  basePoint,
+  childIndex,
+  isRange,
+}: {
+  // The graphical item, for example Area or Bar.
+  item: {
+    props: { key: string };
+    item: {
+      type: { displayName: string };
+      props: { hide: boolean; activeDot: ActiveDotType; dataKey: DataKey<any>; stroke: string; fill: string };
+    };
+  };
+  // found in points array
+  activePoint: any;
+
+  basePoint: any;
+  childIndex: number;
+  isRange: boolean;
+}) => {
+  const { activeDot, dataKey } = item.item.props;
+  const result = [];
+  // item.props is whatever getComposedData returns
+  const { key } = item.props;
+  // item.item.props are the original props on the DOM element
+  const dotProps = {
+    index: childIndex,
+    dataKey,
+    cx: activePoint.x,
+    cy: activePoint.y,
+    r: 4,
+    fill: getMainColorOfGraphicItem(item.item),
+    strokeWidth: 2,
+    stroke: '#fff',
+    payload: activePoint.payload,
+    value: activePoint.value,
+    key: `${key}-activePoint-${childIndex}`,
+    ...filterProps(activeDot, false),
+    ...adaptEventHandlers(activeDot),
+  };
+
+  result.push(renderActiveDot(activeDot, dotProps));
+
+  if (basePoint) {
+    result.push(
+      renderActiveDot(activeDot, {
+        ...dotProps,
+        cx: basePoint.x,
+        cy: basePoint.y,
+        key: `${key}-basePoint-${childIndex}`,
+      }),
+    );
+  } else if (isRange) {
+    result.push(null);
+  }
+
+  return result;
+};

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -37,17 +37,14 @@ export interface PointType {
 
 const renderActivePoints = ({
   activePoint,
-  basePoint,
   childIndex,
   mainColor,
   activeDot,
   dataKey,
-  keyPrefix,
 }: {
   // found in points array
   activePoint: PointType;
   activeDot: ActiveDotType;
-  basePoint: PointType;
   childIndex: number;
   dataKey: DataKey<any>;
   /**
@@ -55,7 +52,6 @@ const renderActivePoints = ({
    * Sometimes stroke, sometimes fill, sometimes combination.
    */
   mainColor: string;
-  keyPrefix: string;
 }) => {
   const result = [];
   const dotProps: DotProps = {
@@ -70,31 +66,17 @@ const renderActivePoints = ({
     stroke: '#fff',
     payload: activePoint.payload,
     value: activePoint.value,
-    key: `${keyPrefix}-activePoint-${childIndex}`,
     ...filterProps(activeDot, false),
     ...adaptEventHandlers(activeDot),
   };
 
   result.push(renderActiveDot(activeDot, dotProps));
 
-  if (basePoint) {
-    result.push(
-      renderActiveDot(activeDot, {
-        ...dotProps,
-        cx: basePoint.x,
-        cy: basePoint.y,
-        key: `${keyPrefix}-basePoint-${childIndex}`,
-      }),
-    );
-  }
-
   return result;
 };
 
 type ActivePointsProps = {
   points: ReadonlyArray<PointType>;
-  isRange: boolean;
-  baseLine: number | Coordinate[];
   /**
    * Different graphical elements have different opinion on what is their main color.
    * Sometimes stroke, sometimes fill, sometimes combination.
@@ -104,7 +86,7 @@ type ActivePointsProps = {
   activeDot: ActiveDotType;
 };
 
-export function ActivePoints({ points, isRange, baseLine, mainColor, activeDot, itemDataKey }: ActivePointsProps) {
+export function ActivePoints({ points, mainColor, activeDot, itemDataKey }: ActivePointsProps) {
   const tooltipAxis = useTooltipAxis();
   const { active: isTooltipActive, index: activeTooltipIndex, label: activeLabel } = useTooltipContext();
   const hasActive = Boolean(isTooltipActive);
@@ -122,23 +104,17 @@ export function ActivePoints({ points, isRange, baseLine, mainColor, activeDot, 
         ? (point: PointType) => tooltipAxisDataKey(point.payload)
         : `payload.${tooltipAxisDataKey}`;
     activePoint = findEntryInArray(points, specifiedKey, activeLabel);
-    // @ts-expect-error doesn't handle the case where baseLine is number
-    basePoint = isRange && baseLine && findEntryInArray(baseLine, specifiedKey, activeLabel);
   } else {
     activePoint = points?.[activeTooltipIndex];
-    // @ts-expect-error doesn't handle the case where baseLine is number
-    basePoint = isRange && baseLine && baseLine[activeTooltipIndex];
   }
 
   if (!isNil(activePoint)) {
     return renderActivePoints({
       activePoint,
-      basePoint,
       childIndex: activeTooltipIndex,
       mainColor,
       dataKey: itemDataKey,
       activeDot,
-      keyPrefix: '',
     });
   }
 

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -29,10 +29,10 @@ const renderActiveDot = (option: ActiveDotType, props: DotProps): React.ReactEle
 };
 
 export interface PointType {
-  x: number;
-  y: number;
-  value: any;
-  payload: any;
+  readonly x: number;
+  readonly y: number;
+  readonly value?: any;
+  readonly payload?: any;
 }
 
 export const renderActivePoints = ({

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -329,12 +329,20 @@ export const useUpdateId = () => `brush-${useContext(UpdateIdContext)}`;
 
 export const useChartLayout = () => useContext(LayoutContext);
 
-export const useCartesianTooltipAxis = () => {
+export const useTooltipAxis = () => {
   const layout = useChartLayout();
   const xAxis = useArbitraryXAxis();
   const yAxis = useArbitraryYAxis();
+  const angleAxis = useArbitraryPolarAngleAxis();
+  const radiusAxis = useArbitraryPolarRadiusAxis();
   if (layout === 'horizontal') {
     return xAxis;
   }
-  return yAxis;
+  if (layout === 'vertical') {
+    return yAxis;
+  }
+  if (layout === 'centric') {
+    return angleAxis;
+  }
+  return radiusAxis;
 };

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -5,6 +5,7 @@ import every from 'lodash/every';
 import {
   CartesianViewBox,
   ChartOffset,
+  LayoutType,
   Margin,
   PolarAngleAxisMap,
   PolarRadiusAxisMap,
@@ -32,7 +33,7 @@ export const ClipPathIdContext = createContext<string | undefined>(undefined);
 export const ChartHeightContext = createContext<number>(0);
 export const ChartWidthContext = createContext<number>(0);
 export const MarginContext = createContext<Margin>({ top: 5, right: 5, bottom: 5, left: 5 });
-
+const LayoutContext = createContext<LayoutType>('horizontal');
 // is the updateId necessary? Can we do without? Perhaps hook dependencies are better than explicit updateId.
 const UpdateIdContext = createContext<number>(0);
 
@@ -43,6 +44,7 @@ export type ChartLayoutContextProviderProps = {
   width: number;
   height: number;
   margin: Margin;
+  layout: LayoutType;
 };
 
 /**
@@ -75,6 +77,7 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
     width,
     height,
     margin,
+    layout,
   } = props;
 
   /**
@@ -98,41 +101,45 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
    * If we do that with one context, then we force re-render on components that might not even be interested
    * in the part of the state that has changed.
    *
-   * By splitting into smaller contexts, we allow each components to be optimized and only re-render when its dependencies change.
+   * By splitting into smaller contexts, we allow each component to be optimized and only re-render when its dependencies change.
    *
    * To actually achieve the optimal re-render, it is necessary to use React.memo().
    * See the test file for details.
    */
   return (
-    <UpdateIdContext.Provider value={updateId}>
-      <DataStartIndexContextProvider value={dataStartIndex}>
-        <DataEndIndexContextProvider value={dataEndIndex}>
-          <MarginContext.Provider value={margin}>
-            <LegendPayloadProvider>
-              <XAxisContext.Provider value={xAxisMap}>
-                <YAxisContext.Provider value={yAxisMap}>
-                  <PolarAngleAxisContext.Provider value={angleAxisMap}>
-                    <PolarRadiusAxisContext.Provider value={radiusAxisMap}>
-                      <OffsetContext.Provider value={offset}>
-                        <ViewBoxContext.Provider value={viewBox}>
-                          <ClipPathIdContext.Provider value={clipPathId}>
-                            <ChartHeightContext.Provider value={height}>
-                              <ChartWidthContext.Provider value={width}>
-                                <TooltipContextProvider value={tooltipContextValue}>{children}</TooltipContextProvider>
-                              </ChartWidthContext.Provider>
-                            </ChartHeightContext.Provider>
-                          </ClipPathIdContext.Provider>
-                        </ViewBoxContext.Provider>
-                      </OffsetContext.Provider>
-                    </PolarRadiusAxisContext.Provider>
-                  </PolarAngleAxisContext.Provider>
-                </YAxisContext.Provider>
-              </XAxisContext.Provider>
-            </LegendPayloadProvider>
-          </MarginContext.Provider>
-        </DataEndIndexContextProvider>
-      </DataStartIndexContextProvider>
-    </UpdateIdContext.Provider>
+    <LayoutContext.Provider value={layout}>
+      <UpdateIdContext.Provider value={updateId}>
+        <DataStartIndexContextProvider value={dataStartIndex}>
+          <DataEndIndexContextProvider value={dataEndIndex}>
+            <MarginContext.Provider value={margin}>
+              <LegendPayloadProvider>
+                <XAxisContext.Provider value={xAxisMap}>
+                  <YAxisContext.Provider value={yAxisMap}>
+                    <PolarAngleAxisContext.Provider value={angleAxisMap}>
+                      <PolarRadiusAxisContext.Provider value={radiusAxisMap}>
+                        <OffsetContext.Provider value={offset}>
+                          <ViewBoxContext.Provider value={viewBox}>
+                            <ClipPathIdContext.Provider value={clipPathId}>
+                              <ChartHeightContext.Provider value={height}>
+                                <ChartWidthContext.Provider value={width}>
+                                  <TooltipContextProvider value={tooltipContextValue}>
+                                    {children}
+                                  </TooltipContextProvider>
+                                </ChartWidthContext.Provider>
+                              </ChartHeightContext.Provider>
+                            </ClipPathIdContext.Provider>
+                          </ViewBoxContext.Provider>
+                        </OffsetContext.Provider>
+                      </PolarRadiusAxisContext.Provider>
+                    </PolarAngleAxisContext.Provider>
+                  </YAxisContext.Provider>
+                </XAxisContext.Provider>
+              </LegendPayloadProvider>
+            </MarginContext.Provider>
+          </DataEndIndexContextProvider>
+        </DataStartIndexContextProvider>
+      </UpdateIdContext.Provider>
+    </LayoutContext.Provider>
   );
 };
 
@@ -319,3 +326,15 @@ export const useMargin = (): Margin => {
 };
 
 export const useUpdateId = () => `brush-${useContext(UpdateIdContext)}`;
+
+export const useChartLayout = () => useContext(LayoutContext);
+
+export const useCartesianTooltipAxis = () => {
+  const layout = useChartLayout();
+  const xAxis = useArbitraryXAxis();
+  const yAxis = useArbitraryYAxis();
+  if (layout === 'horizontal') {
+    return xAxis;
+  }
+  return yAxis;
+};

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -392,7 +392,6 @@ export class Radar extends PureComponent<Props, State> {
           {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
         </Layer>
         <ActivePoints
-          hide={hide}
           points={points}
           isRange={false}
           baseLine={0}

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -1,6 +1,3 @@
-/**
- * @fileOverview Radar
- */
 import React, { PureComponent, ReactElement, MouseEvent, SVGProps } from 'react';
 import Animate from 'react-smooth';
 import isNil from 'lodash/isNil';
@@ -24,6 +21,7 @@ import { Props as PolarAngleAxisProps } from './PolarAngleAxis';
 import { Props as PolarRadiusAxisProps } from './PolarRadiusAxis';
 import { useLegendPayloadDispatch } from '../context/legendPayloadContext';
 import type { Payload as LegendPayload } from '../component/DefaultLegendContent';
+import { ActivePoints } from '../component/ActivePoints';
 
 interface RadarPoint {
   x: number;
@@ -387,11 +385,22 @@ export class Radar extends PureComponent<Props, State> {
     const layerClass = clsx('recharts-radar', className);
 
     return (
-      <Layer className={layerClass}>
-        <SetRadarPayloadLegend {...this.props} />
-        {this.renderPolygon()}
-        {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
-      </Layer>
+      <>
+        <Layer className={layerClass}>
+          <SetRadarPayloadLegend {...this.props} />
+          {this.renderPolygon()}
+          {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
+        </Layer>
+        <ActivePoints
+          hide={hide}
+          points={points}
+          isRange={false}
+          baseLine={0}
+          mainColor={getLegendItemColor(this.props.stroke, this.props.fill)}
+          itemDataKey={this.props.dataKey}
+          activeDot={this.props.activeDot}
+        />
+      </>
     );
   }
 }

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -393,8 +393,6 @@ export class Radar extends PureComponent<Props, State> {
         </Layer>
         <ActivePoints
           points={points}
-          isRange={false}
-          baseLine={0}
           mainColor={getLegendItemColor(this.props.stroke, this.props.fill)}
           itemDataKey={this.props.dataKey}
           activeDot={this.props.activeDot}

--- a/src/util/DataUtils.ts
+++ b/src/util/DataUtils.ts
@@ -104,7 +104,7 @@ export const interpolateNumber = (numberA: number, numberB: number) => {
 };
 
 export function findEntryInArray<T>(
-  ary: Array<T>,
+  ary: ReadonlyArray<T>,
   specifiedKey: number | string | ((entry: T) => unknown),
   specifiedValue: unknown,
 ) {

--- a/test/component/Tooltip/ActiveDot.spec.tsx
+++ b/test/component/Tooltip/ActiveDot.spec.tsx
@@ -111,7 +111,6 @@ describe('ActiveDot', () => {
         dataKey: 'uv',
         fill: '#3182bd',
         index: 2,
-        key: 'item-0-activePoint-2',
         payload: {
           amt: 2400,
           name: 'Page C',
@@ -219,7 +218,6 @@ describe('ActiveDot', () => {
         dataKey: 'uv',
         fill: '#3182bd',
         index: 2,
-        key: 'item-0-activePoint-2',
         payload: {
           amt: 2400,
           name: 'Page C',
@@ -327,7 +325,6 @@ describe('ActiveDot', () => {
         dataKey: 'uv',
         fill: '#3182bd',
         index: 2,
-        key: 'item-0-activePoint-2',
         payload: {
           amt: 2400,
           name: 'Page C',
@@ -433,7 +430,6 @@ describe('ActiveDot', () => {
         cy: 244.245,
         dataKey: 'uv',
         index: 5,
-        key: 'item-0-activePoint-5',
         payload: {
           amt: 2400,
           name: 'Page F',

--- a/test/context/chartLayoutContext.spec.tsx
+++ b/test/context/chartLayoutContext.spec.tsx
@@ -27,6 +27,7 @@ describe('ChartLayoutContextProvider', () => {
     width: 100,
     height: 100,
     children: <div />,
+    layout: 'horizontal',
   };
 
   describe('ClipPathIdContext', () => {


### PR DESCRIPTION
## Description

Active points of Area, Line, and Radar render directly from the graphical components instead of going through `generateCategoricalChart`.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

No element cloning.

## How Has This Been Tested?

tests passing
no visual diff: https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=826

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
