### PR TITLE
refactor: remove unused isFront prop

### DIFF
--- a/demo/component/AreaChart.tsx
+++ b/demo/component/AreaChart.tsx
@@ -307,7 +307,7 @@ export default class AreaChartDemo extends React.Component<any, any> {
             <CartesianGrid stroke="#f5f5f5" />
             <ReferenceArea x1="Page A" x2="Page E" />
             <ReferenceLine y={7500} stroke="#387908" />
-            <ReferenceDot x="Page C" y={1398} r={10} fill="#387908" isFront />
+            <ReferenceDot x="Page C" y={1398} r={10} fill="#387908" />
             <Area type={stepAround} dataKey="pv" stroke="#ff7300" fill="#ff7300" fillOpacity={0.9} />
           </AreaChart>
         </div>

--- a/demo/component/ScatterChart.tsx
+++ b/demo/component/ScatterChart.tsx
@@ -137,7 +137,7 @@ export default class Demo extends Component {
             <ReferenceArea x1={250} x2={300} ifOverflow="extendDomain" label="any label" />
             <ReferenceLine x={159} stroke="red" />
             <ReferenceLine y={237.5} stroke="red" />
-            <ReferenceDot x={170} y={290} r={15} label="AB" stroke="none" fill="red" isFront />
+            <ReferenceDot x={170} y={290} r={15} label="AB" stroke="none" fill="red" />
           </ScatterChart>
         </div>
 

--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -16,7 +16,6 @@ import { filterProps } from '../util/ReactUtils';
 import { useClipPathId, useMaybeXAxis, useMaybeYAxis } from '../context/chartLayoutContext';
 
 interface ReferenceAreaProps {
-  isFront?: boolean;
   ifOverflow?: IfOverflow;
   x1?: number | string;
   x2?: number | string;
@@ -115,7 +114,6 @@ export function ReferenceArea(props: Props) {
 
 ReferenceArea.displayName = 'ReferenceArea';
 ReferenceArea.defaultProps = {
-  isFront: false,
   ifOverflow: 'discard',
   xAxisId: 0,
   yAxisId: 0,

--- a/src/cartesian/ReferenceDot.tsx
+++ b/src/cartesian/ReferenceDot.tsx
@@ -13,7 +13,6 @@ import { useClipPathId, useXAxisOrThrow, useYAxisOrThrow } from '../context/char
 interface ReferenceDotProps {
   r?: number;
 
-  isFront?: boolean;
   ifOverflow?: IfOverflow;
   x?: number | string;
   y?: number | string;
@@ -91,7 +90,6 @@ export function ReferenceDot(props: Props) {
 
 ReferenceDot.displayName = 'ReferenceDot';
 ReferenceDot.defaultProps = {
-  isFront: false,
   ifOverflow: 'discard',
   xAxisId: 0,
   yAxisId: 0,

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -31,7 +31,6 @@ export type Segment = {
 export type ReferenceLinePosition = 'middle' | 'start' | 'end';
 
 interface ReferenceLineProps extends InternalReferenceLineProps {
-  isFront?: boolean;
   ifOverflow?: IfOverflow;
 
   x?: number | string;
@@ -192,7 +191,6 @@ export function ReferenceLine(props: Props) {
 
 ReferenceLine.displayName = 'ReferenceLine';
 ReferenceLine.defaultProps = {
-  isFront: false,
   ifOverflow: 'discard',
   xAxisId: 0,
   yAxisId: 0,

--- a/storybook/stories/API/props/ReferenceComponentShared.ts
+++ b/storybook/stories/API/props/ReferenceComponentShared.ts
@@ -1,15 +1,11 @@
 import { StorybookArgs } from '../../../StorybookArgs';
 
 export const ReferenceComponentStyle: StorybookArgs = {
-  isFront: {
-    description: `If set true, the reference component will be rendered in front of bars in BarChart, etc.`,
-    table: { category: 'Style' },
-  },
   ifOverflow: {
-    description: `Defines how to draw the reference component if it falls partly outside the canvas. 
-    If set to 'discard', the reference component will not be drawn at all. If set to 'hidden', the 
-    reference component will be clipped to the canvas. If set to 'visible', the reference component 
-    will be drawn completely. If set to 'extendDomain', the domain of the overflown axis will be 
+    description: `Defines how to draw the reference component if it falls partly outside the canvas.
+    If set to 'discard', the reference component will not be drawn at all. If set to 'hidden', the
+    reference component will be clipped to the canvas. If set to 'visible', the reference component
+    will be drawn completely. If set to 'extendDomain', the domain of the overflown axis will be
     extended such that the reference component fits into the canvas.`,
     table: { type: { summary: "'discard' | 'hidden' | 'visible' | 'extendDomain'" }, category: 'Style' },
     defaultValue: 'discard',
@@ -37,7 +33,7 @@ export const ReferenceComponentInternalArgs: StorybookArgs = {
     table: { type: { summary: 'Object' }, category: 'Internal' },
   },
   clipPathId: {
-    description: `Used as the id for the clip path which is used to clip the reference component if 
+    description: `Used as the id for the clip path which is used to clip the reference component if
     'ifOverflow' is set to 'hidden'"`,
     table: { type: { summary: 'number | string' }, category: 'Internal' },
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
this prop wasn't used and was super misleading because of that. Remove the docs, types, defaultProps

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- remove confusion, clean up code


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
no tests fail

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Need to update website eventually, added as a breaking 3.x change

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
