### PR TITLE
Funnel reads activeIndex from context instead of props

### DIFF
--- a/src/util/FunnelUtils.tsx
+++ b/src/util/FunnelUtils.tsx
@@ -23,7 +23,7 @@ export function typeGuardTrapezoidProps(option: SVGProps<SVGPathElement>, props:
   };
 }
 
-type FunnelTrapezoidProps = { option: FunnelProps['activeShape'] } & FunnelTrapezoidItem;
+export type FunnelTrapezoidProps = { option: FunnelProps['activeShape'] } & FunnelTrapezoidItem;
 
 export function FunnelTrapezoid(props: FunnelTrapezoidProps) {
   return <Shape shapeType="trapezoid" propTransformer={typeGuardTrapezoidProps} {...props} />;

--- a/storybook/stories/API/chart/FunnelChart.stories.tsx
+++ b/storybook/stories/API/chart/FunnelChart.stories.tsx
@@ -16,12 +16,9 @@ export const Simple: Meta<FunnelProps> = {
   render: (args: Record<string, any>) => {
     const { data } = args;
     return (
-      // <div style={{ height: 200, width: 200 }}>
-      // </div>
       <ResponsiveContainer width="100%" height={200}>
         <FunnelChart layout="horizontal">
           <Funnel
-            activeIndex={args.activeIndex}
             width={400}
             data={data}
             dataKey="value"
@@ -43,7 +40,6 @@ export const Simple: Meta<FunnelProps> = {
   args: {
     shape: {},
     activeShape: { fill: 'gold', stroke: 'purple' },
-    activeIndex: undefined,
     data: [
       {
         fill: '#EEEEEE',

--- a/test/numberAxis/Funnel.spec.tsx
+++ b/test/numberAxis/Funnel.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Cell, Funnel, FunnelChart, FunnelProps, LabelList } from '../../src';
+import { showTooltip } from '../component/Tooltip/tooltipTestHelpers';
+import { funnelChartMouseHoverTooltipSelector } from '../component/Tooltip/tooltipMouseHoverSelectors';
 
 const data = [
   { value: 100, name: '展现' },
@@ -52,12 +54,11 @@ describe('<Funnel />', () => {
   });
 
   it('active shape in simple funnel', () => {
-    const { container } = render(
+    const { container, debug } = render(
       <FunnelChart width={500} height={500}>
         <Funnel
           dataKey="value"
           data={data}
-          activeIndex={1}
           isAnimationActive={false}
           activeShape={(payload: FunnelProps) => (
             <rect
@@ -79,7 +80,11 @@ describe('<Funnel />', () => {
       </FunnelChart>,
     );
 
-    expect(container.querySelectorAll('.custom-active-shape').length).toBe(1);
+    expect(container.querySelectorAll('.custom-active-shape')).toHaveLength(0);
+
+    showTooltip(container, funnelChartMouseHoverTooltipSelector, debug);
+
+    expect(container.querySelectorAll('.custom-active-shape')).toHaveLength(1);
   });
 
   it('Renders funnel custom cell in simple FunnelChart', () => {


### PR DESCRIPTION
## Description

Functional component, plus context

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

One step closer to being able to remove `renderGraphicalChild`

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
