### PR TITLE
Move function inRange to ChartUtils

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -42,6 +42,7 @@ import {
   getStackGroupsByAxisId,
   getTicksOfAxis,
   getTooltipItem,
+  inRange,
   isAxisLTR,
   isCategoricalAxis,
   parseDomainOfCategoryAxis,
@@ -49,7 +50,7 @@ import {
   parseSpecifiedDomain,
 } from '../util/ChartUtils';
 import { detectReferenceElementsDomain } from '../util/DetectReferenceElementsDomain';
-import { inRangeOfSector, polarToCartesian } from '../util/PolarUtils';
+import { polarToCartesian } from '../util/PolarUtils';
 import { shallowEqual } from '../util/ShallowEqual';
 import { eventCenter, SYNC_EVENT } from '../util/Events';
 import {
@@ -1367,13 +1368,14 @@ export const generateCategoricalChart = ({
 
       const scale = boundingRect.width / element.offsetWidth || 1;
 
-      const rangeObj = this.inRange(
+      const rangeObj = inRange(
         e.chartX,
         e.chartY,
         scale,
         this.props.layout,
         this.state.angleAxisMap,
         this.state.radiusAxisMap,
+        this.state.offset,
       );
       if (!rangeObj) {
         return null;
@@ -1398,36 +1400,6 @@ export const generateCategoricalChart = ({
           ...e,
           ...toolTipData,
         };
-      }
-
-      return null;
-    }
-
-    inRange(
-      x: number,
-      y: number,
-      scale = 1,
-      layout: LayoutType,
-      angleAxisMap: AxisMap | undefined,
-      radiusAxisMap: AxisMap | undefined,
-    ): RangeObj {
-      const [scaledX, scaledY] = [x / scale, y / scale];
-
-      if (layout === 'horizontal' || layout === 'vertical') {
-        const { offset } = this.state;
-
-        const isInRange =
-          scaledX >= offset.left &&
-          scaledX <= offset.left + offset.width &&
-          scaledY >= offset.top &&
-          scaledY <= offset.top + offset.height;
-
-        return isInRange ? { x: scaledX, y: scaledY } : null;
-      }
-
-      if (angleAxisMap && radiusAxisMap) {
-        const angleAxis = getAnyElementOfObject(angleAxisMap);
-        return inRangeOfSector({ x: scaledX, y: scaledY }, angleAxis);
       }
 
       return null;

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -213,7 +213,7 @@ function getDefaultDomainByAxisType(axisType: 'number' | string) {
 }
 
 /**
- * Get the content to be displayed in the tooltip
+ * @deprecated this indirectly depends on the list of all children read from DOM. Use Redux instead.
  * @param  {Object} state          Current state
  * @param  {Array}  chartData      The data defined in chart
  * @param  {Number} activeIndex    Active index of data
@@ -1367,7 +1367,14 @@ export const generateCategoricalChart = ({
 
       const scale = boundingRect.width / element.offsetWidth || 1;
 
-      const rangeObj = this.inRange(e.chartX, e.chartY, scale);
+      const rangeObj = this.inRange(
+        e.chartX,
+        e.chartY,
+        scale,
+        this.props.layout,
+        this.state.angleAxisMap,
+        this.state.radiusAxisMap,
+      );
       if (!rangeObj) {
         return null;
       }
@@ -1396,9 +1403,14 @@ export const generateCategoricalChart = ({
       return null;
     }
 
-    inRange(x: number, y: number, scale = 1): RangeObj {
-      const { layout } = this.props;
-
+    inRange(
+      x: number,
+      y: number,
+      scale = 1,
+      layout: LayoutType,
+      angleAxisMap: AxisMap | undefined,
+      radiusAxisMap: AxisMap | undefined,
+    ): RangeObj {
       const [scaledX, scaledY] = [x / scale, y / scale];
 
       if (layout === 'horizontal' || layout === 'vertical') {
@@ -1412,8 +1424,6 @@ export const generateCategoricalChart = ({
 
         return isInRange ? { x: scaledX, y: scaledY } : null;
       }
-
-      const { angleAxisMap, radiusAxisMap } = this.state;
 
       if (angleAxisMap && radiusAxisMap) {
         const angleAxis = getAnyElementOfObject(angleAxisMap);

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -23,7 +23,15 @@ import {
 import { ReactElement, ReactNode } from 'react';
 
 import { ErrorBar } from '../cartesian/ErrorBar';
-import { findEntryInArray, getPercentValue, isNumber, isNumOrStr, mathSign, uniqueId } from './DataUtils';
+import {
+  findEntryInArray,
+  getAnyElementOfObject,
+  getPercentValue,
+  isNumber,
+  isNumOrStr,
+  mathSign,
+  uniqueId,
+} from './DataUtils';
 import { filterProps, findAllByType, findChildByType, getDisplayName } from './ReactUtils';
 // TODO: Cause of circular dependency. Needs refactor.
 // import { RadiusAxisProps, AngleAxisProps } from '../polar/types';
@@ -41,13 +49,15 @@ import {
   Margin,
   NumberDomain,
   PolarLayoutType,
+  RangeObj,
   StackOffsetType,
   TickItem,
   XAxisMap,
 } from './types';
 import { BoundingBox } from './useGetBoundingClientRect';
 import { ValueType } from '../component/DefaultTooltipContent';
-import { AxisObj } from '../chart/types';
+import { AxisMap, AxisObj } from '../chart/types';
+import { inRangeOfSector } from './PolarUtils';
 
 // Exported for backwards compatibility
 export { getLegendProps };
@@ -1455,4 +1465,33 @@ export function getBarPositions({
     }
   }
   return barPosition;
+}
+
+export function inRange(
+  x: number,
+  y: number,
+  scale: number,
+  layout: LayoutType,
+  angleAxisMap: AxisMap | undefined,
+  radiusAxisMap: AxisMap | undefined,
+  offset: ChartOffset,
+): RangeObj {
+  const [scaledX, scaledY] = [x / scale, y / scale];
+
+  if (layout === 'horizontal' || layout === 'vertical') {
+    const isInRange =
+      scaledX >= offset.left &&
+      scaledX <= offset.left + offset.width &&
+      scaledY >= offset.top &&
+      scaledY <= offset.top + offset.height;
+
+    return isInRange ? { x: scaledX, y: scaledY } : null;
+  }
+
+  if (angleAxisMap && radiusAxisMap) {
+    const angleAxis = getAnyElementOfObject(angleAxisMap);
+    return inRangeOfSector({ x: scaledX, y: scaledY }, angleAxis);
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Description

So that it no longer reads `this.props` and `this.state` directly.

## Related Issue

https://github.com/recharts/recharts/issues/4549

## Motivation and Context

I want to reuse this function from Redux selector so I need it to be independent from `generateCategoricalChart` `this`.

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
