### PR TITLE
renderGraphicChild no longer passes activeIndex prop

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1854,17 +1854,14 @@ export const generateCategoricalChart = ({
       return null;
     }
 
-    renderGraphicChild = (element: React.ReactElement, displayName: string, index: number): any[] => {
+    renderGraphicChild = (element: React.ReactElement, displayName: string, index: number): ReactElement | null => {
       const item = this.filterFormatItem(element, displayName, index);
       if (!item) {
         return null;
       }
       const tooltipEventType = this.getTooltipEventType();
-      const { isTooltipActive, activeTooltipIndex } = this.state;
       const { children } = this.props;
       const tooltipItem = findChildByType(children, Tooltip);
-      const { hide, activeBar, activeShape } = item.item.props;
-      const hasActive = Boolean(!hide && isTooltipActive && tooltipItem && (activeBar || activeShape));
       let itemEvents = {};
 
       if (tooltipEventType !== 'axis' && tooltipItem && tooltipItem.props.trigger === 'click') {
@@ -1878,14 +1875,7 @@ export const generateCategoricalChart = ({
         };
       }
 
-      const graphicalItem = cloneElement(element, { ...item.props, ...itemEvents });
-
-      if (hasActive) {
-        const activeIndex = element.props.activeIndex !== undefined ? element.props.activeIndex : activeTooltipIndex;
-        return [cloneElement(element, { ...item.props, ...itemEvents, activeIndex }), null, null];
-      }
-
-      return [graphicalItem, null];
+      return cloneElement(element, { ...item.props, ...itemEvents });
     };
 
     renderCustomized = (element: React.ReactElement, displayName: string, index: number): React.ReactElement =>


### PR DESCRIPTION
## Description

All graphical elements are using context, time to remove this.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

No cloning

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
