### PR TITLE
fix(layer-types): use SVGAttributes instead of SVGProps in forwardRef components, fix Pie refs

### DIFF
--- a/src/container/Layer.tsx
+++ b/src/container/Layer.tsx
@@ -1,7 +1,4 @@
-/**
- * @fileOverview Layer
- */
-import React, { ReactNode, SVGProps } from 'react';
+import React, { ReactNode, SVGAttributes } from 'react';
 import clsx from 'clsx';
 import { filterProps } from '../util/ReactUtils';
 
@@ -10,9 +7,9 @@ interface LayerProps {
   children?: ReactNode;
 }
 
-export type Props = SVGProps<SVGGElement> & LayerProps;
+export type Props = SVGAttributes<SVGGElement> & LayerProps;
 
-export const Layer = React.forwardRef((props: Props, ref: any) => {
+export const Layer = React.forwardRef<SVGGElement, Props>((props: Props, ref) => {
   const { children, className, ...others } = props;
   const layerClass = clsx('recharts-layer', className);
 

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -135,9 +135,9 @@ interface State {
 export type Props = PresentationAttributesAdaptChildEvent<any, SVGElement> & PieProps;
 
 export class Pie extends PureComponent<Props, State> {
-  pieRef: HTMLElement = null;
+  pieRef: SVGGElement = null;
 
-  sectorRefs: HTMLElement[] = [];
+  sectorRefs: SVGGElement[] = [];
 
   static displayName = 'Pie';
 
@@ -497,7 +497,7 @@ export class Pie extends PureComponent<Props, State> {
       };
       return (
         <Layer
-          ref={(ref: HTMLElement) => {
+          ref={(ref: SVGGElement) => {
             if (ref && !this.sectorRefs.includes(ref)) {
               this.sectorRefs.push(ref);
             }
@@ -571,14 +571,14 @@ export class Pie extends PureComponent<Props, State> {
     );
   }
 
-  attachKeyboardHandlers(pieRef: HTMLElement) {
+  attachKeyboardHandlers(pieRef: SVGGElement) {
     // eslint-disable-next-line no-param-reassign
     pieRef.onkeydown = (e: KeyboardEvent) => {
       if (!e.altKey) {
         switch (e.key) {
           case 'ArrowLeft': {
             const next = ++this.state.sectorToFocus % this.sectorRefs.length;
-            (this.sectorRefs[next] as HTMLElement).focus();
+            this.sectorRefs[next].focus();
             this.setState({ sectorToFocus: next });
             break;
           }
@@ -587,12 +587,12 @@ export class Pie extends PureComponent<Props, State> {
               --this.state.sectorToFocus < 0
                 ? this.sectorRefs.length - 1
                 : this.state.sectorToFocus % this.sectorRefs.length;
-            (this.sectorRefs[next] as HTMLElement).focus();
+            this.sectorRefs[next].focus();
             this.setState({ sectorToFocus: next });
             break;
           }
           case 'Escape': {
-            (this.sectorRefs[this.state.sectorToFocus] as HTMLElement).blur();
+            this.sectorRefs[this.state.sectorToFocus].blur();
             this.setState({ sectorToFocus: 0 });
             break;
           }
@@ -642,7 +642,7 @@ export class Pie extends PureComponent<Props, State> {
       <Layer
         tabIndex={this.props.rootTabIndex}
         className={layerClass}
-        ref={(ref: HTMLElement) => {
+        ref={ref => {
           this.pieRef = ref;
         }}
       >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Compiling TS types for `SVGProps<T>` in a component that uses `forwardRef` enumerates the keys of T for some reason and can cause TS build issues when a user builds the project with @types/react version greater than the one we have installed.

This fixes the type error

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4382

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Local `yalc publish`
- Install in a breaking project
- Run `tsc` and see successful build


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
