### PR TITLE
test(reference-line): add test that will fail if we remove defaultProps

### DIFF
--- a/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
+++ b/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MockInstance, vi, beforeEach } from 'vitest';
 import { screen, render } from '@testing-library/react';
-import { BarChart, ReferenceLine, Bar, XAxis, YAxis } from '../../../src';
+import { BarChart, ReferenceLine, Bar, XAxis, YAxis, LineChart, Line } from '../../../src';
 import { CartesianViewBox } from '../../../src/util/types';
 
 describe('<ReferenceLine />', () => {
@@ -364,5 +364,30 @@ describe('<ReferenceLine />', () => {
       </BarChart>,
     );
     expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);
+  });
+
+  /**
+   * Note: this test will fail if we remove defaultProps without proper refactoring
+   * https://github.com/recharts/recharts/issues/3615
+   */
+  test('extends the domain when ifOverflow="extendDomain" and y value is out of normal bounds', () => {
+    const dataMax = Math.max(...data.map(d => d.uv));
+    const { container } = render(
+      <LineChart width={500} height={250} data={data}>
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Line dataKey="uv" />
+        {/* extend the domain by ~100 */}
+        <ReferenceLine y={dataMax + 100} ifOverflow="extendDomain" />
+      </LineChart>,
+    );
+    const refLine = container.querySelectorAll('.recharts-reference-line-line');
+    const yAxis = container.querySelector('.recharts-yAxis');
+    const ticks = yAxis.querySelectorAll('.recharts-cartesian-axis-tick-value');
+    const topTick = ticks[ticks.length - 1];
+    expect(refLine).toHaveLength(1);
+
+    expect(refLine[0]).toHaveAttribute('y', '104.3');
+    expect(topTick.textContent).toEqual('105');
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add unit test that will fail when defaultProps are removed for referenceline. Realized that it seems everything is peachy still when I went to try to remove them again. Nope, still broken and this shows it 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Don't really want to link the defaultProps issue

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
testsss

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tests pass

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
