### PR TITLE
Change the current ErrorBar animation

### DIFF
--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -127,6 +127,8 @@ export function ErrorBar(props: Props) {
       lineCoordinates.push({ x1: xMin, y1: yMin, x2: xMax, y2: yMin });
     }
 
+    const transformOrigin = `${x + offset}px ${y + offset}px`;
+
     return (
       <Layer
         className="recharts-errorBar"
@@ -137,14 +139,16 @@ export function ErrorBar(props: Props) {
           const lineStyle = isAnimationActive ? { transformOrigin: `${coordinates.x1 - 5}px` } : undefined;
           return (
             <Animate
-              from="scale(0, 1)"
-              to="scale(1, 1)"
-              attributeName="transform"
+              from={{ transform: 'scaleY(0)', transformOrigin }}
+              to={{ transform: 'scaleY(1)', transformOrigin }}
               begin={animationBegin}
               easing={animationEasing}
               isActive={isAnimationActive}
               duration={animationDuration}
               key={`line-${coordinates.x1}-${coordinates.x2}-${coordinates.y1}-${coordinates.y2}`}
+              style={{
+                transformOrigin,
+              }}
             >
               <line {...coordinates} style={lineStyle} />
             </Animate>
@@ -165,7 +169,7 @@ ErrorBar.defaultProps = {
   layout: 'horizontal',
   isAnimationActive: true,
   animationBegin: 0,
-  animationDuration: 200,
+  animationDuration: 400,
   animationEasing: 'ease-in-out',
 };
 ErrorBar.displayName = 'ErrorBar';

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -144,7 +144,10 @@ describe('<ErrorBar />', () => {
     );
 
     assertErrorBars(container, 4);
-    assertAnimationStyles(container, true, { transition: 'transform 200ms ease-in-out' });
+    assertAnimationStyles(container, true, {
+      transition: 'transform 400ms ease-in-out,transform-origin 400ms ease-in-out',
+      transform: 'scaleY(1)',
+    });
   });
 
   test('Renders Error Bars without animation', () => {
@@ -170,7 +173,10 @@ describe('<ErrorBar />', () => {
     );
 
     assertErrorBars(container, 4);
-    assertAnimationStyles(container, true, { transition: 'transform 200ms ease-in-out' });
+    assertAnimationStyles(container, true, {
+      transition: 'transform 400ms ease-in-out,transform-origin 400ms ease-in-out',
+      transform: 'scaleY(1)',
+    });
 
     const errorBars = container.querySelectorAll('.recharts-errorBar');
     errorBars.forEach(bar => {
@@ -188,7 +194,10 @@ describe('<ErrorBar />', () => {
     );
 
     assertErrorBars(container, 4);
-    assertAnimationStyles(container, true, { transition: 'transform 400ms ease-in-out' });
+    assertAnimationStyles(container, true, {
+      transition: 'transform 400ms ease-in-out,transform-origin 400ms ease-in-out',
+      transform: 'scaleY(1)',
+    });
   });
 
   test('Renders Error Bars with animation easing', () => {
@@ -201,6 +210,9 @@ describe('<ErrorBar />', () => {
     );
 
     assertErrorBars(container, 4);
-    assertAnimationStyles(container, true, { transition: 'transform 200ms linear' });
+    assertAnimationStyles(container, true, {
+      transition: 'transform 400ms linear,transform-origin 400ms linear',
+      transform: 'scaleY(1)',
+    });
   });
 });


### PR DESCRIPTION
## Description

The current `ErrorBar` animation transitions from left to right. According to the discussions in the previous [PR](https://github.com/recharts/recharts/pull/4311), it has now been changed to expand centrally towards both the top and bottom

## Related Issue

[ErrorBar does not animate](https://github.com/recharts/recharts/issues/4055)

## Motivation and Context

## How Has This Been Tested?

It was tested locally with Storybook and validated through unit tests

## Screenshots (if appropriate):

https://github.com/recharts/recharts/assets/41566276/2fe5908b-4d83-4664-821d-761cd20e847e

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
