### PR TITLE
Activeshape mouseleave fix

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -245,7 +245,7 @@ function BarRectangles(props: BarRectanglesProps) {
   const baseProps = filterProps(rest, false);
   const { data, shape, dataKey, activeBar } = props;
 
-  const { index: activeIndex } = useTooltipContext();
+  const { index: activeIndex, active: isTooltipActive } = useTooltipContext();
   const {
     onMouseEnter: onMouseEnterFromProps,
     onClick: onItemClickFromProps,
@@ -264,7 +264,7 @@ function BarRectangles(props: BarRectanglesProps) {
   return (
     <>
       {data.map((entry, i) => {
-        const isActive = activeBar && i === activeIndex;
+        const isActive = isTooltipActive && activeBar && i === activeIndex;
         const option = isActive ? activeBar : shape;
         const barRectangleProps = {
           ...baseProps,

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -141,7 +141,7 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
   const { shape, activeShape } = allOtherScatterProps;
   const baseProps = filterProps(allOtherScatterProps, false);
 
-  const { index: activeIndex } = useTooltipContext();
+  const { index: activeIndex, active: isTooltipActive } = useTooltipContext();
   const {
     onMouseEnter: onMouseEnterFromProps,
     onClick: onItemClickFromProps,
@@ -156,7 +156,7 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
   return (
     <>
       {points.map((entry, i) => {
-        const isActive = activeShape && activeIndex === i;
+        const isActive = isTooltipActive && activeShape && activeIndex === i;
         const option = isActive ? activeShape : shape;
         const symbolProps = { key: `symbol-${i}`, ...baseProps, ...entry };
 

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -14,7 +14,7 @@ export const doNotDisplayTooltip: TooltipContextValue = {
   payload: [],
   coordinate: { x: 0, y: 0 },
   active: false,
-  index: 0,
+  index: -1,
 };
 
 const TooltipContext = createContext<TooltipContextValue>(doNotDisplayTooltip);

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -198,7 +198,7 @@ type PieSectorsProps = {
 function PieSectors(props: PieSectorsProps) {
   const { sectors, sectorRefs, activeShape, blendStroke, inactiveShape: inactiveShapeProp, allOtherPieProps } = props;
 
-  const { index: activeIndex } = useTooltipContext();
+  const { index: activeIndex, active: isTooltipActive } = useTooltipContext();
   const {
     onMouseEnter: onMouseEnterFromProps,
     onClick: onItemClickFromProps,
@@ -212,7 +212,7 @@ function PieSectors(props: PieSectorsProps) {
 
   return sectors.map((entry, i) => {
     if (entry?.startAngle === 0 && entry?.endAngle === 0 && sectors.length !== 1) return null;
-    const isSectorActive = activeShape && i === activeIndex;
+    const isSectorActive = isTooltipActive && activeShape && i === activeIndex;
     const inactiveShape = activeIndex === -1 ? null : inactiveShapeProp;
     const sectorOptions = isSectorActive ? activeShape : inactiveShape;
     const sectorProps = {

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -64,7 +64,7 @@ function RadialBarSectors(props: RadialBarSectorsProps) {
   const { shape, activeShape, cornerRadius, ...others } = allOtherRadialBarProps;
   const baseProps = filterProps(others, false);
 
-  const { index: activeIndex } = useTooltipContext();
+  const { index: activeIndex, active: isTooltipActive } = useTooltipContext();
   const {
     onMouseEnter: onMouseEnterFromProps,
     onClick: onItemClickFromProps,
@@ -79,7 +79,7 @@ function RadialBarSectors(props: RadialBarSectorsProps) {
   return (
     <>
       {sectors.map((entry, i) => {
-        const isActive = activeShape && i === activeIndex;
+        const isActive = isTooltipActive && activeShape && i === activeIndex;
         const onMouseEnter = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
           // @ts-expect-error the types need a bit of attention
           onMouseEnterFromContext(entry, i, e);

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -13,6 +13,17 @@ type DataType = {
   pv: number;
 };
 
+function assertActiveBarInteractions(container: HTMLElement) {
+  const chart = container.querySelector('.recharts-wrapper');
+  assertNotNull(chart);
+
+  fireEvent.mouseOver(chart, { clientX: 100, clientY: 100 });
+  expect(container.querySelectorAll('.recharts-active-bar')).toHaveLength(1);
+
+  fireEvent.mouseOut(chart);
+  expect(container.querySelectorAll('.recharts-active-bar')).toHaveLength(0);
+}
+
 describe('<BarChart />', () => {
   const data: DataType[] = [
     { name: 'food', uv: 400, pv: 2400 },
@@ -169,13 +180,7 @@ describe('<BarChart />', () => {
       </div>,
     );
 
-    const chart = container.querySelector('.recharts-wrapper');
-    assertNotNull(chart);
-    fireEvent.mouseOver(chart, { clientX: 100, clientY: 100 });
-
-    vi.advanceTimersByTime(100);
-    const bar = container.querySelectorAll('.recharts-active-bar');
-    expect(bar).toHaveLength(1);
+    assertActiveBarInteractions(container);
   });
 
   test('Renders customized active bar when activeBar set to be a ReactElement', () => {
@@ -189,13 +194,7 @@ describe('<BarChart />', () => {
       </div>,
     );
 
-    const chart = container.querySelector('.recharts-wrapper');
-    assertNotNull(chart);
-    fireEvent.mouseOver(chart, { clientX: 100, clientY: 100 });
-    vi.advanceTimersByTime(100);
-
-    const bar = container.querySelectorAll('.recharts-active-bar');
-    expect(bar).toHaveLength(1);
+    assertActiveBarInteractions(container);
   });
 
   test('Renders customized active bar when activeBar is set to be a truthy boolean', () => {
@@ -209,13 +208,7 @@ describe('<BarChart />', () => {
       </div>,
     );
 
-    const chart = container.querySelector('.recharts-wrapper');
-    assertNotNull(chart);
-    fireEvent.mouseOver(chart, { clientX: 100, clientY: 100 });
-
-    vi.advanceTimersByTime(100);
-    const bar = container.querySelectorAll('.recharts-active-bar');
-    expect(bar).toHaveLength(1);
+    assertActiveBarInteractions(container);
   });
 
   test('Does not render customized active bar when activeBar set to be a falsy boolean', () => {
@@ -248,13 +241,7 @@ describe('<BarChart />', () => {
       </div>,
     );
 
-    const chart = container.querySelector('.recharts-wrapper');
-    assertNotNull(chart);
-    fireEvent.mouseOver(chart, { clientX: 100, clientY: 100 });
-
-    vi.advanceTimersByTime(100);
-    const bar = container.querySelectorAll('.recharts-active-bar');
-    expect(bar).toHaveLength(1);
+    assertActiveBarInteractions(container);
   });
 
   test('Render empty when data is empty', () => {
@@ -266,7 +253,7 @@ describe('<BarChart />', () => {
     expect(container.querySelectorAll('path')).toHaveLength(0);
   });
 
-  test('Render customized shapem when shape is set to be a react element', () => {
+  test('Render customized shape when shape is set to be a react element', () => {
     const Shape = (props: any) => {
       const { x, y } = props;
 
@@ -280,7 +267,7 @@ describe('<BarChart />', () => {
     expect(container.querySelectorAll('.customized-shape')).toHaveLength(4);
   });
 
-  test('Render customized shapem when shape is set to be a function', () => {
+  test('Render customized shape when shape is set to be a function', () => {
     const renderShape = (props: BarProps): React.ReactElement => {
       const { x, y } = props;
 

--- a/test/chart/PieChart.spec.tsx
+++ b/test/chart/PieChart.spec.tsx
@@ -16,6 +16,21 @@ import {
 } from '../../src';
 import { testChartLayoutContext } from '../util/context';
 
+function assertActiveShapeInteractions(container: HTMLElement, selectors: string) {
+  const sectorNodes = container.querySelectorAll('.recharts-pie-sector');
+  expect(sectorNodes.length).toBeGreaterThanOrEqual(2);
+  const [sector1, sector2] = Array.from(sectorNodes);
+
+  fireEvent.mouseOver(sector1, { pageX: 200, pageY: 200 });
+  expect(container.querySelectorAll(selectors)).toHaveLength(1);
+
+  fireEvent.mouseOver(sector2, { pageX: 200, pageY: 200 });
+  expect(container.querySelectorAll(selectors)).toHaveLength(1);
+
+  fireEvent.mouseOut(sector2);
+  expect(container.querySelectorAll(selectors)).toHaveLength(0);
+}
+
 describe('<PieChart />', () => {
   const data = [
     { name: 'Group A', value: 400, v: 89 },
@@ -102,13 +117,9 @@ describe('<PieChart />', () => {
         <Tooltip />
       </PieChart>,
     );
-    const sectorNodes = container.querySelectorAll('.recharts-pie-sector');
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { pageX: 200, pageY: 200 });
 
-    const activeSector = container.querySelectorAll('.recharts-active-shape');
-    expect(activeSector).toHaveLength(1);
-    expect(container.querySelectorAll('.customized-active-shape')).toHaveLength(1);
+    assertActiveShapeInteractions(container, '.recharts-active-shape');
+    assertActiveShapeInteractions(container, '.customized-active-shape');
   });
 
   test('With Tooltip render customized active sector when activeShape is set to be a function', () => {
@@ -129,13 +140,8 @@ describe('<PieChart />', () => {
       </PieChart>,
     );
 
-    const sectorNodes = container.querySelectorAll('.recharts-pie-sector');
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { pageX: 200, pageY: 200 });
-
-    const activeSector = container.querySelectorAll('.recharts-active-shape');
-    expect(activeSector).toHaveLength(1);
-    expect(container.querySelectorAll('.customized-active-shape')).toHaveLength(1);
+    assertActiveShapeInteractions(container, '.recharts-active-shape');
+    assertActiveShapeInteractions(container, '.customized-active-shape');
   });
 
   test('With Tooltip render customized active sector when activeShape is set to be an object', () => {
@@ -156,13 +162,8 @@ describe('<PieChart />', () => {
       </PieChart>,
     );
 
-    const sectorNodes = container.querySelectorAll('.recharts-pie-sector');
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { pageX: 100, pageY: 100 });
-
-    const activeSector = container.querySelectorAll('.recharts-active-shape');
-    expect(activeSector).toHaveLength(1);
-    expect(container.querySelectorAll('.customized-active-shape')).toHaveLength(1);
+    assertActiveShapeInteractions(container, '.recharts-active-shape');
+    assertActiveShapeInteractions(container, '.customized-active-shape');
   });
 
   test('With Tooltip render customized active sector when activeShape is set to be a truthy boolean', () => {
@@ -183,12 +184,7 @@ describe('<PieChart />', () => {
       </PieChart>,
     );
 
-    const sectorNodes = container.querySelectorAll('.recharts-pie-sector');
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { pageX: 100, pageY: 100 });
-
-    const activeSector = container.querySelectorAll('.recharts-active-shape');
-    expect(activeSector).toHaveLength(1);
+    assertActiveShapeInteractions(container, '.recharts-active-shape');
   });
 
   test('Renders 6 sectors circles when add Cell to specified props of each slice', () => {

--- a/test/chart/RadialBarChart.spec.tsx
+++ b/test/chart/RadialBarChart.spec.tsx
@@ -14,6 +14,21 @@ import {
 } from '../../src';
 import { testChartLayoutContext } from '../util/context';
 
+function assertActiveShapeInteractions(container: HTMLElement) {
+  const sectorNodes = container.querySelectorAll('.recharts-sector');
+  expect(sectorNodes.length).toBeGreaterThanOrEqual(2);
+  const [sector1, sector2] = Array.from(sectorNodes);
+
+  fireEvent.mouseOver(sector1, { clientX: 200, clientY: 200 });
+  expect(container.querySelectorAll('.recharts-active-shape')).toHaveLength(1);
+
+  fireEvent.mouseOver(sector2, { clientX: 200, clientY: 200 });
+  expect(container.querySelectorAll('.recharts-active-shape')).toHaveLength(1);
+
+  fireEvent.mouseOut(sector2);
+  expect(container.querySelectorAll('.recharts-active-shape')).toHaveLength(0);
+}
+
 describe('<RadialBarChart />', () => {
   const data = [
     { name: '18-24', uv: 31.47, pv: 2400, fill: '#8884d8' },
@@ -256,12 +271,7 @@ describe('<RadialBarChart />', () => {
       </RadialBarChart>,
     );
 
-    const sectorNodes = container.querySelectorAll('.recharts-sector');
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { clientX: 200, clientY: 200 });
-
-    const activeSector = container.querySelectorAll('.recharts-active-shape');
-    expect(activeSector).toHaveLength(1);
+    assertActiveShapeInteractions(container);
   });
 
   test('Renders customized active bar when activeBar set to be a ReactElement', () => {
@@ -281,12 +291,7 @@ describe('<RadialBarChart />', () => {
       </RadialBarChart>,
     );
 
-    const sectorNodes = container.querySelectorAll('.recharts-sector');
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { clientX: 200, clientY: 200 });
-
-    const activeSector = container.querySelectorAll('.recharts-active-shape');
-    expect(activeSector).toHaveLength(1);
+    assertActiveShapeInteractions(container);
   });
 
   test('Renders customized active bar when activeBar is set to be a truthy boolean', () => {
@@ -306,12 +311,7 @@ describe('<RadialBarChart />', () => {
       </RadialBarChart>,
     );
 
-    const sectorNodes = container.querySelectorAll('.recharts-sector');
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { clientX: 200, clientY: 200 });
-
-    const activeSector = container.querySelectorAll('.recharts-active-shape');
-    expect(activeSector).toHaveLength(1);
+    assertActiveShapeInteractions(container);
   });
 
   test('Does not render customized active bar when activeBar set to be a falsy boolean', () => {
@@ -356,13 +356,7 @@ describe('<RadialBarChart />', () => {
       </RadialBarChart>,
     );
 
-    const sectorNodes = container.querySelectorAll('.recharts-sector');
-
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { clientX: 200, clientY: 200 });
-
-    const activeSector = container.querySelectorAll('.recharts-active-shape');
-    expect(activeSector).toHaveLength(1);
+    assertActiveShapeInteractions(container);
   });
 
   describe('RadialBarChart layout context', () => {

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import { vi } from 'vitest';
 import { fireEvent, render } from '@testing-library/react';
 import {
-  ScatterChart,
-  Scatter,
   CartesianGrid,
+  Legend,
+  Scatter,
+  ScatterChart,
+  Symbols,
+  SymbolsProps,
   Tooltip,
   XAxis,
   YAxis,
   ZAxis,
-  Legend,
-  Symbols,
-  SymbolsProps,
 } from '../../src';
 import { testChartLayoutContext } from '../util/context';
 
@@ -92,6 +92,20 @@ describe('ScatterChart of three dimension data', () => {
   });
 });
 
+function assertActiveShapeInteractions(container: HTMLElement) {
+  const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
+  expect(sectorNodes.length).toBeGreaterThanOrEqual(2);
+  const [sector1, sector2] = Array.from(sectorNodes);
+  fireEvent.mouseOver(sector1, { pageX: 200, pageY: 200 });
+  expect(container.querySelectorAll('.recharts-active-shape')).toHaveLength(1);
+
+  fireEvent.mouseOver(sector2, { pageX: 200, pageY: 200 });
+  expect(container.querySelectorAll('.recharts-active-shape')).toHaveLength(1);
+
+  fireEvent.mouseOut(sector2);
+  expect(container.querySelectorAll('.recharts-active-shape')).toHaveLength(0);
+}
+
 describe('ScatterChart of two dimension data', () => {
   const data = [
     { x: 100, y: 200, z: 200 },
@@ -136,12 +150,7 @@ describe('ScatterChart of two dimension data', () => {
       </ScatterChart>,
     );
 
-    const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { pageX: 200, pageY: 200 });
-
-    const activeSector = container.querySelectorAll('.recharts-active-shape');
-    expect(activeSector).toHaveLength(1);
+    assertActiveShapeInteractions(container);
   });
 
   test('Renders customized active shape when activeShape set to be an object as symbols props', () => {
@@ -160,12 +169,7 @@ describe('ScatterChart of two dimension data', () => {
       </ScatterChart>,
     );
 
-    const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { pageX: 200, pageY: 200 });
-
-    const activeSector = container.querySelectorAll('.triangle-symbols-type');
-    expect(activeSector).toHaveLength(1);
+    assertActiveShapeInteractions(container);
   });
 
   test('Renders customized active shape when activeShape set to be a function', () => {
@@ -184,15 +188,10 @@ describe('ScatterChart of two dimension data', () => {
       </ScatterChart>,
     );
 
-    const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { pageX: 200, pageY: 200 });
-
-    const activeSector = container.querySelectorAll('.recharts-active-shape');
-    expect(activeSector).toHaveLength(1);
+    assertActiveShapeInteractions(container);
   });
 
-  test('Renders customized active bar when activeBar set to be a ReactElement', () => {
+  test('Renders customized active shape when activeShape set to be a ReactElement', () => {
     const { container } = render(
       <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
         <XAxis dataKey="x" name="stature" unit="cm" />
@@ -202,15 +201,10 @@ describe('ScatterChart of two dimension data', () => {
       </ScatterChart>,
     );
 
-    const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { pageX: 200, pageY: 200 });
-
-    const activeSector = container.querySelectorAll('.recharts-active-shape');
-    expect(activeSector).toHaveLength(1);
+    assertActiveShapeInteractions(container);
   });
 
-  test('Renders customized active bar when activeBar is set to be a truthy boolean', () => {
+  test('Renders customized active shape when activeShape is set to be a truthy boolean', () => {
     const { container } = render(
       <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
         <XAxis dataKey="x" name="stature" unit="cm" />
@@ -220,15 +214,10 @@ describe('ScatterChart of two dimension data', () => {
       </ScatterChart>,
     );
 
-    const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
-    const [sector] = Array.from(sectorNodes);
-    fireEvent.mouseOver(sector, { pageX: 200, pageY: 200 });
-
-    const activeSector = container.querySelectorAll('.recharts-active-shape');
-    expect(activeSector).toHaveLength(1);
+    assertActiveShapeInteractions(container);
   });
 
-  test('Does not render customized active bar when activeBar set to be a falsy boolean', () => {
+  test('Does not render customized active shape when activeShape set to be a falsy boolean', () => {
     const { container } = render(
       <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
         <XAxis dataKey="x" name="stature" unit="cm" />

--- a/test/component/Tooltip/ActiveDot.spec.tsx
+++ b/test/component/Tooltip/ActiveDot.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { Area, AreaChart, ComposedChart, Line, LineChart, Radar, RadarChart, Tooltip } from '../../../src';
 import { PageData } from '../../_data';
 import { showTooltip } from './tooltipTestHelpers';
@@ -27,7 +27,7 @@ describe('ActiveDot', () => {
         </AreaChart>,
       );
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
-      showTooltip(container, areaChartMouseHoverTooltipSelector, debug);
+      const tooltipTrigger = showTooltip(container, areaChartMouseHoverTooltipSelector, debug);
       const activeDot = container.querySelector('.recharts-active-dot');
       expect(activeDot).toBeVisible();
       expect(activeDot.getAttributeNames()).toEqual(['class']);
@@ -43,6 +43,9 @@ describe('ActiveDot', () => {
       expect(circle.getAttribute('fill')).toEqual('#3182bd');
       expect(circle.getAttribute('stroke-width')).toEqual('2');
       expect(circle.getAttribute('stroke')).toEqual('#fff');
+
+      fireEvent.mouseOut(tooltipTrigger);
+      expect(activeDot).not.toBeVisible();
     });
 
     it('should clone custom Dot element and inject extra sneaky props', () => {
@@ -54,7 +57,7 @@ describe('ActiveDot', () => {
       );
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       expect(container.querySelector('[data-testid="my-custom-dot"]')).not.toBeInTheDocument();
-      showTooltip(container, areaChartMouseHoverTooltipSelector, debug);
+      const tooltipTrigger = showTooltip(container, areaChartMouseHoverTooltipSelector, debug);
       const activeDot = container.querySelector('.recharts-active-dot');
       expect(activeDot).toBeVisible();
       expect(activeDot.getAttributeNames()).toEqual(['class']);
@@ -86,6 +89,9 @@ describe('ActiveDot', () => {
       expect(customElement.getAttribute('stroke')).toEqual('#fff');
       expect(customElement.getAttribute('payload')).toEqual('[object Object]'); // sic!
       expect(customElement.getAttribute('value')).toEqual('0,300');
+
+      fireEvent.mouseOut(tooltipTrigger);
+      expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
     });
 
     it('should render custom Dot component, give it props, and render what it returned', () => {
@@ -102,7 +108,7 @@ describe('ActiveDot', () => {
       );
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
-      showTooltip(container, areaChartMouseHoverTooltipSelector, debug);
+      const tooltipTrigger = showTooltip(container, areaChartMouseHoverTooltipSelector, debug);
       expect(spy).toHaveBeenCalledTimes(1);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
@@ -122,6 +128,9 @@ describe('ActiveDot', () => {
         strokeWidth: 2,
         value: [0, 300],
       });
+
+      fireEvent.mouseOut(tooltipTrigger);
+      expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
     });
   });
 
@@ -134,7 +143,7 @@ describe('ActiveDot', () => {
         </LineChart>,
       );
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
-      showTooltip(container, lineChartMouseHoverTooltipSelector, debug);
+      const tooltipTrigger = showTooltip(container, lineChartMouseHoverTooltipSelector, debug);
       const activeDot = container.querySelector('.recharts-active-dot');
       expect(activeDot).toBeVisible();
       expect(activeDot.getAttributeNames()).toEqual(['class']);
@@ -150,6 +159,9 @@ describe('ActiveDot', () => {
       expect(circle.getAttribute('fill')).toEqual('#3182bd');
       expect(circle.getAttribute('stroke-width')).toEqual('2');
       expect(circle.getAttribute('stroke')).toEqual('#fff');
+
+      fireEvent.mouseOut(tooltipTrigger);
+      expect(activeDot).not.toBeVisible();
     });
 
     it('should clone custom Dot element and inject extra sneaky props', () => {
@@ -161,7 +173,7 @@ describe('ActiveDot', () => {
       );
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       expect(container.querySelector('[data-testid="my-custom-dot"]')).not.toBeInTheDocument();
-      showTooltip(container, lineChartMouseHoverTooltipSelector, debug);
+      const tooltipTrigger = showTooltip(container, lineChartMouseHoverTooltipSelector, debug);
       const activeDot = container.querySelector('.recharts-active-dot');
       expect(activeDot).toBeVisible();
       expect(activeDot.getAttributeNames()).toEqual(['class']);
@@ -193,6 +205,9 @@ describe('ActiveDot', () => {
       expect(customElement.getAttribute('stroke')).toEqual('#fff');
       expect(customElement.getAttribute('payload')).toEqual('[object Object]'); // sic!
       expect(customElement.getAttribute('value')).toEqual('300');
+
+      fireEvent.mouseOut(tooltipTrigger);
+      expect(activeDot).not.toBeVisible();
     });
 
     it('should render custom Dot component, give it props, and render what it returned', () => {
@@ -209,7 +224,7 @@ describe('ActiveDot', () => {
       );
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
-      showTooltip(container, lineChartMouseHoverTooltipSelector, debug);
+      const tooltipTrigger = showTooltip(container, lineChartMouseHoverTooltipSelector, debug);
       expect(spy).toHaveBeenCalledTimes(1);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
@@ -229,6 +244,9 @@ describe('ActiveDot', () => {
         strokeWidth: 2,
         value: 300,
       });
+
+      fireEvent.mouseOut(tooltipTrigger);
+      expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
     });
   });
 
@@ -241,7 +259,7 @@ describe('ActiveDot', () => {
         </ComposedChart>,
       );
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
-      showTooltip(container, composedChartMouseHoverTooltipSelector, debug);
+      const tooltipTrigger = showTooltip(container, composedChartMouseHoverTooltipSelector, debug);
       const activeDot = container.querySelector('.recharts-active-dot');
       expect(activeDot).toBeVisible();
       expect(activeDot.getAttributeNames()).toEqual(['class']);
@@ -257,6 +275,9 @@ describe('ActiveDot', () => {
       expect(circle.getAttribute('fill')).toEqual('#3182bd');
       expect(circle.getAttribute('stroke-width')).toEqual('2');
       expect(circle.getAttribute('stroke')).toEqual('#fff');
+
+      fireEvent.mouseOut(tooltipTrigger);
+      expect(activeDot).not.toBeVisible();
     });
 
     it('should clone custom Dot element and inject extra sneaky props', () => {
@@ -268,7 +289,7 @@ describe('ActiveDot', () => {
       );
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       expect(container.querySelector('[data-testid="my-custom-dot"]')).not.toBeInTheDocument();
-      showTooltip(container, composedChartMouseHoverTooltipSelector, debug);
+      const tooltipTrigger = showTooltip(container, composedChartMouseHoverTooltipSelector, debug);
       const activeDot = container.querySelector('.recharts-active-dot');
       expect(activeDot).toBeVisible();
       expect(activeDot.getAttributeNames()).toEqual(['class']);
@@ -300,6 +321,9 @@ describe('ActiveDot', () => {
       expect(customElement.getAttribute('stroke')).toEqual('#fff');
       expect(customElement.getAttribute('payload')).toEqual('[object Object]'); // sic!
       expect(customElement.getAttribute('value')).toEqual('300');
+
+      fireEvent.mouseOut(tooltipTrigger);
+      expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
     });
 
     it('should render custom Dot component, give it props, and render what it returned', () => {
@@ -316,7 +340,7 @@ describe('ActiveDot', () => {
       );
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
-      showTooltip(container, composedChartMouseHoverTooltipSelector, debug);
+      const tooltipTrigger = showTooltip(container, composedChartMouseHoverTooltipSelector, debug);
       expect(spy).toHaveBeenCalledTimes(1);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
@@ -336,6 +360,9 @@ describe('ActiveDot', () => {
         strokeWidth: 2,
         value: 300,
       });
+
+      fireEvent.mouseOut(tooltipTrigger);
+      expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
     });
   });
 
@@ -348,7 +375,7 @@ describe('ActiveDot', () => {
         </RadarChart>,
       );
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
-      showTooltip(container, radarChartMouseHoverTooltipSelector, debug);
+      const tooltipTrigger = showTooltip(container, radarChartMouseHoverTooltipSelector, debug);
       const activeDot = container.querySelector('.recharts-active-dot');
       expect(activeDot).toBeVisible();
       expect(activeDot.getAttributeNames()).toEqual(['class']);
@@ -364,6 +391,9 @@ describe('ActiveDot', () => {
       expect(circle.getAttribute('r')).toEqual('4');
       expect(circle.getAttribute('stroke-width')).toEqual('2');
       expect(circle.getAttribute('stroke')).toEqual('#fff');
+
+      fireEvent.mouseOut(tooltipTrigger);
+      expect(activeDot).not.toBeVisible();
     });
 
     it('should clone custom Dot element and inject extra sneaky props', () => {
@@ -375,7 +405,7 @@ describe('ActiveDot', () => {
       );
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       expect(container.querySelector('[data-testid="my-custom-dot"]')).not.toBeInTheDocument();
-      showTooltip(container, radarChartMouseHoverTooltipSelector, debug);
+      const tooltipTrigger = showTooltip(container, radarChartMouseHoverTooltipSelector, debug);
       const activeDot = container.querySelector('.recharts-active-dot');
       expect(activeDot).toBeVisible();
       expect(activeDot.getAttributeNames()).toEqual(['class']);
@@ -406,6 +436,9 @@ describe('ActiveDot', () => {
       expect(customElement.getAttribute('stroke')).toEqual('#fff');
       expect(customElement.getAttribute('payload')).toEqual('[object Object]'); // sic!
       expect(customElement.getAttribute('value')).toEqual('189');
+
+      fireEvent.mouseOut(tooltipTrigger);
+      expect(activeDot).not.toBeVisible();
     });
 
     it('should render custom Dot component, give it props, and render what it returned', () => {
@@ -422,7 +455,7 @@ describe('ActiveDot', () => {
       );
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
-      showTooltip(container, radarChartMouseHoverTooltipSelector, debug);
+      const tooltipTrigger = showTooltip(container, radarChartMouseHoverTooltipSelector, debug);
       expect(spy).toHaveBeenCalledTimes(1);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
@@ -441,6 +474,9 @@ describe('ActiveDot', () => {
         strokeWidth: 2,
         value: 189,
       });
+
+      fireEvent.mouseOut(tooltipTrigger);
+      expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
     });
   });
 });

--- a/test/polar/Pie.spec.tsx
+++ b/test/polar/Pie.spec.tsx
@@ -2,55 +2,47 @@ import React from 'react';
 import { vi } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { LabelProps, Pie, PieChart, Sector, SectorProps, Surface } from '../../src';
+import { LabelProps, Pie, PieChart, Sector, SectorProps, Surface, Tooltip } from '../../src';
 import { Point } from '../../src/shape/Curve';
 import { PieSectorDataItem } from '../../src/polar/Pie';
 import { generateMockData } from '../helper/generateMockData';
 import { focusTestHelper } from '../helper/focus';
 import { showTooltip } from '../component/Tooltip/tooltipTestHelpers';
 import { pieChartMouseHoverTooltipSelector } from '../component/Tooltip/tooltipMouseHoverSelectors';
+import { PageData } from '../_data';
 
 type CustomizedLabelLineProps = { points?: Array<Point> };
 
 describe('<Pie />', () => {
   const sectors = [
-    {
-      cx: 250,
-      cy: 250,
-      innerRadius: 50,
-      outerRadius: 100,
-      startAngle: 0,
-      endAngle: 72,
-      name: 'A',
-      value: 40,
-    },
+    { cx: 250, cy: 250, innerRadius: 50, outerRadius: 100, startAngle: 0, endAngle: 72, name: 'A', value: 40 },
     { cx: 250, cy: 250, innerRadius: 50, outerRadius: 100, startAngle: 72, endAngle: 144 },
     { cx: 250, cy: 250, innerRadius: 50, outerRadius: 100, startAngle: 144, endAngle: 216 },
     { cx: 250, cy: 250, innerRadius: 50, outerRadius: 100, startAngle: 216, endAngle: 288 },
     { cx: 250, cy: 250, innerRadius: 50, outerRadius: 100, startAngle: 288, endAngle: 360 },
   ];
 
-  test('Render 5 sectors in a simple Pie', () => {
+  test('Render sectors in a simple Pie', () => {
     const { container } = render(
-      <Surface width={500} height={500}>
+      <PieChart width={500} height={500}>
         <Pie
           isAnimationActive={false}
           cx={250}
           cy={250}
           innerRadius={0}
           outerRadius={200}
-          sectors={sectors}
-          dataKey="cy"
+          data={PageData}
+          dataKey="uv"
         />
-      </Surface>,
+      </PieChart>,
     );
 
-    expect(container.querySelectorAll('.recharts-pie-sector')).toHaveLength(sectors.length);
+    expect(container.querySelectorAll('.recharts-pie-sector')).toHaveLength(PageData.length);
   });
 
   test('Render customized active sector when activeShape is set to be an element', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
+    const { container, debug } = render(
+      <PieChart width={500} height={500}>
         <Pie
           isAnimationActive={false}
           activeShape={<Sector fill="#ff7300" className="customized-active-shape" />}
@@ -58,18 +50,21 @@ describe('<Pie />', () => {
           cy={250}
           innerRadius={0}
           outerRadius={200}
-          sectors={sectors}
-          dataKey="cy"
+          data={PageData}
+          dataKey="uv"
         />
-      </Surface>,
+        <Tooltip />
+      </PieChart>,
     );
+
+    showTooltip(container, pieChartMouseHoverTooltipSelector, debug);
 
     expect(container.querySelectorAll('.customized-active-shape')).toHaveLength(1);
   });
 
   test('Render customized active sector when activeShape is set to be a function', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
+    const { container, debug } = render(
+      <PieChart width={500} height={500}>
         <Pie
           isAnimationActive={false}
           activeShape={(props: SectorProps) => <Sector {...props} fill="#ff7300" className="customized-active-shape" />}
@@ -77,37 +72,43 @@ describe('<Pie />', () => {
           cy={250}
           innerRadius={0}
           outerRadius={200}
-          sectors={sectors}
-          dataKey="cy"
+          data={PageData}
+          dataKey="uv"
         />
-      </Surface>,
+        <Tooltip />
+      </PieChart>,
     );
+
+    showTooltip(container, pieChartMouseHoverTooltipSelector, debug);
 
     expect(container.querySelectorAll('.customized-active-shape')).toHaveLength(1);
   });
 
   test('Render customized active sector when activeShape is set to be an object', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
+    const { container, debug } = render(
+      <PieChart width={500} height={500}>
         <Pie
           isAnimationActive={false}
-          activeShape={{ fill: '#ff7300' }}
+          activeShape={{ fill: '#ff7300', className: 'customized-active-shape' }}
           cx={250}
           cy={250}
           innerRadius={0}
           outerRadius={200}
-          sectors={sectors}
-          dataKey="cy"
+          data={PageData}
+          dataKey="uv"
         />
-      </Surface>,
+        <Tooltip />
+      </PieChart>,
     );
 
-    expect(container.querySelectorAll('.customized-active-shape')).toHaveLength(0);
+    showTooltip(container, pieChartMouseHoverTooltipSelector, debug);
+
+    expect(container.querySelectorAll('.customized-active-shape')).toHaveLength(1);
   });
 
   test('Render customized active sector when inactiveShape is set to be an element', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
+    const { container, debug } = render(
+      <PieChart width={500} height={500}>
         <Pie
           isAnimationActive={false}
           activeShape={<Sector fill="#ff7300" className="customized-active-shape" />}
@@ -116,12 +117,18 @@ describe('<Pie />', () => {
           cy={250}
           innerRadius={0}
           outerRadius={200}
-          sectors={sectors}
-          dataKey="cy"
+          data={PageData}
+          dataKey="uv"
         />
-      </Surface>,
+        <Tooltip />
+      </PieChart>,
     );
-    expect(container.querySelectorAll('.customized-inactive-shape')).toHaveLength(4);
+    expect(container.querySelectorAll('.customized-inactive-shape')).toHaveLength(0);
+
+    showTooltip(container, pieChartMouseHoverTooltipSelector, debug);
+
+    expect(container.querySelectorAll('.customized-active-shape')).toHaveLength(1);
+    expect(container.querySelectorAll('.customized-inactive-shape')).toHaveLength(5);
   });
 
   test('Render customized inactive sector when inactiveShape is set to be a function', () => {
@@ -132,8 +139,8 @@ describe('<Pie />', () => {
     const renderInactiveShape = (props: PieSectorDataItem) => (
       <Sector {...props} fill="#ff7300" className="customized-inactive-shape" />
     );
-    const { container } = render(
-      <Surface width={500} height={500}>
+    const { container, debug } = render(
+      <PieChart width={500} height={500}>
         <Pie
           isAnimationActive={false}
           activeShape={renderActiveShape}
@@ -142,39 +149,72 @@ describe('<Pie />', () => {
           cy={250}
           innerRadius={0}
           outerRadius={200}
-          sectors={sectors}
-          dataKey="cy"
+          data={PageData}
+          dataKey="uv"
         />
-      </Surface>,
+      </PieChart>,
     );
-    expect(container.querySelectorAll('.customized-inactive-shape')).toHaveLength(4);
+    expect(container.querySelectorAll('.customized-inactive-shape')).toHaveLength(0);
+
+    showTooltip(container, pieChartMouseHoverTooltipSelector, debug);
+
+    expect(container.querySelectorAll('.customized-inactive-shape')).toHaveLength(5);
   });
 
   test('Render customized inactive sector when inactiveShape is set to be an object', () => {
-    const { container } = render(
-      <Surface width={500} height={500}>
+    const { container, debug } = render(
+      <PieChart width={500} height={500}>
         <Pie
           isAnimationActive={false}
-          activeShape={{ fill: '#ff7300' }}
-          inactiveShape={{ fill: '#ff7322' }}
+          fill="red"
+          activeShape={{ fill: 'green' }}
+          inactiveShape={{ fill: 'blue' }}
           cx={250}
           cy={250}
           innerRadius={0}
           outerRadius={200}
-          sectors={sectors}
-          dataKey="cy"
+          data={PageData}
+          dataKey="uv"
         />
-      </Surface>,
+        <Tooltip />
+      </PieChart>,
     );
+    const renderedSectors = container.querySelectorAll('.recharts-sector');
+    expect(renderedSectors).toHaveLength(PageData.length);
+    renderedSectors.forEach(s => {
+      expect(s.getAttribute('fill')).toBe('red');
+    });
 
     expect(container.querySelectorAll('.customized-inactive-shape')).toHaveLength(0);
+
+    showTooltip(container, pieChartMouseHoverTooltipSelector, debug);
+
+    const renderedSectors2 = container.querySelectorAll('.recharts-sector');
+    expect(renderedSectors2).toHaveLength(PageData.length);
+    expect(renderedSectors2[0].getAttributeNames()).toEqual([
+      'cx',
+      'cy',
+      'name',
+      'fill',
+      'stroke',
+      'tabindex',
+      'class',
+      'd',
+      'role',
+    ]);
+    expect(renderedSectors2[0]).toHaveAttribute('fill', 'green');
+    expect(renderedSectors2[1]).toHaveAttribute('fill', 'blue');
+    expect(renderedSectors2[2]).toHaveAttribute('fill', 'blue');
+    expect(renderedSectors2[3]).toHaveAttribute('fill', 'blue');
+    expect(renderedSectors2[4]).toHaveAttribute('fill', 'blue');
+    expect(renderedSectors2[5]).toHaveAttribute('fill', 'blue');
   });
 
   test.each([{ data: undefined }, { data: [] }])(
     'when data is $data then activeShape function does not receive payload',
     ({ data }) => {
       const activeShape = vi.fn();
-      const { container, debug } = render(
+      render(
         <PieChart width={400} height={400}>
           <Pie
             isAnimationActive={false}
@@ -184,29 +224,13 @@ describe('<Pie />', () => {
             cy={250}
             innerRadius={0}
             outerRadius={200}
-            sectors={sectors}
-            dataKey="y"
+            dataKey="uv"
             data={data}
           />
+          <Tooltip />
         </PieChart>,
       );
       expect(activeShape).toHaveBeenCalledTimes(0);
-
-      showTooltip(container, pieChartMouseHoverTooltipSelector, debug);
-
-      expect(activeShape).toHaveBeenCalledTimes(1);
-      expect(activeShape).toHaveBeenCalledWith({
-        cx: 250,
-        cy: 250,
-        endAngle: 72,
-        innerRadius: 50,
-        name: 'A',
-        outerRadius: 100,
-        startAngle: 0,
-        stroke: undefined,
-        tabIndex: -1,
-        value: 40,
-      });
     },
   );
 
@@ -315,7 +339,6 @@ describe('<Pie />', () => {
           cy={250}
           innerRadius={0}
           outerRadius={200}
-          sectors={sectors}
           dataKey="this-key-does-not-exist-in-data"
           data={generateMockData(5, 0.603)}
         />


### PR DESCRIPTION
## Description

I missed this piece of logic when moving the activeIndex from props cloning to context. Fixed!

## Related Issue

Reported in https://github.com/recharts/recharts/pull/4524#discussion_r1599539504

## Motivation and Context

bugfix

## How Has This Been Tested?

npm test, storybook

I used this codesandbox to compare with 2.x behaviour: https://codesandbox.io/p/sandbox/jovial-nova-s67t7p?file=%2Fsrc%2FApp.tsx%3A48%2C38

Here is the 2.x code to compare: https://github.com/recharts/recharts/blob/master/src/chart/generateCategoricalChart.tsx#L2002

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
