### PR TITLE
Remove getItemByActiveIndex function and dependencies

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -95,13 +95,6 @@ export interface MousePointer {
   pageY: number;
 }
 
-export type GraphicalItem<Props = Record<string, any>> = ReactElement<
-  Props,
-  string | React.JSXElementConstructor<Props>
-> & {
-  item: ReactElement<Props, string | React.JSXElementConstructor<Props>>;
-};
-
 const ORIENT_MAP = {
   xAxis: ['bottom', 'top'],
   yAxis: ['left', 'right'],

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1831,11 +1831,8 @@ export const generateCategoricalChart = ({
       const graphicalItem = cloneElement(element, { ...item.props, ...itemEvents });
 
       if (hasActive) {
-        if (activeShape || activeBar) {
-          const activeIndex = element.props.activeIndex !== undefined ? element.props.activeIndex : activeTooltipIndex;
-          return [cloneElement(element, { ...item.props, ...itemEvents, activeIndex }), null, null];
-        }
-        return [graphicalItem];
+        const activeIndex = element.props.activeIndex !== undefined ? element.props.activeIndex : activeTooltipIndex;
+        return [cloneElement(element, { ...item.props, ...itemEvents, activeIndex }), null, null];
       }
 
       return [graphicalItem, null];


### PR DESCRIPTION
## Description

What's going on?

I discovered that the only reason that code ever goes to this branch is that it's missing the `activeTooltipIndex`. This is always set for `tooltipEventType: axis` but never for `item`. The reason is that `handleItemMouseEnter` function never set it.

Items that support `tooltipEventType: item` are:

- Bar
- Funnel
- Pie
- RadialBar
- Scatter

<img width="603" alt="image" src="https://github.com/recharts/recharts/assets/1100170/18eed227-2ef7-4ebd-ab31-60a3e470483e">

turns out, all of these already wrap their mouse events using a function call like this: `{...adaptEventsOfChild(this.props, entry, i)}`. And this will provide the index as a second argument! So I added the second argument into `handleItemMouseEnter` and now `activeTooltipIndex` is always set (and correctly) so the branch of code that reads DOM to figure out the index in case it's never set - is now a dead code so I could remove it.

This is also the first time (since I joined the project) that `generateCategoricalChart.tsx` is below 2000 lines of code 🥳 

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

I am on a quest of removing `renderGraphicChild` to allow removing all element cloning.

## How Has This Been Tested?

storybook diff - no diff
manual storybook testing
npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
