### PR TITLE
js suffix added to main path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.12.1",
   "description": "React charts",
   "main": "lib/index.js",
-  "module": "es6/index",
-  "jsnext:main": "es6/index",
+  "module": "es6/index.js",
+  "jsnext:main": "es6/index.js",
   "types": "types/index.d.ts",
   "sideEffects": false,
   "files": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "recharts",
   "version": "2.12.1",
   "description": "React charts",
-  "main": "lib/index",
+  "main": "lib/index.js",
   "module": "es6/index",
   "jsnext:main": "es6/index",
   "types": "types/index.d.ts",

--- a/scripts/buildOutput.test.ts
+++ b/scripts/buildOutput.test.ts
@@ -29,17 +29,17 @@ describe('expected folder structure', () => {
 
     it('should point to a main file', () => {
       expect(packageJson.main).toEqual('lib/index.js');
-      expect(existsSync(`./${packageJson.main}.js`)).toBe(true);
+      expect(existsSync(`./${packageJson.main}`)).toBe(true);
     });
 
     it('should point to a main module file', () => {
       expect(packageJson.module).toEqual('es6/index.js');
-      expect(existsSync(`./${packageJson.module}.js`)).toBe(true);
+      expect(existsSync(`./${packageJson.module}`)).toBe(true);
     });
 
     it('should point to a jsnext:main file', () => {
       expect(packageJson['jsnext:main']).toEqual('es6/index.js');
-      expect(existsSync(`./${packageJson['jsnext:main']}.js`)).toBe(true);
+      expect(existsSync(`./${packageJson['jsnext:main']}`)).toBe(true);
     });
 
     it('should point to a types file', () => {

--- a/scripts/buildOutput.test.ts
+++ b/scripts/buildOutput.test.ts
@@ -28,17 +28,17 @@ describe('expected folder structure', () => {
     });
 
     it('should point to a main file', () => {
-      expect(packageJson.main).toEqual('lib/index');
+      expect(packageJson.main).toEqual('lib/index.js');
       expect(existsSync(`./${packageJson.main}.js`)).toBe(true);
     });
 
     it('should point to a main module file', () => {
-      expect(packageJson.module).toEqual('es6/index');
+      expect(packageJson.module).toEqual('es6/index.js');
       expect(existsSync(`./${packageJson.module}.js`)).toBe(true);
     });
 
     it('should point to a jsnext:main file', () => {
-      expect(packageJson['jsnext:main']).toEqual('es6/index');
+      expect(packageJson['jsnext:main']).toEqual('es6/index.js');
       expect(existsSync(`./${packageJson['jsnext:main']}.js`)).toBe(true);
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I am getting this error using eslint
`Error: Error while loading rule 'import/no-unused-modules': Cannot find module '/Users/alpardobos/Projects/brokerchooser.com/node_modules/recharts/lib/index'. Please verify that the package.json has a valid "main" entry`

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/recharts/recharts/issues/2858

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
