### PR TITLE
Bar reads tooltip trigger handlers from context instead of cloning

### DIFF
--- a/src/chart/types.ts
+++ b/src/chart/types.ts
@@ -84,3 +84,5 @@ export interface CategoricalChartState {
   tooltipPortal?: HTMLElement | null;
   cursorPortal?: SVGElement | null;
 }
+
+export type TooltipTrigger = 'hover' | 'click';

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -19,6 +19,7 @@ import { useGetBoundingClientRect } from '../util/useGetBoundingClientRect';
 import { Cursor, CursorDefinition } from './Cursor';
 import { useTooltipEventType } from '../state/selectors';
 import { useCursorPortal, useTooltipPortal } from '../context/tooltipPortalContext';
+import { TooltipTrigger } from '../chart/types';
 
 export type ContentType<TValue extends ValueType, TName extends NameType> =
   | ReactElement
@@ -87,7 +88,7 @@ export type TooltipProps<TValue extends ValueType, TName extends NameType> = Omi
    * If undefined then defaults to true.
    */
   shared?: boolean;
-  trigger?: 'hover' | 'click';
+  trigger?: TooltipTrigger;
   useTranslate3d?: boolean;
   wrapperStyle?: CSSProperties;
 };

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import { ChartCoordinate } from '../util/types';
+import { ChartCoordinate, Coordinate } from '../util/types';
 
 export type TooltipContextValue = {
   label: string;
@@ -22,3 +22,18 @@ const TooltipContext = createContext<TooltipContextValue>(doNotDisplayTooltip);
 export const TooltipContextProvider = TooltipContext.Provider;
 
 export const useTooltipContext = () => useContext(TooltipContext);
+
+export type ActivateTooltipAction = (
+  tooltipInfo: { tooltipPayload: any; tooltipPosition: Coordinate; cx: number; cy: number },
+  index: number,
+) => void;
+
+export type NoArgumentsAction = () => void;
+
+export const MouseEnterItemDispatchContext = createContext<ActivateTooltipAction | null>(null);
+export const MouseLeaveItemDispatchContext = createContext<NoArgumentsAction | null>(null);
+export const MouseClickItemDispatchContext = createContext<ActivateTooltipAction | null>(null);
+
+export const useMouseEnterItemDispatch = () => useContext(MouseEnterItemDispatchContext);
+export const useMouseLeaveItemDispatch = () => useContext(MouseLeaveItemDispatchContext);
+export const useMouseClickItemDispatch = () => useContext(MouseClickItemDispatchContext);

--- a/src/util/BarUtils.tsx
+++ b/src/util/BarUtils.tsx
@@ -37,6 +37,9 @@ function typeguardBarRectangleProps(
 export type BarRectangleProps = {
   option: ActiveShape<BarProps, SVGPathElement>;
   isActive: boolean;
+  onMouseEnter?: (e: React.MouseEvent<SVGPathElement, MouseEvent>) => void;
+  onMouseLeave?: (e: React.MouseEvent<SVGPathElement, MouseEvent>) => void;
+  onClick?: (e: React.MouseEvent<SVGPathElement, MouseEvent>) => void;
 } & BarProps;
 
 export function BarRectangle(props: BarRectangleProps) {

--- a/test/cartesian/Bar.spec.tsx
+++ b/test/cartesian/Bar.spec.tsx
@@ -121,6 +121,9 @@ describe.each(includingCompact(chartsThatSupportBar))('<Bar /> as a child of $te
         label: 'test',
         onAnimationEnd: expect.any(Function),
         onAnimationStart: expect.any(Function),
+        onMouseEnter: expect.any(Function),
+        onMouseLeave: expect.any(Function),
+        onClick: expect.any(Function),
         width: 20,
         x: expect.any(Number),
         y: 50,
@@ -565,6 +568,149 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
         fireEvent.click(trigger, { clientX: 200, clientY: 200 });
 
         expect(tooltip).not.toBeVisible();
+      });
+    });
+
+    describe('with trigger=click and shared=false', () => {
+      it('should not display anything when hovering over chart root element', () => {
+        const { container } = render(
+          <ChartElement width={500} height={500}>
+            <Bar isAnimationActive={false} data={data} dataKey="value" />
+            <Tooltip trigger="click" shared={false} />
+          </ChartElement>,
+        );
+
+        const tooltip = getTooltip(container);
+        expect(tooltip).not.toBeVisible();
+
+        const trigger = container.querySelector('.recharts-wrapper');
+        assertNotNull(trigger);
+
+        fireEvent.mouseOver(trigger, { clientX: 0, clientY: 0 });
+
+        expect(tooltip).not.toBeVisible();
+      });
+
+      it('should not display anything when clicking on the chart root element', () => {
+        const { container } = render(
+          <ChartElement width={500} height={500}>
+            <Bar isAnimationActive={false} data={data} dataKey="value" />
+            <Tooltip trigger="click" shared={false} />
+          </ChartElement>,
+        );
+
+        const tooltip = getTooltip(container);
+        expect(tooltip).not.toBeVisible();
+
+        const trigger = container.querySelector('.recharts-wrapper');
+        assertNotNull(trigger);
+
+        fireEvent.click(trigger, { clientX: 0, clientY: 0 });
+
+        expect(tooltip).not.toBeVisible();
+      });
+
+      it('should not display tooltip when hovering over the bar element', () => {
+        const { container } = render(
+          <ChartElement width={500} height={500} data={data}>
+            <Bar isAnimationActive={false} dataKey="value" />
+            <Tooltip trigger="click" shared={false} />
+          </ChartElement>,
+        );
+
+        const tooltip = getTooltip(container);
+        expect(tooltip).not.toBeVisible();
+
+        const trigger = container.querySelector('.recharts-bar-rectangle');
+        assertNotNull(trigger);
+
+        fireEvent.mouseOver(trigger, { clientX: 20, clientY: 20 });
+
+        expect(tooltip).not.toBeVisible();
+
+        fireEvent.mouseOut(trigger);
+
+        expect(tooltip).not.toBeVisible();
+      });
+
+      it('should not display tooltip when hovering over the bar background', () => {
+        const { container } = render(
+          <ChartElement width={500} height={500} data={data}>
+            <Bar isAnimationActive={false} dataKey="value" background={{ stroke: 'red' }} />
+            <Tooltip trigger="click" shared={false} />
+          </ChartElement>,
+        );
+
+        const tooltip = getTooltip(container);
+        expect(tooltip).not.toBeVisible();
+
+        const trigger = container.querySelector('.recharts-bar-background-rectangle');
+        assertNotNull(trigger);
+
+        fireEvent.mouseOver(trigger, { clientX: 20, clientY: 20 });
+
+        const trigger2 = container.querySelector('.recharts-bar-background-rectangle');
+        assertNotNull(trigger2);
+
+        expect(tooltip).not.toBeVisible();
+
+        fireEvent.mouseOut(trigger2);
+
+        expect(tooltip).not.toBeVisible();
+      });
+
+      it('should display tooltip when clicking on bar rectangle, and keep it displayed after second click and after mouseLeave', async () => {
+        const { container } = render(
+          <ChartElement width={500} height={500} data={data}>
+            <Bar isAnimationActive={false} dataKey="value" />
+            <Tooltip trigger="click" shared={false} />
+          </ChartElement>,
+        );
+
+        const tooltip = getTooltip(container);
+        expect(tooltip).not.toBeVisible();
+
+        const trigger = container.querySelector('.recharts-bar-rectangle');
+        assertNotNull(trigger);
+
+        fireEvent.click(trigger, { clientX: 200, clientY: 200 });
+        expect(tooltip).toBeVisible();
+
+        fireEvent.click(trigger, { clientX: 200, clientY: 200 });
+        expect(tooltip).toBeVisible();
+
+        fireEvent.mouseLeave(trigger);
+        expect(tooltip).toBeVisible();
+
+        fireEvent.mouseLeave(container);
+        expect(tooltip).toBeVisible();
+      });
+
+      it('should display tooltip when clicking on bar background, and keep it displayed after second click and after mouseLeave', async () => {
+        const { container } = render(
+          <ChartElement width={500} height={500} data={data}>
+            <Bar isAnimationActive={false} dataKey="value" background={{ stroke: 'red' }} />
+            <Tooltip trigger="click" shared={false} />
+          </ChartElement>,
+        );
+
+        const tooltip = getTooltip(container);
+        expect(tooltip).not.toBeVisible();
+
+        const trigger = container.querySelector('.recharts-bar-background-rectangle');
+        assertNotNull(trigger);
+
+        fireEvent.click(trigger, { clientX: 200, clientY: 200 });
+        expect(tooltip).toBeVisible();
+
+        fireEvent.click(trigger, { clientX: 200, clientY: 200 });
+        expect(tooltip).toBeVisible();
+
+        fireEvent.mouseLeave(trigger);
+        expect(tooltip).toBeVisible();
+
+        fireEvent.mouseLeave(container);
+        expect(tooltip).toBeVisible();
       });
     });
   });


### PR DESCRIPTION
## Description

Tooltip event handlers are the last blocker before we can remove `renderGraphicChild`, and with it `renderMap` and `renderByOrder`.

This is how things could work; I used Bar as the first implementation because I think it's the most complex one. Others will follow in a separate PR if we agree this is the way to go.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Less element cloning

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
