### PR TITLE
Tooltip data in redux, Line first

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -51,6 +51,7 @@
   "es6/util/cursor/getRadialCursorPoints.js",
   "es6/util/cursor/getCursorRectangle.js",
   "es6/util/cursor/getCursorPoints.js",
+  "es6/state/tooltipSlice.js",
   "es6/state/store.js",
   "es6/state/selectors.js",
   "es6/state/optionsSlice.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -51,6 +51,7 @@
   "lib/util/cursor/getRadialCursorPoints.js",
   "lib/util/cursor/getCursorRectangle.js",
   "lib/util/cursor/getCursorPoints.js",
+  "lib/state/tooltipSlice.js",
   "lib/state/store.js",
   "lib/state/selectors.js",
   "lib/state/optionsSlice.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -51,6 +51,7 @@
   "types/util/cursor/getRadialCursorPoints.d.ts",
   "types/util/cursor/getCursorRectangle.d.ts",
   "types/util/cursor/getCursorPoints.d.ts",
+  "types/state/tooltipSlice.d.ts",
   "types/state/store.d.ts",
   "types/state/selectors.d.ts",
   "types/state/optionsSlice.d.ts",

--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -7,6 +7,7 @@ import sortBy from 'lodash/sortBy';
 import isNil from 'lodash/isNil';
 import clsx from 'clsx';
 import { isNumOrStr } from '../util/DataUtils';
+import { DataKey } from '../util/types';
 
 function defaultFormatter<TValue extends ValueType>(value: TValue) {
   return Array.isArray(value) && isNumOrStr(value[0]) && isNumOrStr(value[1]) ? (value.join(' ~ ') as TValue) : value;
@@ -30,7 +31,8 @@ export interface Payload<TValue extends ValueType, TName extends NameType> {
   name?: TName;
   value?: TValue;
   unit?: ReactNode;
-  dataKey?: string | number;
+  fill?: string;
+  dataKey?: DataKey<any>;
   payload?: any;
   chartType?: string;
   stroke?: string;

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -114,7 +114,11 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
   } = props;
   const viewBox = useViewBox();
   const accessibilityLayer = useAccessibilityLayer();
-  const { active: activeFromContext, payload, coordinate, label } = useTooltipContext();
+  const { active: activeFromContext, payload: payloadFromProps, coordinate, label } = useTooltipContext();
+  // TODO this will fail tests until Area, Bar, and Line all push their own payloads
+  // const payloadFromContext = useAppSelector(selectTooltipPayload);
+  // const payload = payloadFromContext?.length > 0 ? payloadFromContext : payloadFromProps;
+  const payload = payloadFromProps;
   const tooltipEventType = useTooltipEventType(shared);
   const tooltipPortalFromContext = useTooltipPortal();
   /*

--- a/src/context/chartDataContext.tsx
+++ b/src/context/chartDataContext.tsx
@@ -1,10 +1,8 @@
-import { createContext, useContext, useEffect } from 'react';
+import { useEffect } from 'react';
 import { ChartData, setChartData } from '../state/chartDataSlice';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { RechartsRootState } from '../state/store';
-
-const DataStartIndexContext = createContext<number>(0);
-const DataEndIndexContext = createContext<number>(0);
+import { BrushStartEndIndex } from './brushUpdateContext';
 
 export const ChartDataContextProvider = (props: { chartData: ChartData }): null => {
   const { chartData } = props;
@@ -17,8 +15,8 @@ export const ChartDataContextProvider = (props: { chartData: ChartData }): null 
   }, [chartData, dispatch]);
   return null;
 };
-export const DataStartIndexContextProvider = DataStartIndexContext.Provider;
-export const DataEndIndexContextProvider = DataEndIndexContext.Provider;
+
+const selectChartData = (state: RechartsRootState): ChartData | undefined => state.chartData.chartData;
 
 /**
  * "data" is the data of the chart - it has no type because this part of recharts is very flexible.
@@ -36,8 +34,12 @@ export const DataEndIndexContextProvider = DataEndIndexContext.Provider;
  *
  * @return data array for some charts and undefined for other
  */
-export const useChartData = (): ChartData | undefined =>
-  useAppSelector((state: RechartsRootState) => state.chartData.chartData);
+export const useChartData = (): ChartData | undefined => useAppSelector(selectChartData);
+
+const selectDataIndex = (state: RechartsRootState): BrushStartEndIndex => {
+  const { dataStartIndex, dataEndIndex } = state.chartData;
+  return { startIndex: dataStartIndex, endIndex: dataEndIndex };
+};
 
 /**
  * startIndex and endIndex are data boundaries, set through Brush.
@@ -45,7 +47,5 @@ export const useChartData = (): ChartData | undefined =>
  * @return object with startIndex and endIndex
  */
 export const useDataIndex = () => {
-  const startIndex = useContext(DataStartIndexContext);
-  const endIndex = useContext(DataEndIndexContext);
-  return { startIndex, endIndex };
+  return useAppSelector(selectDataIndex);
 };

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -21,7 +21,6 @@ import { LegendPayloadProvider } from './legendPayloadContext';
 import { TooltipContextProvider, TooltipContextValue } from './tooltipContext';
 import { PolarRadiusAxisProps } from '../polar/PolarRadiusAxis';
 import { PolarAngleAxisProps } from '../polar/PolarAngleAxis';
-import { DataEndIndexContextProvider, DataStartIndexContextProvider } from './chartDataContext';
 import { useAppDispatch } from '../state/hooks';
 import { setActiveTooltipIndex } from '../state/tooltipSlice';
 
@@ -69,8 +68,6 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
       activePayload,
       isTooltipActive,
       activeCoordinate,
-      dataStartIndex,
-      dataEndIndex,
       updateId,
       activeTooltipIndex,
     },
@@ -114,35 +111,29 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
   return (
     <LayoutContext.Provider value={layout}>
       <UpdateIdContext.Provider value={updateId}>
-        <DataStartIndexContextProvider value={dataStartIndex}>
-          <DataEndIndexContextProvider value={dataEndIndex}>
-            <MarginContext.Provider value={margin}>
-              <LegendPayloadProvider>
-                <XAxisContext.Provider value={xAxisMap}>
-                  <YAxisContext.Provider value={yAxisMap}>
-                    <PolarAngleAxisContext.Provider value={angleAxisMap}>
-                      <PolarRadiusAxisContext.Provider value={radiusAxisMap}>
-                        <OffsetContext.Provider value={offset}>
-                          <ViewBoxContext.Provider value={viewBox}>
-                            <ClipPathIdContext.Provider value={clipPathId}>
-                              <ChartHeightContext.Provider value={height}>
-                                <ChartWidthContext.Provider value={width}>
-                                  <TooltipContextProvider value={tooltipContextValue}>
-                                    {children}
-                                  </TooltipContextProvider>
-                                </ChartWidthContext.Provider>
-                              </ChartHeightContext.Provider>
-                            </ClipPathIdContext.Provider>
-                          </ViewBoxContext.Provider>
-                        </OffsetContext.Provider>
-                      </PolarRadiusAxisContext.Provider>
-                    </PolarAngleAxisContext.Provider>
-                  </YAxisContext.Provider>
-                </XAxisContext.Provider>
-              </LegendPayloadProvider>
-            </MarginContext.Provider>
-          </DataEndIndexContextProvider>
-        </DataStartIndexContextProvider>
+        <MarginContext.Provider value={margin}>
+          <LegendPayloadProvider>
+            <XAxisContext.Provider value={xAxisMap}>
+              <YAxisContext.Provider value={yAxisMap}>
+                <PolarAngleAxisContext.Provider value={angleAxisMap}>
+                  <PolarRadiusAxisContext.Provider value={radiusAxisMap}>
+                    <OffsetContext.Provider value={offset}>
+                      <ViewBoxContext.Provider value={viewBox}>
+                        <ClipPathIdContext.Provider value={clipPathId}>
+                          <ChartHeightContext.Provider value={height}>
+                            <ChartWidthContext.Provider value={width}>
+                              <TooltipContextProvider value={tooltipContextValue}>{children}</TooltipContextProvider>
+                            </ChartWidthContext.Provider>
+                          </ChartHeightContext.Provider>
+                        </ClipPathIdContext.Provider>
+                      </ViewBoxContext.Provider>
+                    </OffsetContext.Provider>
+                  </PolarRadiusAxisContext.Provider>
+                </PolarAngleAxisContext.Provider>
+              </YAxisContext.Provider>
+            </XAxisContext.Provider>
+          </LegendPayloadProvider>
+        </MarginContext.Provider>
       </UpdateIdContext.Provider>
     </LayoutContext.Provider>
   );

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -22,6 +22,8 @@ import { TooltipContextProvider, TooltipContextValue } from './tooltipContext';
 import { PolarRadiusAxisProps } from '../polar/PolarRadiusAxis';
 import { PolarAngleAxisProps } from '../polar/PolarAngleAxis';
 import { DataEndIndexContextProvider, DataStartIndexContextProvider } from './chartDataContext';
+import { useAppDispatch } from '../state/hooks';
+import { setActiveTooltipIndex } from '../state/tooltipSlice';
 
 export const XAxisContext = createContext<XAxisMap | undefined>(undefined);
 export const YAxisContext = createContext<YAxisMap | undefined>(undefined);
@@ -92,6 +94,9 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
     active: isTooltipActive,
     index: activeTooltipIndex,
   };
+
+  const dispatch = useAppDispatch();
+  dispatch(setActiveTooltipIndex(tooltipContextValue.index));
 
   /*
    * This pretends to be a single context but actually is split into multiple smaller ones.

--- a/src/state/chartDataSlice.ts
+++ b/src/state/chartDataSlice.ts
@@ -1,4 +1,5 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import { BrushStartEndIndex } from '../context/brushUpdateContext';
 
 /**
  * This is the data that's coming through main chart `data` prop
@@ -31,19 +32,20 @@ const chartDataSlice = createSlice({
   initialState,
   /* eslint-disable no-param-reassign */
   reducers: {
-    setChartData(state, action: PayloadAction<ChartData>) {
+    setChartData(state, action: PayloadAction<ChartData | undefined>) {
       state.chartData = action.payload;
+      if (state.dataEndIndex <= 0 && action.payload != null) {
+        state.dataEndIndex = action.payload.length - 1;
+      }
     },
-    setDataStartIndex(state, action: PayloadAction<number>) {
-      state.dataStartIndex = action.payload;
-    },
-    setDataEndIndex(state, action: PayloadAction<number>) {
-      state.dataEndIndex = action.payload;
+    setDataStartEndIndexes(state, action: PayloadAction<BrushStartEndIndex>) {
+      state.dataStartIndex = action.payload.startIndex;
+      state.dataEndIndex = action.payload.endIndex;
     },
   },
   /* eslint-enable no-param-reassign */
 });
 
-export const { setChartData, setDataStartIndex, setDataEndIndex } = chartDataSlice.actions;
+export const { setChartData, setDataStartEndIndexes } = chartDataSlice.actions;
 
 export const chartDataReducer = chartDataSlice.reducer;

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -1,5 +1,7 @@
 import { useAppSelector } from './hooks';
 import { RechartsRootState } from './store';
+import { TooltipPayload } from './tooltipSlice';
+import { getTooltipEntry, getValueByDataKey } from '../util/ChartUtils';
 
 export const useChartName = (): string => {
   return useAppSelector((state: RechartsRootState) => state.options.chartName);
@@ -15,4 +17,29 @@ export function useTooltipEventType(shared: boolean | undefined) {
   }
   const eventType = shared ? 'axis' : 'item';
   return validateTooltipEventTypes.includes(eventType) ? eventType : defaultTooltipEventType;
+}
+
+export function selectTooltipPayload(state: RechartsRootState): TooltipPayload | undefined {
+  const { activeIndex, tooltipItemPayloads } = state.tooltip;
+  const chartData = state.chartData.chartData;
+  /*
+   * If a payload has data specified directly from the graphical item, prefer that.
+   * Otherwise, fill in data from the chart level, using the same index.
+   */
+  return tooltipItemPayloads.map(({ dataDefinedOnItem, settings }) => {
+    const finalData = dataDefinedOnItem ?? chartData;
+
+    // TODO slicing
+    const sliced = finalData;
+
+    // TODO settings coming from Tooltip props
+    const tooltipPayload = sliced[activeIndex];
+    const tooltipEntry = getTooltipEntry({
+      tooltipEntrySettings: settings,
+      dataKey: settings.dataKey,
+      payload: tooltipPayload,
+      value: getValueByDataKey(tooltipPayload, settings.dataKey),
+    });
+    return tooltipEntry;
+  });
 }

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -21,6 +21,9 @@ export function useTooltipEventType(shared: boolean | undefined) {
 
 export function selectTooltipPayload(state: RechartsRootState): TooltipPayload | undefined {
   const { activeIndex, tooltipItemPayloads } = state.tooltip;
+  if (activeIndex === -1) {
+    return undefined;
+  }
   const { chartData } = state.chartData;
   /*
    * If a payload has data specified directly from the graphical item, prefer that.
@@ -33,12 +36,12 @@ export function selectTooltipPayload(state: RechartsRootState): TooltipPayload |
     const sliced = finalData;
 
     // TODO settings coming from Tooltip props
-    const tooltipPayload = sliced[activeIndex];
+    const tooltipPayload = sliced?.[activeIndex];
     const tooltipEntry = getTooltipEntry({
       tooltipEntrySettings: settings,
-      dataKey: settings.dataKey,
+      dataKey: settings?.dataKey,
       payload: tooltipPayload,
-      value: getValueByDataKey(tooltipPayload, settings.dataKey),
+      value: getValueByDataKey(tooltipPayload, settings?.dataKey),
     });
     return tooltipEntry;
   });

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -21,7 +21,7 @@ export function useTooltipEventType(shared: boolean | undefined) {
 
 export function selectTooltipPayload(state: RechartsRootState): TooltipPayload | undefined {
   const { activeIndex, tooltipItemPayloads } = state.tooltip;
-  const chartData = state.chartData.chartData;
+  const { chartData } = state.chartData;
   /*
    * If a payload has data specified directly from the graphical item, prefer that.
    * Otherwise, fill in data from the chart level, using the same index.

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -19,12 +19,19 @@ export function useTooltipEventType(shared: boolean | undefined) {
   return validateTooltipEventTypes.includes(eventType) ? eventType : defaultTooltipEventType;
 }
 
+function getSliced<T>(arr: ReadonlyArray<T>, startIndex: number, endIndex: number): ReadonlyArray<T> {
+  if (arr && startIndex + endIndex !== 0) {
+    return arr.slice(startIndex, endIndex + 1);
+  }
+  return arr;
+}
+
 export function selectTooltipPayload(state: RechartsRootState): TooltipPayload | undefined {
   const { activeIndex, tooltipItemPayloads } = state.tooltip;
   if (activeIndex === -1) {
     return undefined;
   }
-  const { chartData } = state.chartData;
+  const { chartData, dataStartIndex, dataEndIndex } = state.chartData;
   /*
    * If a payload has data specified directly from the graphical item, prefer that.
    * Otherwise, fill in data from the chart level, using the same index.
@@ -32,8 +39,7 @@ export function selectTooltipPayload(state: RechartsRootState): TooltipPayload |
   return tooltipItemPayloads.map(({ dataDefinedOnItem, settings }) => {
     const finalData = dataDefinedOnItem ?? chartData;
 
-    // TODO slicing
-    const sliced = finalData;
+    const sliced = getSliced(finalData, dataStartIndex, dataEndIndex);
 
     // TODO settings coming from Tooltip props
     const tooltipPayload = sliced?.[activeIndex];

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,9 +1,11 @@
 import { Action, combineReducers, configureStore, Dispatch } from '@reduxjs/toolkit';
 import { optionsReducer } from './optionsSlice';
+import { tooltipReducer } from './tooltipSlice';
 import { chartDataReducer } from './chartDataSlice';
 
 const rootReducer = combineReducers({
   options: optionsReducer,
+  tooltip: tooltipReducer,
   chartData: chartDataReducer,
 });
 

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -1,0 +1,75 @@
+import { createSlice, current, PayloadAction } from '@reduxjs/toolkit';
+import { NameType, Payload, ValueType } from '../component/DefaultTooltipContent';
+
+/**
+ * One Tooltip can display multiple TooltipPayloadEntries at a time.
+ */
+export type TooltipPayloadEntry = Payload<ValueType, NameType>;
+
+/**
+ * So what happens is that the tooltip payload is decided based on the available data, and the dataKey.
+ * The dataKey can either be defined on the graphical element (like Line, or Bar)
+ * or on the tooltip itself.
+ *
+ * The data can be defined in the chart element, or in the graphical item.
+ *
+ * So this type is all the settings, other than the data + dataKey complications.
+ */
+export type TooltipEntrySettings = Omit<TooltipPayloadEntry, 'payload' | 'value'>;
+
+/**
+ * This is what Tooltip renders.
+ */
+export type TooltipPayload = ReadonlyArray<TooltipPayloadEntry>;
+
+type TooltipIndex = number;
+
+export type TooltipPayloadConfiguration = {
+  // This is the data that is the same for all tooltip payloads, regardless of activeIndex
+  settings: TooltipEntrySettings;
+  // This is the data that changes for each index
+  dataDefinedOnItem: unknown[] | undefined;
+};
+
+export type TooltipState = {
+  /**
+   * This is the current data index that is set for the chart.
+   * This can come from mouse events, keyboard events, or hardcoded in props
+   * in property `defaultIndex` on Tooltip.
+   */
+  activeIndex: TooltipIndex;
+  /**
+   * One graphical item will have one configuration;
+   * hovering over multiple of them (for example with tooltipEventType===axis)
+   * may render multiple tooltip payloads.
+   */
+  tooltipItemPayloads: ReadonlyArray<TooltipPayloadConfiguration>;
+};
+
+const initialState: TooltipState = {
+  activeIndex: -1,
+  tooltipItemPayloads: [],
+};
+
+const tooltipSlice = createSlice({
+  name: 'tooltip',
+  initialState,
+  reducers: {
+    addTooltipEntrySettings(state, action: PayloadAction<TooltipPayloadConfiguration>) {
+      state.tooltipItemPayloads.push(action.payload);
+    },
+    removeTooltipEntrySettings(state, action: PayloadAction<TooltipPayloadConfiguration>) {
+      const index = current(state).tooltipItemPayloads.indexOf(action.payload);
+      if (index > -1) {
+        state.tooltipItemPayloads.splice(index, 1);
+      }
+    },
+    setActiveTooltipIndex(state, action: PayloadAction<TooltipIndex>) {
+      state.activeIndex = action.payload;
+    },
+  },
+});
+
+export const { addTooltipEntrySettings, removeTooltipEntrySettings, setActiveTooltipIndex } = tooltipSlice.actions;
+
+export const tooltipReducer = tooltipSlice.reducer;

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -54,6 +54,7 @@ const initialState: TooltipState = {
 const tooltipSlice = createSlice({
   name: 'tooltip',
   initialState,
+  /* eslint-disable no-param-reassign */
   reducers: {
     addTooltipEntrySettings(state, action: PayloadAction<TooltipPayloadConfiguration>) {
       state.tooltipItemPayloads.push(action.payload);
@@ -68,6 +69,7 @@ const tooltipSlice = createSlice({
       state.activeIndex = action.payload;
     },
   },
+  /* eslint-enable no-param-reassign */
 });
 
 export const { addTooltipEntrySettings, removeTooltipEntrySettings, setActiveTooltipIndex } = tooltipSlice.actions;

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1,3 +1,14 @@
+import flatMap from 'lodash/flatMap';
+import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
+import isFunction from 'lodash/isFunction';
+import isNan from 'lodash/isNaN';
+import isNil from 'lodash/isNil';
+import isString from 'lodash/isString';
+import max from 'lodash/max';
+import min from 'lodash/min';
+import sortBy from 'lodash/sortBy';
+import upperFirst from 'lodash/upperFirst';
 import * as d3Scales from 'victory-vendor/d3-scale';
 import {
   Series,
@@ -8,17 +19,6 @@ import {
   stackOffsetWiggle,
   stackOrderNone,
 } from 'victory-vendor/d3-shape';
-import max from 'lodash/max';
-import min from 'lodash/min';
-import isNil from 'lodash/isNil';
-import isFunction from 'lodash/isFunction';
-import isString from 'lodash/isString';
-import get from 'lodash/get';
-import flatMap from 'lodash/flatMap';
-import isNan from 'lodash/isNaN';
-import upperFirst from 'lodash/upperFirst';
-import isEqual from 'lodash/isEqual';
-import sortBy from 'lodash/sortBy';
 
 import { ReactElement, ReactNode } from 'react';
 
@@ -27,24 +27,26 @@ import { findEntryInArray, getPercentValue, isNumber, isNumOrStr, mathSign, uniq
 import { filterProps, findAllByType, findChildByType, getDisplayName } from './ReactUtils';
 // TODO: Cause of circular dependency. Needs refactor.
 // import { RadiusAxisProps, AngleAxisProps } from '../polar/types';
+import { Legend } from '../component/Legend';
+import { TooltipEntrySettings, TooltipPayloadEntry } from '../state/tooltipSlice';
+import { getLegendProps } from './getLegendProps';
+import { getNiceTickValues, getTickValuesFixedDomain } from './scale';
 import {
   AxisType,
   BaseAxisProps,
+  CategoricalDomain,
+  ChartOffset,
   DataKey,
   LayoutType,
-  PolarLayoutType,
-  NumberDomain,
-  TickItem,
-  CategoricalDomain,
-  StackOffsetType,
   Margin,
-  ChartOffset,
+  NumberDomain,
+  PolarLayoutType,
+  StackOffsetType,
+  TickItem,
   XAxisMap,
 } from './types';
-import { getLegendProps } from './getLegendProps';
 import { BoundingBox } from './useGetBoundingClientRect';
-import { getNiceTickValues, getTickValuesFixedDomain } from './scale';
-import { Legend } from '../component/Legend';
+import { ValueType } from '../component/DefaultTooltipContent';
 
 // Exported for backwards compatibility
 export { getLegendProps };
@@ -1296,6 +1298,12 @@ export const parseDomainOfCategoryAxis = <T>(
   return specifiedDomain;
 };
 
+/**
+ * @deprecated instead use {@link getTooltipEntry}
+ * @param graphicalItem do not use
+ * @param payload do not use
+ * @return do not use
+ */
 export const getTooltipItem = (
   graphicalItem: {
     type: { displayName: string };
@@ -1329,6 +1337,25 @@ export const getTooltipItem = (
     hide,
   };
 };
+
+export function getTooltipEntry({
+  tooltipEntrySettings,
+  dataKey,
+  payload,
+  value,
+}: {
+  tooltipEntrySettings: TooltipEntrySettings;
+  dataKey: string | number;
+  payload: any;
+  value: ValueType;
+}): TooltipPayloadEntry {
+  return {
+    ...tooltipEntrySettings,
+    dataKey,
+    payload,
+    value,
+  };
+}
 
 export const isAxisLTR = (axisMap: XAxisMap) => {
   const axes = Object.values(axisMap ?? {});

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1345,7 +1345,7 @@ export function getTooltipEntry({
   value,
 }: {
   tooltipEntrySettings: TooltipEntrySettings;
-  dataKey: string | number;
+  dataKey: DataKey<any>;
   payload: any;
   value: ValueType;
 }): TooltipPayloadEntry {
@@ -1355,6 +1355,16 @@ export function getTooltipEntry({
     payload,
     value,
   };
+}
+
+export function getTooltipNameProp(nameFromItem: string | undefined, dataKey: DataKey<any>): string | undefined {
+  if (nameFromItem) {
+    return nameFromItem;
+  }
+  if (typeof dataKey === 'string') {
+    return dataKey;
+  }
+  return undefined;
 }
 
 export const isAxisLTR = (axisMap: XAxisMap) => {

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -15,6 +15,6 @@ const config = {
     "prioritizePerformanceOverAccuracy": true
   },
   ignoreStatic: true,
-  mutate: ['src/component/Legend.tsx']
+  mutate: ['src/state/selectors.ts']
 };
 export default config;

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -12,7 +12,7 @@ import {
   TooltipPayloadConfiguration,
   TooltipPayloadEntry,
 } from '../../src/state/tooltipSlice';
-import { setChartData } from '../../src/state/chartDataSlice';
+import { setChartData, setDataStartEndIndexes } from '../../src/state/chartDataSlice';
 
 describe('useTooltipEventType', () => {
   type TooltipEventTypeTestScenario = {
@@ -178,7 +178,41 @@ describe('selectTooltipPayload', () => {
     expect(selectTooltipPayload(store.getState())).toEqual([expectedEntry]);
   });
 
-  it.todo('should return sliced data if set by Brush');
+  it('should return sliced data if set by Brush', () => {
+    const store = createRechartsStore();
+    const tooltipSettings: TooltipPayloadConfiguration = {
+      settings: {
+        stroke: 'red',
+        fill: 'green',
+        dataKey: 'y',
+        name: 'foo',
+      },
+      dataDefinedOnItem: [
+        { x: 1, y: 2 },
+        { x: 3, y: 4 },
+      ],
+    };
+    store.dispatch(addTooltipEntrySettings(tooltipSettings));
+    store.dispatch(
+      setChartData([
+        { x: 1, y: 2 },
+        { x: 3, y: 4 },
+      ]),
+    );
+    expect(selectTooltipPayload(store.getState())).toEqual(undefined);
+    store.dispatch(setActiveTooltipIndex(0));
+    store.dispatch(setDataStartEndIndexes({ startIndex: 1, endIndex: 10 }));
+    const expectedEntry: TooltipPayloadEntry = {
+      name: 'foo',
+      dataKey: 'y',
+      stroke: 'red',
+      fill: 'green',
+      payload: { x: 3, y: 4 },
+      value: 4,
+    };
+    expect(selectTooltipPayload(store.getState())).toEqual([expectedEntry]);
+  });
+
   it.todo('should prefer to use dataKey from tooltipAxis, if it is defined');
   it.todo('should do something - not quite sure what exactly yet - with tooltipAxis.allowDuplicatedCategory');
 });

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -1,58 +1,66 @@
 import React from 'react';
 import { describe, it, test, expect } from 'vitest';
 import { render } from '@testing-library/react';
-import { useTooltipEventType } from '../../src/state/selectors';
-import { RechartsRootState } from '../../src/state/store';
+import { selectTooltipPayload, useTooltipEventType } from '../../src/state/selectors';
+import { createRechartsStore, RechartsRootState } from '../../src/state/store';
 import { RechartsStoreProvider } from '../../src/state/RechartsStoreProvider';
 import { TooltipEventType } from '../../src/util/types';
-
-type TooltipEventTypeTestScenario = {
-  testName: string;
-  shared: undefined | boolean;
-  defaultTooltipEventType: TooltipEventType;
-  validateTooltipEventTypes: ReadonlyArray<TooltipEventType>;
-  expected: TooltipEventType;
-};
-
-const testCases: ReadonlyArray<TooltipEventTypeTestScenario> = [
-  {
-    testName: 'default case',
-    shared: undefined,
-    defaultTooltipEventType: 'item',
-    validateTooltipEventTypes: [],
-    expected: 'item',
-  },
-  {
-    testName: 'shared and axis type is allowed',
-    shared: true,
-    defaultTooltipEventType: 'item',
-    validateTooltipEventTypes: ['axis', 'item'],
-    expected: 'axis',
-  },
-  {
-    testName: 'shared but axis type is not allowed',
-    shared: true,
-    defaultTooltipEventType: 'item',
-    validateTooltipEventTypes: ['item'],
-    expected: 'item',
-  },
-  {
-    testName: 'not shared and item type is allowed',
-    shared: false,
-    defaultTooltipEventType: 'axis',
-    validateTooltipEventTypes: ['axis', 'item'],
-    expected: 'item',
-  },
-  {
-    testName: 'not shared but item type is not allowed',
-    shared: false,
-    defaultTooltipEventType: 'axis',
-    validateTooltipEventTypes: ['axis'],
-    expected: 'axis',
-  },
-];
+import { useAppSelector } from '../../src/state/hooks';
+import {
+  addTooltipEntrySettings,
+  setActiveTooltipIndex,
+  TooltipPayloadConfiguration,
+  TooltipPayloadEntry,
+} from '../../src/state/tooltipSlice';
+import { setChartData } from '../../src/state/chartDataSlice';
 
 describe('useTooltipEventType', () => {
+  type TooltipEventTypeTestScenario = {
+    testName: string;
+    shared: undefined | boolean;
+    defaultTooltipEventType: TooltipEventType;
+    validateTooltipEventTypes: ReadonlyArray<TooltipEventType>;
+    expected: TooltipEventType;
+  };
+
+  const testCases: ReadonlyArray<TooltipEventTypeTestScenario> = [
+    {
+      testName: 'default case',
+      shared: undefined,
+      defaultTooltipEventType: 'item',
+      validateTooltipEventTypes: [],
+      expected: 'item',
+    },
+    {
+      testName: 'shared and axis type is allowed',
+      shared: true,
+      defaultTooltipEventType: 'item',
+      validateTooltipEventTypes: ['axis', 'item'],
+      expected: 'axis',
+    },
+    {
+      testName: 'shared but axis type is not allowed',
+      shared: true,
+      defaultTooltipEventType: 'item',
+      validateTooltipEventTypes: ['item'],
+      expected: 'item',
+    },
+    {
+      testName: 'not shared and item type is allowed',
+      shared: false,
+      defaultTooltipEventType: 'axis',
+      validateTooltipEventTypes: ['axis', 'item'],
+      expected: 'item',
+    },
+    {
+      testName: 'not shared but item type is not allowed',
+      shared: false,
+      defaultTooltipEventType: 'axis',
+      validateTooltipEventTypes: ['axis'],
+      expected: 'axis',
+    },
+  ];
+
   it('should return undefined when outside of Redux context', () => {
     expect.assertions(1);
     const Comp = (): null => {
@@ -82,4 +90,95 @@ describe('useTooltipEventType', () => {
       );
     },
   );
+});
+
+describe('selectTooltipPayload', () => {
+  it('should return undefined when outside of Redux context', () => {
+    expect.assertions(1);
+    const Comp = (): null => {
+      const payload = useAppSelector(selectTooltipPayload);
+      expect(payload).toBe(undefined);
+      return null;
+    };
+    render(<Comp />);
+  });
+
+  it('initial state should return undefined', () => {
+    const store = createRechartsStore();
+    expect(selectTooltipPayload(store.getState())).toEqual(undefined);
+  });
+
+  it('should return settings and data from a graphical item, if activeIndex is set', () => {
+    const store = createRechartsStore();
+    const tooltipSettings1: TooltipPayloadConfiguration = {
+      settings: undefined,
+      dataDefinedOnItem: undefined,
+    };
+    const expectedEntry1: TooltipPayloadEntry = {
+      payload: undefined,
+      dataKey: undefined,
+      value: undefined,
+    };
+    const tooltipSettings2: TooltipPayloadConfiguration = {
+      settings: {
+        stroke: 'red',
+        fill: 'green',
+        dataKey: 'x',
+        name: 'foo',
+      },
+      dataDefinedOnItem: [
+        { x: 8, y: 9 },
+        { x: 10, y: 11 },
+      ],
+    };
+    const expectedEntry2: TooltipPayloadEntry = {
+      name: 'foo',
+      dataKey: 'x',
+      stroke: 'red',
+      fill: 'green',
+      payload: { x: 10, y: 11 },
+      value: 10,
+    };
+    store.dispatch(addTooltipEntrySettings(tooltipSettings1));
+    store.dispatch(addTooltipEntrySettings(tooltipSettings2));
+    expect(selectTooltipPayload(store.getState())).toEqual(undefined);
+    store.dispatch(setActiveTooltipIndex(1));
+    expect(selectTooltipPayload(store.getState())).toEqual([expectedEntry1, expectedEntry2]);
+  });
+
+  it('should fill in chartData, if it is not defined on the item', () => {
+    const store = createRechartsStore();
+    const tooltipSettings: TooltipPayloadConfiguration = {
+      settings: {
+        stroke: 'red',
+        fill: 'green',
+        dataKey: 'y',
+        name: 'foo',
+      },
+      dataDefinedOnItem: undefined,
+    };
+    store.dispatch(addTooltipEntrySettings(tooltipSettings));
+    store.dispatch(
+      setChartData([
+        { x: 1, y: 2 },
+        { x: 3, y: 4 },
+      ]),
+    );
+    store.dispatch(setActiveTooltipIndex(0));
+
+    const expectedEntry: TooltipPayloadEntry = {
+      name: 'foo',
+      dataKey: 'y',
+      stroke: 'red',
+      fill: 'green',
+      payload: { x: 1, y: 2 },
+      value: 2,
+    };
+
+    expect(selectTooltipPayload(store.getState())).toEqual([expectedEntry]);
+  });
+
+  it.todo('should return sliced data if set by Brush');
+  it.todo('should prefer to use dataKey from tooltipAxis, if it is defined');
+  it.todo('should do something - not quite sure what exactly yet - with tooltipAxis.allowDuplicatedCategory');
 });


### PR DESCRIPTION
## Description

Okay this is how I think Tooltip can work. The tooltip state is not used anywhere yet, that will come in next PR. If we can merge as-is I will follow up.

Good news is - Tooltip works, it reads data from graphical children without the need to lookup all the children in generateCategoricalChart.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Element cloning

## How Has This Been Tested?

npm test - passes
storybooks - working

if I uncomment the Tooltip code and try - LineChart works, tests fail because of two unfinished tasks:
- Tooltip uses either context payload, or props payload, not both - so the test that has ComposedChart with Area + Bar + Line fails. This will be fixed when all three Area + Bar + Line use redux, can't have that done with just one.
- It's missing the part where it should read props from Tooltip and use those
- ~Brush slicing is not yet implemented~ okay I fixed and pushed this one

I will fix both.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
