### PR TITLE
feat: add useDisplayedChartData to splice by start/end index

### DIFF
--- a/src/context/chartDataContext.tsx
+++ b/src/context/chartDataContext.tsx
@@ -27,6 +27,23 @@ export const DataEndIndexContextProvider = DataEndIndexContext.Provider;
 export const useChartData = () => useContext(ChartDataContext);
 
 /**
+ * Return the chart data sliced by current Brush index
+ * @todo this does not account for child data and is parent data only, account for data children from the graphical child
+ * @return data array that takes Brush startIndex, endIndex into account
+ */
+export const useDisplayedChartData = () => {
+  const data = useContext(ChartDataContext);
+  const startIndex = useContext(DataStartIndexContext);
+  const endIndex = useContext(DataEndIndexContext);
+
+  if (data && data.length && Number.isInteger(startIndex) && Number.isInteger(endIndex)) {
+    return data.slice(startIndex, endIndex + 1);
+  }
+
+  return data;
+};
+
+/**
  * startIndex and endIndex are data boundaries, set through Brush.
  *
  * @return object with startIndex and endIndex

--- a/test/context/chartDataContext.spec.tsx
+++ b/test/context/chartDataContext.spec.tsx
@@ -1,0 +1,55 @@
+import React, { ComponentType } from 'react';
+import { render } from '@testing-library/react';
+import { CategoricalChartState } from '../../src/chart/types';
+import { useDisplayedChartData, ChartDataContextProvider } from '../../src/context/chartDataContext';
+import { ChartLayoutContextProvider, ChartLayoutContextProviderProps } from '../../src/context/chartLayoutContext';
+
+const minimalState: CategoricalChartState = {
+  offset: {},
+};
+const mockContextProviderProps: ChartLayoutContextProviderProps = {
+  margin: { top: 0, right: 0, bottom: 0, left: 0 },
+  state: minimalState,
+  clipPathId: 'my mock ID',
+  width: 100,
+  height: 100,
+  children: <div />,
+  layout: 'horizontal',
+};
+
+describe('chartDataContext', () => {
+  it('should get all data when there are no indices', () => {
+    expect.assertions(1);
+    const MockConsumer: ComponentType = () => {
+      const data = useDisplayedChartData();
+      expect(data).toEqual([{ test: 'hello' }, { test: 'world' }]);
+      return null;
+    };
+    render(
+      <ChartDataContextProvider value={[{ test: 'hello' }, { test: 'world' }]}>
+        <ChartLayoutContextProvider {...mockContextProviderProps} state={minimalState}>
+          <MockConsumer />
+        </ChartLayoutContextProvider>
+      </ChartDataContextProvider>,
+    );
+  });
+
+  it('should get all data when there are no indices', () => {
+    expect.assertions(1);
+    const MockConsumer: ComponentType = () => {
+      const data = useDisplayedChartData();
+      expect(data).toEqual([{ test: 'world' }]);
+      return null;
+    };
+    render(
+      <ChartDataContextProvider value={[{ test: 'hello' }, { test: 'world' }]}>
+        <ChartLayoutContextProvider
+          {...mockContextProviderProps}
+          state={{ ...minimalState, dataStartIndex: 1, dataEndIndex: 2 }}
+        >
+          <MockConsumer />
+        </ChartLayoutContextProvider>
+      </ChartDataContextProvider>,
+    );
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
idk if I made up that we need this or if we actually do

Mostly just making this PR for review @PavelVanecek where should we store sliced data? Slice it only as we read it like this?

Move data to redux? idk 🙃 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
