### PR TITLE
2.x: Support react 19

### DIFF
--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -47,88 +47,95 @@ interface ErrorBarProps extends InternalErrorBarProps {
 
 export type Props = SVGProps<SVGLineElement> & ErrorBarProps;
 
-export function ErrorBar(props: Props) {
-  const { offset, layout, width, dataKey, data, dataPointFormatter, xAxis, yAxis, ...others } = props;
-  const svgProps = filterProps(others, false);
+// eslint-disable-next-line react/prefer-stateless-function -- requires static defaultProps
+export class ErrorBar extends React.Component<Props> {
+  static defaultProps = {
+    stroke: 'black',
+    strokeWidth: 1.5,
+    width: 5,
+    offset: 0,
+    layout: 'horizontal',
+  };
 
-  invariant(
-    !(props.direction === 'x' && xAxis.type !== 'number'),
-    'ErrorBar requires Axis type property to be "number".',
-  );
+  static displayName = 'ErrorBar';
 
-  const errorBars = data.map((entry: any) => {
-    const { x, y, value, errorVal } = dataPointFormatter(entry, dataKey);
+  render() {
+    const { offset, layout, width, dataKey, data, dataPointFormatter, xAxis, yAxis, ...others } = this.props;
+    const svgProps = filterProps(others, false);
 
-    if (!errorVal) {
-      return null;
-    }
-
-    const lineCoordinates = [];
-    let lowBound, highBound;
-
-    if (Array.isArray(errorVal)) {
-      [lowBound, highBound] = errorVal;
-    } else {
-      lowBound = highBound = errorVal;
-    }
-
-    if (layout === 'vertical') {
-      // error bar for horizontal charts, the y is fixed, x is a range value
-      const { scale } = xAxis;
-
-      const yMid = y + offset;
-      const yMin = yMid + width;
-      const yMax = yMid - width;
-
-      const xMin = scale(value - lowBound);
-      const xMax = scale(value + highBound);
-
-      // the right line of |--|
-      lineCoordinates.push({ x1: xMax, y1: yMin, x2: xMax, y2: yMax });
-      // the middle line of |--|
-      lineCoordinates.push({ x1: xMin, y1: yMid, x2: xMax, y2: yMid });
-      // the left line of |--|
-      lineCoordinates.push({ x1: xMin, y1: yMin, x2: xMin, y2: yMax });
-    } else if (layout === 'horizontal') {
-      // error bar for horizontal charts, the x is fixed, y is a range value
-      const { scale } = yAxis;
-
-      const xMid = x + offset;
-      const xMin = xMid - width;
-      const xMax = xMid + width;
-
-      const yMin = scale(value - lowBound);
-      const yMax = scale(value + highBound);
-
-      // the top line
-      lineCoordinates.push({ x1: xMin, y1: yMax, x2: xMax, y2: yMax });
-      // the middle line
-      lineCoordinates.push({ x1: xMid, y1: yMin, x2: xMid, y2: yMax });
-      // the bottom line
-      lineCoordinates.push({ x1: xMin, y1: yMin, x2: xMax, y2: yMin });
-    }
-
-    return (
-      <Layer
-        className="recharts-errorBar"
-        key={`bar-${lineCoordinates.map(c => `${c.x1}-${c.x2}-${c.y1}-${c.y2}`)}`}
-        {...svgProps}
-      >
-        {lineCoordinates.map(coordinates => (
-          <line {...coordinates} key={`line-${coordinates.x1}-${coordinates.x2}-${coordinates.y1}-${coordinates.y2}`} />
-        ))}
-      </Layer>
+    invariant(
+      !(this.props.direction === 'x' && xAxis.type !== 'number'),
+      'ErrorBar requires Axis type property to be "number".',
     );
-  });
 
-  return <Layer className="recharts-errorBars">{errorBars}</Layer>;
+    const errorBars = data.map((entry: any) => {
+      const { x, y, value, errorVal } = dataPointFormatter(entry, dataKey);
+
+      if (!errorVal) {
+        return null;
+      }
+
+      const lineCoordinates = [];
+      let lowBound, highBound;
+
+      if (Array.isArray(errorVal)) {
+        [lowBound, highBound] = errorVal;
+      } else {
+        lowBound = highBound = errorVal;
+      }
+
+      if (layout === 'vertical') {
+        // error bar for horizontal charts, the y is fixed, x is a range value
+        const { scale } = xAxis;
+
+        const yMid = y + offset;
+        const yMin = yMid + width;
+        const yMax = yMid - width;
+
+        const xMin = scale(value - lowBound);
+        const xMax = scale(value + highBound);
+
+        // the right line of |--|
+        lineCoordinates.push({ x1: xMax, y1: yMin, x2: xMax, y2: yMax });
+        // the middle line of |--|
+        lineCoordinates.push({ x1: xMin, y1: yMid, x2: xMax, y2: yMid });
+        // the left line of |--|
+        lineCoordinates.push({ x1: xMin, y1: yMin, x2: xMin, y2: yMax });
+      } else if (layout === 'horizontal') {
+        // error bar for horizontal charts, the x is fixed, y is a range value
+        const { scale } = yAxis;
+
+        const xMid = x + offset;
+        const xMin = xMid - width;
+        const xMax = xMid + width;
+
+        const yMin = scale(value - lowBound);
+        const yMax = scale(value + highBound);
+
+        // the top line
+        lineCoordinates.push({ x1: xMin, y1: yMax, x2: xMax, y2: yMax });
+        // the middle line
+        lineCoordinates.push({ x1: xMid, y1: yMin, x2: xMid, y2: yMax });
+        // the bottom line
+        lineCoordinates.push({ x1: xMin, y1: yMin, x2: xMax, y2: yMin });
+      }
+
+      return (
+        <Layer
+          className="recharts-errorBar"
+          key={`bar-${lineCoordinates.map(c => `${c.x1}-${c.x2}-${c.y1}-${c.y2}`)}`}
+          {...svgProps}
+        >
+          {lineCoordinates.map(coordinates => (
+            <line
+              {...coordinates}
+              key={`line-${coordinates.x1}-${coordinates.x2}-${coordinates.y1}-${coordinates.y2}`}
+            />
+          ))}
+        </Layer>
+      );
+    });
+
+    return <Layer className="recharts-errorBars">{errorBars}</Layer>;
+  }
 }
-
-ErrorBar.defaultProps = {
-  stroke: 'black',
-  strokeWidth: 1.5,
-  width: 5,
-  offset: 0,
-  layout: 'horizontal',
-};
-ErrorBar.displayName = 'ErrorBar';

--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -67,61 +67,65 @@ const getRect = (hasX1: boolean, hasX2: boolean, hasY1: boolean, hasY2: boolean,
   return rectWithPoints(p1, p2);
 };
 
-export function ReferenceArea(props: Props) {
-  const { x1, x2, y1, y2, className, alwaysShow, clipPathId } = props;
+// eslint-disable-next-line react/prefer-stateless-function -- requires static defaultProps
+export class ReferenceArea extends React.Component<Props> {
+  static displayName = 'ReferenceArea';
 
-  warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
+  static defaultProps = {
+    isFront: false,
+    ifOverflow: 'discard',
+    xAxisId: 0,
+    yAxisId: 0,
+    r: 10,
+    fill: '#ccc',
+    fillOpacity: 0.5,
+    stroke: 'none',
+    strokeWidth: 1,
+  };
 
-  const hasX1 = isNumOrStr(x1);
-  const hasX2 = isNumOrStr(x2);
-  const hasY1 = isNumOrStr(y1);
-  const hasY2 = isNumOrStr(y2);
+  static renderRect = (option: ReferenceAreaProps['shape'], props: any) => {
+    let rect;
 
-  const { shape } = props;
+    if (React.isValidElement(option)) {
+      rect = React.cloneElement(option, props);
+    } else if (isFunction(option)) {
+      rect = option(props);
+    } else {
+      rect = <Rectangle {...props} className="recharts-reference-area-rect" />;
+    }
 
-  if (!hasX1 && !hasX2 && !hasY1 && !hasY2 && !shape) {
-    return null;
+    return rect;
+  };
+
+  render() {
+    const { x1, x2, y1, y2, className, alwaysShow, clipPathId } = this.props;
+
+    warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
+
+    const hasX1 = isNumOrStr(x1);
+    const hasX2 = isNumOrStr(x2);
+    const hasY1 = isNumOrStr(y1);
+    const hasY2 = isNumOrStr(y2);
+
+    const { shape } = this.props;
+
+    if (!hasX1 && !hasX2 && !hasY1 && !hasY2 && !shape) {
+      return null;
+    }
+
+    const rect = getRect(hasX1, hasX2, hasY1, hasY2, this.props);
+
+    if (!rect && !shape) {
+      return null;
+    }
+
+    const clipPath = ifOverflowMatches(this.props, 'hidden') ? `url(#${clipPathId})` : undefined;
+
+    return (
+      <Layer className={clsx('recharts-reference-area', className)}>
+        {ReferenceArea.renderRect(shape, { clipPath, ...filterProps(this.props, true), ...rect })}
+        {Label.renderCallByParent(this.props, rect)}
+      </Layer>
+    );
   }
-
-  const rect = getRect(hasX1, hasX2, hasY1, hasY2, props);
-
-  if (!rect && !shape) {
-    return null;
-  }
-
-  const clipPath = ifOverflowMatches(props, 'hidden') ? `url(#${clipPathId})` : undefined;
-
-  return (
-    <Layer className={clsx('recharts-reference-area', className)}>
-      {ReferenceArea.renderRect(shape, { clipPath, ...filterProps(props, true), ...rect })}
-      {Label.renderCallByParent(props, rect)}
-    </Layer>
-  );
 }
-
-ReferenceArea.displayName = 'ReferenceArea';
-ReferenceArea.defaultProps = {
-  isFront: false,
-  ifOverflow: 'discard',
-  xAxisId: 0,
-  yAxisId: 0,
-  r: 10,
-  fill: '#ccc',
-  fillOpacity: 0.5,
-  stroke: 'none',
-  strokeWidth: 1,
-};
-
-ReferenceArea.renderRect = (option: ReferenceAreaProps['shape'], props: any) => {
-  let rect;
-
-  if (React.isValidElement(option)) {
-    rect = React.cloneElement(option, props);
-  } else if (isFunction(option)) {
-    rect = option(props);
-  } else {
-    rect = <Rectangle {...props} className="recharts-reference-area-rect" />;
-  }
-
-  return rect;
-};

--- a/src/cartesian/ReferenceDot.tsx
+++ b/src/cartesian/ReferenceDot.tsx
@@ -54,71 +54,76 @@ const getCoordinate = (props: Props) => {
   return result;
 };
 
-export function ReferenceDot(props: Props) {
-  const { x, y, r, alwaysShow, clipPathId } = props;
-  const isX = isNumOrStr(x);
-  const isY = isNumOrStr(y);
+// eslint-disable-next-line react/prefer-stateless-function -- requires static defaultProps
+export class ReferenceDot extends React.Component<Props> {
+  static displayName = 'ReferenceDot';
 
-  warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
-
-  if (!isX || !isY) {
-    return null;
-  }
-
-  const coordinate = getCoordinate(props);
-
-  if (!coordinate) {
-    return null;
-  }
-
-  const { x: cx, y: cy } = coordinate;
-
-  const { shape, className } = props;
-
-  const clipPath = ifOverflowMatches(props, 'hidden') ? `url(#${clipPathId})` : undefined;
-
-  const dotProps = {
-    clipPath,
-    ...filterProps(props, true),
-    cx,
-    cy,
+  static defaultProps = {
+    isFront: false,
+    ifOverflow: 'discard',
+    xAxisId: 0,
+    yAxisId: 0,
+    r: 10,
+    fill: '#fff',
+    stroke: '#ccc',
+    fillOpacity: 1,
+    strokeWidth: 1,
   };
 
-  return (
-    <Layer className={clsx('recharts-reference-dot', className)}>
-      {ReferenceDot.renderDot(shape, dotProps)}
-      {Label.renderCallByParent(props, {
-        x: cx - r,
-        y: cy - r,
-        width: 2 * r,
-        height: 2 * r,
-      })}
-    </Layer>
-  );
-}
+  static renderDot = (option: Props['shape'], props: any) => {
+    let dot;
 
-ReferenceDot.displayName = 'ReferenceDot';
-ReferenceDot.defaultProps = {
-  isFront: false,
-  ifOverflow: 'discard',
-  xAxisId: 0,
-  yAxisId: 0,
-  r: 10,
-  fill: '#fff',
-  stroke: '#ccc',
-  fillOpacity: 1,
-  strokeWidth: 1,
-};
-ReferenceDot.renderDot = (option: Props['shape'], props: any) => {
-  let dot;
+    if (React.isValidElement(option)) {
+      dot = React.cloneElement(option, props);
+    } else if (isFunction(option)) {
+      dot = option(props);
+    } else {
+      dot = <Dot {...props} cx={props.cx} cy={props.cy} className="recharts-reference-dot-dot" />;
+    }
 
-  if (React.isValidElement(option)) {
-    dot = React.cloneElement(option, props);
-  } else if (isFunction(option)) {
-    dot = option(props);
-  } else {
-    dot = <Dot {...props} cx={props.cx} cy={props.cy} className="recharts-reference-dot-dot" />;
+    return dot;
+  };
+
+  render() {
+    const { x, y, r, alwaysShow, clipPathId } = this.props;
+    const isX = isNumOrStr(x);
+    const isY = isNumOrStr(y);
+
+    warn(alwaysShow === undefined, 'The alwaysShow prop is deprecated. Please use ifOverflow="extendDomain" instead.');
+
+    if (!isX || !isY) {
+      return null;
+    }
+
+    const coordinate = getCoordinate(this.props);
+
+    if (!coordinate) {
+      return null;
+    }
+
+    const { x: cx, y: cy } = coordinate;
+
+    const { shape, className } = this.props;
+
+    const clipPath = ifOverflowMatches(this.props, 'hidden') ? `url(#${clipPathId})` : undefined;
+
+    const dotProps = {
+      clipPath,
+      ...filterProps(this.props, true),
+      cx,
+      cy,
+    };
+
+    return (
+      <Layer className={clsx('recharts-reference-dot', className)}>
+        {ReferenceDot.renderDot(shape, dotProps)}
+        {Label.renderCallByParent(this.props, {
+          x: cx - r,
+          y: cy - r,
+          width: 2 * r,
+          height: 2 * r,
+        })}
+      </Layer>
+    );
   }
-
-  return dot;
-};
+}

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -137,7 +137,7 @@ export const getEndPoints = (
   return null;
 };
 
-export function ReferenceLine(props: Props) {
+function ReferenceLineImpl(props: Props) {
   const { x: fixedX, y: fixedY, segment, xAxisId, yAxisId, shape, className, alwaysShow } = props;
 
   const clipPathId = useClipPathId();
@@ -192,15 +192,23 @@ export function ReferenceLine(props: Props) {
   );
 }
 
-ReferenceLine.displayName = 'ReferenceLine';
-ReferenceLine.defaultProps = {
-  isFront: false,
-  ifOverflow: 'discard',
-  xAxisId: 0,
-  yAxisId: 0,
-  fill: 'none',
-  stroke: '#ccc',
-  fillOpacity: 1,
-  strokeWidth: 1,
-  position: 'middle',
-};
+// eslint-disable-next-line react/prefer-stateless-function -- requires static defaultProps
+export class ReferenceLine extends React.Component {
+  static displayName = 'ReferenceLine';
+
+  static defaultProps = {
+    isFront: false,
+    ifOverflow: 'discard',
+    xAxisId: 0,
+    yAxisId: 0,
+    fill: 'none',
+    stroke: '#ccc',
+    fillOpacity: 1,
+    strokeWidth: 1,
+    position: 'middle',
+  };
+
+  render() {
+    return <ReferenceLineImpl {...this.props} />;
+  }
+}

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview X Axis
  */
-import type { FunctionComponent, SVGProps } from 'react';
+import type { SVGProps } from 'react';
 import React from 'react';
 import clsx from 'clsx';
 import { useChartHeight, useChartWidth, useXAxisOrThrow } from '../context/chartLayoutContext';
@@ -36,7 +36,7 @@ interface XAxisProps extends BaseAxisProps {
 
 export type Props = Omit<SVGProps<SVGElement>, 'scale'> & XAxisProps;
 
-export const XAxis: FunctionComponent<Props> = ({ xAxisId }: Props) => {
+function XAxisImpl({ xAxisId }: Props) {
   const width = useChartWidth();
   const height = useChartHeight();
   const axisOptions = useXAxisOrThrow(xAxisId);
@@ -54,22 +54,30 @@ export const XAxis: FunctionComponent<Props> = ({ xAxisId }: Props) => {
       ticksGenerator={(axis: any) => getTicksOfAxis(axis, true)}
     />
   );
-};
+}
 
-XAxis.displayName = 'XAxis';
-XAxis.defaultProps = {
-  allowDecimals: true,
-  hide: false,
-  orientation: 'bottom',
-  width: 0,
-  height: 30,
-  mirror: false,
-  xAxisId: 0,
-  tickCount: 5,
-  type: 'category',
-  padding: { left: 0, right: 0 },
-  allowDataOverflow: false,
-  scale: 'auto',
-  reversed: false,
-  allowDuplicatedCategory: true,
-};
+// eslint-disable-next-line react/prefer-stateless-function -- requires static defaultProps
+export class XAxis extends React.Component<Props> {
+  static displayName = 'XAxis';
+
+  static defaultProps = {
+    allowDecimals: true,
+    hide: false,
+    orientation: 'bottom',
+    width: 0,
+    height: 30,
+    mirror: false,
+    xAxisId: 0,
+    tickCount: 5,
+    type: 'category',
+    padding: { left: 0, right: 0 },
+    allowDataOverflow: false,
+    scale: 'auto',
+    reversed: false,
+    allowDuplicatedCategory: true,
+  };
+
+  render() {
+    return <XAxisImpl {...this.props} />;
+  }
+}

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Y Axis
  */
 import React from 'react';
-import type { FunctionComponent, SVGProps } from 'react';
+import type { SVGProps } from 'react';
 import clsx from 'clsx';
 import { BaseAxisProps, AxisInterval } from '../util/types';
 import { useChartHeight, useChartWidth, useYAxisOrThrow } from '../context/chartLayoutContext';
@@ -36,7 +36,7 @@ interface YAxisProps extends BaseAxisProps {
 
 export type Props = Omit<SVGProps<SVGElement>, 'scale'> & YAxisProps;
 
-export const YAxis: FunctionComponent<Props> = ({ yAxisId }: Props) => {
+const YAxisImpl = ({ yAxisId }: Props) => {
   const width = useChartWidth();
   const height = useChartHeight();
   const axisOptions = useYAxisOrThrow(yAxisId);
@@ -56,20 +56,28 @@ export const YAxis: FunctionComponent<Props> = ({ yAxisId }: Props) => {
   );
 };
 
-YAxis.displayName = 'YAxis';
-YAxis.defaultProps = {
-  allowDuplicatedCategory: true,
-  allowDecimals: true,
-  hide: false,
-  orientation: 'left',
-  width: 60,
-  height: 0,
-  mirror: false,
-  yAxisId: 0,
-  tickCount: 5,
-  type: 'number',
-  padding: { top: 0, bottom: 0 },
-  allowDataOverflow: false,
-  scale: 'auto',
-  reversed: false,
-};
+// eslint-disable-next-line react/prefer-stateless-function -- requires static defaultProps
+export class YAxis extends React.Component<Props> {
+  static displayName = 'YAxis';
+
+  static defaultProps = {
+    allowDuplicatedCategory: true,
+    allowDecimals: true,
+    hide: false,
+    orientation: 'left',
+    width: 60,
+    height: 0,
+    mirror: false,
+    yAxisId: 0,
+    tickCount: 5,
+    type: 'number',
+    padding: { top: 0, bottom: 0 },
+    allowDataOverflow: false,
+    scale: 'auto',
+    reversed: false,
+  };
+
+  render() {
+    return <YAxisImpl {...this.props} />;
+  }
+}

--- a/src/cartesian/ZAxis.tsx
+++ b/src/cartesian/ZAxis.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Z Axis
  */
-import type { FunctionComponent } from 'react';
+import React from 'react';
 import { ScaleType, DataKey, AxisDomain } from '../util/types';
 
 export interface Props {
@@ -21,12 +21,18 @@ export interface Props {
   domain?: AxisDomain;
 }
 
-export const ZAxis: FunctionComponent<Props> = () => null;
+// eslint-disable-next-line react/prefer-stateless-function -- requires static defaultProps
+export class ZAxis extends React.Component<Props> {
+  static displayName = 'ZAxis';
 
-ZAxis.displayName = 'ZAxis';
-ZAxis.defaultProps = {
-  zAxisId: 0,
-  range: [64, 64],
-  scale: 'auto',
-  type: 'number',
-};
+  static defaultProps = {
+    zAxisId: 0,
+    range: [64, 64],
+    scale: 'auto',
+    type: 'number',
+  };
+
+  render(): React.ReactNode {
+    return null;
+  }
+}

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -171,9 +171,9 @@ export class Pie extends PureComponent<Props, State> {
     return sign * deltaAngle;
   };
 
-  static getRealPieData = (item: Pie) => {
-    const { data, children } = item.props;
-    const presentationProps = filterProps(item.props, false);
+  static getRealPieData = (itemProps: Props) => {
+    const { data, children } = itemProps;
+    const presentationProps = filterProps(itemProps, false);
     const cells = findAllByType(children, Cell);
 
     if (data && data.length) {
@@ -192,27 +192,37 @@ export class Pie extends PureComponent<Props, State> {
     return [];
   };
 
-  static parseCoordinateOfPie = (item: Pie, offset: ChartOffset) => {
+  static parseCoordinateOfPie = (itemProps: Props, offset: ChartOffset) => {
     const { top, left, width, height } = offset;
     const maxPieRadius = getMaxRadius(width, height);
-    const cx = left + getPercentValue(item.props.cx, width, width / 2);
-    const cy = top + getPercentValue(item.props.cy, height, height / 2);
-    const innerRadius = getPercentValue(item.props.innerRadius, maxPieRadius, 0);
-    const outerRadius = getPercentValue(item.props.outerRadius, maxPieRadius, maxPieRadius * 0.8);
-    const maxRadius = item.props.maxRadius || Math.sqrt(width * width + height * height) / 2;
+    const cx = left + getPercentValue(itemProps.cx, width, width / 2);
+    const cy = top + getPercentValue(itemProps.cy, height, height / 2);
+    const innerRadius = getPercentValue(itemProps.innerRadius, maxPieRadius, 0);
+    const outerRadius = getPercentValue(itemProps.outerRadius, maxPieRadius, maxPieRadius * 0.8);
+    const maxRadius = itemProps.maxRadius || Math.sqrt(width * width + height * height) / 2;
 
     return { cx, cy, innerRadius, outerRadius, maxRadius };
   };
 
-  static getComposedData = ({ item, offset }: { item: Pie; offset: ChartOffset }): Omit<Props, 'dataKey'> => {
-    const pieData = Pie.getRealPieData(item);
+  static getComposedData = ({
+    item,
+    offset,
+  }: {
+    item: React.ReactElement<Props>;
+    offset: ChartOffset;
+  }): Omit<Props, 'dataKey'> => {
+    const itemProps: Props =
+      (item.type as any).defaultProps !== undefined
+        ? { ...(item.type as any).defaultProps, ...item.props }
+        : item.props;
+    const pieData = Pie.getRealPieData(itemProps);
     if (!pieData || !pieData.length) {
       return null;
     }
 
-    const { cornerRadius, startAngle, endAngle, paddingAngle, dataKey, nameKey, valueKey, tooltipType } = item.props;
-    const minAngle = Math.abs(item.props.minAngle);
-    const coordinate = Pie.parseCoordinateOfPie(item, offset);
+    const { cornerRadius, startAngle, endAngle, paddingAngle, dataKey, nameKey, valueKey, tooltipType } = itemProps;
+    const minAngle = Math.abs(itemProps.minAngle);
+    const coordinate = Pie.parseCoordinateOfPie(itemProps, offset);
     const deltaAngle = Pie.parseDeltaAngle(startAngle, endAngle);
     const absDeltaAngle = Math.abs(deltaAngle);
 

--- a/test/chart/generateCategoricalChart.spec.tsx
+++ b/test/chart/generateCategoricalChart.spec.tsx
@@ -84,28 +84,24 @@ describe('generateCategoricalChart', () => {
     allowDuplicatedCategory: true,
   };
 
-  const xAxes: ReadonlyArray<ReactElement> = [
-    // @ts-expect-error this isn't a proper ReactElement
-    {
-      props: { ...axisProps, xAxisId: 0, dataKey: 'name' },
-    },
-  ];
+  function FakeAxis(_props: Record<string, any>) {
+    return null;
+  }
+
+  const xAxes: ReadonlyArray<ReactElement> = [<FakeAxis xAxisId={0} dataKey="name" {...axisProps} />];
 
   const yAxes: ReadonlyArray<ReactElement> = [
-    // @ts-expect-error this isn't a proper ReactElement
-    {
-      props: {
-        ...axisProps,
-        orientation: 'left',
-        width: 0,
-        height: 30,
-        mirror: false,
-        yAxisId: 0,
-        tickCount: 2,
-        type: 'number',
-        dataKey: 'uv',
-      },
-    },
+    <FakeAxis
+      {...axisProps}
+      orientation="left"
+      width={0}
+      height={30}
+      mirror={false}
+      yAxisId={0}
+      tickCount={2}
+      type="number"
+      dataKey="uv"
+    />,
   ];
 
   describe('getAxisMapByAxes', () => {


### PR DESCRIPTION
Best reviewed without whitespace changes

<!--- Provide a general summary of your changes in the Title above -->

## Description


`defaultProps` are no longer supported on function components. To simplify migration, the components that do rely on the original defaultProps behavior were migrated to class components.

Libraries also need to manually apply `defaultProps` if they expect that these are resolved by the JSX runtime. In React 19, defaultProps are only resolved by the time the component instances may access props not when a parent renders or reads from the JSX e.g. via `children.props`.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Adds support for React 19 to `recharts@2.x` without having to patch published files. 

Complete React 19 support would require https://github.com/recharts/recharts/pull/4541 but that's a breaking change. Consumers of 2.x will have to use `resolutions` or `overrides` with their package managers to ensure the correct `react-is` version is used


## How Has This Been Tested?

We've been using `recharts` in various (internal) surfaces at Vercel. We've applied this patch to our codebase and charts have been working when they were previously broken.

The following components we use explicitly:
* `ResponsiveContainer`
* `LineChart`
* `CartesianGrid`
* `XAxis`
* `Tooltip`
* `YAxis`
* `Legend`
* `Line`
* `PieChart`
* `Cell`
* `Pie`
* `Sector`

We also use [`SparkAreaChart` from `@tremor/react`](https://github.com/tremorlabs/tremor/blob/0a6c9a08381feae148286ab2075497dc347ce587/src/components/spark-elements/SparkAreaChart/SparkAreaChart.tsx) which uses `recharts` to implement that chart.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
