### PR TITLE
Remove unused state property activeItem

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1576,7 +1576,6 @@ export const generateCategoricalChart = ({
       this.setState(() => ({
         activeTooltipIndex: index,
         isTooltipActive: true,
-        activeItem: el,
         activePayload: el.tooltipPayload,
         activeCoordinate: el.tooltipPosition || { x: el.cx, y: el.cy },
       }));

--- a/src/chart/types.ts
+++ b/src/chart/types.ts
@@ -60,9 +60,6 @@ export interface CategoricalChartState {
 
   tooltipAxisBandSize?: number;
 
-  /** active item */
-  activeItem?: any;
-
   /** Active label of data */
   activeLabel?: string;
 


### PR DESCRIPTION
## Description

This appears to be unused.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

I want to avoid putting DOM elements into Redux store unless completely necessary. I think this one is not necessary.

## How Has This Been Tested?

npm test

https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=879

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
