### PR TITLE
Resolved Same Key Rendering Issue to Namespace ScatterPoints with parent key

### DIFF
--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -304,7 +304,7 @@ export class Scatter extends PureComponent<Props, State> {
           className="recharts-scatter-symbol"
           {...adaptEventsOfChild(this.props, entry, i)}
           // eslint-disable-next-line react/no-array-index-key
-          key={`symbol-${entry?.cx}-${entry?.cy}-${entry?.size}-${i}`}
+          key={`symbol-${this.props.key}-${entry?.cx}-${entry?.cy}-${entry?.size}-${i}`}
           role="img"
         >
           <ScatterSymbol option={option} isActive={isActive} {...props} />


### PR DESCRIPTION
As above, this update should add the parent key to the mapped children points of a scatter component to namespace the points specific to a Scatter rendering which should allow similar data to be displayed correctly on the map

## Description

- Added the key of the parent Scatter into the rendered Layer wrapped for the Scatter Points

## Related Issue

https://github.com/recharts/recharts/issues/4004

## Motivation and Context

This change will allow a ScatterChart to render multiple Scatter components built off the same dataset (currently it will throw key matching errors).

## How Has This Been Tested?

This has been tested locally but more testing will most likely be required

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
