### PR TITLE
Add tooltipPayloadSearcher

### DIFF
--- a/src/chart/AreaChart.tsx
+++ b/src/chart/AreaChart.tsx
@@ -6,6 +6,7 @@ import { Area } from '../cartesian/Area';
 import { XAxis } from '../cartesian/XAxis';
 import { YAxis } from '../cartesian/YAxis';
 import { formatAxisMap } from '../util/CartesianUtils';
+import { arrayTooltipSearcher } from '../state/optionsSlice';
 
 export const AreaChart = generateCategoricalChart({
   chartName: 'AreaChart',
@@ -15,4 +16,5 @@ export const AreaChart = generateCategoricalChart({
     { axisType: 'yAxis', AxisComp: YAxis },
   ],
   formatAxisMap,
+  tooltipPayloadSearcher: arrayTooltipSearcher,
 });

--- a/src/chart/BarChart.tsx
+++ b/src/chart/BarChart.tsx
@@ -6,6 +6,7 @@ import { Bar } from '../cartesian/Bar';
 import { XAxis } from '../cartesian/XAxis';
 import { YAxis } from '../cartesian/YAxis';
 import { formatAxisMap } from '../util/CartesianUtils';
+import { arrayTooltipSearcher } from '../state/optionsSlice';
 
 export const BarChart = generateCategoricalChart({
   chartName: 'BarChart',
@@ -17,4 +18,5 @@ export const BarChart = generateCategoricalChart({
     { axisType: 'yAxis', AxisComp: YAxis },
   ],
   formatAxisMap,
+  tooltipPayloadSearcher: arrayTooltipSearcher,
 });

--- a/src/chart/ComposedChart.tsx
+++ b/src/chart/ComposedChart.tsx
@@ -10,6 +10,7 @@ import { XAxis } from '../cartesian/XAxis';
 import { YAxis } from '../cartesian/YAxis';
 import { ZAxis } from '../cartesian/ZAxis';
 import { formatAxisMap } from '../util/CartesianUtils';
+import { arrayTooltipSearcher } from '../state/optionsSlice';
 
 export const ComposedChart = generateCategoricalChart({
   chartName: 'ComposedChart',
@@ -20,4 +21,5 @@ export const ComposedChart = generateCategoricalChart({
     { axisType: 'zAxis', AxisComp: ZAxis },
   ],
   formatAxisMap,
+  tooltipPayloadSearcher: arrayTooltipSearcher,
 });

--- a/src/chart/FunnelChart.tsx
+++ b/src/chart/FunnelChart.tsx
@@ -1,8 +1,6 @@
-/**
- * @fileOverview Funnel Chart
- */
 import { generateCategoricalChart } from './generateCategoricalChart';
 import { Funnel } from '../numberAxis/Funnel';
+import { arrayTooltipSearcher } from '../state/optionsSlice';
 
 export const FunnelChart = generateCategoricalChart({
   chartName: 'FunnelChart',
@@ -13,4 +11,5 @@ export const FunnelChart = generateCategoricalChart({
   defaultProps: {
     layout: 'centric',
   },
+  tooltipPayloadSearcher: arrayTooltipSearcher,
 });

--- a/src/chart/LineChart.tsx
+++ b/src/chart/LineChart.tsx
@@ -6,6 +6,7 @@ import { Line } from '../cartesian/Line';
 import { XAxis } from '../cartesian/XAxis';
 import { YAxis } from '../cartesian/YAxis';
 import { formatAxisMap } from '../util/CartesianUtils';
+import { arrayTooltipSearcher } from '../state/optionsSlice';
 
 export const LineChart = generateCategoricalChart({
   chartName: 'LineChart',
@@ -15,4 +16,5 @@ export const LineChart = generateCategoricalChart({
     { axisType: 'yAxis', AxisComp: YAxis },
   ],
   formatAxisMap,
+  tooltipPayloadSearcher: arrayTooltipSearcher,
 });

--- a/src/chart/PieChart.tsx
+++ b/src/chart/PieChart.tsx
@@ -6,6 +6,7 @@ import { PolarAngleAxis } from '../polar/PolarAngleAxis';
 import { PolarRadiusAxis } from '../polar/PolarRadiusAxis';
 import { formatAxisMap } from '../util/PolarUtils';
 import { Pie } from '../polar/Pie';
+import { arrayTooltipSearcher } from '../state/optionsSlice';
 
 export const PieChart = generateCategoricalChart({
   chartName: 'PieChart',
@@ -26,4 +27,5 @@ export const PieChart = generateCategoricalChart({
     innerRadius: 0,
     outerRadius: '80%',
   },
+  tooltipPayloadSearcher: arrayTooltipSearcher,
 });

--- a/src/chart/RadarChart.tsx
+++ b/src/chart/RadarChart.tsx
@@ -6,6 +6,7 @@ import { Radar } from '../polar/Radar';
 import { PolarAngleAxis } from '../polar/PolarAngleAxis';
 import { PolarRadiusAxis } from '../polar/PolarRadiusAxis';
 import { formatAxisMap } from '../util/PolarUtils';
+import { arrayTooltipSearcher } from '../state/optionsSlice';
 
 export const RadarChart = generateCategoricalChart({
   chartName: 'RadarChart',
@@ -24,4 +25,5 @@ export const RadarChart = generateCategoricalChart({
     innerRadius: 0,
     outerRadius: '80%',
   },
+  tooltipPayloadSearcher: arrayTooltipSearcher,
 });

--- a/src/chart/RadialBarChart.tsx
+++ b/src/chart/RadialBarChart.tsx
@@ -6,6 +6,7 @@ import { PolarAngleAxis } from '../polar/PolarAngleAxis';
 import { PolarRadiusAxis } from '../polar/PolarRadiusAxis';
 import { formatAxisMap } from '../util/PolarUtils';
 import { RadialBar } from '../polar/RadialBar';
+import { arrayTooltipSearcher } from '../state/optionsSlice';
 
 export const RadialBarChart = generateCategoricalChart({
   chartName: 'RadialBarChart',
@@ -26,4 +27,5 @@ export const RadialBarChart = generateCategoricalChart({
     innerRadius: 0,
     outerRadius: '80%',
   },
+  tooltipPayloadSearcher: arrayTooltipSearcher,
 });

--- a/src/chart/ScatterChart.tsx
+++ b/src/chart/ScatterChart.tsx
@@ -7,6 +7,7 @@ import { XAxis } from '../cartesian/XAxis';
 import { YAxis } from '../cartesian/YAxis';
 import { ZAxis } from '../cartesian/ZAxis';
 import { formatAxisMap } from '../util/CartesianUtils';
+import { arrayTooltipSearcher } from '../state/optionsSlice';
 
 export const ScatterChart = generateCategoricalChart({
   chartName: 'ScatterChart',
@@ -19,4 +20,5 @@ export const ScatterChart = generateCategoricalChart({
     { axisType: 'zAxis', AxisComp: ZAxis },
   ],
   formatAxisMap,
+  tooltipPayloadSearcher: arrayTooltipSearcher,
 });

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -362,12 +362,14 @@ const defaultState: State = {
   nestIndex: [] as TreemapNode[],
 };
 
-function renderContentItem(
-  content: any,
-  nodeProps: TreemapNode,
-  type: string,
-  colorPanel: string[],
-): React.ReactElement {
+type ContentItemProps = {
+  content: any;
+  nodeProps: TreemapNode;
+  type: string;
+  colorPanel: string[];
+};
+
+function ContentItem({ content, nodeProps, type, colorPanel }: ContentItemProps): React.ReactElement {
   if (React.isValidElement(content)) {
     return React.cloneElement(content, nodeProps);
   }
@@ -625,9 +627,9 @@ export class Treemap extends PureComponent<Props, State> {
     if (!isAnimationActive) {
       return (
         <Layer {...event}>
-          {renderContentItem(
-            content,
-            {
+          <ContentItem
+            content={content}
+            nodeProps={{
               ...nodeProps,
               isAnimationActive: false,
               isUpdateAnimationActive: false,
@@ -635,10 +637,10 @@ export class Treemap extends PureComponent<Props, State> {
               height,
               x,
               y,
-            },
-            type,
-            colorPanel,
-          )}
+            }}
+            type={type}
+            colorPanel={colorPanel}
+          />
         </Layer>
       );
     }
@@ -666,14 +668,12 @@ export class Treemap extends PureComponent<Props, State> {
             duration={animationDuration}
           >
             <Layer {...event}>
-              {(() => {
-                // when animation is in progress , only render depth=1 nodes
-                if (depth > 2 && !isAnimationFinished) {
-                  return null;
-                }
-                return renderContentItem(
-                  content,
-                  {
+              {/* when animation is in progress , only render depth=1 nodes */}
+              {/* Why is his condition here, after Smooth and Smooth render? Why not return earlier, before Smooth is rendered? */}
+              {depth > 2 && !isAnimationFinished ? null : (
+                <ContentItem
+                  content={content}
+                  nodeProps={{
                     ...nodeProps,
                     isAnimationActive,
                     isUpdateAnimationActive: !isUpdateAnimationActive,
@@ -681,11 +681,11 @@ export class Treemap extends PureComponent<Props, State> {
                     height: currHeight,
                     x: currX,
                     y: currY,
-                  },
-                  type,
-                  colorPanel,
-                );
-              })()}
+                  }}
+                  type={type}
+                  colorPanel={colorPanel}
+                />
+              )}
             </Layer>
           </Smooth>
         )}

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -23,8 +23,16 @@ import { CursorPortalContext, TooltipPortalContext } from '../context/tooltipPor
 import { RechartsWrapper } from './RechartsWrapper';
 import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
+import { ChartOptions } from '../state/optionsSlice';
+import { RechartsStoreProvider } from '../state/RechartsStoreProvider';
 
 const NODE_VALUE_KEY = 'value';
+
+const options: ChartOptions = {
+  chartName: 'Treemap',
+  defaultTooltipEventType: 'item',
+  validateTooltipEventTypes: ['item'],
+};
 
 const computeNode = ({
   depth,
@@ -753,40 +761,42 @@ export class Treemap extends PureComponent<Props, State> {
     const viewBox = { x: 0, y: 0, width, height };
 
     return (
-      <CursorPortalContext.Provider value={this.state.cursorPortal}>
-        <TooltipPortalContext.Provider value={this.state.tooltipPortal}>
-          <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
-          <ViewBoxContext.Provider value={viewBox}>
-            <TooltipContextProvider value={this.getTooltipContext()}>
-              <RechartsWrapper
-                className={className}
-                style={style}
-                width={width}
-                height={height}
-                ref={(node: HTMLDivElement) => {
-                  if (this.state.tooltipPortal == null) {
-                    this.setState({ tooltipPortal: node });
-                  }
-                }}
-              >
-                <Surface {...attrs} width={width} height={type === 'nest' ? height - 30 : height}>
-                  <g
-                    className="recharts-cursor-portal"
-                    ref={(node: SVGElement) => {
-                      if (this.state.cursorPortal == null) {
-                        this.setState({ cursorPortal: node });
-                      }
-                    }}
-                  />
-                  {this.renderAllNodes()}
-                  {children}
-                </Surface>
-                {type === 'nest' && this.renderNestIndex()}
-              </RechartsWrapper>
-            </TooltipContextProvider>
-          </ViewBoxContext.Provider>
-        </TooltipPortalContext.Provider>
-      </CursorPortalContext.Provider>
+      <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={this.props.className ?? 'Treemap'}>
+        <CursorPortalContext.Provider value={this.state.cursorPortal}>
+          <TooltipPortalContext.Provider value={this.state.tooltipPortal}>
+            <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
+            <ViewBoxContext.Provider value={viewBox}>
+              <TooltipContextProvider value={this.getTooltipContext()}>
+                <RechartsWrapper
+                  className={className}
+                  style={style}
+                  width={width}
+                  height={height}
+                  ref={(node: HTMLDivElement) => {
+                    if (this.state.tooltipPortal == null) {
+                      this.setState({ tooltipPortal: node });
+                    }
+                  }}
+                >
+                  <Surface {...attrs} width={width} height={type === 'nest' ? height - 30 : height}>
+                    <g
+                      className="recharts-cursor-portal"
+                      ref={(node: SVGElement) => {
+                        if (this.state.cursorPortal == null) {
+                          this.setState({ cursorPortal: node });
+                        }
+                      }}
+                    />
+                    {this.renderAllNodes()}
+                    {children}
+                  </Surface>
+                  {type === 'nest' && this.renderNestIndex()}
+                </RechartsWrapper>
+              </TooltipContextProvider>
+            </ViewBoxContext.Provider>
+          </TooltipPortalContext.Provider>
+        </CursorPortalContext.Provider>
+      </RechartsStoreProvider>
     );
   }
 }

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -839,6 +839,7 @@ export const generateCategoricalChart = ({
   axisComponents,
   formatAxisMap,
   defaultProps,
+  tooltipPayloadSearcher,
 }: CategoricalChartOptions) => {
   const getFormatItems = (props: CategoricalChartProps, currentState: CategoricalChartState): any[] => {
     const { graphicalItems, stackGroups, offset, updateId, dataStartIndex, dataEndIndex } = currentState;
@@ -1966,6 +1967,7 @@ export const generateCategoricalChart = ({
       chartName,
       defaultTooltipEventType,
       validateTooltipEventTypes,
+      tooltipPayloadSearcher,
     };
     return (
       <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={props.id ?? chartName}>

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -53,7 +53,7 @@ export const useMouseEnterItemDispatch = <T extends TooltipPayloadType>(
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseEnterFromProps?.(data, index, event);
     onMouseEnterFromContext?.(data, index, event);
-    dispatch(setActiveMouseOverItemIndex({ activeIndex: index, activeDataKey: dataKey }));
+    dispatch(setActiveMouseOverItemIndex({ activeIndex: String(index), activeDataKey: dataKey }));
   };
 };
 
@@ -78,6 +78,6 @@ export const useMouseClickItemDispatch = <T extends TooltipPayloadType>(
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseClickFromProps?.(data, index, event);
     onMouseClickFromContext?.(data, index, event);
-    dispatch(setActiveClickItemIndex({ activeIndex: index, activeDataKey: dataKey }));
+    dispatch(setActiveClickItemIndex({ activeIndex: String(index), activeDataKey: dataKey }));
   };
 };

--- a/src/state/mouseEventsMiddleware.ts
+++ b/src/state/mouseEventsMiddleware.ts
@@ -2,7 +2,7 @@ import { createAction, createListenerMiddleware, ListenerEffectAPI, PayloadActio
 import { AppDispatch, RechartsRootState } from './store';
 import { selectActiveIndexFromMousePointer } from './selectors';
 import { MousePointer } from '../chart/generateCategoricalChart';
-import { setMouseClickAxisIndex, setMouseOverAxisIndex } from './tooltipSlice';
+import { setMouseClickAxisIndex, setMouseOverAxisIndex, TooltipIndex } from './tooltipSlice';
 
 export const mouseClickAction = createAction<MousePointer>('mouseClick');
 
@@ -12,7 +12,7 @@ mouseClickMiddleware.startListening({
   actionCreator: mouseClickAction,
   effect: (action: PayloadAction<MousePointer>, listenerApi: ListenerEffectAPI<RechartsRootState, AppDispatch>) => {
     const mousePointer = action.payload;
-    const activeIndex: number | undefined = selectActiveIndexFromMousePointer(listenerApi.getState(), mousePointer);
+    const activeIndex: TooltipIndex = selectActiveIndexFromMousePointer(listenerApi.getState(), mousePointer);
     if (activeIndex != null) {
       listenerApi.dispatch(setMouseClickAxisIndex({ activeIndex, activeDataKey: undefined }));
     }
@@ -27,7 +27,7 @@ mouseMoveMiddleware.startListening({
   actionCreator: mouseMoveAction,
   effect: (action: PayloadAction<MousePointer>, listenerApi: ListenerEffectAPI<RechartsRootState, AppDispatch>) => {
     const mousePointer = action.payload;
-    const activeIndex: number | undefined = selectActiveIndexFromMousePointer(listenerApi.getState(), mousePointer);
+    const activeIndex: TooltipIndex = selectActiveIndexFromMousePointer(listenerApi.getState(), mousePointer);
     if (activeIndex != null) {
       listenerApi.dispatch(setMouseOverAxisIndex({ activeIndex, activeDataKey: undefined }));
     }

--- a/src/state/optionsSlice.ts
+++ b/src/state/optionsSlice.ts
@@ -1,13 +1,29 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { TooltipEventType } from '../util/types';
+import { TooltipPayloadSearcher } from './tooltipSlice';
 
 export type ChartOptions = {
   chartName?: string;
   defaultTooltipEventType?: TooltipEventType;
   validateTooltipEventTypes?: ReadonlyArray<TooltipEventType>;
+  // Should this instead be a property of a graphical item? Do we want to mix items with different data types in one chart?
+  tooltipPayloadSearcher: TooltipPayloadSearcher | undefined;
 };
 
-const initialState: ChartOptions = {};
+export const arrayTooltipSearcher: TooltipPayloadSearcher = (
+  data: unknown[],
+  strIndex: string | undefined,
+): unknown => {
+  const numIndex = Number(strIndex);
+  if (Number.isNaN(numIndex)) {
+    return undefined;
+  }
+  return data?.[numIndex];
+};
+
+const initialState: ChartOptions = {
+  tooltipPayloadSearcher: undefined,
+};
 
 const optionsSlice = createSlice({
   name: 'options',

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -248,15 +248,11 @@ const selectChartCoordinates: (state: RechartsRootState, event: MousePointer) =>
     },
   );
 
-const selectContainerScale: (state: RechartsRootState) => number | undefined = createSelector(
+export const selectContainerScale: (state: RechartsRootState) => number | undefined = createSelector(
   selectRootContainer,
   selectRootContainerDomRect,
-  (container: RechartsHTMLContainer | undefined, rect: DOMRect | undefined): number => {
-    if (!container || !rect) {
-      return 1;
-    }
-    return rect.width / container.offsetWidth;
-  },
+  (container: RechartsHTMLContainer | undefined, rect: DOMRect | undefined): number =>
+    rect?.width / container?.offsetWidth || 1,
 );
 
 export const combineActiveIndex = (

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -2,7 +2,14 @@ import { createSelector } from '@reduxjs/toolkit';
 import sortBy from 'lodash/sortBy';
 import { useAppSelector } from './hooks';
 import { RechartsRootState } from './store';
-import { TooltipPayload, TooltipPayloadConfiguration, TooltipPayloadEntry, TooltipState } from './tooltipSlice';
+import {
+  TooltipEntrySettings,
+  TooltipIndex,
+  TooltipPayload,
+  TooltipPayloadConfiguration,
+  TooltipPayloadEntry,
+  TooltipState,
+} from './tooltipSlice';
 import {
   calculateActiveTickIndex,
   calculateTooltipPos,
@@ -67,9 +74,9 @@ export function selectActiveIndex(
   tooltipEventType: TooltipEventType,
   trigger: TooltipTrigger,
   defaultIndex: number | undefined,
-): number {
+): TooltipIndex {
   const tooltipState: TooltipState = selectTooltipState(state);
-  let activeIndex: number;
+  let activeIndex: TooltipIndex;
   if (tooltipEventType === 'item') {
     if (trigger === 'hover') {
       activeIndex = tooltipState.itemInteraction.activeMouseOverIndex;
@@ -81,8 +88,8 @@ export function selectActiveIndex(
   } else {
     activeIndex = tooltipState.axisInteraction.activeClickAxisIndex;
   }
-  if (activeIndex === -1 && defaultIndex != null) {
-    return defaultIndex;
+  if (activeIndex == null && defaultIndex != null) {
+    return `${defaultIndex}`;
   }
   return activeIndex;
 }
@@ -90,8 +97,13 @@ export function selectActiveIndex(
 const selectActiveLabel = createSelector(
   selectTooltipTicks,
   selectActiveIndex,
-  (tooltipTicks: ReadonlyArray<TickItem>, activeIndex: number): string | undefined =>
-    tooltipTicks?.[activeIndex]?.value,
+  (tooltipTicks: ReadonlyArray<TickItem>, activeIndex: TooltipIndex): string | undefined => {
+    const n = Number(activeIndex);
+    if (Number.isNaN(n)) {
+      return undefined;
+    }
+    return tooltipTicks?.[n]?.value;
+  },
 );
 
 function selectFinalData(dataDefinedOnItem: ReadonlyArray<unknown>, dataDefinedOnChart: ReadonlyArray<unknown>) {
@@ -131,12 +143,12 @@ export function selectTooltipPayloadConfigurations(
 
 export const combineTooltipPayload = (
   tooltipItemPayloads: ReadonlyArray<TooltipPayloadConfiguration>,
-  activeIndex: number,
+  activeIndex: TooltipIndex,
   chartDataState: ChartDataState,
   tooltipAxis: BaseAxisProps | undefined,
   activeLabel: string | undefined,
 ): TooltipPayload | undefined => {
-  if (activeIndex === -1) {
+  if (activeIndex == null) {
     return undefined;
   }
   const { chartData, dataStartIndex, dataEndIndex } = chartDataState;
@@ -153,18 +165,19 @@ export const combineTooltipPayload = (
     if (tooltipAxis?.dataKey && !tooltipAxis?.allowDuplicatedCategory) {
       tooltipPayload = findEntryInArray(sliced, tooltipAxis.dataKey, activeLabel);
     } else {
-      tooltipPayload = sliced?.[activeIndex];
+      // TODO replace the array access with chart-specific getter
+      tooltipPayload = sliced?.[Number(activeIndex)];
     }
 
     if (Array.isArray(tooltipPayload)) {
       tooltipPayload.forEach(item => {
-        const newSettings = {
+        const newSettings: TooltipEntrySettings = {
           ...settings,
           name: item.name,
           unit: item.unit,
-          // @ts-expect-error okay so color and fill are erased to keep 100% the identical behaviour to recharts 2.x - but there's nothing stopping us from returning them here. It's technically a breaking change.
+          // color and fill are erased to keep 100% the identical behaviour to recharts 2.x - but there's nothing stopping us from returning them here. It's technically a breaking change.
           color: undefined,
-          // @ts-expect-error okay so color and fill are erased to keep 100% the identical behaviour to recharts 2.x - but there's nothing stopping us from returning them here. It's technically a breaking change.
+          // color and fill are erased to keep 100% the identical behaviour to recharts 2.x - but there's nothing stopping us from returning them here. It's technically a breaking change.
           fill: undefined,
         };
         agg.push(
@@ -267,35 +280,33 @@ export const combineActiveIndex = (
   tooltipTicks: ReadonlyArray<TickItem> | undefined,
   orderedTooltipTicks: ReadonlyArray<TickItem> | undefined,
   offset: ChartOffset,
-): number | undefined => {
+): TooltipIndex => {
   if (!chartEvent || !scale || !layout || !tooltipAxis || !tooltipTicks) {
-    return undefined;
+    return null;
   }
   const rangeObj = inRange(chartEvent.chartX, chartEvent.chartY, scale, layout, angleAxisMap, radiusAxisMap, offset);
   if (!rangeObj) {
-    return undefined;
+    return null;
   }
   const pos: number | undefined = calculateTooltipPos(rangeObj, layout);
 
   const activeIndex = calculateActiveTickIndex(pos, orderedTooltipTicks, tooltipTicks, tooltipAxis);
 
-  return activeIndex;
+  return String(activeIndex);
 };
 
-export const selectActiveIndexFromMousePointer: (
-  state: RechartsRootState,
-  mousePointer: MousePointer,
-) => number | undefined = createSelector(
-  selectChartCoordinates,
-  selectContainerScale,
-  selectChartLayout,
-  selectXAxisMap,
-  selectYAxisMap,
-  selectPolarAngleAxisMap,
-  selectPolarRadiusAxisMap,
-  selectTooltipAxis,
-  selectTooltipTicks,
-  selectOrderedTooltipTicks,
-  selectChartOffset,
-  combineActiveIndex,
-);
+export const selectActiveIndexFromMousePointer: (state: RechartsRootState, mousePointer: MousePointer) => TooltipIndex =
+  createSelector(
+    selectChartCoordinates,
+    selectContainerScale,
+    selectChartLayout,
+    selectXAxisMap,
+    selectYAxisMap,
+    selectPolarAngleAxisMap,
+    selectPolarRadiusAxisMap,
+    selectTooltipAxis,
+    selectTooltipTicks,
+    selectOrderedTooltipTicks,
+    selectChartOffset,
+    combineActiveIndex,
+  );

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -23,7 +23,16 @@ export type TooltipEntrySettings = Omit<TooltipPayloadEntry, 'payload' | 'value'
  */
 export type TooltipPayload = ReadonlyArray<TooltipPayloadEntry>;
 
-type TooltipIndex = number;
+/**
+ * null means no active index
+ * string means: whichever index from the chart data it is.
+ * Different charts have different requirements on data shapes,
+ * and are also responsible for providing a function that will accept this index
+ * and return data.
+ */
+export type TooltipIndex = string | null;
+
+// TODO type TooltipPayloadSearcher = (data: unknown[], index: TooltipIndex) => TooltipPayload | undefined;
 
 export type TooltipPayloadConfiguration = {
   // This is the data that is the same for all tooltip payloads, regardless of activeIndex
@@ -85,7 +94,7 @@ export type TooltipState = {
     /**
      * Same as the index above but this one only gets set by clicking on a chart item.
      */
-    activeClickIndex: TooltipIndex | undefined;
+    activeClickIndex: TooltipIndex;
     /**
      * Same as the dataKey above but this one only gets set by clicking on a chart item.
      */
@@ -100,9 +109,9 @@ export type TooltipState = {
   axisInteraction: {
     activeClick: boolean;
     activeHover: boolean;
-    activeMouseOverAxisIndex: number | undefined;
+    activeMouseOverAxisIndex: TooltipIndex;
     activeMouseOverAxisDataKey: DataKey<any> | undefined;
-    activeClickAxisIndex: number | undefined;
+    activeClickAxisIndex: TooltipIndex;
     activeClickAxisDataKey: DataKey<any> | undefined;
   };
   /**
@@ -117,17 +126,17 @@ const initialState: TooltipState = {
   itemInteraction: {
     activeClick: false,
     activeHover: false,
-    activeMouseOverIndex: -1,
+    activeMouseOverIndex: null,
     activeMouseOverDataKey: undefined,
-    activeClickIndex: -1,
+    activeClickIndex: null,
     activeClickDataKey: undefined,
   },
   axisInteraction: {
     activeClick: false,
     activeHover: false,
-    activeMouseOverAxisIndex: -1,
+    activeMouseOverAxisIndex: null,
     activeMouseOverAxisDataKey: undefined,
-    activeClickAxisIndex: -1,
+    activeClickAxisIndex: null,
     activeClickAxisDataKey: undefined,
   },
   tooltipItemPayloads: [],
@@ -167,7 +176,7 @@ const tooltipSlice = createSlice({
     },
     setMouseOverAxisIndex(
       state,
-      action: PayloadAction<{ activeIndex: number; activeDataKey: DataKey<any> | undefined }>,
+      action: PayloadAction<{ activeIndex: TooltipIndex; activeDataKey: DataKey<any> | undefined }>,
     ) {
       state.axisInteraction.activeHover = true;
       state.axisInteraction.activeMouseOverAxisIndex = action.payload.activeIndex;
@@ -175,7 +184,7 @@ const tooltipSlice = createSlice({
     },
     setMouseClickAxisIndex(
       state,
-      action: PayloadAction<{ activeIndex: number; activeDataKey: DataKey<any> | undefined }>,
+      action: PayloadAction<{ activeIndex: TooltipIndex; activeDataKey: DataKey<any> | undefined }>,
     ) {
       state.axisInteraction.activeClick = true;
       state.axisInteraction.activeClickAxisIndex = action.payload.activeIndex;

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -32,13 +32,22 @@ export type TooltipPayload = ReadonlyArray<TooltipPayloadEntry>;
  */
 export type TooltipIndex = string | null;
 
-// TODO type TooltipPayloadSearcher = (data: unknown[], index: TooltipIndex) => TooltipPayload | undefined;
+/**
+ * Different items have different data shapes so the state has no opinion on what the data shape should be;
+ * the only requirement is that the chart also provides a searcher function
+ * that accepts the data, and a key, and returns whatever the payload in Tooltip should be.
+ */
+export type TooltipPayloadSearcher<T = unknown, R = unknown> = (data: T, index: TooltipIndex) => R | undefined;
 
 export type TooltipPayloadConfiguration = {
   // This is the data that is the same for all tooltip payloads, regardless of activeIndex
   settings: TooltipEntrySettings;
-  // This is the data that changes for each index
-  dataDefinedOnItem: unknown[] | undefined;
+  /**
+   * This is the data that the item has provided, all of it mixed together.
+   * Later as user is interacting with the chart, a redux selector will use this
+   * data + activeIndex, pass it to the TooltipPayloadSearcher, and render the result in a Tooltip.
+   */
+  dataDefinedOnItem: unknown;
 };
 
 /**

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -29,6 +29,7 @@ import { PolarRadiusAxisProps } from '../polar/PolarRadiusAxis';
 import type { Props as XAxisProps } from '../cartesian/XAxis';
 import type { Props as YAxisProps } from '../cartesian/YAxis';
 import type { Props as DotProps } from '../shape/Dot';
+import { TooltipPayloadSearcher } from '../state/tooltipSlice';
 
 /**
  * Determines how values are stacked:
@@ -1302,19 +1303,7 @@ export interface CategoricalChartOptions {
   axisComponents?: BaseAxisProps[];
   formatAxisMap?: any;
   defaultProps?: any;
-}
-
-export interface TreemapNode {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  depth: number;
-  index: number;
-  children?: any;
-  name: string;
-  value: number;
-  [k: string]: any;
+  tooltipPayloadSearcher: TooltipPayloadSearcher;
 }
 
 export interface SankeyNode {

--- a/test/chart/Treemap.spec.tsx
+++ b/test/chart/Treemap.spec.tsx
@@ -48,8 +48,8 @@ describe('<Treemap />', () => {
         ({ clipPathId, viewBox, xAxisMap, yAxisMap }) => {
           expect(clipPathId).toBe(undefined);
           expect(viewBox).toEqual({ x: 0, y: 0, width: 100, height: 50 });
-          expect(xAxisMap).toBe(undefined);
-          expect(yAxisMap).toBe(undefined);
+          expect(xAxisMap).toEqual({});
+          expect(yAxisMap).toEqual({});
         },
       ),
     );
@@ -77,7 +77,7 @@ describe('<Treemap />', () => {
             <YAxis type="category" dataKey="name" />
           </Treemap>,
         ),
-      ).toThrowError('Invariant failed: Could not find Recharts context');
+      ).toThrowError('Invariant failed: Could not find xAxis by id "0" [number]. There are no available ids.');
     });
   });
 });

--- a/test/component/Cursor.spec.tsx
+++ b/test/component/Cursor.spec.tsx
@@ -6,6 +6,7 @@ import { assertNotNull } from '../helper/assertNotNull';
 import { RechartsRootState } from '../../src/state/store';
 import { RechartsStoreProvider } from '../../src/state/RechartsStoreProvider';
 import { TooltipContextProvider, TooltipContextValue } from '../../src/context/tooltipContext';
+import { arrayTooltipSearcher } from '../../src/state/optionsSlice';
 
 const defaultProps: CursorProps = {
   cursor: true,
@@ -33,7 +34,10 @@ const connectedProps: CursorConnectedProps = {
 };
 
 const preloadedState: Partial<RechartsRootState> = {
-  options: { chartName: '' },
+  options: {
+    chartName: '',
+    tooltipPayloadSearcher: arrayTooltipSearcher,
+  },
 };
 
 const preloadedRadialState: Partial<RechartsRootState> = {
@@ -155,6 +159,7 @@ describe('Cursor', () => {
         ...preloadedState,
         options: {
           chartName: 'ScatterChart',
+          tooltipPayloadSearcher: arrayTooltipSearcher,
         },
       };
       const { container } = render(

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -38,6 +38,7 @@ import { TooltipTrigger } from '../../src/chart/types';
 import { produceState } from './produceState';
 import { RechartsHTMLContainer, setContainer } from '../../src/state/layoutSlice';
 import { getMockDomRect } from '../helper/mockGetBoundingClientRect';
+import { arrayTooltipSearcher } from '../../src/state/optionsSlice';
 
 const exampleTooltipPayloadConfiguration1: TooltipPayloadConfiguration = {
   settings: {
@@ -118,6 +119,12 @@ const allTooltipCombinations: ReadonlyArray<TestCaseTooltipCombination> = [
 ];
 const allTooltipEventTypes: ReadonlyArray<TooltipEventType> = ['axis', 'item'];
 
+const preloadedState: Partial<RechartsRootState> = {
+  options: {
+    tooltipPayloadSearcher: arrayTooltipSearcher,
+  },
+};
+
 describe('useTooltipEventType', () => {
   type TooltipEventTypeTestScenario = {
     testName: string;
@@ -184,11 +191,15 @@ describe('useTooltipEventType', () => {
         expect(eventType).toBe(expected);
         return null;
       };
-      const preloadedState: Partial<RechartsRootState> = {
-        options: { defaultTooltipEventType, validateTooltipEventTypes },
+      const myPreloadedState: Partial<RechartsRootState> = {
+        options: {
+          defaultTooltipEventType,
+          validateTooltipEventTypes,
+          tooltipPayloadSearcher: arrayTooltipSearcher,
+        },
       };
       render(
-        <RechartsStoreProvider preloadedState={preloadedState}>
+        <RechartsStoreProvider preloadedState={myPreloadedState}>
           <Comp />
         </RechartsStoreProvider>,
       );
@@ -219,7 +230,7 @@ describe('selectTooltipPayload', () => {
   );
 
   it('should return settings and data from axis hover, if activeIndex is set for the item', () => {
-    const store = createRechartsStore();
+    const store = createRechartsStore(preloadedState);
     const tooltipSettings1: TooltipPayloadConfiguration = {
       settings: undefined,
       dataDefinedOnItem: undefined,
@@ -262,7 +273,7 @@ describe('selectTooltipPayload', () => {
   });
 
   it('should fill in chartData, if it is not defined on the item for item hover', () => {
-    const store = createRechartsStore();
+    const store = createRechartsStore(preloadedState);
     const tooltipSettings: TooltipPayloadConfiguration = {
       settings: {
         stroke: 'red',
@@ -296,7 +307,7 @@ describe('selectTooltipPayload', () => {
   });
 
   it('should return sliced data if set by Brush for item hover', () => {
-    const store = createRechartsStore();
+    const store = createRechartsStore(preloadedState);
     const tooltipSettings: TooltipPayloadConfiguration = {
       settings: {
         stroke: 'red',
@@ -340,6 +351,7 @@ describe('selectTooltipPayload', () => {
       chartDataState,
       tooltipAxis,
       activeLabel,
+      arrayTooltipSearcher,
     );
     const expectedEntry1: TooltipPayloadEntry = {
       name: 'stature',
@@ -383,6 +395,7 @@ describe('selectTooltipPayload', () => {
       chartDataState,
       tooltipAxis,
       activeLabel,
+      arrayTooltipSearcher,
     );
     const expected: TooltipPayloadEntry = { dataKey: 'dataKeyOnAxis', payload: null, value: undefined };
     expect(actual).toEqual([expected]);
@@ -740,7 +753,7 @@ describe('selectContainerScale', () => {
     /*
      * This is a little bit of a case of "trust me" because:
      8 jsdom returns zeroes everywhere so that doesn't test anything
-     * and the browser spec is everything so I went and tested it in Firefox version 126.0
+     * and the browser spec is everything, so I went and tested it in Firefox version 126.0
      * In a browser devtools I select arbitrary element and run:
      *
         console.table({

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -23,6 +23,7 @@ import {
   setActiveMouseOverItemIndex,
   setMouseClickAxisIndex,
   setMouseOverAxisIndex,
+  TooltipIndex,
   TooltipPayload,
   TooltipPayloadConfiguration,
   TooltipPayloadEntry,
@@ -253,7 +254,7 @@ describe('selectTooltipPayload', () => {
     store.dispatch(addTooltipEntrySettings(tooltipSettings1));
     store.dispatch(addTooltipEntrySettings(tooltipSettings2));
     expect(selectTooltipPayload(store.getState(), 'axis', 'hover', undefined)).toEqual(undefined);
-    store.dispatch(setMouseOverAxisIndex({ activeIndex: 1, activeDataKey: undefined }));
+    store.dispatch(setMouseOverAxisIndex({ activeIndex: '1', activeDataKey: undefined }));
     expect(selectTooltipPayload(store.getState(), 'axis', 'hover', undefined)).toEqual([
       expectedEntry1,
       expectedEntry2,
@@ -279,7 +280,7 @@ describe('selectTooltipPayload', () => {
         { x: 3, y: 4 },
       ]),
     );
-    store.dispatch(setActiveMouseOverItemIndex({ activeIndex: 0, activeDataKey: 'y' }));
+    store.dispatch(setActiveMouseOverItemIndex({ activeIndex: '0', activeDataKey: 'y' }));
 
     const expectedEntry: TooltipPayloadEntry = {
       name: 'foo',
@@ -316,7 +317,7 @@ describe('selectTooltipPayload', () => {
       ]),
     );
     expect(selectTooltipPayload(store.getState(), 'item', 'hover', undefined)).toEqual(undefined);
-    store.dispatch(setActiveMouseOverItemIndex({ activeIndex: 0, activeDataKey: 'y' }));
+    store.dispatch(setActiveMouseOverItemIndex({ activeIndex: '0', activeDataKey: 'y' }));
     store.dispatch(setDataStartEndIndexes({ startIndex: 1, endIndex: 10 }));
     const expectedEntry: TooltipPayloadEntry = {
       name: 'foo',
@@ -335,7 +336,7 @@ describe('selectTooltipPayload', () => {
     const activeLabel: string | undefined = undefined;
     const actual: TooltipPayload | undefined = combineTooltipPayload(
       [exampleTooltipPayloadConfiguration1],
-      0,
+      '0',
       chartDataState,
       tooltipAxis,
       activeLabel,
@@ -378,7 +379,7 @@ describe('selectTooltipPayload', () => {
     const activeLabel: string | undefined = undefined;
     const actual: TooltipPayload | undefined = combineTooltipPayload(
       [tooltipPayloadConfiguration],
-      0,
+      '0',
       chartDataState,
       tooltipAxis,
       activeLabel,
@@ -391,55 +392,61 @@ describe('selectTooltipPayload', () => {
 });
 
 describe('selectActiveIndex', () => {
-  it('should return -1 for initial state', () => {
+  it('should return null for initial state', () => {
     const initialState = createRechartsStore().getState();
-    expect(selectActiveIndex(initialState, 'axis', 'hover', undefined)).toBe(-1);
-    expect(selectActiveIndex(initialState, 'axis', 'click', undefined)).toBe(-1);
-    expect(selectActiveIndex(initialState, 'item', 'hover', undefined)).toBe(-1);
-    expect(selectActiveIndex(initialState, 'item', 'click', undefined)).toBe(-1);
+    const expected: TooltipIndex = null;
+    expect(selectActiveIndex(initialState, 'axis', 'hover', undefined)).toBe(expected);
+    expect(selectActiveIndex(initialState, 'axis', 'click', undefined)).toBe(expected);
+    expect(selectActiveIndex(initialState, 'item', 'hover', undefined)).toBe(expected);
+    expect(selectActiveIndex(initialState, 'item', 'click', undefined)).toBe(expected);
   });
 
   it('should return defaultIndex if it is defined', () => {
     const initialState = createRechartsStore().getState();
-    expect(selectActiveIndex(initialState, 'axis', 'hover', 7)).toBe(7);
-    expect(selectActiveIndex(initialState, 'axis', 'click', 7)).toBe(7);
-    expect(selectActiveIndex(initialState, 'item', 'hover', 7)).toBe(7);
-    expect(selectActiveIndex(initialState, 'item', 'click', 7)).toBe(7);
+    const expected: TooltipIndex = '7';
+    expect(selectActiveIndex(initialState, 'axis', 'hover', 7)).toBe(expected);
+    expect(selectActiveIndex(initialState, 'axis', 'click', 7)).toBe(expected);
+    expect(selectActiveIndex(initialState, 'item', 'hover', 7)).toBe(expected);
+    expect(selectActiveIndex(initialState, 'item', 'click', 7)).toBe(expected);
   });
 
   it('should ignore defaultIndex if item hover index is set', () => {
     const state = produceState(draft => {
-      draft.tooltip.itemInteraction.activeMouseOverIndex = 7;
+      draft.tooltip.itemInteraction.activeMouseOverIndex = '7';
     });
-    expect(selectActiveIndex(state, 'axis', 'hover', 8)).toBe(8);
-    expect(selectActiveIndex(state, 'axis', 'click', 8)).toBe(8);
-    expect(selectActiveIndex(state, 'item', 'hover', 8)).toBe(7);
-    expect(selectActiveIndex(state, 'item', 'click', 8)).toBe(8);
+    expect(selectActiveIndex(state, 'axis', 'hover', 8)).toBe('8' satisfies TooltipIndex);
+    expect(selectActiveIndex(state, 'axis', 'click', 8)).toBe('8' satisfies TooltipIndex);
+    expect(selectActiveIndex(state, 'item', 'hover', 8)).toBe('7' satisfies TooltipIndex);
+    expect(selectActiveIndex(state, 'item', 'click', 8)).toBe('8' satisfies TooltipIndex);
   });
 
   it('should return item hover index', () => {
     const state = produceState(draft => {
-      draft.tooltip.itemInteraction.activeMouseOverIndex = 7;
+      draft.tooltip.itemInteraction.activeMouseOverIndex = '7';
     });
-    expect(selectActiveIndex(state, 'item', 'hover', 9)).toBe(7);
+    const expected: TooltipIndex = '7';
+    expect(selectActiveIndex(state, 'item', 'hover', 9)).toBe(expected);
   });
   it('should return item click index', () => {
     const state = produceState(draft => {
-      draft.tooltip.itemInteraction.activeClickIndex = 7;
+      draft.tooltip.itemInteraction.activeClickIndex = '7';
     });
-    expect(selectActiveIndex(state, 'item', 'click', 11)).toBe(7);
+    const expected: TooltipIndex = '7';
+    expect(selectActiveIndex(state, 'item', 'click', 11)).toBe(expected);
   });
   it('should return axis hover index', () => {
     const state = produceState(draft => {
-      draft.tooltip.axisInteraction.activeMouseOverAxisIndex = 7;
+      draft.tooltip.axisInteraction.activeMouseOverAxisIndex = '7';
     });
-    expect(selectActiveIndex(state, 'axis', 'hover', 13)).toBe(7);
+    const expected: TooltipIndex = '7';
+    expect(selectActiveIndex(state, 'axis', 'hover', 13)).toBe(expected);
   });
   it('should return axis click index', () => {
     const state = produceState(draft => {
-      draft.tooltip.axisInteraction.activeClickAxisIndex = 7;
+      draft.tooltip.axisInteraction.activeClickAxisIndex = '7';
     });
-    expect(selectActiveIndex(state, 'axis', 'click', 17)).toBe(7);
+    const expected: TooltipIndex = '7';
+    expect(selectActiveIndex(state, 'axis', 'click', 17)).toBe(expected);
   });
 });
 
@@ -483,27 +490,27 @@ describe('selectTooltipPayloadConfigurations', () => {
   });
 
   it('should filter by dataKey with tooltipEventType: item and trigger: hover', () => {
-    exampleStore.dispatch(setActiveMouseOverItemIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+    exampleStore.dispatch(setActiveMouseOverItemIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
     expect(selectTooltipPayloadConfigurations(exampleStore.getState(), 'item', 'hover')).toEqual([
       exampleTooltipPayloadConfiguration1,
     ]);
-    exampleStore.dispatch(setActiveMouseOverItemIndex({ activeIndex: 1, activeDataKey: 'dataKey2' }));
+    exampleStore.dispatch(setActiveMouseOverItemIndex({ activeIndex: '1', activeDataKey: 'dataKey2' }));
     expect(selectTooltipPayloadConfigurations(exampleStore.getState(), 'item', 'hover')).toEqual([
       exampleTooltipPayloadConfiguration2,
     ]);
   });
 
   it('should return nothing if the tooltipEventType is hover but the only interactions are clicks', () => {
-    exampleStore.dispatch(setActiveClickItemIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+    exampleStore.dispatch(setActiveClickItemIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
     expect(selectTooltipPayloadConfigurations(exampleStore.getState(), 'item', 'hover')).toEqual([]);
-    exampleStore.dispatch(setMouseClickAxisIndex({ activeIndex: 1, activeDataKey: 'dataKey2' }));
+    exampleStore.dispatch(setMouseClickAxisIndex({ activeIndex: '1', activeDataKey: 'dataKey2' }));
     expect(selectTooltipPayloadConfigurations(exampleStore.getState(), 'item', 'hover')).toEqual([]);
   });
 
   it('should return nothing if the tooltipEventType is click but the only interactions are hovers', () => {
-    exampleStore.dispatch(setActiveMouseOverItemIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+    exampleStore.dispatch(setActiveMouseOverItemIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
     expect(selectTooltipPayloadConfigurations(exampleStore.getState(), 'item', 'click')).toEqual([]);
-    exampleStore.dispatch(setMouseOverAxisIndex({ activeIndex: 1, activeDataKey: 'dataKey2' }));
+    exampleStore.dispatch(setMouseOverAxisIndex({ activeIndex: '1', activeDataKey: 'dataKey2' }));
     expect(selectTooltipPayloadConfigurations(exampleStore.getState(), 'item', 'click')).toEqual([]);
   });
 });
@@ -536,14 +543,14 @@ describe('selectIsTooltipActive', () => {
       it('should return false if user is clicking on a graphical item', () => {
         // in browser, this is difficult to reproduce - one usually has to mouse over first before clicking
         const store = createRechartsStore();
-        store.dispatch(setActiveClickItemIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+        store.dispatch(setActiveClickItemIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(false);
       });
 
       it('should return false if user is clicking on an axis', () => {
         // in browser, this is difficult to reproduce - one usually has to mouse over first before clicking
         const store = createRechartsStore();
-        store.dispatch(setMouseClickAxisIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+        store.dispatch(setMouseClickAxisIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(false);
       });
     });
@@ -552,9 +559,9 @@ describe('selectIsTooltipActive', () => {
       const tooltipEventType = 'item';
       it('should return true if user is hovering over a graphical item but not axis', () => {
         const store = createRechartsStore();
-        store.dispatch(setMouseOverAxisIndex({ activeIndex: 1, activeDataKey: undefined }));
+        store.dispatch(setMouseOverAxisIndex({ activeIndex: '1', activeDataKey: undefined }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(false);
-        store.dispatch(setActiveMouseOverItemIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+        store.dispatch(setActiveMouseOverItemIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
         store.dispatch(mouseLeaveItem());
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(false);
@@ -568,11 +575,11 @@ describe('selectIsTooltipActive', () => {
       it(`should return true if user is hovering over an axis,
           and then continue returning true when user hovers over and then leaves a graphical item`, () => {
         const store = createRechartsStore();
-        store.dispatch(setActiveMouseOverItemIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+        store.dispatch(setActiveMouseOverItemIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(false);
-        store.dispatch(setMouseOverAxisIndex({ activeIndex: 1, activeDataKey: undefined }));
+        store.dispatch(setMouseOverAxisIndex({ activeIndex: '1', activeDataKey: undefined }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
-        store.dispatch(setActiveMouseOverItemIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+        store.dispatch(setActiveMouseOverItemIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
         store.dispatch(mouseLeaveItem());
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
@@ -588,13 +595,13 @@ describe('selectIsTooltipActive', () => {
     describe.each(allTooltipEventTypes)('tooltipEventType: %s', tooltipEventType => {
       it('should return false if user is hovering over a graphical item', () => {
         const store = createRechartsStore();
-        store.dispatch(setActiveMouseOverItemIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+        store.dispatch(setActiveMouseOverItemIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(false);
       });
 
       it('should return false if user is hovering over an axis', () => {
         const store = createRechartsStore();
-        store.dispatch(setMouseOverAxisIndex({ activeIndex: 1, activeDataKey: undefined }));
+        store.dispatch(setMouseOverAxisIndex({ activeIndex: '1', activeDataKey: undefined }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(false);
       });
     });
@@ -604,19 +611,19 @@ describe('selectIsTooltipActive', () => {
       it(`should return true if user is clicking a graphical item and continue returning true forever,
           because recharts does not allow ever turning off a tooltip that was triggered by a click`, () => {
         const store = createRechartsStore();
-        store.dispatch(setActiveClickItemIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+        store.dispatch(setActiveClickItemIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
-        store.dispatch(setActiveClickItemIndex({ activeIndex: 2, activeDataKey: undefined }));
+        store.dispatch(setActiveClickItemIndex({ activeIndex: '2', activeDataKey: undefined }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
         store.dispatch(mouseLeaveItem());
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
-        store.dispatch(setMouseClickAxisIndex({ activeIndex: 1, activeDataKey: undefined }));
+        store.dispatch(setMouseClickAxisIndex({ activeIndex: '1', activeDataKey: undefined }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
       });
 
       it('should return false if user is clicking on an axis', () => {
         const store = createRechartsStore();
-        store.dispatch(setMouseClickAxisIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+        store.dispatch(setMouseClickAxisIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(false);
       });
     });
@@ -625,13 +632,13 @@ describe('selectIsTooltipActive', () => {
       const tooltipEventType = 'axis';
       it('should return true if user is clicking on an axis, and continue returning true forever', () => {
         const store = createRechartsStore();
-        store.dispatch(setMouseClickAxisIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+        store.dispatch(setMouseClickAxisIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
-        store.dispatch(setMouseClickAxisIndex({ activeIndex: 2, activeDataKey: undefined }));
+        store.dispatch(setMouseClickAxisIndex({ activeIndex: '2', activeDataKey: undefined }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
         store.dispatch(mouseLeaveItem());
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
-        store.dispatch(setActiveClickItemIndex({ activeIndex: 1, activeDataKey: 'dataKey1' }));
+        store.dispatch(setActiveClickItemIndex({ activeIndex: '1', activeDataKey: 'dataKey1' }));
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
       });
     });
@@ -735,11 +742,11 @@ describe('selectContainerScale', () => {
      8 jsdom returns zeroes everywhere so that doesn't test anything
      * and the browser spec is everything so I went and tested it in Firefox version 126.0
      * In a browser devtools I select arbitrary element and run:
-     * 
-        console.table({ 
+     *
+        console.table({
          'getBoundingClientRect().width': $0.getBoundingClientRect().width,
          offsetWidth: $0.offsetWidth,
-         scale: $0.getBoundingClientRect().width / $0.offsetWidth 
+         scale: $0.getBoundingClientRect().width / $0.offsetWidth
         })
      *
      * This shows rect: 100, offsetWidth: 100, scale: 1

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -5,6 +5,7 @@ import { Store } from '@reduxjs/toolkit';
 import {
   combineTooltipPayload,
   selectActiveIndex,
+  selectContainerScale,
   selectIsTooltipActive,
   selectRootContainerDomRect,
   selectTooltipPayload,
@@ -693,5 +694,92 @@ describe('selectRootContainerDomRect', () => {
     expect(selectRootContainerDomRect(store.getState())).toEqual(mockRect);
     spy.mockReturnValue(mockRectUpdated);
     expect(selectRootContainerDomRect(store.getState())).toEqual(mockRectUpdated);
+  });
+});
+
+describe('selectContainerScale', () => {
+  it('should return undefined when called outside of Redux context', () => {
+    expect.assertions(1);
+    const Comp = (): null => {
+      const scale = useAppSelector(selectContainerScale);
+      expect(scale).toBe(undefined);
+      return null;
+    };
+    render(<Comp />);
+  });
+
+  it('should return 1 for initial state', () => {
+    const store = createRechartsStore();
+    expect(selectContainerScale(store.getState())).toBe(1);
+  });
+
+  it('should return 1 when container is set and has width and DOMRect with matching widths', () => {
+    const store = createRechartsStore();
+    const mockRect: DOMRect = getMockDomRect({
+      x: 1,
+      y: 2,
+      width: 3,
+      height: 4,
+    });
+    const mockElement: RechartsHTMLContainer = {
+      offsetWidth: 3,
+      getBoundingClientRect: () => mockRect,
+    };
+    store.dispatch(setContainer(mockElement));
+    expect(selectContainerScale(store.getState())).toBe(1);
+  });
+
+  it('should return scale as the ratio of DOMRect / offsetWidth', () => {
+    /*
+     * This is a little bit of a case of "trust me" because:
+     8 jsdom returns zeroes everywhere so that doesn't test anything
+     * and the browser spec is everything so I went and tested it in Firefox version 126.0
+     * In a browser devtools I select arbitrary element and run:
+     * 
+        console.table({ 
+         'getBoundingClientRect().width': $0.getBoundingClientRect().width,
+         offsetWidth: $0.offsetWidth,
+         scale: $0.getBoundingClientRect().width / $0.offsetWidth 
+        })
+     *
+     * This shows rect: 100, offsetWidth: 100, scale: 1
+     * Then I went and changed the `scale` CSS property to 1.5 using devtools and
+     * run the console.log again, and this time it shows
+     * rect: 150, offsetWidth: 100, scale: 1.5
+     * So there we go.
+     */
+    const store = createRechartsStore();
+    const mockRect: DOMRect = getMockDomRect({
+      x: 1,
+      y: 2,
+      width: 3,
+      height: 4,
+    });
+    const mockElement: RechartsHTMLContainer = {
+      offsetWidth: 5,
+      getBoundingClientRect: () => mockRect,
+    };
+    store.dispatch(setContainer(mockElement));
+    expect(selectContainerScale(store.getState())).toBe(3 / 5);
+  });
+
+  it('should return scale: 1 in jsdom because jsdom returns zeroes everywhere', () => {
+    /*
+     * This is a little bit of optimization for the test environment
+     * but without this fix, like half of the tests start throwing an error.
+     * Perhaps instead we should enforce mocking proper DOMRect
+     * on the container, in all tests,
+     * but for now this workaround is easier and doesn't hurt anyone.
+     */
+    const store = createRechartsStore();
+    const mockRect: DOMRect = getMockDomRect({
+      width: 0,
+    });
+    const mockElement: RechartsHTMLContainer = {
+      offsetWidth: 0,
+      getBoundingClientRect: () => mockRect,
+    };
+    store.dispatch(setContainer(mockElement));
+    expect(selectContainerScale(store.getState())).toBe(1);
   });
 });


### PR DESCRIPTION
## Description

So one-dimensional arrays and tooltip data got us this far but it won't work with Treemap and I suspect it won't work with Sankey either. Instead of using numeric activeIndex, and doing array lookup, we need to use string index and allow each chart to generate (and fetch) its own implementation of the index.

Most charts are going to continue using the array lookup, Treemap has its own now and I expect Sankey will have its own version too (because of the two nodes/links arrays)

## Related Issue

https://github.com/recharts/recharts/issues/4549

## Motivation and Context

I'm pretty deep down the rabbit hole but I am still doing this so that I can remove direct DOM access, I promise.

## How Has This Been Tested?

npm test, storybook

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
