### PR TITLE
Scatter reads activeIndex from context instead of props

### DIFF
--- a/storybook/stories/Examples/ScatterChart.stories.tsx
+++ b/storybook/stories/Examples/ScatterChart.stories.tsx
@@ -27,7 +27,6 @@ export default {
 export const Simple: Meta<ScatterProps> = {
   args: {
     activeShape: { fill: 'red' },
-    activeIndex: undefined,
   },
   render: args => {
     const data = [
@@ -53,13 +52,7 @@ export const Simple: Meta<ScatterProps> = {
           <CartesianGrid />
           <XAxis type="number" dataKey="x" name="stature" unit="cm" />
           <YAxis type="number" dataKey="y" name="weight" unit="kg" />
-          <Scatter
-            activeShape={args.activeShape}
-            activeIndex={args.activeIndex}
-            name="A school"
-            data={data}
-            fill="#8884d8"
-          />
+          <Scatter activeShape={args.activeShape} name="A school" data={data} fill="#8884d8" />
           <Tooltip cursor={{ strokeDasharray: '3 3' }} />
         </ScatterChart>
       </ResponsiveContainer>


### PR DESCRIPTION
## Description



## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Less props, more context

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
