### PR TITLE
Pie no longer checks for array activeIndex

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -107,7 +107,7 @@ interface PieProps extends PieDef {
   labelLine?: PieLabelLine;
   label?: PieLabel;
 
-  activeIndex?: number | number[];
+  activeIndex?: number;
   animationEasing?: AnimationTiming;
   isAnimationActive?: boolean;
   animationBegin?: number;
@@ -384,21 +384,6 @@ export class Pie extends PureComponent<Props, State> {
 
   id = uniqueId('recharts-pie-');
 
-  isActiveIndex(i: number) {
-    const { activeIndex } = this.props;
-
-    if (Array.isArray(activeIndex)) {
-      return activeIndex.indexOf(i) !== -1;
-    }
-
-    return i === activeIndex;
-  }
-
-  hasActiveIndex() {
-    const { activeIndex } = this.props;
-    return Array.isArray(activeIndex) ? activeIndex.length !== 0 : activeIndex || activeIndex === 0;
-  }
-
   handleAnimationEnd = () => {
     const { onAnimationEnd } = this.props;
 
@@ -506,11 +491,11 @@ export class Pie extends PureComponent<Props, State> {
   }
 
   renderSectorsStatically(sectors: PieSectorDataItem[]) {
-    const { activeShape, blendStroke, inactiveShape: inactiveShapeProp } = this.props;
+    const { activeShape, activeIndex, blendStroke, inactiveShape: inactiveShapeProp } = this.props;
     return sectors.map((entry, i) => {
       if (entry?.startAngle === 0 && entry?.endAngle === 0 && sectors.length !== 1) return null;
-      const isActive = this.isActiveIndex(i);
-      const inactiveShape = inactiveShapeProp && this.hasActiveIndex() ? inactiveShapeProp : null;
+      const isActive = i === activeIndex;
+      const inactiveShape = activeIndex == null ? null : inactiveShapeProp;
       const sectorOptions = isActive ? activeShape : inactiveShape;
       const sectorProps = {
         ...entry,

--- a/test/polar/Pie.spec.tsx
+++ b/test/polar/Pie.spec.tsx
@@ -349,26 +349,6 @@ describe('<Pie />', () => {
     expect(container.querySelectorAll('.customized-inactive-shape')).toHaveLength(0);
   });
 
-  test('Support multiple active sectors', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
-        <Pie
-          isAnimationActive={false}
-          activeIndex={[0, 2]}
-          activeShape={<Sector fill="#ff7300" className="customized-active-shape" />}
-          cx={250}
-          cy={250}
-          innerRadius={0}
-          outerRadius={200}
-          sectors={sectors}
-          dataKey="cy"
-        />
-      </Surface>,
-    );
-
-    expect(container.querySelectorAll('.customized-active-shape')).toHaveLength(2);
-  });
-
   test('Render customized label when label is set to be a react element', () => {
     const Label = (props: LabelProps) => {
       const { x, y } = props;


### PR DESCRIPTION
## Description

This was introduced in 2016 in commit https://github.com/recharts/recharts/commit/c9a62ce31039572108e8fa3b8e8d58ad70a0e34e

but the tooltipActiveIndex, outside of a unit test, is never an array so this is a dead code.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Remove unused code

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
