### PR TITLE
Scatter sends item data to Redux store

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -115,8 +115,8 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
   const viewBox = useViewBox();
   const accessibilityLayer = useAccessibilityLayer();
   const { active: activeFromContext, payload: payloadFromProps, coordinate, label } = useTooltipContext();
-  // TODO this will fail tests until Tooltip props and tooltipAxis are in Redux
-  // const payloadFromContext = useAppSelector(selectTooltipPayload);
+  // TODO this will fail tests if we use the selector, uncomment and fix
+  // const payloadFromContext = useAppSelector(state => selectTooltipPayload(state, shared));
   // const payload = payloadFromContext?.length > 0 ? payloadFromContext : payloadFromProps;
   const payload = payloadFromProps;
   const tooltipEventType = useTooltipEventType(shared);

--- a/src/state/chartDataSlice.ts
+++ b/src/state/chartDataSlice.ts
@@ -21,7 +21,7 @@ export type ChartDataState = {
   dataEndIndex: number;
 };
 
-const initialState: ChartDataState = {
+export const initialChartDataState: ChartDataState = {
   chartData: undefined,
   dataStartIndex: 0,
   dataEndIndex: 0,
@@ -31,7 +31,7 @@ type BrushStartEndIndexActionPayload = Partial<BrushStartEndIndex>;
 
 const chartDataSlice = createSlice({
   name: 'chartData',
-  initialState,
+  initialState: initialChartDataState,
   reducers: {
     setChartData(state, action: PayloadAction<ChartData | undefined>) {
       state.chartData = action.payload;

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -1,11 +1,11 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppSelector } from './hooks';
 import { RechartsRootState } from './store';
-import { TooltipPayload, TooltipState } from './tooltipSlice';
+import { TooltipPayload, TooltipPayloadEntry, TooltipState } from './tooltipSlice';
 import { getTicksOfAxis, getTooltipEntry, getValueByDataKey } from '../util/ChartUtils';
 import { ChartDataState } from './chartDataSlice';
 import { selectTooltipAxis } from '../context/useTooltipAxis';
-import { BaseAxisProps, TickItem } from '../util/types';
+import { BaseAxisProps, DataKey, TickItem } from '../util/types';
 import { findEntryInArray } from '../util/DataUtils';
 
 export const useChartName = (): string => {
@@ -47,44 +47,94 @@ const selectActiveLabel = createSelector(
     tooltipTicks?.[activeIndex]?.value,
 );
 
-export const selectTooltipPayload: (state: RechartsRootState) => TooltipPayload | undefined = createSelector(
+function selectFinalData(
+  dataDefinedOnItem: ReadonlyArray<unknown>,
+  dataDefinedOnChart: ReadonlyArray<unknown>,
+  sharedTooltip: boolean | undefined,
+) {
+  /*
+   * If a payload has data specified directly from the graphical item, prefer that.
+   * Otherwise, fill in data from the chart level, using the same index.
+   */
+  if (sharedTooltip === false) {
+    return dataDefinedOnItem;
+  }
+  if (dataDefinedOnItem?.length > 0) {
+    return dataDefinedOnItem;
+  }
+  return dataDefinedOnChart;
+}
+
+export const combineTooltipPayload = (
+  tooltipState: TooltipState,
+  chartDataState: ChartDataState,
+  tooltipAxis: BaseAxisProps | undefined,
+  activeLabel: string | undefined,
+  shared: boolean | undefined,
+): TooltipPayload | undefined => {
+  const { activeIndex, tooltipItemPayloads } = tooltipState;
+  if (activeIndex === -1) {
+    return undefined;
+  }
+  const { chartData, dataStartIndex, dataEndIndex } = chartDataState;
+
+  const init: Array<TooltipPayloadEntry> = [];
+
+  return tooltipItemPayloads.reduce((agg, { dataDefinedOnItem, settings }): Array<TooltipPayloadEntry> => {
+    const finalData = selectFinalData(dataDefinedOnItem, chartData, shared);
+
+    const sliced = getSliced(finalData, dataStartIndex, dataEndIndex);
+
+    const finalDataKey: DataKey<any> | undefined = settings?.dataKey ?? tooltipAxis?.dataKey;
+    let tooltipPayload: unknown;
+    if (tooltipAxis?.dataKey && !tooltipAxis?.allowDuplicatedCategory) {
+      tooltipPayload = findEntryInArray(sliced, tooltipAxis.dataKey, activeLabel);
+    } else {
+      tooltipPayload = sliced?.[activeIndex];
+    }
+
+    if (Array.isArray(tooltipPayload)) {
+      tooltipPayload.forEach(item => {
+        const newSettings = {
+          ...settings,
+          name: item.name,
+          unit: item.unit,
+          // @ts-expect-error okay so color and fill are erased to keep 100% the identical behaviour to recharts 2.x - but there's nothing stopping us from returning them here. It's technically a breaking change.
+          color: undefined,
+          // @ts-expect-error okay so color and fill are erased to keep 100% the identical behaviour to recharts 2.x - but there's nothing stopping us from returning them here. It's technically a breaking change.
+          fill: undefined,
+        };
+        agg.push(
+          getTooltipEntry({
+            tooltipEntrySettings: newSettings,
+            dataKey: item.dataKey,
+            payload: item.payload,
+            value: getValueByDataKey(item.payload, item.dataKey),
+          }),
+        );
+      });
+    } else {
+      agg.push(
+        getTooltipEntry({
+          tooltipEntrySettings: settings,
+          dataKey: finalDataKey,
+          payload: tooltipPayload,
+          value: getValueByDataKey(tooltipPayload, finalDataKey),
+        }),
+      );
+    }
+    return agg;
+  }, init);
+};
+
+export const selectTooltipPayload: (
+  state: RechartsRootState,
+  shared: boolean | undefined,
+) => TooltipPayload | undefined = createSelector(
   selectTooltipState,
   selectChartData,
   selectTooltipAxis,
   selectActiveLabel,
-  (
-    tooltipState: TooltipState,
-    chartDataState: ChartDataState,
-    tooltipAxis: BaseAxisProps | undefined,
-    activeLabel: string | undefined,
-  ) => {
-    const { activeIndex, tooltipItemPayloads } = tooltipState;
-    if (activeIndex === -1) {
-      return undefined;
-    }
-    const { chartData, dataStartIndex, dataEndIndex } = chartDataState;
-
-    /*
-     * If a payload has data specified directly from the graphical item, prefer that.
-     * Otherwise, fill in data from the chart level, using the same index.
-     */
-    return tooltipItemPayloads.map(({ dataDefinedOnItem, settings }) => {
-      const finalData = dataDefinedOnItem ?? chartData;
-
-      const sliced = getSliced(finalData, dataStartIndex, dataEndIndex);
-
-      let tooltipPayload: unknown;
-      if (tooltipAxis?.dataKey && !tooltipAxis?.allowDuplicatedCategory) {
-        tooltipPayload = findEntryInArray(sliced, tooltipAxis.dataKey, activeLabel);
-      } else {
-        tooltipPayload = sliced?.[activeIndex];
-      }
-      return getTooltipEntry({
-        tooltipEntrySettings: settings,
-        dataKey: settings?.dataKey,
-        payload: tooltipPayload,
-        value: getValueByDataKey(tooltipPayload, settings?.dataKey),
-      });
-    });
-  },
+  (_: void, shared: boolean | undefined) => shared,
+  combineTooltipPayload,
 );

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -1,18 +1,25 @@
 import React from 'react';
 import { describe, it, test, expect } from 'vitest';
 import { render } from '@testing-library/react';
-import { selectTooltipPayload, useTooltipEventType } from '../../src/state/selectors';
+import { combineTooltipPayload, selectTooltipPayload, useTooltipEventType } from '../../src/state/selectors';
 import { createRechartsStore, RechartsRootState } from '../../src/state/store';
 import { RechartsStoreProvider } from '../../src/state/RechartsStoreProvider';
-import { TooltipEventType } from '../../src/util/types';
+import { BaseAxisProps, TooltipEventType } from '../../src/util/types';
 import { useAppSelector } from '../../src/state/hooks';
 import {
   addTooltipEntrySettings,
   setActiveTooltipIndex,
+  TooltipPayload,
   TooltipPayloadConfiguration,
   TooltipPayloadEntry,
+  TooltipState,
 } from '../../src/state/tooltipSlice';
-import { setChartData, setDataStartEndIndexes } from '../../src/state/chartDataSlice';
+import {
+  ChartDataState,
+  initialChartDataState,
+  setChartData,
+  setDataStartEndIndexes,
+} from '../../src/state/chartDataSlice';
 
 describe('useTooltipEventType', () => {
   type TooltipEventTypeTestScenario = {
@@ -96,7 +103,7 @@ describe('selectTooltipPayload', () => {
   it('should return undefined when outside of Redux context', () => {
     expect.assertions(1);
     const Comp = (): null => {
-      const payload = useAppSelector(selectTooltipPayload);
+      const payload = useAppSelector(state => selectTooltipPayload(state, true));
       expect(payload).toBe(undefined);
       return null;
     };
@@ -105,7 +112,7 @@ describe('selectTooltipPayload', () => {
 
   it('initial state should return undefined', () => {
     const store = createRechartsStore();
-    expect(selectTooltipPayload(store.getState())).toEqual(undefined);
+    expect(selectTooltipPayload(store.getState(), true)).toEqual(undefined);
   });
 
   it('should return settings and data from a graphical item, if activeIndex is set', () => {
@@ -143,9 +150,9 @@ describe('selectTooltipPayload', () => {
     };
     store.dispatch(addTooltipEntrySettings(tooltipSettings1));
     store.dispatch(addTooltipEntrySettings(tooltipSettings2));
-    expect(selectTooltipPayload(store.getState())).toEqual(undefined);
+    expect(selectTooltipPayload(store.getState(), true)).toEqual(undefined);
     store.dispatch(setActiveTooltipIndex(1));
-    expect(selectTooltipPayload(store.getState())).toEqual([expectedEntry1, expectedEntry2]);
+    expect(selectTooltipPayload(store.getState(), true)).toEqual([expectedEntry1, expectedEntry2]);
   });
 
   it('should fill in chartData, if it is not defined on the item', () => {
@@ -179,7 +186,7 @@ describe('selectTooltipPayload', () => {
       unit: 'bar',
     };
 
-    expect(selectTooltipPayload(store.getState())).toEqual([expectedEntry]);
+    expect(selectTooltipPayload(store.getState(), true)).toEqual([expectedEntry]);
   });
 
   it('should return sliced data if set by Brush', () => {
@@ -203,7 +210,7 @@ describe('selectTooltipPayload', () => {
         { x: 3, y: 4 },
       ]),
     );
-    expect(selectTooltipPayload(store.getState())).toEqual(undefined);
+    expect(selectTooltipPayload(store.getState(), true)).toEqual(undefined);
     store.dispatch(setActiveTooltipIndex(0));
     store.dispatch(setDataStartEndIndexes({ startIndex: 1, endIndex: 10 }));
     const expectedEntry: TooltipPayloadEntry = {
@@ -214,9 +221,109 @@ describe('selectTooltipPayload', () => {
       payload: { x: 3, y: 4 },
       value: 4,
     };
-    expect(selectTooltipPayload(store.getState())).toEqual([expectedEntry]);
+    expect(selectTooltipPayload(store.getState(), true)).toEqual([expectedEntry]);
   });
 
-  it.todo('should prefer to use dataKey from tooltipAxis, if it is defined');
+  it('should return array of payloads for Scatter because Scatter naturally does its own special thing', () => {
+    const tooltipPayloadConfiguration: TooltipPayloadConfiguration = {
+      settings: {
+        fill: 'fill',
+        name: 'name is ignored in Scatter in recharts 2.x',
+        color: 'color',
+      },
+      dataDefinedOnItem: [
+        [
+          {
+            name: 'stature',
+            unit: 'cm',
+            value: 100,
+            payload: {
+              x: 100,
+              y: 200,
+              z: 200,
+            },
+            dataKey: 'x',
+          },
+          {
+            name: 'weight',
+            unit: 'kg',
+            value: 200,
+            payload: {
+              x: 100,
+              y: 200,
+              z: 200,
+            },
+            dataKey: 'y',
+          },
+        ],
+      ],
+    };
+    const tooltipState: TooltipState = {
+      activeIndex: 0,
+      tooltipItemPayloads: [tooltipPayloadConfiguration],
+    };
+    const chartDataState: ChartDataState = initialChartDataState;
+    const tooltipAxis: BaseAxisProps | undefined = undefined;
+    const activeLabel: string | undefined = undefined;
+    const shared = false;
+    const actual: TooltipPayload | undefined = combineTooltipPayload(
+      tooltipState,
+      chartDataState,
+      tooltipAxis,
+      activeLabel,
+      shared,
+    );
+    const expectedEntry1: TooltipPayloadEntry = {
+      name: 'stature',
+      unit: 'cm',
+      value: 100,
+      payload: {
+        x: 100,
+        y: 200,
+        z: 200,
+      },
+      dataKey: 'x',
+    };
+    const expectedEntry2: TooltipPayloadEntry = {
+      name: 'weight',
+      unit: 'kg',
+      value: 200,
+      payload: {
+        x: 100,
+        y: 200,
+        z: 200,
+      },
+      dataKey: 'y',
+    };
+    const expected: ReadonlyArray<TooltipPayloadEntry> = [expectedEntry1, expectedEntry2];
+    expect(actual).toEqual(expected);
+  });
+
+  it('should use dataKey from tooltipAxis, if item dataKey is undefined', () => {
+    const tooltipPayloadConfiguration: TooltipPayloadConfiguration = {
+      settings: {},
+      dataDefinedOnItem: [],
+    };
+    const tooltipState: TooltipState = {
+      activeIndex: 0,
+      tooltipItemPayloads: [tooltipPayloadConfiguration],
+    };
+    const chartDataState: ChartDataState = initialChartDataState;
+    const tooltipAxis: BaseAxisProps = {
+      dataKey: 'dataKeyOnAxis',
+    };
+    const activeLabel: string | undefined = undefined;
+    const shared = false;
+    const actual: TooltipPayload | undefined = combineTooltipPayload(
+      tooltipState,
+      chartDataState,
+      tooltipAxis,
+      activeLabel,
+      shared,
+    );
+    const expected: TooltipPayloadEntry = { dataKey: 'dataKeyOnAxis', payload: null, value: undefined };
+    expect(actual).toEqual([expected]);
+  });
+
   it.todo('should do something - not quite sure what exactly yet - with tooltipAxis.allowDuplicatedCategory');
 });


### PR DESCRIPTION
## Description

Scatter is a little bit different from others - it always pushes an array of tooltip payloads because it always shows two values (one for X, second for Y coordinate).

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Render tooltip from redux only, delete generateCategoricalChart code

## How Has This Been Tested?

npm test, storybook

https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=951

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
