### PR TITLE
Change anonymous functions to functions in XAxis and YAxis component

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -1,13 +1,13 @@
 /**
  * @fileOverview X Axis
  */
-import type { FunctionComponent, SVGProps } from 'react';
-import React from 'react';
 import clsx from 'clsx';
+import type { ReactElement, SVGProps } from 'react';
+import React from 'react';
 import { useChartHeight, useChartWidth, useXAxisOrThrow } from '../context/chartLayoutContext';
-import { CartesianAxis } from './CartesianAxis';
-import { BaseAxisProps, AxisInterval } from '../util/types';
 import { getTicksOfAxis } from '../util/ChartUtils';
+import { AxisInterval, BaseAxisProps } from '../util/types';
+import { CartesianAxis } from './CartesianAxis';
 
 /** Define of XAxis props */
 interface XAxisProps extends BaseAxisProps {
@@ -36,7 +36,7 @@ interface XAxisProps extends BaseAxisProps {
 
 export type Props = Omit<SVGProps<SVGElement>, 'scale'> & XAxisProps;
 
-export const XAxis: FunctionComponent<Props> = ({ xAxisId }: Props) => {
+export function XAxis({ xAxisId }: Props): ReactElement<Props> | null {
   const width = useChartWidth();
   const height = useChartHeight();
   const axisOptions = useXAxisOrThrow(xAxisId);
@@ -54,7 +54,7 @@ export const XAxis: FunctionComponent<Props> = ({ xAxisId }: Props) => {
       ticksGenerator={(axis: any) => getTicksOfAxis(axis, true)}
     />
   );
-};
+}
 
 XAxis.displayName = 'XAxis';
 XAxis.defaultProps = {

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -1,13 +1,13 @@
 /**
  * @fileOverview Y Axis
  */
-import React from 'react';
-import type { FunctionComponent, SVGProps } from 'react';
 import clsx from 'clsx';
-import { BaseAxisProps, AxisInterval } from '../util/types';
+import type { ReactElement, SVGProps } from 'react';
+import React from 'react';
 import { useChartHeight, useChartWidth, useYAxisOrThrow } from '../context/chartLayoutContext';
-import { CartesianAxis } from './CartesianAxis';
 import { getTicksOfAxis } from '../util/ChartUtils';
+import { AxisInterval, BaseAxisProps } from '../util/types';
+import { CartesianAxis } from './CartesianAxis';
 
 interface YAxisProps extends BaseAxisProps {
   /** The unique id of y-axis */
@@ -36,7 +36,7 @@ interface YAxisProps extends BaseAxisProps {
 
 export type Props = Omit<SVGProps<SVGElement>, 'scale'> & YAxisProps;
 
-export const YAxis: FunctionComponent<Props> = ({ yAxisId }: Props) => {
+export function YAxis({ yAxisId }: Props): ReactElement<Props> | null {
   const width = useChartWidth();
   const height = useChartHeight();
   const axisOptions = useYAxisOrThrow(yAxisId);
@@ -53,7 +53,7 @@ export const YAxis: FunctionComponent<Props> = ({ yAxisId }: Props) => {
       ticksGenerator={(axis: any) => getTicksOfAxis(axis, true)}
     />
   );
-};
+}
 
 YAxis.displayName = 'YAxis';
 YAxis.defaultProps = {


### PR DESCRIPTION
#Change anonymous functions to functions in XAxis and YAxis component

## Description

I changed `export const YAxis: FunctionComponent<Props> = ({ yAxisId }: Props)` and `export const XAxis: FunctionComponent<Props> = ({ xAxisId }: Props)` to normal functions to avoid the **Warning about defaultProps Support in XAxis**.

## Related Issue

## Motivation and Context

This solve the problem about defaultProps warning
[Support for defaultProps will be removed from function components in a future major release.](https://github.com/recharts/recharts/issues/3615)

## How Has This Been Tested?

npm test, storybooks

## Screenshots (if appropriate):

![xaxis](https://github.com/recharts/recharts/assets/48159152/4a65abd5-7ac7-4bba-b36a-6e101ccbc32f)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [X] All existing tests passed.
