### PR TITLE
PieChart keyboard tests, set accessibilityLayer to true in storybook args

### DIFF
--- a/storybook/stories/API/chart/PieChart.stories.tsx
+++ b/storybook/stories/API/chart/PieChart.stories.tsx
@@ -3,6 +3,7 @@ import { Pie, PieChart, ResponsiveContainer, Tooltip } from '../../../../src';
 import { pageData } from '../../data';
 import { CategoricalChartProps } from '../props/ChartProps';
 import { ActiveShapeProps } from '../props/ActiveShapeProps';
+import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 
 export default {
   argTypes: {
@@ -26,6 +27,7 @@ export const Simple = {
     );
   },
   args: {
+    ...getStoryArgsFromArgsTypesObject(CategoricalChartProps),
     data: pageData,
     activeShape: { fill: 'red' },
   },
@@ -43,6 +45,7 @@ export const Donut = {
     );
   },
   args: {
+    ...getStoryArgsFromArgsTypesObject(CategoricalChartProps),
     data: pageData,
   },
 };

--- a/storybook/stories/API/props/ChartProps.ts
+++ b/storybook/stories/API/props/ChartProps.ts
@@ -84,7 +84,7 @@ toggling between multiple dataKey.`,
       type: {
         summary: 'boolean',
       },
-      defaultValue: false,
+      defaultValue: true,
       category: 'General',
     },
   },
@@ -275,7 +275,7 @@ toggling between multiple dataKey.`,
   },
   stackOffset: {
     description: `Determines how values are stacked:
-    
+
 - \`none\` is the default, it adds values on top of each other. No smarts. Negative values will overlap.
 - \`expand\` make it so that the values always add up to 1 - so the chart will look like a rectangle.
 - \`wiggle\` and \`silhouette\` tries to keep the chart centered.

--- a/test/chart/AccessibilityLayer.spec.tsx
+++ b/test/chart/AccessibilityLayer.spec.tsx
@@ -1,7 +1,19 @@
 import React, { useState } from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
-import { Area, AreaChart, CartesianGrid, Funnel, FunnelChart, Legend, Tooltip, XAxis, YAxis } from '../../src';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Funnel,
+  FunnelChart,
+  Legend,
+  Pie,
+  PieChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from '../../src';
 import { assertNotNull } from '../helper/assertNotNull';
 import { getTooltip } from '../component/Tooltip/tooltipTestHelpers';
 import { PageData } from '../_data';
@@ -510,6 +522,32 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
     });
   });
 
+  describe('PieChart', () => {
+    test('Add tabindex and role to the svg element', () => {
+      const { container } = render(
+        <PieChart width={100} height={50} accessibilityLayer={accessibilityLayer}>
+          <Pie data={PageData} dataKey="uv" />
+        </PieChart>,
+      );
+
+      const svg = container.querySelector('svg');
+      assertChartA11yAttributes(svg);
+    });
+
+    test('does not show tooltip using keyboard', async () => {
+      const mockMouseMovements = vi.fn();
+
+      const { container } = render(
+        <PieChart width={100} height={50} accessibilityLayer={accessibilityLayer} onMouseMove={mockMouseMovements}>
+          <Pie dataKey="uv" data={PageData} />
+          <Tooltip />
+        </PieChart>,
+      );
+
+      assertNoKeyboardInteractions(container);
+    });
+  });
+
   describe('FunnelChart', () => {
     test('Add tabindex and role to the svg element', () => {
       const { container } = render(
@@ -680,6 +718,32 @@ describe('AccessibilityLayer with accessibilityLayer=false', () => {
           <Tooltip />
           <Legend />
         </FunnelChart>,
+      );
+
+      assertNoKeyboardInteractions(container);
+    });
+  });
+
+  describe('PieChart', () => {
+    test('does not tabindex and role to the svg element', () => {
+      const { container } = render(
+        <PieChart width={100} height={50} accessibilityLayer={accessibilityLayer}>
+          <Pie data={PageData} dataKey="uv" />
+        </PieChart>,
+      );
+
+      const svg = container.querySelector('svg');
+      assertNoA11yAttributes(svg);
+    });
+
+    test('does not show tooltip using keyboard', async () => {
+      const mockMouseMovements = vi.fn();
+
+      const { container } = render(
+        <PieChart width={100} height={50} accessibilityLayer={accessibilityLayer} onMouseMove={mockMouseMovements}>
+          <Pie dataKey="uv" data={PageData} />
+          <Tooltip />
+        </PieChart>,
       );
 
       assertNoKeyboardInteractions(container);


### PR DESCRIPTION
## Description

Tests and storybook only

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

I want to refactor Pie to use context next, but that happens to store all the DOM elements as refs for what looks like an a11y feature. I don't want to store refs but I don't want to break keyboard controls either.

Also turns out that the keyboard features on Pie do not show tooltip anyway.

Also https://github.com/recharts/recharts/discussions/4484

## How Has This Been Tested?

npm test, storybook

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
