### PR TITLE
Remove Bar case from getItemByXY

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -13,7 +13,6 @@ import invariant from 'tiny-invariant';
 import { Surface } from '../container/Surface';
 import { Tooltip } from '../component/Tooltip';
 import { Legend } from '../component/Legend';
-import { isInRectangle } from '../shape/Rectangle';
 
 import {
   filterProps,
@@ -1898,17 +1897,7 @@ export const generateCategoricalChart = ({
           const { props, item } = graphicalItem;
           const itemDisplayName = getDisplayName(item.type);
 
-          if (itemDisplayName === 'Bar') {
-            const activeBarItem = (props.data || []).find(
-              (entry: { x: number; y: number; width: number; height: number }) => {
-                return isInRectangle(chartXY, entry);
-              },
-            );
-
-            if (activeBarItem) {
-              return { graphicalItem, payload: activeBarItem };
-            }
-          } else if (itemDisplayName === 'RadialBar') {
+          if (itemDisplayName === 'RadialBar') {
             const activeBarItem = (props.data || []).find((entry: GeometrySector) => {
               return inRangeOfSector(chartXY, entry);
             });

--- a/src/shape/Rectangle.tsx
+++ b/src/shape/Rectangle.tsx
@@ -78,28 +78,6 @@ interface RectangleProps {
   animationEasing?: AnimationTiming;
 }
 
-export const isInRectangle = (
-  point: { x: number; y: number },
-  rect: { x: number; y: number; width: number; height: number },
-): boolean => {
-  if (!point || !rect) {
-    return false;
-  }
-  const { x: px, y: py } = point;
-  const { x, y, width, height } = rect;
-
-  if (Math.abs(width) > 0 && Math.abs(height) > 0) {
-    const minX = Math.min(x, x + width);
-    const maxX = Math.max(x, x + width);
-    const minY = Math.min(y, y + height);
-    const maxY = Math.max(y, y + height);
-
-    return px >= minX && px <= maxX && py >= minY && py <= maxY;
-  }
-
-  return false;
-};
-
 export type Props = Omit<SVGProps<SVGPathElement>, 'radius'> & RectangleProps;
 
 const defaultProps = {


### PR DESCRIPTION
## Description

This code is never executed. There is no combination of props and state that goes this path so this is a dead code.

Further evidenced by the lack of coverage: https://app.codecov.io/gh/recharts/recharts/blob/3.x/src%2Fshape%2FRectangle.tsx#L81

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Remove unused code

## How Has This Been Tested?

storybooks

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
