### PR TITLE
RadialBar reads activeIndex from context instead of props

### DIFF
--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -48,6 +48,39 @@ type RadialBarDataItem = SectorProps & {
 
 type RadialBarBackground = ActiveShape<SectorProps>;
 
+type RadialBarSectorsProps = {
+  sectors: SectorProps[];
+  allOtherRadialBarProps: RadialBarProps;
+};
+
+function RadialBarSectors(props: RadialBarSectorsProps) {
+  const { sectors, allOtherRadialBarProps } = props;
+  const { shape, activeShape, activeIndex, cornerRadius, ...others } = allOtherRadialBarProps;
+  const baseProps = filterProps(others, false);
+
+  return (
+    <>
+      {sectors.map((entry, i) => {
+        const isActive = i === activeIndex;
+        const radialBarSectorProps: RadialBarSectorProps = {
+          ...baseProps,
+          cornerRadius: parseCornerRadius(cornerRadius),
+          ...entry,
+          ...adaptEventsOfChild(allOtherRadialBarProps, entry, i),
+          key: `sector-${i}`,
+          className: `recharts-radial-bar-sector ${entry.className}`,
+          forceCornerRadius: others.forceCornerRadius,
+          cornerIsExternal: others.cornerIsExternal,
+          isActive,
+          option: isActive ? activeShape : shape,
+        };
+
+        return <RadialBarSector {...radialBarSectorProps} />;
+      })}
+    </>
+  );
+}
+
 interface InternalRadialBarProps {
   animationId?: string | number;
   className?: string;
@@ -302,26 +335,7 @@ export class RadialBar extends PureComponent<RadialBarProps, State> {
   };
 
   renderSectorsStatically(sectors: SectorProps[]) {
-    const { shape, activeShape, activeIndex, cornerRadius, ...others } = this.props;
-    const baseProps = filterProps(others, false);
-
-    return sectors.map((entry, i) => {
-      const isActive = i === activeIndex;
-      const props: RadialBarSectorProps = {
-        ...baseProps,
-        cornerRadius: parseCornerRadius(cornerRadius),
-        ...entry,
-        ...adaptEventsOfChild(this.props, entry, i),
-        key: `sector-${i}`,
-        className: `recharts-radial-bar-sector ${entry.className}`,
-        forceCornerRadius: others.forceCornerRadius,
-        cornerIsExternal: others.cornerIsExternal,
-        isActive,
-        option: isActive ? activeShape : shape,
-      };
-
-      return <RadialBarSector {...props} />;
-    });
+    return <RadialBarSectors sectors={sectors} allOtherRadialBarProps={this.props} />;
   }
 
   renderSectorsWithAnimation() {

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -307,14 +307,6 @@ export class RadialBar extends PureComponent<RadialBarProps, State> {
     return null;
   }
 
-  getDeltaAngle() {
-    const { startAngle, endAngle } = this.props;
-    const sign = mathSign(endAngle - startAngle);
-    const deltaAngle = Math.min(Math.abs(endAngle - startAngle), 360);
-
-    return sign * deltaAngle;
-  }
-
   handleAnimationEnd = () => {
     const { onAnimationEnd } = this.props;
     this.setState({ isAnimationFinished: true });

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -37,6 +37,7 @@ import {
 import { polarToCartesian } from '../util/PolarUtils';
 import type { Payload as LegendPayload } from '../component/DefaultLegendContent';
 import { useLegendPayloadDispatch } from '../context/legendPayloadContext';
+import { useTooltipContext } from '../context/tooltipContext';
 // TODO: Cause of circular dependency. Needs refactoring of functions that need them.
 // import { AngleAxisProps, RadiusAxisProps } from './types';
 
@@ -55,13 +56,15 @@ type RadialBarSectorsProps = {
 
 function RadialBarSectors(props: RadialBarSectorsProps) {
   const { sectors, allOtherRadialBarProps } = props;
-  const { shape, activeShape, activeIndex, cornerRadius, ...others } = allOtherRadialBarProps;
+  const { shape, activeShape, cornerRadius, ...others } = allOtherRadialBarProps;
   const baseProps = filterProps(others, false);
+
+  const { index: activeIndex } = useTooltipContext();
 
   return (
     <>
       {sectors.map((entry, i) => {
-        const isActive = i === activeIndex;
+        const isActive = activeShape && i === activeIndex;
         const radialBarSectorProps: RadialBarSectorProps = {
           ...baseProps,
           cornerRadius: parseCornerRadius(cornerRadius),
@@ -90,7 +93,6 @@ interface InternalRadialBarProps {
   endAngle?: number;
   shape?: ActiveShape<SectorProps, SVGPathElement>;
   activeShape?: ActiveShape<SectorProps, SVGPathElement>;
-  activeIndex?: number;
   dataKey: string | number | ((obj: any) => any);
   cornerRadius?: string | number;
   forceCornerRadius?: boolean;

--- a/storybook/stories/API/chart/RadialBarChart.stories.tsx
+++ b/storybook/stories/API/chart/RadialBarChart.stories.tsx
@@ -21,7 +21,7 @@ export const Simple: Meta<RadialBarProps> = {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <RadialBarChart data={data}>
-          <RadialBar dataKey="uv" activeShape={args.activeShape} activeIndex={args.activeIndex} />
+          <RadialBar dataKey="uv" activeShape={args.activeShape} />
           <Tooltip />
         </RadialBarChart>
       </ResponsiveContainer>
@@ -30,7 +30,6 @@ export const Simple: Meta<RadialBarProps> = {
   args: {
     data: pageData,
     activeShape: { fill: 'red' },
-    activeIndex: undefined,
   },
 };
 


### PR DESCRIPTION
## Description

Similar to the other PRs

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Remove element cloning

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
