### PR TITLE
Area + Bar send their tooltip data to redux store

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Area
  */
-import React, { PureComponent, SVGProps } from 'react';
+import React, { PureComponent, SVGProps, useEffect } from 'react';
 import clsx from 'clsx';
 import Animate from 'react-smooth';
 import isFunction from 'lodash/isFunction';
@@ -15,7 +15,7 @@ import { Layer } from '../container/Layer';
 import { LabelList } from '../component/LabelList';
 import { Global } from '../util/Global';
 import { isNumber, uniqueId, interpolateNumber } from '../util/DataUtils';
-import { getCateCoordinateOfLine, getValueByDataKey } from '../util/ChartUtils';
+import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
 import { Props as XAxisProps } from './XAxis';
 import { Props as YAxisProps } from './YAxis';
 import {
@@ -35,6 +35,12 @@ import { filterProps, isDotProps } from '../util/ReactUtils';
 import type { Payload as LegendPayload } from '../component/DefaultLegendContent';
 import { useLegendPayloadDispatch } from '../context/legendPayloadContext';
 import { ActivePoints } from '../component/ActivePoints';
+import {
+  addTooltipEntrySettings,
+  removeTooltipEntrySettings,
+  TooltipPayloadConfiguration,
+} from '../state/tooltipSlice';
+import { useAppDispatch } from '../state/hooks';
 
 interface AreaPointItem extends CurvePoint {
   value?: number | number[];
@@ -127,6 +133,35 @@ const computeLegendPayloadFromAreaData = (props: Props): Array<LegendPayload> =>
 
 function SetAreaLegend(props: Props): null {
   useLegendPayloadDispatch(computeLegendPayloadFromAreaData, props);
+  return null;
+}
+
+function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
+  const { dataKey, data, stroke, strokeWidth, fill, name, hide } = props;
+  return {
+    dataDefinedOnItem: data,
+    settings: {
+      stroke,
+      strokeWidth,
+      fill,
+      dataKey,
+      name: getTooltipNameProp(name, dataKey),
+      hide,
+      type: props.tooltipType,
+      color: getLegendItemColor(stroke, fill),
+    },
+  };
+}
+
+function SetTooltipEntrySettings(props: Props): null {
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    const tooltipEntrySettings: TooltipPayloadConfiguration = getTooltipEntrySettings(props);
+    dispatch(addTooltipEntrySettings(tooltipEntrySettings));
+    return () => {
+      dispatch(removeTooltipEntrySettings(tooltipEntrySettings));
+    };
+  }, [props, dispatch]);
   return null;
 }
 
@@ -581,7 +616,12 @@ export class Area extends PureComponent<Props, State> {
       this.props;
 
     if (hide || !points || !points.length) {
-      return <SetAreaLegend {...this.props} />;
+      return (
+        <>
+          <SetAreaLegend {...this.props} />
+          <SetTooltipEntrySettings {...this.props} />
+        </>
+      );
     }
 
     const { isAnimationFinished } = this.state;
@@ -599,6 +639,7 @@ export class Area extends PureComponent<Props, State> {
       <>
         <Layer className={layerClass}>
           <SetAreaLegend {...this.props} />
+          <SetTooltipEntrySettings {...this.props} />
           {needClipX || needClipY ? (
             <defs>
               <clipPath id={`clipPath-${clipPathId}`}>

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -137,7 +137,7 @@ function SetAreaLegend(props: Props): null {
 }
 
 function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
-  const { dataKey, data, stroke, strokeWidth, fill, name, hide } = props;
+  const { dataKey, data, stroke, strokeWidth, fill, name, hide, unit } = props;
   return {
     dataDefinedOnItem: data,
     settings: {
@@ -149,6 +149,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
       hide,
       type: props.tooltipType,
       color: getLegendItemColor(stroke, fill),
+      unit,
     },
   };
 }

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -145,7 +145,7 @@ function SetBarLegend(props: Props): null {
 }
 
 function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
-  const { dataKey, data, stroke, strokeWidth, fill, name, hide } = props;
+  const { dataKey, data, stroke, strokeWidth, fill, name, hide, unit } = props;
   return {
     dataDefinedOnItem: data,
     settings: {
@@ -157,6 +157,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
       hide,
       type: props.tooltipType,
       color: props.fill,
+      unit,
     },
   };
 }

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -123,7 +123,7 @@ function SetLineLegend(props: Props): null {
 }
 
 function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
-  const { dataKey, data, stroke, strokeWidth, fill, name, hide } = props;
+  const { dataKey, data, stroke, strokeWidth, fill, name, hide, unit } = props;
   return {
     dataDefinedOnItem: data,
     settings: {
@@ -135,6 +135,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
       hide,
       type: props.tooltipType,
       color: props.stroke,
+      unit,
     },
   };
 }

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -115,7 +115,7 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
   const viewBox = useViewBox();
   const accessibilityLayer = useAccessibilityLayer();
   const { active: activeFromContext, payload: payloadFromProps, coordinate, label } = useTooltipContext();
-  // TODO this will fail tests until Area, Bar, and Line all push their own payloads
+  // TODO this will fail tests until Tooltip props and tooltipAxis are in Redux
   // const payloadFromContext = useAppSelector(selectTooltipPayload);
   // const payload = payloadFromContext?.length > 0 ? payloadFromContext : payloadFromProps;
   const payload = payloadFromProps;

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -41,7 +41,7 @@ export function selectTooltipPayload(state: RechartsRootState): TooltipPayload |
 
     const sliced = getSliced(finalData, dataStartIndex, dataEndIndex);
 
-    // TODO settings coming from Tooltip props
+    // TODO settings coming from Tooltip props, and tooltipAxis
     const tooltipPayload = sliced?.[activeIndex];
     const tooltipEntry = getTooltipEntry({
       tooltipEntrySettings: settings,

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1357,9 +1357,12 @@ export function getTooltipEntry({
   };
 }
 
-export function getTooltipNameProp(nameFromItem: string | undefined, dataKey: DataKey<any>): string | undefined {
+export function getTooltipNameProp(
+  nameFromItem: string | number | undefined,
+  dataKey: DataKey<any>,
+): string | undefined {
   if (nameFromItem) {
-    return nameFromItem;
+    return String(nameFromItem);
   }
   if (typeof dataKey === 'string') {
     return dataKey;

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -125,6 +125,7 @@ describe('selectTooltipPayload', () => {
         fill: 'green',
         dataKey: 'x',
         name: 'foo',
+        unit: 'bar',
       },
       dataDefinedOnItem: [
         { x: 8, y: 9 },
@@ -138,6 +139,7 @@ describe('selectTooltipPayload', () => {
       fill: 'green',
       payload: { x: 10, y: 11 },
       value: 10,
+      unit: 'bar',
     };
     store.dispatch(addTooltipEntrySettings(tooltipSettings1));
     store.dispatch(addTooltipEntrySettings(tooltipSettings2));
@@ -154,6 +156,7 @@ describe('selectTooltipPayload', () => {
         fill: 'green',
         dataKey: 'y',
         name: 'foo',
+        unit: 'bar',
       },
       dataDefinedOnItem: undefined,
     };
@@ -173,6 +176,7 @@ describe('selectTooltipPayload', () => {
       fill: 'green',
       payload: { x: 1, y: 2 },
       value: 2,
+      unit: 'bar',
     };
 
     expect(selectTooltipPayload(store.getState())).toEqual([expectedEntry]);


### PR DESCRIPTION
## Description

Following up on the idea from https://github.com/recharts/recharts/pull/4518

This is still failing tests - to start actually using the Redux data in Tooltip, I need to migrate the tooltipAxis next.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

No element cloning.

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
