### PR TITLE
Remove RadialBar branch from getItemByXY

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1867,7 +1867,7 @@ export const generateCategoricalChart = ({
          */
         const {
           graphicalItem: { item: xyItem = element, childIndex },
-        } = this.getItemByXY() ?? { graphicalItem };
+        } = this.getItemByActiveIndex() ?? { graphicalItem };
 
         const elementProps = { ...item.props, ...itemEvents, activeIndex: childIndex };
 
@@ -1888,7 +1888,7 @@ export const generateCategoricalChart = ({
         ...this.state,
       });
 
-    public getItemByXY() {
+    public getItemByActiveIndex() {
       const { formattedGraphicalItems, activeItem } = this.state;
       if (formattedGraphicalItems && formattedGraphicalItems.length) {
         for (let i = 0, len = formattedGraphicalItems.length; i < len; i++) {

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -65,7 +65,6 @@ import {
   ChartOffset,
   Coordinate,
   DataKey,
-  GeometrySector,
   LayoutType,
   Margin,
   MouseInfo,
@@ -1868,7 +1867,7 @@ export const generateCategoricalChart = ({
          */
         const {
           graphicalItem: { item: xyItem = element, childIndex },
-        } = this.getItemByXY(this.state.activeCoordinate) ?? { graphicalItem };
+        } = this.getItemByXY() ?? { graphicalItem };
 
         const elementProps = { ...item.props, ...itemEvents, activeIndex: childIndex };
 
@@ -1889,23 +1888,14 @@ export const generateCategoricalChart = ({
         ...this.state,
       });
 
-    public getItemByXY(chartXY: { x: number; y: number }) {
+    public getItemByXY() {
       const { formattedGraphicalItems, activeItem } = this.state;
       if (formattedGraphicalItems && formattedGraphicalItems.length) {
         for (let i = 0, len = formattedGraphicalItems.length; i < len; i++) {
           const graphicalItem = formattedGraphicalItems[i];
-          const { props, item } = graphicalItem;
-          const itemDisplayName = getDisplayName(item.type);
+          const { item } = graphicalItem;
 
-          if (itemDisplayName === 'RadialBar') {
-            const activeBarItem = (props.data || []).find((entry: GeometrySector) => {
-              return inRangeOfSector(chartXY, entry);
-            });
-
-            if (activeBarItem) {
-              return { graphicalItem, payload: activeBarItem };
-            }
-          } else if (
+          if (
             isFunnel(graphicalItem, activeItem) ||
             isPie(graphicalItem, activeItem) ||
             isScatter(graphicalItem, activeItem)


### PR DESCRIPTION
## Description

it's unreachable code for two reasons:

1. ~RadialBar does not have `activeBar` prop~ it does have `activeShape` prop! But it's still not reaching this code because of reason (2)
2. ~Even if I go ahead and add the `activeBar` prop (it doesn't do anything) and then silence it with typescript,~ it still doesn't reach this branch because activeTooltipIndex defaults to zero

Same story as Bar before: https://github.com/recharts/recharts/pull/4408

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Remove dead code

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
