### PR TITLE
Extract RechartsWrapper to its own component

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -108,6 +108,7 @@
   "es6/chart/SunburstChart.js",
   "es6/chart/ScatterChart.js",
   "es6/chart/Sankey.js",
+  "es6/chart/RechartsWrapper.js",
   "es6/chart/RadialBarChart.js",
   "es6/chart/RadarChart.js",
   "es6/chart/PieChart.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -108,6 +108,7 @@
   "lib/chart/SunburstChart.js",
   "lib/chart/ScatterChart.js",
   "lib/chart/Sankey.js",
+  "lib/chart/RechartsWrapper.js",
   "lib/chart/RadialBarChart.js",
   "lib/chart/RadarChart.js",
   "lib/chart/PieChart.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -108,6 +108,7 @@
   "types/chart/SunburstChart.d.ts",
   "types/chart/ScatterChart.d.ts",
   "types/chart/Sankey.d.ts",
+  "types/chart/RechartsWrapper.d.ts",
   "types/chart/RadialBarChart.d.ts",
   "types/chart/RadarChart.d.ts",
   "types/chart/PieChart.d.ts",

--- a/src/chart/RechartsWrapper.tsx
+++ b/src/chart/RechartsWrapper.tsx
@@ -1,0 +1,25 @@
+import React, { CSSProperties, DOMAttributes, forwardRef, ReactNode, Ref } from 'react';
+import clsx from 'clsx';
+
+export type RechartsWrapperProps = {
+  children: ReactNode;
+  width: number;
+  height: number;
+  className?: string;
+  style?: CSSProperties;
+  ref?: Ref<HTMLDivElement>;
+  wrapperEvents?: DOMAttributes<HTMLDivElement>;
+};
+
+export const RechartsWrapper = forwardRef(
+  ({ children, width, height, className, style, wrapperEvents }: RechartsWrapperProps, ref: Ref<HTMLDivElement>) => (
+    <div
+      className={clsx('recharts-wrapper', className)}
+      style={{ position: 'relative', cursor: 'default', width, height, ...style }}
+      {...wrapperEvents}
+      ref={ref}
+    >
+      {children}
+    </div>
+  ),
+);

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -6,7 +6,6 @@ import get from 'lodash/get';
 import sortBy from 'lodash/sortBy';
 import throttle from 'lodash/throttle';
 
-import clsx from 'clsx';
 // eslint-disable-next-line no-restricted-imports
 import type { DebouncedFunc } from 'lodash';
 import invariant from 'tiny-invariant';
@@ -94,6 +93,7 @@ import {
   MouseLeaveItemDispatchContext,
   TooltipPayloadType,
 } from '../context/tooltipContext';
+import { RechartsWrapper } from './RechartsWrapper';
 
 export interface MousePointer {
   pageX: number;
@@ -1330,6 +1330,11 @@ export const generateCategoricalChart = ({
       this.throttleTriggeredAfterMouseMove.cancel();
     }
 
+    /**
+     * @deprecated instead use `useTooltipEventType` hook
+     *
+     * @returns do not use
+     */
     getTooltipEventType(): TooltipEventType {
       const tooltipItem = findChildByType(this.props.children, Tooltip);
 
@@ -1935,10 +1940,12 @@ export const generateCategoricalChart = ({
                             margin={this.props.margin}
                             layout={this.props.layout}
                           >
-                            <div
-                              className={clsx('recharts-wrapper', className)}
-                              style={{ position: 'relative', cursor: 'default', width, height, ...style }}
-                              {...wrapperEvents}
+                            <RechartsWrapper
+                              className={className}
+                              style={style}
+                              wrapperEvents={wrapperEvents}
+                              width={width}
+                              height={height}
                               ref={(node: HTMLDivElement) => {
                                 this.container = node;
                                 if (this.state.tooltipPortal == null) {
@@ -1965,7 +1972,7 @@ export const generateCategoricalChart = ({
                                 />
                                 {renderByOrder(children, this.renderMap)}
                               </Surface>
-                            </div>
+                            </RechartsWrapper>
                           </ChartLayoutContextProvider>
                         </AccessibilityContextProvider>
                       </BrushUpdateDispatchContext.Provider>


### PR DESCRIPTION
## Description

I want to use hooks and dispatch here later so it has to be a functional component.

There are charts that are not using generateCategoricalChart, and they have almost the same component and could reuse this one too. With one difference, aria role. This uses `region` the other charts use `application`, which one is correct? @julianna-ciq what would be the correct labelling? I was studying the spec but as far as I can tell, neither is a good fit for interactive charts.

## Related Issue

https://github.com/recharts/recharts/discussions/3717

## Motivation and Context

Use redux instead of element cloning.

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
