### PR TITLE
refactor: remove tooltipAxisBandSize from chart state

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -651,7 +651,6 @@ const tooltipTicksGenerator = (axisMap: AxisMap) => {
     tooltipTicks,
     orderedTooltipTicks: sortBy(tooltipTicks, o => o.coordinate),
     tooltipAxis: axis,
-    tooltipAxisBandSize: getBandSizeOfAxis(axis, tooltipTicks),
   };
 };
 

--- a/src/chart/types.ts
+++ b/src/chart/types.ts
@@ -59,8 +59,6 @@ export interface CategoricalChartState {
   /** active tooltip payload */
   activePayload?: TooltipPayloadType;
 
-  tooltipAxisBandSize?: number;
-
   /** Active label of data */
   activeLabel?: string;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- remove `tooltipAxisBandSize` from chart state, it is now only accessed via hooks

BUT - `getBandSizeOfAxis` is still called multiple places in the generator, oh well one thing at a time.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
remove gross global state

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit tests pass, no more references

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
