### PR TITLE
All Tooltip item payloads in store

### DIFF
--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -196,7 +196,7 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
 }
 
 function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
-  const { dataKey, points, stroke, strokeWidth, fill, name, hide } = props;
+  const { dataKey, points, stroke, strokeWidth, fill, name, hide, tooltipType } = props;
   return {
     dataDefinedOnItem: points.map((p: ScatterPointItem) => p.tooltipPayload),
     settings: {
@@ -206,7 +206,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
       dataKey,
       name: getTooltipNameProp(name, dataKey),
       hide,
-      type: props.tooltipType,
+      type: tooltipType,
       color: fill,
       unit: '', // why doesn't Scatter support unit?
     },

--- a/src/chart/SunburstChart.tsx
+++ b/src/chart/SunburstChart.tsx
@@ -10,6 +10,8 @@ import { ViewBoxContext } from '../context/chartLayoutContext';
 import { doNotDisplayTooltip, TooltipContextProvider, TooltipContextValue } from '../context/tooltipContext';
 import { CursorPortalContext, TooltipPortalContext } from '../context/tooltipPortalContext';
 import { RechartsWrapper } from './RechartsWrapper';
+import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
+import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 
 export interface SunburstData {
   [key: string]: any;
@@ -85,6 +87,29 @@ function getMaxDepthOf(node: SunburstData): number {
   // Calculate depth for each child and find the maximum
   const childDepths = node.children.map(d => getMaxDepthOf(d));
   return 1 + Math.max(...childDepths);
+}
+
+function getTooltipEntrySettings({
+  dataKey,
+  data,
+  stroke,
+  fill,
+}: Pick<SunburstChartProps, 'dataKey' | 'data' | 'stroke' | 'fill'>): TooltipPayloadConfiguration {
+  return {
+    dataDefinedOnItem: data.children,
+    // Sunburst does not support many of the properties as other charts do so there's plenty of defaults here
+    settings: {
+      stroke,
+      strokeWidth: undefined,
+      fill,
+      dataKey,
+      name: dataKey,
+      hide: false,
+      type: undefined,
+      color: fill,
+      unit: '',
+    },
+  };
 }
 
 export const SunburstChart = ({
@@ -233,6 +258,7 @@ export const SunburstChart = ({
                   }}
                 />
                 <Layer className={layerClass}>{sectors}</Layer>
+                <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={{ dataKey, data, stroke, fill }} />
                 {children}
               </Surface>
             </RechartsWrapper>

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -21,6 +21,8 @@ import { ViewBoxContext } from '../context/chartLayoutContext';
 import { TooltipContextProvider, TooltipContextValue } from '../context/tooltipContext';
 import { CursorPortalContext, TooltipPortalContext } from '../context/tooltipPortalContext';
 import { RechartsWrapper } from './RechartsWrapper';
+import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
+import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 
 const NODE_VALUE_KEY = 'value';
 
@@ -306,6 +308,24 @@ const defaultState: State = {
 
   nestIndex: [] as TreemapNode[],
 };
+
+function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
+  const { dataKey, data, stroke, fill } = props;
+  return {
+    dataDefinedOnItem: data,
+    settings: {
+      stroke,
+      strokeWidth: undefined,
+      fill,
+      dataKey,
+      name: '',
+      hide: false,
+      type: undefined,
+      color: fill,
+      unit: '',
+    },
+  };
+}
 
 export class Treemap extends PureComponent<Props, State> {
   static displayName = 'Treemap';
@@ -735,6 +755,7 @@ export class Treemap extends PureComponent<Props, State> {
     return (
       <CursorPortalContext.Provider value={this.state.cursorPortal}>
         <TooltipPortalContext.Provider value={this.state.tooltipPortal}>
+          <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
           <ViewBoxContext.Provider value={viewBox}>
             <TooltipContextProvider value={this.getTooltipContext()}>
               <RechartsWrapper

--- a/src/numberAxis/Funnel.tsx
+++ b/src/numberAxis/Funnel.tsx
@@ -17,7 +17,7 @@ import { Cell, Props as CellProps } from '../component/Cell';
 import { findAllByType, filterProps } from '../util/ReactUtils';
 import { Global } from '../util/Global';
 import { interpolateNumber } from '../util/DataUtils';
-import { getValueByDataKey } from '../util/ChartUtils';
+import { getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
 import {
   LegendType,
   TooltipType,
@@ -36,6 +36,8 @@ import {
   useMouseLeaveItemDispatch,
   useTooltipContext,
 } from '../context/tooltipContext';
+import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
+import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 
 export interface FunnelTrapezoidItem extends TrapezoidProps {
   value?: number | string;
@@ -91,6 +93,24 @@ type FunnelTrapezoidsProps = {
   activeShape: ActiveShape<FunnelTrapezoidItem, SVGPathElement>;
   allOtherFunnelProps: FunnelProps;
 };
+
+function getTooltipEntrySettings(props: FunnelProps): TooltipPayloadConfiguration {
+  const { dataKey, trapezoids, stroke, strokeWidth, fill, name, hide, tooltipType } = props;
+  return {
+    dataDefinedOnItem: trapezoids,
+    settings: {
+      stroke,
+      strokeWidth,
+      fill,
+      dataKey,
+      name: getTooltipNameProp(name, dataKey),
+      hide,
+      type: tooltipType,
+      color: fill,
+      unit: '', // Funnel does not have unit, why?
+    },
+  };
+}
 
 function FunnelTrapezoids(props: FunnelTrapezoidsProps) {
   const { trapezoids, shape, activeShape, allOtherFunnelProps } = props;
@@ -423,13 +443,14 @@ export class Funnel extends PureComponent<FunnelProps, State> {
     const { isAnimationFinished } = this.state;
 
     if (hide || !trapezoids || !trapezoids.length) {
-      return null;
+      return <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />;
     }
 
     const layerClass = clsx('recharts-trapezoids', className);
 
     return (
       <Layer className={layerClass}>
+        <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
         {this.renderTrapezoids()}
         {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, trapezoids)}
       </Layer>

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -22,6 +22,7 @@ import {
   truncateByDomain,
   getBaseValueOfBar,
   getTooltipItem,
+  getTooltipNameProp,
 } from '../util/ChartUtils';
 import {
   LegendType,
@@ -43,6 +44,8 @@ import {
   useMouseLeaveItemDispatch,
   useTooltipContext,
 } from '../context/tooltipContext';
+import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
+import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 // TODO: Cause of circular dependency. Needs refactoring of functions that need them.
 // import { AngleAxisProps, RadiusAxisProps } from './types';
 
@@ -178,6 +181,24 @@ const computeLegendPayloadFromRadarData = ({ data, legendType }: RadialBarPayloa
 function SetRadialBarPayloadLegend(props: RadialBarPayloadInputProps): null {
   useLegendPayloadDispatch(computeLegendPayloadFromRadarData, props);
   return null;
+}
+
+function getTooltipEntrySettings(props: RadialBarProps): TooltipPayloadConfiguration {
+  const { dataKey, data, stroke, strokeWidth, name, hide, fill, tooltipType } = props;
+  return {
+    dataDefinedOnItem: data,
+    settings: {
+      stroke,
+      strokeWidth,
+      fill,
+      dataKey,
+      name: getTooltipNameProp(name, dataKey),
+      hide,
+      type: tooltipType,
+      color: fill,
+      unit: '', // Why does RadialBar not support unit?
+    },
+  };
 }
 
 export class RadialBar extends PureComponent<RadialBarProps, State> {
@@ -449,7 +470,10 @@ export class RadialBar extends PureComponent<RadialBarProps, State> {
     const { hide, data, className, background, isAnimationActive } = this.props;
 
     if (hide || !data || !data.length) {
-      return null;
+      <>
+        <SetRadialBarPayloadLegend data={this.props.data} legendType={this.props.legendType} />
+        <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
+      </>;
     }
 
     const { isAnimationFinished } = this.state;
@@ -458,6 +482,7 @@ export class RadialBar extends PureComponent<RadialBarProps, State> {
     return (
       <Layer className={layerClass}>
         <SetRadialBarPayloadLegend data={this.props.data} legendType={this.props.legendType} />
+        <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
         {background && <Layer className="recharts-radial-bar-background">{this.renderBackground(data)}</Layer>}
 
         <Layer className="recharts-radial-bar-sectors">{this.renderSectors()}</Layer>

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -184,7 +184,7 @@ const FunnelChartTestCase: TooltipPayloadTestCase = {
         isAnimationActive={false}
         dataKey="uv"
         nameKey="name"
-        name="This is not going to the tooltip title unfortunately"
+        name="This is now definitely going to the tooltip title same as other charts"
         data={PageData}
       />
       {children}
@@ -192,7 +192,7 @@ const FunnelChartTestCase: TooltipPayloadTestCase = {
   ),
   mouseHoverSelector: funnelChartMouseHoverTooltipSelector,
   expectedTooltipTitle: '',
-  expectedTooltipContent: ['Page A : 400'],
+  expectedTooltipContent: ['This is now definitely going to the tooltip title same as other charts : 400'],
 };
 
 const PieChartWithCustomNameKeyTestCase: TooltipPayloadTestCase = {

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -297,7 +297,6 @@ const ScatterChartTestCase: TooltipPayloadTestCase = {
   expectedTooltipContent: ['stature : 400cm', 'weight : 2400kg'],
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const SunburstChartTestCase: TooltipPayloadTestCase = {
   name: 'SunburstChart',
   Wrapper: ({ children }) => (


### PR DESCRIPTION
## Description

Send all item data to redux store. All except Sankey that is, Sankey is different, I will need to figure out what to do with that next.

Also this accidentally fixed a bug where Funnel `name` was not used in tooltip title, like it is in other charts.

## Related Issue

https://github.com/recharts/recharts/issues/4549

## Motivation and Context

Get rid of element cloning

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
