### PR TITLE
Tooltip reads payload from state

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -119,7 +119,7 @@
       }
     },
     {
-      "files": ["src/state/*Slice.ts"],
+      "files": ["src/state/*Slice.ts", "test/state/*.spec.tsx"],
       // param-reassign is allowed in slices following Redux recommendation: https://redux-toolkit.js.org/usage/immer-reducers#linting-state-mutations
       "rules": { "no-param-reassign": ["error", { "props": false }] }
     }

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -181,9 +181,9 @@ function BarBackground(props: BarBackgroundProps) {
     ...restOfAllOtherProps
   } = allOtherBarProps;
 
-  const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps);
+  const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps, dataKey);
   const onMouseLeaveFromContext = useMouseLeaveItemDispatch(onMouseLeaveFromProps);
-  const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps);
+  const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps, dataKey);
   if (!backgroundFromProps) {
     return null;
   }
@@ -255,9 +255,9 @@ function BarRectangles(props: BarRectanglesProps) {
     ...restOfAllOtherProps
   } = rest;
 
-  const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps);
+  const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps, dataKey);
   const onMouseLeaveFromContext = useMouseLeaveItemDispatch(onMouseLeaveFromProps);
-  const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps);
+  const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps, dataKey);
 
   if (!data) {
     return null;

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -152,9 +152,9 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
     ...restOfAllOtherProps
   } = allOtherScatterProps;
 
-  const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps);
+  const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps, allOtherScatterProps.dataKey);
   const onMouseLeaveFromContext = useMouseLeaveItemDispatch(onMouseLeaveFromProps);
-  const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps);
+  const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps, allOtherScatterProps.dataKey);
 
   return (
     <>

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -23,7 +23,6 @@ import { TooltipContextProvider, TooltipContextValue } from './tooltipContext';
 import { PolarRadiusAxisProps } from '../polar/PolarRadiusAxis';
 import { PolarAngleAxisProps } from '../polar/PolarAngleAxis';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
-import { setActiveMouseOverItemIndex } from '../state/tooltipSlice';
 import { setPolarAngleAxisMap, setPolarRadiusAxisMap, setXAxisMap, setYAxisMap } from '../state/axisSlice';
 import { RechartsRootState } from '../state/store';
 import { setLayout } from '../state/layoutSlice';
@@ -92,7 +91,6 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
   };
 
   const dispatch = useAppDispatch();
-  dispatch(setActiveMouseOverItemIndex(tooltipContextValue.index));
   dispatch(setXAxisMap(xAxisMap));
   dispatch(setYAxisMap(yAxisMap));
   dispatch(setPolarAngleAxisMap(angleAxisMap));

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -23,7 +23,7 @@ import { TooltipContextProvider, TooltipContextValue } from './tooltipContext';
 import { PolarRadiusAxisProps } from '../polar/PolarRadiusAxis';
 import { PolarAngleAxisProps } from '../polar/PolarAngleAxis';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
-import { setActiveTooltipIndex } from '../state/tooltipSlice';
+import { setActiveMouseOverItemIndex } from '../state/tooltipSlice';
 import { setPolarAngleAxisMap, setPolarRadiusAxisMap, setXAxisMap, setYAxisMap } from '../state/axisSlice';
 import { RechartsRootState } from '../state/store';
 import { setLayout } from '../state/layoutSlice';
@@ -92,7 +92,7 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
   };
 
   const dispatch = useAppDispatch();
-  dispatch(setActiveTooltipIndex(tooltipContextValue.index));
+  dispatch(setActiveMouseOverItemIndex(tooltipContextValue.index));
   dispatch(setXAxisMap(xAxisMap));
   dispatch(setYAxisMap(yAxisMap));
   dispatch(setPolarAngleAxisMap(angleAxisMap));

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, useContext } from 'react';
 import { ChartCoordinate, Coordinate } from '../util/types';
+import { useAppDispatch } from '../state/hooks';
+import { setActiveMouseOverItemIndex } from '../state/tooltipSlice';
 
 export type TooltipContextValue = {
   label: string;
@@ -45,29 +47,35 @@ export const MouseClickItemDispatchContext = createContext<ActivateTooltipAction
 export const useMouseEnterItemDispatch = <T extends TooltipPayloadType>(
   onMouseEnterFromProps: undefined | ActivateTooltipAction<T>,
 ): ActivateTooltipAction<T> => {
+  const dispatch = useAppDispatch();
   const onMouseEnterFromContext: undefined | ActivateTooltipAction<T> = useContext(MouseEnterItemDispatchContext);
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseEnterFromProps?.(data, index, event);
     onMouseEnterFromContext?.(data, index, event);
+    dispatch(setActiveMouseOverItemIndex(index));
   };
 };
 
 export const useMouseLeaveItemDispatch = <T extends TooltipPayloadType>(
   onMouseLeaveFromProps: undefined | ActivateTooltipAction<T>,
 ): ActivateTooltipAction<T> => {
+  const dispatch = useAppDispatch();
   const onMouseLeaveFromContext: undefined | ActivateTooltipAction<T> = useContext(MouseLeaveItemDispatchContext);
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseLeaveFromProps?.(data, index, event);
     onMouseLeaveFromContext?.(data, index, event);
+    dispatch(setActiveMouseOverItemIndex(index));
   };
 };
 
 export const useMouseClickItemDispatch = <T extends TooltipPayloadType>(
   onMouseClickFromProps: undefined | ActivateTooltipAction<T>,
 ): undefined | ActivateTooltipAction<T> => {
+  const dispatch = useAppDispatch();
   const onMouseClickFromContext: undefined | ActivateTooltipAction<T> = useContext(MouseClickItemDispatchContext);
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseClickFromProps?.(data, index, event);
     onMouseClickFromContext?.(data, index, event);
+    dispatch(setActiveMouseOverItemIndex(index));
   };
 };

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext } from 'react';
 import { ChartCoordinate, Coordinate } from '../util/types';
 import { useAppDispatch } from '../state/hooks';
-import { setActiveMouseOverItemIndex } from '../state/tooltipSlice';
+import { setActiveClickItemIndex, setActiveMouseOverItemIndex } from '../state/tooltipSlice';
 
 export type TooltipContextValue = {
   label: string;
@@ -76,7 +76,6 @@ export const useMouseClickItemDispatch = <T extends TooltipPayloadType>(
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseClickFromProps?.(data, index, event);
     onMouseClickFromContext?.(data, index, event);
-    // TODO make this the click index dispatch
-    dispatch(setActiveMouseOverItemIndex({ activeIndex: index, activeDataKey: undefined }));
+    dispatch(setActiveClickItemIndex({ activeIndex: index, activeDataKey: undefined }));
   };
 };

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from 'react';
-import { ChartCoordinate, Coordinate } from '../util/types';
+import { ChartCoordinate, Coordinate, DataKey } from '../util/types';
 import { useAppDispatch } from '../state/hooks';
 import { setActiveClickItemIndex, setActiveMouseOverItemIndex } from '../state/tooltipSlice';
 
@@ -45,14 +45,15 @@ export const MouseLeaveItemDispatchContext = createContext<ActivateTooltipAction
 export const MouseClickItemDispatchContext = createContext<ActivateTooltipAction<TooltipPayloadType> | null>(null);
 
 export const useMouseEnterItemDispatch = <T extends TooltipPayloadType>(
-  onMouseEnterFromProps: undefined | ActivateTooltipAction<T>,
+  onMouseEnterFromProps: ActivateTooltipAction<T> | undefined,
+  dataKey: DataKey<any>,
 ): ActivateTooltipAction<T> => {
   const dispatch = useAppDispatch();
   const onMouseEnterFromContext: undefined | ActivateTooltipAction<T> = useContext(MouseEnterItemDispatchContext);
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseEnterFromProps?.(data, index, event);
     onMouseEnterFromContext?.(data, index, event);
-    dispatch(setActiveMouseOverItemIndex({ activeIndex: index, activeDataKey: undefined }));
+    dispatch(setActiveMouseOverItemIndex({ activeIndex: index, activeDataKey: dataKey }));
   };
 };
 
@@ -69,13 +70,14 @@ export const useMouseLeaveItemDispatch = <T extends TooltipPayloadType>(
 };
 
 export const useMouseClickItemDispatch = <T extends TooltipPayloadType>(
-  onMouseClickFromProps: undefined | ActivateTooltipAction<T>,
-): undefined | ActivateTooltipAction<T> => {
+  onMouseClickFromProps: ActivateTooltipAction<T> | undefined,
+  dataKey: DataKey<any>,
+): ActivateTooltipAction<T> | undefined => {
   const dispatch = useAppDispatch();
   const onMouseClickFromContext: undefined | ActivateTooltipAction<T> = useContext(MouseClickItemDispatchContext);
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseClickFromProps?.(data, index, event);
     onMouseClickFromContext?.(data, index, event);
-    dispatch(setActiveClickItemIndex({ activeIndex: index, activeDataKey: undefined }));
+    dispatch(setActiveClickItemIndex({ activeIndex: index, activeDataKey: dataKey }));
   };
 };

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -52,7 +52,7 @@ export const useMouseEnterItemDispatch = <T extends TooltipPayloadType>(
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseEnterFromProps?.(data, index, event);
     onMouseEnterFromContext?.(data, index, event);
-    dispatch(setActiveMouseOverItemIndex(index));
+    dispatch(setActiveMouseOverItemIndex({ activeIndex: index, activeDataKey: undefined }));
   };
 };
 
@@ -64,7 +64,7 @@ export const useMouseLeaveItemDispatch = <T extends TooltipPayloadType>(
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseLeaveFromProps?.(data, index, event);
     onMouseLeaveFromContext?.(data, index, event);
-    dispatch(setActiveMouseOverItemIndex(index));
+    dispatch(setActiveMouseOverItemIndex({ activeIndex: -1, activeDataKey: undefined }));
   };
 };
 
@@ -76,6 +76,7 @@ export const useMouseClickItemDispatch = <T extends TooltipPayloadType>(
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseClickFromProps?.(data, index, event);
     onMouseClickFromContext?.(data, index, event);
-    dispatch(setActiveMouseOverItemIndex(index));
+    // TODO make this the click index dispatch
+    dispatch(setActiveMouseOverItemIndex({ activeIndex: index, activeDataKey: undefined }));
   };
 };

--- a/src/numberAxis/Funnel.tsx
+++ b/src/numberAxis/Funnel.tsx
@@ -102,9 +102,9 @@ function FunnelTrapezoids(props: FunnelTrapezoidsProps) {
     ...restOfAllOtherProps
   } = allOtherFunnelProps;
 
-  const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps);
+  const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps, allOtherFunnelProps.dataKey);
   const onMouseLeaveFromContext = useMouseLeaveItemDispatch(onMouseLeaveFromProps);
-  const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps);
+  const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps, allOtherFunnelProps.dataKey);
 
   return trapezoids.map((entry, i) => {
     const isActiveIndex = activeShape && activeIndex === i;

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -206,9 +206,9 @@ function PieSectors(props: PieSectorsProps) {
     ...restOfAllOtherProps
   } = allOtherPieProps;
 
-  const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps);
+  const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps, allOtherPieProps.dataKey);
   const onMouseLeaveFromContext = useMouseLeaveItemDispatch(onMouseLeaveFromProps);
-  const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps);
+  const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps, allOtherPieProps.dataKey);
 
   return sectors.map((entry, i) => {
     if (entry?.startAngle === 0 && entry?.endAngle === 0 && sectors.length !== 1) return null;

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -72,9 +72,9 @@ function RadialBarSectors(props: RadialBarSectorsProps) {
     ...restOfAllOtherProps
   } = allOtherRadialBarProps;
 
-  const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps);
+  const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps, allOtherRadialBarProps.dataKey);
   const onMouseLeaveFromContext = useMouseLeaveItemDispatch(onMouseLeaveFromProps);
-  const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps);
+  const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps, allOtherRadialBarProps.dataKey);
 
   return (
     <>

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -67,12 +67,13 @@ function selectFinalData(
 
 export const combineTooltipPayload = (
   tooltipState: TooltipState,
+  activeIndex: number,
   chartDataState: ChartDataState,
   tooltipAxis: BaseAxisProps | undefined,
   activeLabel: string | undefined,
   shared: boolean | undefined,
 ): TooltipPayload | undefined => {
-  const { activeIndex, tooltipItemPayloads } = tooltipState;
+  const { tooltipItemPayloads } = tooltipState;
   if (activeIndex === -1) {
     return undefined;
   }
@@ -132,6 +133,7 @@ export const selectTooltipPayload: (
   shared: boolean | undefined,
 ) => TooltipPayload | undefined = createSelector(
   selectTooltipState,
+  selectActiveIndex,
   selectChartData,
   selectTooltipAxis,
   selectActiveLabel,

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -39,7 +39,10 @@ const selectTooltipTicks = createSelector(selectTooltipAxis, (tooltipAxis: BaseA
 );
 
 // TODO support for tooltipEventType, and trigger
-const selectActiveIndex = createSelector(selectTooltipState, (tooltipState: TooltipState) => tooltipState.activeIndex);
+export const selectActiveIndex: (state: RechartsRootState) => number = createSelector(
+  selectTooltipState,
+  (tooltipState: TooltipState) => tooltipState.activeIndex,
+);
 
 const selectActiveLabel = createSelector(
   selectTooltipTicks,
@@ -66,7 +69,7 @@ function selectFinalData(
   return dataDefinedOnChart;
 }
 
-function selectTooltipItemPayloads(state: RechartsRootState) {
+function selectTooltipItemPayloads(state: RechartsRootState): ReadonlyArray<TooltipPayloadConfiguration> {
   // TODO support for tooltipEventType, and trigger
   return state.tooltip.tooltipItemPayloads;
 }

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -86,19 +86,17 @@ export function selectTooltipPayloadConfigurations(
   if (tooltipEventType === 'axis') {
     return tooltipState.tooltipItemPayloads;
   }
-  // TODO
-  return tooltipState.tooltipItemPayloads;
-  // let filterByDataKey: DataKey<any> | undefined;
+  let filterByDataKey: DataKey<any> | undefined;
   /*
    * By now we already know that tooltipEventType is 'item', so we can only search in itemInteractions.
    * item means that only the hovered or clicked item will be present in the tooltip.
    */
-  // if (trigger === 'hover') {
-  //   filterByDataKey = tooltipState.itemInteraction.activeMouseOverDataKey;
-  // } else {
-  //   filterByDataKey = tooltipState.itemInteraction.activeClickDataKey;
-  // }
-  // return tooltipState.tooltipItemPayloads.filter(tpc => tpc.settings?.dataKey === filterByDataKey);
+  if (trigger === 'hover') {
+    filterByDataKey = tooltipState.itemInteraction.activeMouseOverDataKey;
+  } else {
+    filterByDataKey = tooltipState.itemInteraction.activeClickDataKey;
+  }
+  return tooltipState.tooltipItemPayloads.filter(tpc => tpc.settings?.dataKey === filterByDataKey);
 }
 
 export const combineTooltipPayload = (

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -13,7 +13,7 @@ export const useChartName = (): string => {
   return useAppSelector((state: RechartsRootState) => state.options.chartName);
 };
 
-export function useTooltipEventType(shared: boolean | undefined) {
+export function useTooltipEventType(shared: boolean | undefined): TooltipEventType {
   const defaultTooltipEventType = useAppSelector((state: RechartsRootState) => state.options.defaultTooltipEventType);
   const validateTooltipEventTypes = useAppSelector(
     (state: RechartsRootState) => state.options.validateTooltipEventTypes,

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { useAppSelector } from './hooks';
 import { RechartsRootState } from './store';
-import { TooltipPayload, TooltipPayloadEntry, TooltipState } from './tooltipSlice';
+import { TooltipPayload, TooltipPayloadConfiguration, TooltipPayloadEntry, TooltipState } from './tooltipSlice';
 import { getTicksOfAxis, getTooltipEntry, getValueByDataKey } from '../util/ChartUtils';
 import { ChartDataState } from './chartDataSlice';
 import { selectTooltipAxis } from '../context/useTooltipAxis';
@@ -38,6 +38,7 @@ const selectTooltipTicks = createSelector(selectTooltipAxis, (tooltipAxis: BaseA
   getTicksOfAxis(tooltipAxis, false, true),
 );
 
+// TODO support for tooltipEventType, and trigger
 const selectActiveIndex = createSelector(selectTooltipState, (tooltipState: TooltipState) => tooltipState.activeIndex);
 
 const selectActiveLabel = createSelector(
@@ -65,15 +66,19 @@ function selectFinalData(
   return dataDefinedOnChart;
 }
 
+function selectTooltipItemPayloads(state: RechartsRootState) {
+  // TODO support for tooltipEventType, and trigger
+  return state.tooltip.tooltipItemPayloads;
+}
+
 export const combineTooltipPayload = (
-  tooltipState: TooltipState,
+  tooltipItemPayloads: ReadonlyArray<TooltipPayloadConfiguration>,
   activeIndex: number,
   chartDataState: ChartDataState,
   tooltipAxis: BaseAxisProps | undefined,
   activeLabel: string | undefined,
   shared: boolean | undefined,
 ): TooltipPayload | undefined => {
-  const { tooltipItemPayloads } = tooltipState;
   if (activeIndex === -1) {
     return undefined;
   }
@@ -132,7 +137,7 @@ export const selectTooltipPayload: (
   state: RechartsRootState,
   shared: boolean | undefined,
 ) => TooltipPayload | undefined = createSelector(
-  selectTooltipState,
+  selectTooltipItemPayloads,
   selectActiveIndex,
   selectChartData,
   selectTooltipAxis,

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -63,9 +63,30 @@ function selectFinalData(dataDefinedOnItem: ReadonlyArray<unknown>, dataDefinedO
   return dataDefinedOnChart;
 }
 
-function selectTooltipItemPayloads(state: RechartsRootState): ReadonlyArray<TooltipPayloadConfiguration> {
-  // TODO support for tooltipEventType, and trigger
-  return state.tooltip.tooltipItemPayloads;
+export function selectTooltipPayloadConfigurations(
+  state: RechartsRootState,
+  tooltipEventType: TooltipEventType,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  trigger: TooltipTrigger,
+): ReadonlyArray<TooltipPayloadConfiguration> {
+  const tooltipState = selectTooltipState(state);
+  // if tooltip reacts to axis interaction, then we display all items at the same time.
+  if (tooltipEventType === 'axis') {
+    return tooltipState.tooltipItemPayloads;
+  }
+  // TODO
+  return tooltipState.tooltipItemPayloads;
+  // let filterByDataKey: DataKey<any> | undefined;
+  /*
+   * By now we already know that tooltipEventType is 'item', so we can only search in itemInteractions.
+   * item means that only the hovered or clicked item will be present in the tooltip.
+   */
+  // if (trigger === 'hover') {
+  //   filterByDataKey = tooltipState.itemInteraction.activeMouseOverDataKey;
+  // } else {
+  //   filterByDataKey = tooltipState.itemInteraction.activeClickDataKey;
+  // }
+  // return tooltipState.tooltipItemPayloads.filter(tpc => tpc.settings?.dataKey === filterByDataKey);
 }
 
 export const combineTooltipPayload = (
@@ -134,7 +155,7 @@ export const selectTooltipPayload: (
   tooltipEventType: TooltipEventType,
   trigger: TooltipTrigger,
 ) => TooltipPayload | undefined = createSelector(
-  selectTooltipItemPayloads,
+  selectTooltipPayloadConfigurations,
   selectActiveIndex,
   selectChartData,
   selectTooltipAxis,

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -39,11 +39,23 @@ const selectTooltipTicks = createSelector(selectTooltipAxis, (tooltipAxis: BaseA
   getTicksOfAxis(tooltipAxis, false, true),
 );
 
-export const selectActiveIndex: (
+export function selectActiveIndex(
   state: RechartsRootState,
   tooltipEventType: TooltipEventType,
   trigger: TooltipTrigger,
-) => number = createSelector(selectTooltipState, (tooltipState: TooltipState) => tooltipState.activeIndex);
+): number {
+  const tooltipState: TooltipState = selectTooltipState(state);
+  if (tooltipEventType === 'item') {
+    if (trigger === 'hover') {
+      return tooltipState.itemInteraction.activeMouseOverIndex;
+    }
+    return tooltipState.itemInteraction.activeClickIndex;
+  }
+  if (trigger === 'hover') {
+    return tooltipState.axisInteraction.activeMouseOverAxisIndex;
+  }
+  return tooltipState.axisInteraction.activeClickAxisIndex;
+}
 
 const selectActiveLabel = createSelector(
   selectTooltipTicks,

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -64,12 +64,13 @@ const tooltipSlice = createSlice({
         state.tooltipItemPayloads.splice(index, 1);
       }
     },
-    setActiveTooltipIndex(state, action: PayloadAction<TooltipIndex>) {
+    setActiveMouseOverItemIndex(state, action: PayloadAction<TooltipIndex>) {
       state.activeIndex = action.payload;
     },
   },
 });
 
-export const { addTooltipEntrySettings, removeTooltipEntrySettings, setActiveTooltipIndex } = tooltipSlice.actions;
+export const { addTooltipEntrySettings, removeTooltipEntrySettings, setActiveMouseOverItemIndex } =
+  tooltipSlice.actions;
 
 export const tooltipReducer = tooltipSlice.reducer;

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -32,13 +32,57 @@ export type TooltipPayloadConfiguration = {
   dataDefinedOnItem: unknown[] | undefined;
 };
 
+/**
+ * The tooltip interaction state stores:
+ *
+ * - Which graphical item is user interacting with at the moment,
+ * - which axis (or, which part of chart background) is user interacting with at the moment
+ * - The data that individual graphical items wish to be displayed in case the tooltip gets activated
+ */
 export type TooltipState = {
   /**
-   * This is the current data index that is set for the chart.
-   * This can come from mouse events, keyboard events, or hardcoded in props
-   * in property `defaultIndex` on Tooltip.
+   * This is the state of interactions with individual graphical items.
    */
-  activeIndex: TooltipIndex;
+  itemInteraction: {
+    /**
+     * This is the current data index that is set for the chart.
+     * This can come from mouse events, keyboard events, or hardcoded in props
+     * in property `defaultIndex` on Tooltip.
+     *
+     * This is only set for mouse hover.
+     *
+     * If there is nothing hovering over a chart item right now then this is -1.
+     */
+    activeMouseOverIndex: TooltipIndex;
+    /**
+     * In case of multiple graphical items, this is the dataKey that is set for the item.
+     * Very useful for `Tooltip.shared=false`, where activeIndex can display multiple values,
+     * but we only want to display one of them.
+     *
+     * This is only set for mouse hover.
+     *
+     * If there is nothing hovering over a chart item right now then this is undefined.
+     */
+    activeMouseOverDataKey: DataKey<any> | undefined;
+    /**
+     * Same as the index above but this one only gets set by clicking on a chart item.
+     */
+    activeClickIndex: TooltipIndex | undefined;
+    /**
+     * Same as the dataKey above but this one only gets set by clicking on a chart item.
+     */
+    activeClickDataKey: DataKey<any> | undefined;
+  };
+  /**
+   * This is the state of interaction with the bar background - which will get mapped
+   * to the axis index.
+   */
+  axisInteraction: {
+    activeMouseOverAxisIndex: number | undefined;
+    activeMouseOverAxisDataKey: DataKey<any> | undefined;
+    activeClickAxisIndex: number | undefined;
+    activeClickAxisDataKey: DataKey<any> | undefined;
+  };
   /**
    * One graphical item will have one configuration;
    * hovering over multiple of them (for example with tooltipEventType===axis)
@@ -48,7 +92,18 @@ export type TooltipState = {
 };
 
 const initialState: TooltipState = {
-  activeIndex: -1,
+  itemInteraction: {
+    activeMouseOverIndex: -1,
+    activeMouseOverDataKey: undefined,
+    activeClickIndex: -1,
+    activeClickDataKey: undefined,
+  },
+  axisInteraction: {
+    activeMouseOverAxisIndex: -1,
+    activeMouseOverAxisDataKey: undefined,
+    activeClickAxisIndex: -1,
+    activeClickAxisDataKey: undefined,
+  },
   tooltipItemPayloads: [],
 };
 
@@ -69,7 +124,8 @@ const tooltipSlice = createSlice({
       state,
       action: PayloadAction<{ activeIndex: TooltipIndex; activeDataKey: DataKey<any> | undefined }>,
     ) {
-      state.activeIndex = action.payload.activeIndex;
+      state.itemInteraction.activeMouseOverIndex = action.payload.activeIndex;
+      state.itemInteraction.activeMouseOverDataKey = action.payload.activeDataKey;
     },
   },
 });

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, current, PayloadAction } from '@reduxjs/toolkit';
 import { NameType, Payload, ValueType } from '../component/DefaultTooltipContent';
+import { DataKey } from '../util/types';
 
 /**
  * One Tooltip can display multiple TooltipPayloadEntries at a time.
@@ -64,8 +65,11 @@ const tooltipSlice = createSlice({
         state.tooltipItemPayloads.splice(index, 1);
       }
     },
-    setActiveMouseOverItemIndex(state, action: PayloadAction<TooltipIndex>) {
-      state.activeIndex = action.payload;
+    setActiveMouseOverItemIndex(
+      state,
+      action: PayloadAction<{ activeIndex: TooltipIndex; activeDataKey: DataKey<any> | undefined }>,
+    ) {
+      state.activeIndex = action.payload.activeIndex;
     },
   },
 });

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -127,10 +127,37 @@ const tooltipSlice = createSlice({
       state.itemInteraction.activeMouseOverIndex = action.payload.activeIndex;
       state.itemInteraction.activeMouseOverDataKey = action.payload.activeDataKey;
     },
+    setActiveClickItemIndex(
+      state,
+      action: PayloadAction<{ activeIndex: TooltipIndex; activeDataKey: DataKey<any> | undefined }>,
+    ) {
+      state.itemInteraction.activeClickIndex = action.payload.activeIndex;
+      state.itemInteraction.activeClickDataKey = action.payload.activeDataKey;
+    },
+    setMouseOverAxisIndex(
+      state,
+      action: PayloadAction<{ activeIndex: number; activeDataKey: DataKey<any> | undefined }>,
+    ) {
+      state.axisInteraction.activeMouseOverAxisIndex = action.payload.activeIndex;
+      state.axisInteraction.activeMouseOverAxisDataKey = action.payload.activeDataKey;
+    },
+    setMouseClickAxisIndex(
+      state,
+      action: PayloadAction<{ activeIndex: number; activeDataKey: DataKey<any> | undefined }>,
+    ) {
+      state.axisInteraction.activeClickAxisIndex = action.payload.activeIndex;
+      state.axisInteraction.activeClickAxisDataKey = action.payload.activeDataKey;
+    },
   },
 });
 
-export const { addTooltipEntrySettings, removeTooltipEntrySettings, setActiveMouseOverItemIndex } =
-  tooltipSlice.actions;
+export const {
+  addTooltipEntrySettings,
+  removeTooltipEntrySettings,
+  setActiveMouseOverItemIndex,
+  setActiveClickItemIndex,
+  setMouseOverAxisIndex,
+  setMouseClickAxisIndex,
+} = tooltipSlice.actions;
 
 export const tooltipReducer = tooltipSlice.reducer;

--- a/test/state/produceState.ts
+++ b/test/state/produceState.ts
@@ -1,0 +1,7 @@
+import { produce, WritableDraft } from 'immer';
+import { createRechartsStore, RechartsRootState } from '../../src/state/store';
+
+export function produceState(cb: (draft: WritableDraft<RechartsRootState>) => void): RechartsRootState {
+  const initialState = createRechartsStore().getState();
+  return produce(initialState, cb);
+}

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -12,7 +12,6 @@ import {
   TooltipPayload,
   TooltipPayloadConfiguration,
   TooltipPayloadEntry,
-  TooltipState,
 } from '../../src/state/tooltipSlice';
 import {
   ChartDataState,
@@ -258,16 +257,12 @@ describe('selectTooltipPayload', () => {
         ],
       ],
     };
-    const tooltipState: TooltipState = {
-      activeIndex: 0,
-      tooltipItemPayloads: [tooltipPayloadConfiguration],
-    };
     const chartDataState: ChartDataState = initialChartDataState;
     const tooltipAxis: BaseAxisProps | undefined = undefined;
     const activeLabel: string | undefined = undefined;
     const shared = false;
     const actual: TooltipPayload | undefined = combineTooltipPayload(
-      tooltipState,
+      [tooltipPayloadConfiguration],
       0,
       chartDataState,
       tooltipAxis,
@@ -305,10 +300,6 @@ describe('selectTooltipPayload', () => {
       settings: {},
       dataDefinedOnItem: [],
     };
-    const tooltipState: TooltipState = {
-      activeIndex: 0,
-      tooltipItemPayloads: [tooltipPayloadConfiguration],
-    };
     const chartDataState: ChartDataState = initialChartDataState;
     const tooltipAxis: BaseAxisProps = {
       dataKey: 'dataKeyOnAxis',
@@ -316,7 +307,7 @@ describe('selectTooltipPayload', () => {
     const activeLabel: string | undefined = undefined;
     const shared = false;
     const actual: TooltipPayload | undefined = combineTooltipPayload(
-      tooltipState,
+      [tooltipPayloadConfiguration],
       0,
       chartDataState,
       tooltipAxis,

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -238,7 +238,7 @@ describe('selectTooltipPayload', () => {
     store.dispatch(addTooltipEntrySettings(tooltipSettings1));
     store.dispatch(addTooltipEntrySettings(tooltipSettings2));
     expect(selectTooltipPayload(store.getState(), 'item', 'hover')).toEqual(undefined);
-    store.dispatch(setActiveMouseOverItemIndex(1)); // TODO this should be only item hover action
+    store.dispatch(setActiveMouseOverItemIndex({ activeIndex: 1, activeDataKey: 'x' }));
     expect(selectTooltipPayload(store.getState(), 'item', 'hover')).toEqual([expectedEntry1, expectedEntry2]);
   });
 
@@ -263,7 +263,7 @@ describe('selectTooltipPayload', () => {
           { x: 3, y: 4 },
         ]),
       );
-      store.dispatch(setActiveMouseOverItemIndex(0));
+      store.dispatch(setActiveMouseOverItemIndex({ activeIndex: 0, activeDataKey: 'y' }));
 
       const expectedEntry: TooltipPayloadEntry = {
         name: 'foo',
@@ -303,7 +303,7 @@ describe('selectTooltipPayload', () => {
         ]),
       );
       expect(selectTooltipPayload(store.getState(), tooltipEventType, trigger)).toEqual(undefined);
-      store.dispatch(setActiveMouseOverItemIndex(0));
+      store.dispatch(setActiveMouseOverItemIndex({ activeIndex: 0, activeDataKey: 'y' }));
       store.dispatch(setDataStartEndIndexes({ startIndex: 1, endIndex: 10 }));
       const expectedEntry: TooltipPayloadEntry = {
         name: 'foo',

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -268,6 +268,7 @@ describe('selectTooltipPayload', () => {
     const shared = false;
     const actual: TooltipPayload | undefined = combineTooltipPayload(
       tooltipState,
+      0,
       chartDataState,
       tooltipAxis,
       activeLabel,
@@ -316,6 +317,7 @@ describe('selectTooltipPayload', () => {
     const shared = false;
     const actual: TooltipPayload | undefined = combineTooltipPayload(
       tooltipState,
+      0,
       chartDataState,
       tooltipAxis,
       activeLabel,

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -14,7 +14,7 @@ import { BaseAxisProps, TooltipEventType } from '../../src/util/types';
 import { useAppSelector } from '../../src/state/hooks';
 import {
   addTooltipEntrySettings,
-  setActiveTooltipIndex,
+  setActiveMouseOverItemIndex,
   TooltipPayload,
   TooltipPayloadConfiguration,
   TooltipPayloadEntry,
@@ -238,7 +238,7 @@ describe('selectTooltipPayload', () => {
     store.dispatch(addTooltipEntrySettings(tooltipSettings1));
     store.dispatch(addTooltipEntrySettings(tooltipSettings2));
     expect(selectTooltipPayload(store.getState(), 'item', 'hover')).toEqual(undefined);
-    store.dispatch(setActiveTooltipIndex(1)); // TODO this should be only item hover action
+    store.dispatch(setActiveMouseOverItemIndex(1)); // TODO this should be only item hover action
     expect(selectTooltipPayload(store.getState(), 'item', 'hover')).toEqual([expectedEntry1, expectedEntry2]);
   });
 
@@ -263,7 +263,7 @@ describe('selectTooltipPayload', () => {
           { x: 3, y: 4 },
         ]),
       );
-      store.dispatch(setActiveTooltipIndex(0));
+      store.dispatch(setActiveMouseOverItemIndex(0));
 
       const expectedEntry: TooltipPayloadEntry = {
         name: 'foo',
@@ -303,7 +303,7 @@ describe('selectTooltipPayload', () => {
         ]),
       );
       expect(selectTooltipPayload(store.getState(), tooltipEventType, trigger)).toEqual(undefined);
-      store.dispatch(setActiveTooltipIndex(0));
+      store.dispatch(setActiveMouseOverItemIndex(0));
       store.dispatch(setDataStartEndIndexes({ startIndex: 1, endIndex: 10 }));
       const expectedEntry: TooltipPayloadEntry = {
         name: 'foo',


### PR DESCRIPTION
## Description

There's still fallback to generateCategoricalChart payload because this doesn't cover all cases - I will follow up on that in next PR.

At least all tests are passing for this change and there was no visual diff either so that's nice.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Remove element cloning

## How Has This Been Tested?

npm test, storybooks

https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=961

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
