### PR TITLE
BarBackground and BarRectangles read activeIndex from context instead of props

### DIFF
--- a/src/util/BarUtils.tsx
+++ b/src/util/BarUtils.tsx
@@ -34,7 +34,7 @@ function typeguardBarRectangleProps(
   };
 }
 
-type BarRectangleProps = {
+export type BarRectangleProps = {
   option: ActiveShape<BarProps, SVGPathElement>;
   isActive: boolean;
 } & BarProps;


### PR DESCRIPTION
## Description

One less prop that was not meant to be a prop

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

No element cloning

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
