### PR TITLE
Cursor now renders as a child of Tooltip

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -78,7 +78,6 @@ import {
 } from '../util/types';
 import { AccessibilityManager } from './AccessibilityManager';
 import { isDomainSpecifiedByUser } from '../util/isDomainSpecifiedByUser';
-import { Cursor } from '../component/Cursor';
 import { ChartLayoutContextProvider } from '../context/chartLayoutContext';
 import { AxisMap, CategoricalChartState } from './types';
 import { AccessibilityContextProvider } from '../context/accessibilityContext';
@@ -1170,7 +1169,6 @@ export const generateCategoricalChart = ({
       };
 
       this.setState(nextState);
-      this.renderCursor(tooltipElem);
 
       // Make sure that anyone who keyboard-only users who tab to the chart will start their
       // cursors at defaultIndex
@@ -1787,25 +1785,6 @@ export const generateCategoricalChart = ({
       return null;
     }
 
-    renderCursor = (element: ReactElement) => {
-      const tooltipEventType = this.getTooltipEventType();
-
-      const key = element.key || '_recharts-cursor';
-
-      return <Cursor key={key} element={element} tooltipEventType={tooltipEventType} />;
-    };
-
-    /**
-     * Draw Tooltip
-     * @return {ReactElement}  The instance of Tooltip
-     */
-    renderTooltip = (): React.ReactElement => {
-      const { children } = this.props;
-      const tooltipItem = findChildByType(children, Tooltip);
-
-      return tooltipItem;
-    };
-
     renderGraphicChild = (element: React.ReactElement, displayName: string, index: number): any[] => {
       const item = this.filterFormatItem(element, displayName, index);
       if (!item) {
@@ -1863,7 +1842,7 @@ export const generateCategoricalChart = ({
       Scatter: { handler: this.renderGraphicChild },
       Pie: { handler: this.renderGraphicChild },
       Funnel: { handler: this.renderGraphicChild },
-      Tooltip: { handler: this.renderCursor, once: true },
+      Tooltip: { handler: renderAsIs, once: true },
       PolarGrid: { handler: renderAsIs, once: true },
       PolarAngleAxis: { handler: renderAsIs },
       PolarRadiusAxis: { handler: renderAsIs },
@@ -1948,7 +1927,6 @@ export const generateCategoricalChart = ({
                       <ClipPath clipPathId={this.clipPathId} offset={this.state.offset} />
                       {renderByOrder(children, this.renderMap)}
                     </Surface>
-                    {this.renderTooltip()}
                   </div>
                 </ChartLayoutContextProvider>
               </AccessibilityContextProvider>

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, PureComponent, ReactElement, ReactNode, SVGProps } from 'react';
+import React, { CSSProperties, PureComponent, ReactElement, ReactNode } from 'react';
 import {
   DefaultTooltipContent,
   NameType,
@@ -15,6 +15,8 @@ import { useViewBox } from '../context/chartLayoutContext';
 import { TooltipContextValue, useTooltipContext } from '../context/tooltipContext';
 import { useAccessibilityLayer } from '../context/accessibilityContext';
 import { useGetBoundingClientRect } from '../util/useGetBoundingClientRect';
+import { Cursor, CursorDefinition } from './Cursor';
+import { useTooltipEventType } from '../state/selectors';
 
 export type ContentType<TValue extends ValueType, TName extends NameType> =
   | ReactElement
@@ -61,7 +63,7 @@ export type TooltipProps<TValue extends ValueType, TName extends NameType> = Omi
   animationDuration?: AnimationDuration;
   animationEasing?: AnimationTiming;
   content?: ContentType<TValue, TName>;
-  cursor?: boolean | ReactElement | SVGProps<SVGElement>;
+  cursor?: CursorDefinition;
   filterNull?: boolean;
   defaultIndex?: number;
   isAnimationActive?: boolean;
@@ -96,10 +98,13 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
     reverseDirection,
     useTranslate3d,
     wrapperStyle,
+    cursor,
+    shared,
   } = props;
   const viewBox = useViewBox();
   const accessibilityLayer = useAccessibilityLayer();
   const { active: activeFromContext, payload, coordinate, label } = useTooltipContext();
+  const tooltipEventType = useTooltipEventType(shared);
   /*
    * The user can set `active=true` on the Tooltip in which case the Tooltip will stay always active,
    * or `active=false` in which case the Tooltip never shows.
@@ -124,32 +129,35 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
   const hasPayload = finalPayload.length > 0;
 
   return (
-    <TooltipBoundingBox
-      allowEscapeViewBox={allowEscapeViewBox}
-      animationDuration={animationDuration}
-      animationEasing={animationEasing}
-      isAnimationActive={isAnimationActive}
-      active={finalIsActive}
-      coordinate={coordinate}
-      hasPayload={hasPayload}
-      offset={offset}
-      position={position}
-      reverseDirection={reverseDirection}
-      useTranslate3d={useTranslate3d}
-      viewBox={viewBox}
-      wrapperStyle={wrapperStyle}
-      lastBoundingBox={lastBoundingBox}
-      innerRef={updateBoundingBox}
-    >
-      {renderContent(content, {
-        ...props,
-        payload: finalPayload,
-        label,
-        active: finalIsActive,
-        coordinate,
-        accessibilityLayer,
-      })}
-    </TooltipBoundingBox>
+    <>
+      <TooltipBoundingBox
+        allowEscapeViewBox={allowEscapeViewBox}
+        animationDuration={animationDuration}
+        animationEasing={animationEasing}
+        isAnimationActive={isAnimationActive}
+        active={finalIsActive}
+        coordinate={coordinate}
+        hasPayload={hasPayload}
+        offset={offset}
+        position={position}
+        reverseDirection={reverseDirection}
+        useTranslate3d={useTranslate3d}
+        viewBox={viewBox}
+        wrapperStyle={wrapperStyle}
+        lastBoundingBox={lastBoundingBox}
+        innerRef={updateBoundingBox}
+      >
+        {renderContent(content, {
+          ...props,
+          payload: finalPayload,
+          label,
+          active: finalIsActive,
+          coordinate,
+          accessibilityLayer,
+        })}
+      </TooltipBoundingBox>
+      {finalIsActive && <Cursor cursor={cursor} tooltipEventType={tooltipEventType} />}
+    </>
   );
 }
 

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -4,3 +4,15 @@ import { RechartsRootState } from './store';
 export const useChartName = (): string => {
   return useAppSelector((state: RechartsRootState) => state.options.chartName);
 };
+
+export function useTooltipEventType(shared: boolean | undefined) {
+  const defaultTooltipEventType = useAppSelector((state: RechartsRootState) => state.options.defaultTooltipEventType);
+  const validateTooltipEventTypes = useAppSelector(
+    (state: RechartsRootState) => state.options.validateTooltipEventTypes,
+  );
+  if (shared == null) {
+    return defaultTooltipEventType;
+  }
+  const eventType = shared ? 'axis' : 'item';
+  return validateTooltipEventTypes.includes(eventType) ? eventType : defaultTooltipEventType;
+}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1278,6 +1278,20 @@ export const adaptEventsOfChild = (
   return out;
 };
 
+/**
+ * 'axis' means that all graphical items belonging to this axis tick will be highlighted,
+ * and all will be present in the tooltip.
+ * Tooltip with 'axis' will display when hovering on the chart background.
+ *
+ * 'item' means only the one graphical item being hovered will show in the tooltip.
+ * Tooltip with 'item' will display when hovering over individual graphical items.
+ *
+ * This is calculated internally;
+ * charts have a `defaultTooltipEventType` and `validateTooltipEventTypes` options.
+ *
+ * Users then use <Tooltip shared={true} /> or <Tooltip shared={false} /> to control their preference,
+ * and charts will then see what is allowed and what is not.
+ */
 export type TooltipEventType = 'axis' | 'item';
 
 export interface CategoricalChartOptions {

--- a/storybook/stories/API/ResponsiveContainer.stories.tsx
+++ b/storybook/stories/API/ResponsiveContainer.stories.tsx
@@ -32,8 +32,8 @@ export const API: StoryObj<typeof ResponsiveContainer> = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+          <Tooltip />
         </AreaChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/Area.stories.tsx
+++ b/storybook/stories/API/cartesian/Area.stories.tsx
@@ -64,11 +64,11 @@ export const API = {
           {/* All components are added to show the interaction with the Area properties */}
           <Area fill="red" stackId="1" dataKey="pv" />
           <Legend />
-          <Tooltip />
           <XAxis dataKey="name" />
           <YAxis />
           {/* The target component */}
           <Area dataKey="uv" {...args} />
+          <Tooltip />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/Bar.stories.tsx
+++ b/storybook/stories/API/cartesian/Bar.stories.tsx
@@ -477,11 +477,11 @@ export const API = {
           {/* All components are added to show the interaction with the Bar properties */}
           <Bar fill="red" stackId="1" dataKey="pv" />
           <Legend />
-          <Tooltip />
           <XAxis dataKey="name" />
           <YAxis />
           {/* The target component */}
           <Bar dataKey="uv" {...args} />
+          <Tooltip />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/Line.stories.tsx
+++ b/storybook/stories/API/cartesian/Line.stories.tsx
@@ -48,11 +48,11 @@ export const API = {
         >
           {/* All components are added to show the interaction with the Area properties */}
           <Legend />
-          <Tooltip />
           <XAxis dataKey="name" />
           <YAxis />
           {/* The target component */}
           <Line dataKey="uv" {...args} />
+          <Tooltip />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/XAxis.stories.tsx
+++ b/storybook/stories/API/cartesian/XAxis.stories.tsx
@@ -324,9 +324,9 @@ export const API = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis {...args} />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Line dataKey="y" />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/YAxis.stories.tsx
+++ b/storybook/stories/API/cartesian/YAxis.stories.tsx
@@ -35,9 +35,9 @@ export const API = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis />
           <YAxis {...args} />
-          <Tooltip />
           <Legend />
           <Line dataKey="y" />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/chart/AreaChart.stories.tsx
+++ b/storybook/stories/API/chart/AreaChart.stories.tsx
@@ -19,8 +19,8 @@ export const Simple = {
       <ResponsiveContainer width="100%" height={400}>
         <AreaChart {...args}>
           <Area dataKey="pv" strokeWidth={3} stroke="#2451B7" fill="#5376C4" />
-          <Tooltip />
           <CartesianGrid opacity={0.1} vertical={false} />
+          <Tooltip />
         </AreaChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/chart/BarChart.stories.tsx
+++ b/storybook/stories/API/chart/BarChart.stories.tsx
@@ -53,10 +53,10 @@ export const Stacked = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Bar dataKey="uv" stackId="a" fill="green" barSize={50} />
           <Bar dataKey="pv" stackId="a" fill="red" barSize={30} />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/chart/ComposedChart.stories.tsx
+++ b/storybook/stories/API/chart/ComposedChart.stories.tsx
@@ -73,7 +73,6 @@ export const ComplexChart = {
         <YAxis />
         <Legend layout="vertical" align="right" verticalAlign="middle" />
         <CartesianGrid stroke="#f5f5f5" />
-        <Tooltip />
         <Area type="monotone" dataKey="amt" fill="#8884d8" stroke="#8884d8" />
         <Bar dataKey="uv" fill="#ff7300" />
         <Bar dataKey="pv" barSize={20} fill="#413ea0" />
@@ -84,6 +83,7 @@ export const ComplexChart = {
             <Line dataKey="uv" stroke="#ff7300" dot={false} />
           </LineChart>
         </Brush>
+        <Tooltip />
       </>
     ),
   },
@@ -99,12 +99,12 @@ export const LineBarAreaScatter = {
         <YAxis />
         <Legend layout="vertical" align="right" verticalAlign="middle" />
         <CartesianGrid stroke="#f5f5f5" />
-        <Tooltip />
         <Area type="monotone" dataKey="amt" fill="#8884d8" stroke="#8884d8" />
         <Line type="monotone" dataKey="uv" stroke="#ff7300" />
         <Bar dataKey="pv" barSize={20} fill="#413ea0" />
         <Scatter dataKey="pv" fill="red" />
         <Brush />
+        <Tooltip />
       </>
     ),
   },
@@ -120,9 +120,9 @@ export const LineBarHorizontal = {
         <YAxis />
         <Legend />
         <CartesianGrid stroke="#f5f5f5" />
-        <Tooltip />
         <Bar dataKey="pv" barSize={20} fill="#413ea0" />
         <Line type="monotone" dataKey="pv" stroke="#ff7300" />
+        <Tooltip />
       </>
     ),
   },
@@ -155,11 +155,11 @@ export const LineBarAreaScatterTimeScale = {
                 tick={{ fontSize: 10, fill: 'red' }}
               />
               <YAxis />
-              <Tooltip />
               <Legend />
               <Area type="monotone" dataKey="y" fill="#8884d8" stroke="#8884d8" />
               <Bar dataKey="y" barSize={20} fill="#413ea0" />
               <Line type="monotone" dataKey="y" stroke="#ff7300" />
+              <Tooltip />
             </Composed>
           </div>
         </div>

--- a/storybook/stories/API/chart/Customized.stories.tsx
+++ b/storybook/stories/API/chart/Customized.stories.tsx
@@ -17,7 +17,7 @@ import { pageData } from '../../data';
 
 const GeneralProps: Args = {
   component: {
-    description: `Use react element or function to render arbitrary customized content 
+    description: `Use react element or function to render arbitrary customized content
       which can use the internal state and props of chart.`,
     table: {
       type: {
@@ -56,11 +56,11 @@ const SimpleCustomized = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
           {args.customizedComponent}
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/chart/LineChart.stories.tsx
+++ b/storybook/stories/API/chart/LineChart.stories.tsx
@@ -32,13 +32,13 @@ export const SynchronizedTooltip = {
       <div>
         <LineChart {...args}>
           <Line isAnimationActive={false} type="monotone" dataKey="uv" stroke="#ff7300" />
-          <Tooltip />
           <XAxis dataKey="name" />
+          <Tooltip />
         </LineChart>
         <LineChart {...args}>
           <Line isAnimationActive={false} type="monotone" dataKey="uv" stroke="#ff7300" />
-          <Tooltip />
           <XAxis dataKey="name" />
+          <Tooltip />
         </LineChart>
       </div>
     );

--- a/storybook/stories/API/component/Customized.stories.tsx
+++ b/storybook/stories/API/component/Customized.stories.tsx
@@ -82,12 +82,12 @@ export const API = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
           {/* The target component */}
           <Customized component={component} />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/component/Tooltip.stories.tsx
+++ b/storybook/stories/API/component/Tooltip.stories.tsx
@@ -237,9 +237,9 @@ export const API = {
           }}
           data={pageData}
         >
+          <Line dataKey="uv" />
           {/* The target component */}
           <Tooltip {...args} />
-          <Line dataKey="uv" />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/polar/RadialBar.stories.tsx
+++ b/storybook/stories/API/polar/RadialBar.stories.tsx
@@ -40,9 +40,9 @@ export const API = {
       <ResponsiveContainer width="100%" height={400}>
         <RadialBarChart width={400} height={400} data={pageDataWithFillColor}>
           <Legend />
-          <Tooltip />
           <PolarAngleAxis />
           <RadialBar dataKey="uv" {...args} />
+          <Tooltip />
         </RadialBarChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/AreaChart.stories.tsx
+++ b/storybook/stories/Examples/AreaChart.stories.tsx
@@ -30,8 +30,8 @@ export const Simple = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+          <Tooltip />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -56,10 +56,10 @@ export const StackedAreaChart = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip active defaultIndex={2} />
           <Area type="monotone" dataKey="uv" stackId="1" stroke="#8884d8" fill="#8884d8" />
           <Area type="monotone" dataKey="pv" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
           <Area type="monotone" dataKey="amt" stackId="1" stroke="#ffc658" fill="#ffc658" />
+          <Tooltip active defaultIndex={2} />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -133,10 +133,10 @@ export const PercentAreaChart = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="month" />
           <YAxis tickFormatter={toPercent} />
-          <Tooltip content={renderTooltipContent} defaultIndex={3} active />
           <Area type="monotone" dataKey="uv" stackId="1" stroke="#8884d8" fill="#8884d8" />
           <Area type="monotone" dataKey="pv" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
           <Area type="monotone" dataKey="amt" stackId="1" stroke="#ffc658" fill="#ffc658" />
+          <Tooltip content={renderTooltipContent} defaultIndex={3} active />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -163,9 +163,9 @@ export const CardinalAreaChart = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" fillOpacity={0.3} />
           <Area type={cardinal} dataKey="uv" stroke="#82ca9d" fill="#82ca9d" fillOpacity={0.3} />
+          <Tooltip />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -235,8 +235,8 @@ export const AreaChartConnectNulls = {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
             <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+            <Tooltip />
           </AreaChart>
         </ResponsiveContainer>
         <ResponsiveContainer width="100%" height={200}>
@@ -254,8 +254,8 @@ export const AreaChartConnectNulls = {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
             <Area connectNulls type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+            <Tooltip />
           </AreaChart>
         </ResponsiveContainer>
       </div>
@@ -284,8 +284,8 @@ export const SynchronisedAreaChart = {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
             <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+            <Tooltip />
           </AreaChart>
         </ResponsiveContainer>
         <p>Maybe some other content</p>
@@ -306,8 +306,8 @@ export const SynchronisedAreaChart = {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
             <Area type="monotone" dataKey="pv" stroke="#82ca9d" fill="#82ca9d" />
+            <Tooltip />
           </AreaChart>
         </ResponsiveContainer>
       </div>
@@ -394,7 +394,6 @@ export const AreaChartFillByValue = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <defs>
             <linearGradient id="splitColor" x1="0" y1="0" x2="0" y2="1">
               <stop offset={off} stopColor="green" stopOpacity={1} />
@@ -402,6 +401,7 @@ export const AreaChartFillByValue = {
             </linearGradient>
           </defs>
           <Area type="monotone" dataKey="uv" stroke="#000" fill="url(#splitColor)" />
+          <Tooltip />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -425,8 +425,8 @@ export const AreaChartRange = {
         >
           <XAxis dataKey="day" />
           <YAxis />
-          <Tooltip defaultIndex={4} active />
           <Area dataKey="temperature" stroke="#d82428" fill="#8884d8" />
+          <Tooltip defaultIndex={4} active />
         </AreaChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart.stories.tsx
@@ -56,10 +56,10 @@ export const Simple = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Bar dataKey="pv" fill="#8884d8" activeBar={<Rectangle fill="pink" stroke="blue" />} />
           <Bar dataKey="uv" fill="#82ca9d" activeBar={<Rectangle fill="gold" stroke="purple" />} />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -84,10 +84,10 @@ export const Stacked = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Bar dataKey="pv" stackId="a" fill="#8884d8" />
           <Bar dataKey="uv" stackId="a" fill="#82ca9d" />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -115,12 +115,12 @@ export const StackedWithErrorBar = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis type="number" />
           <YAxis dataKey="name" type="category" />
-          <Tooltip />
           <Legend />
           <Bar dataKey="pv" stackId="a" fill="#8884d8" />
           <Bar dataKey="uv" stackId="a" fill="#82ca9d">
             <ErrorBar dataKey="pvError" width={5} stroke="red" direction="x" />
           </Bar>
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -145,11 +145,11 @@ export const Mix = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Bar dataKey="pv" stackId="a" fill="#8884d8" />
           <Bar dataKey="amt" stackId="a" fill="#82ca9d" />
           <Bar dataKey="uv" fill="#ffc658" />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -187,12 +187,12 @@ export const CustomShape = {
       >
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="name" />
-        <Tooltip />
         <YAxis />
         <Bar dataKey="uv" fill="#8884d8" shape={<TriangleBar />} label={{ position: 'top' }}>
           {pageData.map(({ name }, index) => (
             <Cell key={`cell-${name}`} fill={colors[index % 20]} />
           ))}
+          <Tooltip />
         </Bar>
       </BarChart>
     );
@@ -262,11 +262,11 @@ export const PositiveAndNegative = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <ReferenceLine y={0} stroke="#000" />
           <Bar dataKey="pv" fill="#8884d8" />
           <Bar dataKey="uv" fill="#82ca9d" />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -333,12 +333,12 @@ export const WithBrush = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend verticalAlign="top" wrapperStyle={{ lineHeight: '40px' }} />
           <ReferenceLine y={0} stroke="#000" />
           <Brush dataKey="name" height={30} stroke="#8884d8" />
           <Bar dataKey="pv" fill="#8884d8" />
           <Bar dataKey="uv" fill="#82ca9d" />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -450,12 +450,12 @@ export const WithMinHeight = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Bar dataKey="pv" fill="#8884d8" minPointSize={5}>
             <LabelList dataKey="name" content={renderCustomizedLabel} />
           </Bar>
           <Bar dataKey="uv" fill="#82ca9d" minPointSize={10} />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -526,11 +526,11 @@ export const StackedBySign = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <ReferenceLine y={0} stroke="#000" />
           <Bar dataKey="pv" fill="#8884d8" stackId="stack" />
           <Bar dataKey="uv" fill="#82ca9d" stackId="stack" />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -556,10 +556,10 @@ export const Biaxial = {
           <XAxis dataKey="name" />
           <YAxis yAxisId="left" orientation="left" stroke="#8884d8" />
           <YAxis yAxisId="right" orientation="right" stroke="#82ca9d" />
-          <Tooltip />
           <Legend />
           <Bar yAxisId="left" dataKey="pv" fill="#8884d8" />
           <Bar yAxisId="right" dataKey="uv" fill="#82ca9d" />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -584,10 +584,10 @@ export const HasBackground = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Bar dataKey="pv" fill="#8884d8" background={{ fill: '#eee' }} />
           <Bar dataKey="uv" fill="#82ca9d" />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -723,10 +723,10 @@ export const WithMultiXAxis = {
             xAxisId="quarter"
           />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Bar dataKey="pv" fill="#8884d8" />
           <Bar dataKey="uv" fill="#82ca9d" />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -751,10 +751,10 @@ export const NoPadding = {
         >
           <XAxis dataKey="name" scale="point" padding={{ left: 10, right: 10 }} />
           <YAxis />
-          <Tooltip />
           <Legend />
           <CartesianGrid strokeDasharray="3 3" />
           <Bar dataKey="pv" fill="#8884d8" background={{ fill: '#eee' }} />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -801,11 +801,11 @@ export const WithMinPointSize = {
         >
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <CartesianGrid strokeDasharray="3 3" />
           <Bar dataKey="pv" fill="purple" minPointSize={value => (value === 0 ? 0 : 2)} stackId="a" />
           <Bar dataKey="uv" fill="green" minPointSize={value => (value === 0 ? 0 : 2)} stackId="a" />
           <Bar dataKey="uv" fill="blue" minPointSize={value => (value === 0 ? 0 : 2)} />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -830,9 +830,9 @@ export const OneDataPointPercentSize = {
         >
           <XAxis dataKey={v => v[0]} type="number" domain={[0, 10]} />
           <YAxis />
-          <Tooltip />
           <CartesianGrid strokeDasharray="3 3" />
           <Bar dataKey={v => v[1]} />
+          <Tooltip />
         </BarChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/BarChart/StockPrice.stories.tsx
+++ b/storybook/stories/Examples/BarChart/StockPrice.stories.tsx
@@ -120,8 +120,6 @@ export const StockPriceChart = {
         <BarChart data={data}>
           <XAxis dataKey="date" />
           <YAxis domain={[minValue, maxValue]} />
-          {/* @ts-expect-error custom components do not have a good type support */}
-          <Tooltip content={<CustomTooltip />} />
           <Legend />
           {/* @ts-expect-error custom components do not have a good type support */}
           <Bar dataKey="openClose" fill="#8884d8" shape={<Candlestick />}>
@@ -129,6 +127,8 @@ export const StockPriceChart = {
               <Cell key={`cell-${date}`} />
             ))}
           </Bar>
+          {/* @ts-expect-error custom components do not have a good type support */}
+          <Tooltip content={<CustomTooltip />} />
         </BarChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/ComposedChart/AccessibilityLayer.stories.tsx
+++ b/storybook/stories/Examples/ComposedChart/AccessibilityLayer.stories.tsx
@@ -36,9 +36,9 @@ export const AreaChartWithAccessibilityLayer: StoryObj = {
           <Area isAnimationActive={false} dataKey="uv" {...args} />
           {/* All further components are added to show the interaction with the Area properties */}
           <Legend />
-          <Tooltip />
           <XAxis dataKey="name" />
           <YAxis />
+          <Tooltip />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -81,10 +81,10 @@ export const AccessibleWithButton = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          {toggle && <Tooltip />}
           <Area type="monotone" dataKey="uv" stackId="1" stroke="#8884d8" fill="#8884d8" />
           <Area type="monotone" dataKey="pv" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
           <Area type="monotone" dataKey="amt" stackId="1" stroke="#ffc658" fill="#ffc658" />
+          {toggle && <Tooltip />}
         </AreaChart>
       </div>
     );

--- a/storybook/stories/Examples/DataKey/ToggleBetweenDataKeys.stories.tsx
+++ b/storybook/stories/Examples/DataKey/ToggleBetweenDataKeys.stories.tsx
@@ -33,9 +33,9 @@ export const Default = {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
             <Legend />
             <Line type="monotone" dataKey={dataKey} stroke="#8884d8" activeDot={{ r: 8 }} />
+            <Tooltip />
           </LineChart>
         </ResponsiveContainer>
       </>
@@ -66,9 +66,9 @@ export const UsingReactKey = {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
             <Legend />
             <Line type="monotone" dataKey={dataKey} stroke="#8884d8" activeDot={{ r: 8 }} />
+            <Tooltip />
           </LineChart>
         </ResponsiveContainer>
       </>
@@ -100,9 +100,9 @@ export const UsingDataKey = {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
             <Legend />
             <Line type="monotone" dataKey={dataKey} stroke="#8884d8" activeDot={{ r: 8 }} />
+            <Tooltip />
           </LineChart>
         </ResponsiveContainer>
       </>

--- a/storybook/stories/Examples/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart.stories.tsx
@@ -45,10 +45,10 @@ export const Simple = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -85,10 +85,10 @@ export const Dashed = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip defaultIndex={3} active />
           <Legend />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" strokeDasharray="5 5" />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" strokeDasharray="3 4 5 2" />
+          <Tooltip defaultIndex={3} active />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -114,10 +114,10 @@ export const Vertical = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis type="number" />
           <YAxis dataKey="name" type="category" />
-          <Tooltip defaultIndex={4} active />
           <Legend />
           <Line dataKey="pv" stroke="#8884d8" />
           <Line dataKey="uv" stroke="#82ca9d" />
+          <Tooltip defaultIndex={4} active />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -142,10 +142,10 @@ export const BiAxial = {
           <XAxis dataKey="name" />
           <YAxis yAxisId="left" />
           <YAxis yAxisId="right" orientation="right" />
-          <Tooltip />
           <Legend />
           <Line yAxisId="left" type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
           <Line yAxisId="right" type="monotone" dataKey="uv" stroke="#82ca9d" />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -170,10 +170,10 @@ export const VerticalWithSpecifiedDomain = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis type="number" domain={[0, 'dataMax + 1000']} />
           <YAxis dataKey="name" type="category" />
-          <Tooltip />
           <Legend />
           <Line dataKey="pv" stroke="#8884d8" />
           <Line dataKey="uv" stroke="#82ca9d" />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -208,8 +208,8 @@ export const ConnectNulls = {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
             <Line type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+            <Tooltip />
           </LineChart>
         </ResponsiveContainer>
 
@@ -228,8 +228,8 @@ export const ConnectNulls = {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
             <Line connectNulls type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+            <Tooltip />
           </LineChart>
         </ResponsiveContainer>
       </>
@@ -244,10 +244,10 @@ export const WithXAxisPadding = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" padding={{ left: 30, right: 30 }} />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -271,12 +271,12 @@ export const WithReferenceLines = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <ReferenceLine x="Page C" stroke="red" label="Anything" />
           <ReferenceLine y={1600} label="Something" stroke="red" />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -345,10 +345,10 @@ export const WithCustomizedDot = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" dot={<CustomizedDot />} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -375,9 +375,9 @@ export const ClipDot: StoryObj = {
             dot={{ clipDot: args.clipDot, r: 4, strokeWidth: 2, fill: '#ffffff', fillOpacity: 1 }}
           />
           <Line isAnimationActive={false} dataKey="pv" {...args} dot={{ clipDot: args.clipDot }} />
-          <Tooltip />
           <XAxis dataKey="name" allowDataOverflow />
           <YAxis />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -440,10 +440,10 @@ export const WithCustomizedLabel = {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" height={60} tick={<CustomizedAxisTick />} />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" label={<CustomizedLabel />} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -470,8 +470,8 @@ export const Synchronized = {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
             <Line type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+            <Tooltip />
           </LineChart>
         </ResponsiveContainer>
         <p>Maybe some other content</p>
@@ -492,9 +492,9 @@ export const Synchronized = {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
             <Line type="monotone" dataKey="pv" stroke="#82ca9d" fill="#82ca9d" />
             <Brush />
+            <Tooltip />
           </LineChart>
         </ResponsiveContainer>
 
@@ -514,8 +514,8 @@ export const Synchronized = {
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
-            <Tooltip />
             <Area type="monotone" dataKey="pv" stroke="#82ca9d" fill="#82ca9d" />
+            <Tooltip />
           </AreaChart>
         </ResponsiveContainer>
       </>
@@ -634,13 +634,13 @@ export const HighlightAndZoom = {
             <XAxis allowDataOverflow dataKey="name" domain={left && right ? [left, right] : undefined} type="number" />
             <YAxis allowDataOverflow domain={[bottom, top]} type="number" yAxisId="1" />
             <YAxis orientation="right" allowDataOverflow domain={[bottom2, top2]} type="number" yAxisId="2" />
-            <Tooltip />
             <Line yAxisId="1" type="natural" dataKey="cost" stroke="#8884d8" animationDuration={300} />
             <Line yAxisId="2" type="natural" dataKey="impression" stroke="#82ca9d" animationDuration={300} />
 
             {refAreaLeft && refAreaRight ? (
               <ReferenceArea yAxisId="1" x1={refAreaLeft} x2={refAreaRight} strokeOpacity={0.3} />
             ) : null}
+            <Tooltip />
           </LineChart>
         </ResponsiveContainer>
       </div>
@@ -656,11 +656,11 @@ export const LineChartHasMultiSeries = {
           <CartesianGrid />
           <XAxis dataKey="name" />
           <YAxis />
-          <Tooltip />
           <Legend />
           <Line dataKey="uv" />
           <Line dataKey="pv" />
           <Line dataKey="amt" />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -913,7 +913,6 @@ export const ToggleChildrenComponentsExceptCartesianGrid: StoryObj = {
                 tickMargin={25}
               />
               {yAxisComponents}
-              <Tooltip />
               <Line
                 name="PV"
                 type="monotone"
@@ -931,6 +930,7 @@ export const ToggleChildrenComponentsExceptCartesianGrid: StoryObj = {
                 yAxisId={yAxisComponents[1].props.yAxisId}
                 dot={false}
               />
+              <Tooltip />
             </>
           )}
         </LineChart>
@@ -948,11 +948,11 @@ export const WithBrush: StoryObj = {
           <XAxis dataKey="name" />
           <YAxis />
           <CartesianGrid strokeDasharray="3 3" />
-          <Tooltip />
           <Legend />
           <Brush dataKey="name" startIndex={2} height={30} stroke="#8884d8" />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -980,11 +980,11 @@ export const HideOnLegendClick: StoryObj = {
           <XAxis dataKey="name" />
           <YAxis />
           <CartesianGrid strokeDasharray="3 3" />
-          <Tooltip />
           <Legend height={36} iconType="circle" onClick={props => handleLegendClick(props.dataKey)} />
 
           <Line hide={activeSeries.includes('uv')} type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
           <Line hide={activeSeries.includes('pv')} type="monotone" dataKey="pv" stroke="#987" fill="#8884d8" />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -1005,7 +1005,6 @@ export const LineTrailingIcon: StoryObj = {
           <XAxis dataKey="name" />
           <YAxis />
           <CartesianGrid strokeDasharray="3 3" />
-          <Tooltip />
           <Legend />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" />
           <Line
@@ -1015,6 +1014,7 @@ export const LineTrailingIcon: StoryObj = {
             tooltipType="none"
             dot={{ stroke: 'red', strokeWidth: 1, r: 4 }}
           />
+          <Tooltip />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/RadarChart.stories.tsx
+++ b/storybook/stories/Examples/RadarChart.stories.tsx
@@ -68,12 +68,12 @@ export const ShouldBeCorrectAngle: StoryObj = {
     ];
     return (
       <RadarChart width={600} height={300} data={data} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
-        <Tooltip />
         <PolarGrid />
         <PolarRadiusAxis angle={90} type="number" />
         <PolarAngleAxis dataKey="angle" type="number" domain={[0, 360]} tickCount={9} />
 
         <Radar dataKey="value" fillOpacity={0} stroke="#000" />
+        <Tooltip />
       </RadarChart>
     );
   },
@@ -91,12 +91,12 @@ export const RadarWithLegend: StoryObj = {
       <RadarChart data={data} width={360} height={360}>
         <PolarGrid gridType="circle" />
         <Legend />
-        <Tooltip defaultIndex={2} />
         <PolarRadiusAxis type="number" dataKey="r" />
 
         <PolarAngleAxis dataKey="angle" axisLineType="circle" type="number" domain={[0, 360]} />
 
         <Radar type="number" name="r" dataKey="r" fillOpacity={0} stroke="#000" />
+        <Tooltip defaultIndex={2} />
       </RadarChart>
     );
   },

--- a/storybook/stories/Examples/ResponsiveContainer/MultiChartFlexbox.stories.tsx
+++ b/storybook/stories/Examples/ResponsiveContainer/MultiChartFlexbox.stories.tsx
@@ -36,8 +36,8 @@ export const MultiChartFlexbox = {
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="name" />
               <YAxis />
-              <Tooltip />
               <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+              <Tooltip />
             </AreaChart>
           </ResponsiveContainer>
           <ResponsiveContainer className="flex-child">
@@ -53,8 +53,8 @@ export const MultiChartFlexbox = {
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="name" />
               <YAxis />
-              <Tooltip />
               <Line type="monotone" dataKey="amt" stroke="orange" />
+              <Tooltip />
             </LineChart>
           </ResponsiveContainer>
         </div>
@@ -85,8 +85,8 @@ export const ResponsiveContainerWithFlexbox = {
                 <XAxis dataKey="name" />
                 <YAxis />
                 <CartesianGrid strokeDasharray="3 3" />
-                <Tooltip />
                 <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+                <Tooltip />
               </AreaChart>
             </ResponsiveContainer>
           </div>
@@ -96,8 +96,8 @@ export const ResponsiveContainerWithFlexbox = {
                 <XAxis dataKey="name" />
                 <YAxis />
                 <CartesianGrid strokeDasharray="3 3" />
-                <Tooltip />
                 <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+                <Tooltip />
               </AreaChart>
             </ResponsiveContainer>
           </div>

--- a/storybook/stories/Examples/ScatterChart.stories.tsx
+++ b/storybook/stories/Examples/ScatterChart.stories.tsx
@@ -53,7 +53,6 @@ export const Simple: Meta<ScatterProps> = {
           <CartesianGrid />
           <XAxis type="number" dataKey="x" name="stature" unit="cm" />
           <YAxis type="number" dataKey="y" name="weight" unit="kg" />
-          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
           <Scatter
             activeShape={args.activeShape}
             activeIndex={args.activeIndex}
@@ -61,6 +60,7 @@ export const Simple: Meta<ScatterProps> = {
             data={data}
             fill="#8884d8"
           />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
         </ScatterChart>
       </ResponsiveContainer>
     );
@@ -100,10 +100,10 @@ export const ThreeDim = {
           <XAxis type="number" dataKey="x" name="stature" unit="cm" />
           <YAxis type="number" dataKey="y" name="weight" unit="kg" />
           <ZAxis type="number" dataKey="z" range={[60, 400]} name="score" unit="km" />
-          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
           <Legend />
           <Scatter name="A school" data={data01} fill="#8884d8" shape="star" />
           <Scatter name="B school" data={data02} fill="#82ca9d" shape="triangle" />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
         </ScatterChart>
       </ResponsiveContainer>
     );
@@ -142,10 +142,10 @@ export const JointLine = {
           <XAxis type="number" dataKey="x" name="stature" unit="cm" />
           <YAxis type="number" dataKey="y" name="weight" unit="kg" />
           <ZAxis type="number" range={[100]} />
-          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
           <Legend />
           <Scatter name="A school" data={data01} fill="#8884d8" line shape="cross" />
           <Scatter name="B school" data={data02} fill="#82ca9d" line shape="diamond" />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
         </ScatterChart>
       </ResponsiveContainer>
     );
@@ -282,8 +282,8 @@ export const BubbleChart = {
               label={{ value: 'Sunday', position: 'insideRight' }}
             />
             <ZAxis type="number" dataKey="value" domain={domain} range={range} />
-            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
             <Scatter data={data01} fill="#8884d8" />
+            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
           </ScatterChart>
         </ResponsiveContainer>
 
@@ -317,8 +317,8 @@ export const BubbleChart = {
               label={{ value: 'Monday', position: 'insideRight' }}
             />
             <ZAxis type="number" dataKey="value" domain={domain} range={range} />
-            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
             <Scatter data={data02} fill="#8884d8" />
+            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
           </ScatterChart>
         </ResponsiveContainer>
 
@@ -352,8 +352,8 @@ export const BubbleChart = {
               label={{ value: 'Tuesday', position: 'insideRight' }}
             />
             <ZAxis type="number" dataKey="value" domain={domain} range={range} />
-            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
             <Scatter data={data01} fill="#8884d8" />
+            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
           </ScatterChart>
         </ResponsiveContainer>
 
@@ -387,8 +387,8 @@ export const BubbleChart = {
               label={{ value: 'Wednesday', position: 'insideRight' }}
             />
             <ZAxis type="number" dataKey="value" domain={domain} range={range} />
-            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
             <Scatter data={data02} fill="#8884d8" />
+            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
           </ScatterChart>
         </ResponsiveContainer>
 
@@ -422,8 +422,8 @@ export const BubbleChart = {
               label={{ value: 'Thursday', position: 'insideRight' }}
             />
             <ZAxis type="number" dataKey="value" domain={domain} range={range} />
-            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
             <Scatter data={data01} fill="#8884d8" />
+            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
           </ScatterChart>
         </ResponsiveContainer>
 
@@ -457,8 +457,8 @@ export const BubbleChart = {
               label={{ value: 'Friday', position: 'insideRight' }}
             />
             <ZAxis type="number" dataKey="value" domain={domain} range={range} />
-            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
             <Scatter data={data02} fill="#8884d8" />
+            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
           </ScatterChart>
         </ResponsiveContainer>
 
@@ -491,8 +491,8 @@ export const BubbleChart = {
               label={{ value: 'Saturday', position: 'insideRight' }}
             />
             <ZAxis type="number" dataKey="value" domain={domain} range={range} />
-            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
             <Scatter data={data01} fill="#8884d8" />
+            <Tooltip cursor={{ strokeDasharray: '3 3' }} wrapperStyle={{ zIndex: 100 }} content={renderTooltip} />
           </ScatterChart>
         </ResponsiveContainer>
       </div>
@@ -524,10 +524,10 @@ export const WithLabels = {
           <CartesianGrid />
           <XAxis type="number" dataKey="x" name="stature" unit="cm" />
           <YAxis type="number" dataKey="y" name="weight" unit="kg" />
-          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
           <Scatter name="A school" data={data} fill="#8884d8">
             <LabelList dataKey="x" />
           </Scatter>
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
         </ScatterChart>
       </ResponsiveContainer>
     );
@@ -580,9 +580,9 @@ export const MultipleYAxes = {
             orientation="right"
             stroke="#82ca9d"
           />
-          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
           <Scatter yAxisId="left" name="A school" data={data01} fill="#8884d8" />
           <Scatter yAxisId="right" name="A school" data={data02} fill="#82ca9d" />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
         </ScatterChart>
       </ResponsiveContainer>
     );
@@ -614,12 +614,12 @@ export const WithCells = {
         <CartesianGrid />
         <XAxis type="number" dataKey="x" name="stature" unit="cm" />
         <YAxis type="number" dataKey="y" name="weight" unit="kg" />
-        <Tooltip cursor={{ strokeDasharray: '3 3' }} />
         <Scatter name="A school" data={data} fill="#8884d8">
           {data.map(({ x }, index) => (
             <Cell key={`cell-${x}`} fill={COLORS[index % COLORS.length]} />
           ))}
         </Scatter>
+        <Tooltip cursor={{ strokeDasharray: '3 3' }} />
       </ScatterChart>
     );
   },

--- a/storybook/stories/Examples/Tooltip.stories.tsx
+++ b/storybook/stories/Examples/Tooltip.stories.tsx
@@ -28,10 +28,10 @@ const SimpleTooltipStory = {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <ComposedChart data={pageData}>
-          <Tooltip {...tooltipArgs} />
           <XAxis dataKey="name" />
           <YAxis />
           <Line dataKey="uv" />
+          <Tooltip {...tooltipArgs} />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -184,10 +184,10 @@ export const SeparateDataSetsForChart = {
         <ComposedChart data={areaData}>
           <XAxis dataKey="category" type="category" />
           <YAxis dataKey="value" />
-          <Tooltip />
 
           <Area dataKey="value" />
           <Line dataKey="value" data={lineData} />
+          <Tooltip />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -267,11 +267,11 @@ export const LargeDataArray = {
           }}
           data={generateMockData(1000, 334058656)}
         >
-          {/* The target component */}
-          <Tooltip {...args} />
           <Line dataKey="x" />
           <Line dataKey="y" />
           <Line dataKey="z" />
+          {/* The target component */}
+          <Tooltip {...args} />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -295,10 +295,10 @@ export const IncludeHidden = {
           }}
           data={pageData}
         >
-          {/* The target component */}
-          <Tooltip includeHidden {...args} />
           <Line dataKey="uv" />
           <Line dataKey="pv" hide />
+          {/* The target component */}
+          <Tooltip includeHidden {...args} />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -311,9 +311,9 @@ export const SharedTooltipInBarChart = {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <BarChart data={pageData}>
-          <Tooltip {...args} />
           <Bar dataKey="uv" fill="green" />
           <Bar dataKey="pv" fill="red" />
+          <Tooltip {...args} />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -330,9 +330,9 @@ export const SharedTooltipInRadialBarChart = {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <RadialBarChart data={pageData}>
-          <Tooltip {...args} />
           <RadialBar dataKey="uv" fill="green" />
           <RadialBar dataKey="pv" fill="red" />
+          <Tooltip {...args} />
         </RadialBarChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/Brush/Brush.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Brush/Brush.stories.tsx
@@ -88,7 +88,6 @@ export const PanoramicBrush = {
         <XAxis dataKey="name" />
         <YAxis />
         <CartesianGrid strokeDasharray="3 3" />
-        <Tooltip />
         <Legend />
         <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
         <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
@@ -101,6 +100,7 @@ export const PanoramicBrush = {
             <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
           </LineChart>
         </Brush>
+        <Tooltip />
       </ComposedChart>
     );
   },

--- a/test/component/Cursor.spec.tsx
+++ b/test/component/Cursor.spec.tsx
@@ -2,19 +2,14 @@ import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/react';
 import { Cursor, CursorConnectedProps, CursorInternal, CursorProps } from '../../src/component/Cursor';
-import { Tooltip, TooltipProps } from '../../src/component/Tooltip';
 import { assertNotNull } from '../helper/assertNotNull';
 import { RechartsRootState } from '../../src/state/store';
 import { RechartsStoreProvider } from '../../src/state/RechartsStoreProvider';
 import { LayoutContext } from '../../src/context/chartLayoutContext';
 import { TooltipContextProvider, TooltipContextValue } from '../../src/context/tooltipContext';
 
-function getTooltipElement(props: TooltipProps<any, any>) {
-  return <Tooltip {...props} />;
-}
-
 const defaultProps: CursorProps = {
-  element: getTooltipElement({}),
+  cursor: true,
   tooltipEventType: 'axis',
 };
 
@@ -50,7 +45,7 @@ describe('Cursor', () => {
       }
       const props: CursorConnectedProps = {
         ...connectedProps,
-        element: getTooltipElement({ cursor: <MyCustomCursor /> }),
+        cursor: <MyCustomCursor />,
       };
       const { getByText } = render(
         <TooltipContextProvider value={tooltipContext}>
@@ -133,7 +128,7 @@ describe('Cursor', () => {
       }
       const props: CursorProps = {
         ...defaultProps,
-        element: getTooltipElement({ cursor: <MyCustomCursor /> }),
+        cursor: <MyCustomCursor />,
       };
       const { getByText } = render(
         <RechartsStoreProvider preloadedState={preloadedState}>

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { describe, it, test, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { useTooltipEventType } from '../../src/state/selectors';
+import { RechartsRootState } from '../../src/state/store';
+import { RechartsStoreProvider } from '../../src/state/RechartsStoreProvider';
+import { TooltipEventType } from '../../src/util/types';
+
+type TooltipEventTypeTestScenario = {
+  testName: string;
+  shared: undefined | boolean;
+  defaultTooltipEventType: TooltipEventType;
+  validateTooltipEventTypes: ReadonlyArray<TooltipEventType>;
+  expected: TooltipEventType;
+};
+
+const testCases: ReadonlyArray<TooltipEventTypeTestScenario> = [
+  {
+    testName: 'default case',
+    shared: undefined,
+    defaultTooltipEventType: 'item',
+    validateTooltipEventTypes: [],
+    expected: 'item',
+  },
+  {
+    testName: 'shared and axis type is allowed',
+    shared: true,
+    defaultTooltipEventType: 'item',
+    validateTooltipEventTypes: ['axis', 'item'],
+    expected: 'axis',
+  },
+  {
+    testName: 'shared but axis type is not allowed',
+    shared: true,
+    defaultTooltipEventType: 'item',
+    validateTooltipEventTypes: ['item'],
+    expected: 'item',
+  },
+  {
+    testName: 'not shared and item type is allowed',
+    shared: false,
+    defaultTooltipEventType: 'axis',
+    validateTooltipEventTypes: ['axis', 'item'],
+    expected: 'item',
+  },
+  {
+    testName: 'not shared but item type is not allowed',
+    shared: false,
+    defaultTooltipEventType: 'axis',
+    validateTooltipEventTypes: ['axis'],
+    expected: 'axis',
+  },
+];
+
+describe('useTooltipEventType', () => {
+  it('should return undefined when outside of Redux context', () => {
+    expect.assertions(1);
+    const Comp = (): null => {
+      const eventType = useTooltipEventType(undefined);
+      expect(eventType).toBe(undefined);
+      return null;
+    };
+    render(<Comp />);
+  });
+
+  test.each(testCases)(
+    '$testName should return $expected',
+    ({ shared, defaultTooltipEventType, validateTooltipEventTypes, expected }) => {
+      expect.assertions(1);
+      const Comp = (): null => {
+        const eventType = useTooltipEventType(shared);
+        expect(eventType).toBe(expected);
+        return null;
+      };
+      const preloadedState: Partial<RechartsRootState> = {
+        options: { defaultTooltipEventType, validateTooltipEventTypes },
+      };
+      render(
+        <RechartsStoreProvider preloadedState={preloadedState}>
+          <Comp />
+        </RechartsStoreProvider>,
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Description

Two fewer components being cloned.

This change follows Sankey and other non-generateCategoricalChart meaning, order of children now matters. So if people put Tooltip first, it renders behind other elements like Bars. SVG doesn't have z-index so that's not an option. I updated all storybooks to reflect that; we will need to put it as a breaking change.

This should also completely remove the `foreignObject` warning since every Tooltip is now rendered inside SVG.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

## How Has This Been Tested?

There are some minor visual differences, not sure why. Here's the diff results I ran from my computer: https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=860

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
