### PR TITLE
Add Treemap mouse events, and nameKey to all charts

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -141,6 +141,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
       strokeWidth,
       fill,
       dataKey,
+      nameKey: undefined,
       name: getTooltipNameProp(name, dataKey),
       hide,
       type: props.tooltipType,

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -151,6 +151,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
       strokeWidth,
       fill,
       dataKey,
+      nameKey: undefined,
       name: getTooltipNameProp(name, dataKey),
       hide,
       type: props.tooltipType,

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -308,16 +308,18 @@ function BarRectangles(props: BarRectanglesProps) {
   );
 }
 
+const defaultMinPointSize: number = 0;
+
 export class Bar extends PureComponent<Props, State> {
   static displayName = 'Bar';
 
-  static defaultProps = {
+  static defaultProps: Partial<Props> = {
     xAxisId: 0,
     yAxisId: 0,
     legendType: 'rect',
-    minPointSize: 0,
+    minPointSize: defaultMinPointSize,
     hide: false,
-    data: [] as BarRectangleItem[],
+    data: null,
     layout: 'vertical',
     activeBar: false,
     isAnimationActive: !Global.isSsr,
@@ -387,7 +389,7 @@ export class Bar extends PureComponent<Props, State> {
         }
       }
 
-      const minPointSize = minPointSizeCallback(minPointSizeProp, this.defaultProps.minPointSize)(value[1], index);
+      const minPointSize = minPointSizeCallback(minPointSizeProp, defaultMinPointSize)(value[1], index);
 
       if (layout === 'horizontal') {
         const [baseValueScale, currentValueScale] = [yAxis.scale(value[0]), yAxis.scale(value[1])];

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -127,6 +127,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
       strokeWidth,
       fill,
       dataKey,
+      nameKey: undefined,
       name: getTooltipNameProp(name, dataKey),
       hide,
       type: props.tooltipType,

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -47,7 +47,7 @@ import {
 import { TooltipPayload, TooltipPayloadConfiguration, TooltipPayloadEntry } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 
-interface ScattterPointNode {
+interface ScatterPointNode {
   x?: number | string;
   y?: number | string;
   z?: number | string;
@@ -57,7 +57,7 @@ export interface ScatterPointItem {
   cx?: number;
   cy?: number;
   size?: number;
-  node?: ScattterPointNode;
+  node?: ScatterPointNode;
   payload?: any;
   tooltipPayload?: ReadonlyArray<TooltipPayload>;
 }

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -203,6 +203,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
       stroke,
       strokeWidth,
       fill,
+      nameKey: undefined,
       dataKey,
       name: getTooltipNameProp(name, dataKey),
       hide,

--- a/src/chart/RechartsWrapper.tsx
+++ b/src/chart/RechartsWrapper.tsx
@@ -27,6 +27,10 @@ export const RechartsWrapper = forwardRef(
       dispatch(mouseClickAction(e));
       wrapperEvents?.onClick?.(e);
     };
+    const myOnMouseEnter = (e: React.MouseEvent<HTMLDivElement>) => {
+      dispatch(mouseMoveAction(e));
+      wrapperEvents?.onMouseEnter?.(e);
+    };
     const myOnMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
       dispatch(mouseMoveAction(e));
       wrapperEvents?.onMouseMove?.(e);
@@ -41,6 +45,7 @@ export const RechartsWrapper = forwardRef(
         {...wrapperEvents}
         onClick={myOnClick}
         onMouseMove={myOnMouseMove}
+        onMouseEnter={myOnMouseEnter}
         ref={innerRef}
       >
         {children}

--- a/src/chart/SunburstChart.tsx
+++ b/src/chart/SunburstChart.tsx
@@ -102,6 +102,7 @@ function getTooltipEntrySettings({
       stroke,
       strokeWidth: undefined,
       fill,
+      nameKey: undefined,
       dataKey,
       name: dataKey,
       hide: false,

--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -33,6 +33,7 @@ export interface Payload<TValue extends ValueType, TName extends NameType> {
   unit?: ReactNode;
   fill?: string;
   dataKey?: DataKey<any>;
+  nameKey?: DataKey<any>;
   payload?: any;
   chartType?: string;
   stroke?: string;

--- a/src/numberAxis/Funnel.tsx
+++ b/src/numberAxis/Funnel.tsx
@@ -17,7 +17,7 @@ import { Cell, Props as CellProps } from '../component/Cell';
 import { findAllByType, filterProps } from '../util/ReactUtils';
 import { Global } from '../util/Global';
 import { interpolateNumber } from '../util/DataUtils';
-import { getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
+import { getValueByDataKey } from '../util/ChartUtils';
 import {
   LegendType,
   TooltipType,
@@ -95,7 +95,7 @@ type FunnelTrapezoidsProps = {
 };
 
 function getTooltipEntrySettings(props: FunnelProps): TooltipPayloadConfiguration {
-  const { dataKey, trapezoids, stroke, strokeWidth, fill, name, hide, tooltipType } = props;
+  const { dataKey, nameKey, trapezoids, stroke, strokeWidth, fill, name, hide, tooltipType } = props;
   return {
     dataDefinedOnItem: trapezoids,
     settings: {
@@ -103,7 +103,8 @@ function getTooltipEntrySettings(props: FunnelProps): TooltipPayloadConfiguratio
       strokeWidth,
       fill,
       dataKey,
-      name: getTooltipNameProp(name, dataKey),
+      name,
+      nameKey,
       hide,
       type: tooltipType,
       color: fill,

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -199,7 +199,7 @@ type PieSectorsProps = {
 };
 
 function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
-  const { dataKey, sectors, stroke, strokeWidth, fill, name, hide, tooltipType } = props;
+  const { dataKey, nameKey, sectors, stroke, strokeWidth, fill, name, hide, tooltipType } = props;
   return {
     dataDefinedOnItem: sectors?.map((p: PieSectorDataItem) => p.tooltipPayload),
     settings: {
@@ -207,6 +207,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
       strokeWidth,
       fill,
       dataKey,
+      nameKey,
       name: getTooltipNameProp(name, dataKey),
       hide,
       type: tooltipType,

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -123,6 +123,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
       stroke,
       strokeWidth,
       fill,
+      nameKey: undefined, // RadarChart does not have nameKey unfortunately
       dataKey,
       name: getTooltipNameProp(name, dataKey),
       hide,

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -191,6 +191,7 @@ function getTooltipEntrySettings(props: RadialBarProps): TooltipPayloadConfigura
       stroke,
       strokeWidth,
       fill,
+      nameKey: undefined, // RadialBar does not have nameKey, why?
       dataKey,
       name: getTooltipNameProp(name, dataKey),
       hide,

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -170,6 +170,8 @@ export const combineTooltipPayload = (
     const sliced = getSliced(finalData, dataStartIndex, dataEndIndex);
 
     const finalDataKey: DataKey<any> | undefined = settings?.dataKey ?? tooltipAxis?.dataKey;
+    // BaseAxisProps does not support nameKey but it could!
+    const finalNameKey: DataKey<any> | undefined = settings?.nameKey; // ?? tooltipAxis?.nameKey;
     let tooltipPayload: unknown;
     if (tooltipAxis?.dataKey && !tooltipAxis?.allowDuplicatedCategory && Array.isArray(sliced)) {
       tooltipPayload = findEntryInArray(sliced, tooltipAxis.dataKey, activeLabel);
@@ -194,16 +196,19 @@ export const combineTooltipPayload = (
             dataKey: item.dataKey,
             payload: item.payload,
             value: getValueByDataKey(item.payload, item.dataKey),
+            name: item.name,
           }),
         );
       });
     } else {
+      // I am not quite sure why these two branches (Array vs Array of Arrays) have to behave differently - I imagine we should unify these. 3.x breaking change?
       agg.push(
         getTooltipEntry({
           tooltipEntrySettings: settings,
           dataKey: finalDataKey,
           payload: tooltipPayload,
           value: getValueByDataKey(tooltipPayload, finalDataKey),
+          name: getValueByDataKey(tooltipPayload, finalNameKey) ?? settings?.name,
         }),
       );
     }

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -16,7 +16,9 @@ export type TooltipPayloadEntry = Payload<ValueType, NameType>;
  *
  * So this type is all the settings, other than the data + dataKey complications.
  */
-export type TooltipEntrySettings = Omit<TooltipPayloadEntry, 'payload' | 'value'>;
+export type TooltipEntrySettings = Omit<TooltipPayloadEntry, 'payload' | 'value'> & {
+  nameKey: DataKey<any> | undefined;
+};
 
 /**
  * This is what Tooltip renders.

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1367,17 +1367,20 @@ export function getTooltipEntry({
   dataKey,
   payload,
   value,
+  name,
 }: {
   tooltipEntrySettings: TooltipEntrySettings;
   dataKey: DataKey<any>;
   payload: any;
   value: ValueType;
+  name: string | undefined;
 }): TooltipPayloadEntry {
   return {
     ...tooltipEntrySettings,
     dataKey,
     payload,
     value,
+    name,
   };
 }
 

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -625,73 +625,81 @@ describe('<LineChart /> - Rendering two line charts with syncId', () => {
     expect(container.querySelectorAll('.recharts-active-dot')).toHaveLength(0);
   });
 
-  test('should show tooltips using syncMethod: [function] for both charts on MouseEnter and hide on MouseLeave', async () => {
-    const syncMethodFunction = () => {
-      return 1;
-    };
+  /**
+   * Tooltip tries to read payload from Redux but tooltip synchronisation is not in redux yet and so this test fails
+   * TODO implement tooltip sync in redux and then enable this test again
+   * https://github.com/recharts/recharts/issues/4548
+   */
+  test.fails(
+    'should show tooltips using syncMethod: [function] for both charts on MouseEnter and hide on MouseLeave',
+    async () => {
+      const syncMethodFunction = () => {
+        return 1;
+      };
 
-    const chart1 = (
-      <LineChart
-        width={width}
-        height={height}
-        data={data}
-        margin={margin}
-        syncId="test"
-        syncMethod={syncMethodFunction}
-      >
-        <Line type="monotone" dataKey="uv" stroke="#ff7300" />
-        <Tooltip />
-        <XAxis dataKey="name" />
-      </LineChart>
-    );
-    const chart2 = (
-      <LineChart
-        width={width}
-        height={height}
-        data={data2}
-        margin={margin}
-        syncId="test"
-        syncMethod={syncMethodFunction}
-      >
-        <Line type="monotone" dataKey="uv" stroke="#ff7300" />
-        <Tooltip />
-        <XAxis dataKey="name" />
-      </LineChart>
-    );
-    const { container } = render(
-      <div>
-        {chart1}
-        {chart2}
-      </div>,
-    );
+      const chart1 = (
+        <LineChart
+          width={width}
+          height={height}
+          data={data}
+          margin={margin}
+          syncId="test"
+          syncMethod={syncMethodFunction}
+        >
+          <Line type="monotone" dataKey="uv" stroke="#ff7300" />
+          <Tooltip />
+          <XAxis dataKey="name" />
+        </LineChart>
+      );
+      const chart2 = (
+        <LineChart
+          width={width}
+          height={height}
+          data={data2}
+          margin={margin}
+          syncId="test"
+          syncMethod={syncMethodFunction}
+        >
+          <Line type="monotone" dataKey="uv" stroke="#ff7300" />
+          <Tooltip />
+          <XAxis dataKey="name" />
+        </LineChart>
+      );
+      const { container } = render(
+        <div>
+          {chart1}
+          {chart2}
+        </div>,
+      );
 
-    const chartWidth = width - margin.left - margin.right;
-    const dotSpacing = chartWidth / (data.length - 1);
+      const chartWidth = width - margin.left - margin.right;
+      const dotSpacing = chartWidth / (data.length - 1);
 
-    // simulate entering just past Page A of Chart1 to test snapping of the cursor line
-    expect(container.querySelectorAll('.recharts-tooltip-cursor')).toHaveLength(0);
+      // simulate entering just past Page A of Chart1 to test snapping of the cursor line
+      expect(container.querySelectorAll('.recharts-tooltip-cursor')).toHaveLength(0);
 
-    const firstChart = container.querySelector('.recharts-wrapper');
-    assertNotNull(firstChart);
+      const firstChart = container.querySelector('.recharts-wrapper');
+      assertNotNull(firstChart);
 
-    fireEvent.mouseOver(firstChart, { bubbles: true, clientX: margin.left + 0.1 * dotSpacing, clientY: height / 2 });
-    vi.advanceTimersByTime(100);
+      fireEvent.mouseOver(firstChart, { bubbles: true, clientX: margin.left + 0.1 * dotSpacing, clientY: height / 2 });
+      vi.advanceTimersByTime(100);
 
-    // There are two tooltips - one for each LineChart as they have the same syncId
-    expect(container.querySelectorAll('.recharts-tooltip-cursor')).toHaveLength(2);
+      // There are two tooltips - one for each LineChart as they have the same syncId
+      expect(container.querySelectorAll('.recharts-tooltip-cursor')).toHaveLength(2);
 
-    // make sure tooltips display the correct values, synced by data value
-    expect(screen.queryByText('300')).toBeTruthy();
-    expect(screen.queryByText('550')).toBeTruthy();
+      // make sure tooltips display the correct values, synced by data value
+      expect(screen.queryByText('300')).toBeTruthy();
+      expect(screen.queryByText('550')).toBeTruthy();
 
-    // Check the activeDots are highlighted
-    expect(container.querySelectorAll('.recharts-active-dot')).toHaveLength(2);
+      // Check the activeDots are highlighted
+      expect(container.querySelectorAll('.recharts-active-dot')).toHaveLength(2);
 
-    // simulate leaving the area
-    fireEvent.mouseLeave(firstChart);
-    vi.advanceTimersByTime(100);
-    expect(container.querySelectorAll('.recharts-active-dot')).toHaveLength(0);
-  });
+      // simulate leaving the area
+      fireEvent.mouseLeave(firstChart);
+      vi.advanceTimersByTime(100);
+      expect(container.querySelectorAll('.recharts-active-dot')).toHaveLength(0);
+    },
+  );
 
   test('Render a line with clipDot option on the dot and expect attributes not to be NaN', () => {
     const { container } = render(

--- a/test/chart/Treemap.spec.tsx
+++ b/test/chart/Treemap.spec.tsx
@@ -96,11 +96,13 @@ describe('addToTreemapNodeIndex + treemapPayloadSearcher tandem', () => {
     index: 0,
     node: dummyRoot,
     dataKey: 'value',
+    nameKey: undefined,
+    nestedActiveTooltipIndex: undefined,
   });
   it('should return index for root node and then look it up', () => {
+    expect(computedRootNode.children[4]).toBeDefined();
     const activeIndex = addToTreemapNodeIndex(undefined, 4);
     expect(activeIndex).toEqual('children[4]');
-    expect(computedRootNode.children[4]).toBeDefined();
     expect(treemapPayloadSearcher(computedRootNode, activeIndex)).toBe(computedRootNode.children[4]);
   });
 

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -1519,7 +1519,6 @@ describe('<Legend />', () => {
       const { container } = render(
         <BarChart width={500} height={500} data={numericalData}>
           <Legend />
-          {/* @ts-expect-error TypeScript correctly points out that dataKey is required but I want a test for this anyway */}
           <Bar />
         </BarChart>,
       );

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -156,7 +156,7 @@ const ComposedChartTestCase: TooltipPayloadTestCase = {
   ),
   mouseHoverSelector: composedChartMouseHoverTooltipSelector,
   expectedTooltipTitle: '2',
-  expectedTooltipContent: ['uv : 300kg', 'My custom name : 1398$$$', 'amt : 2400'],
+  expectedTooltipContent: ['My custom name : 1398$$$', 'uv : 300kg', 'amt : 2400'],
 };
 
 const PieChartTestCase: TooltipPayloadTestCase = {

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -180,11 +180,24 @@ const FunnelChartTestCase: TooltipPayloadTestCase = {
   name: 'FunnelChart',
   Wrapper: ({ children }) => (
     <FunnelChart width={700} height={500}>
+      <Funnel isAnimationActive={false} dataKey="uv" data={PageData} />
+      {children}
+    </FunnelChart>
+  ),
+  mouseHoverSelector: funnelChartMouseHoverTooltipSelector,
+  expectedTooltipTitle: '',
+  expectedTooltipContent: ['Page A : 400'],
+};
+
+const FunnelChartWithNameTestCase: TooltipPayloadTestCase = {
+  name: 'FunnelChart with name',
+  Wrapper: ({ children }) => (
+    <FunnelChart width={700} height={500}>
       <Funnel
         isAnimationActive={false}
         dataKey="uv"
-        nameKey="name"
-        name="This is now definitely going to the tooltip title same as other charts"
+        nameKey="does not exist in the data"
+        name="This is now going to the tooltip title and it will override the 'name' property in data"
         data={PageData}
       />
       {children}
@@ -192,7 +205,28 @@ const FunnelChartTestCase: TooltipPayloadTestCase = {
   ),
   mouseHoverSelector: funnelChartMouseHoverTooltipSelector,
   expectedTooltipTitle: '',
-  expectedTooltipContent: ['This is now definitely going to the tooltip title same as other charts : 400'],
+  expectedTooltipContent: [
+    "This is now going to the tooltip title and it will override the 'name' property in data : 400",
+  ],
+};
+
+const FunnelChartTestCaseWithNameKey: TooltipPayloadTestCase = {
+  name: 'FunnelChart with nameKey',
+  Wrapper: ({ children }) => (
+    <FunnelChart width={700} height={500}>
+      <Funnel
+        isAnimationActive={false}
+        dataKey="uv"
+        nameKey="pv"
+        name="This is now ignored because the nameKey pulls the name out of the data"
+        data={PageData}
+      />
+      {children}
+    </FunnelChart>
+  ),
+  mouseHoverSelector: funnelChartMouseHoverTooltipSelector,
+  expectedTooltipTitle: '',
+  expectedTooltipContent: ['2400 : 400'],
 };
 
 const PieChartWithCustomNameKeyTestCase: TooltipPayloadTestCase = {
@@ -337,6 +371,8 @@ const testCases: ReadonlyArray<TooltipPayloadTestCase> = [
   LineChartVerticalTestCase,
   ComposedChartTestCase,
   FunnelChartTestCase,
+  FunnelChartWithNameTestCase,
+  FunnelChartTestCaseWithNameKey,
   PieChartTestCase,
   PieChartWithCustomNameKeyTestCase,
   RadarChartTestCase,

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -614,6 +614,8 @@ describe('Tooltip visibility', () => {
           <Line dataKey="uv" hide name="3" />
           <Scatter dataKey="uv" hide name="4" />
           <Line dataKey="uv" name="5" />
+          <XAxis type="number" dataKey="uv" name="stature" unit="cm" />
+          <YAxis type="number" dataKey="pv" name="weight" unit="kg" />
           <Tooltip
             includeHidden
             content={({ payload }) => {
@@ -630,7 +632,7 @@ describe('Tooltip visibility', () => {
       assertNotNull(chart);
       fireEvent.mouseOver(chart, { clientX: 200, clientY: 200 });
 
-      expect(tooltipPayload.map(({ name }) => name).join('')).toBe('12345');
+      expect(tooltipPayload.map(({ name }) => name).join('')).toBe('123statureweight5');
     });
 
     test('false - Should hide tooltip for hidden items', () => {

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -46,6 +46,7 @@ const exampleTooltipPayloadConfiguration1: TooltipPayloadConfiguration = {
     name: 'name is ignored in Scatter in recharts 2.x',
     color: 'color',
     dataKey: 'dataKey1',
+    nameKey: 'nameKey1',
   },
   dataDefinedOnItem: [
     [
@@ -81,6 +82,7 @@ const exampleTooltipPayloadConfiguration2: TooltipPayloadConfiguration = {
     name: 'name 2',
     color: 'color 2',
     dataKey: 'dataKey2',
+    nameKey: 'nameKey2',
   },
   dataDefinedOnItem: [
     [
@@ -238,6 +240,7 @@ describe('selectTooltipPayload', () => {
     const expectedEntry1: TooltipPayloadEntry = {
       payload: undefined,
       dataKey: undefined,
+      nameKey: undefined,
       value: undefined,
     };
     const tooltipSettings2: TooltipPayloadConfiguration = {
@@ -245,6 +248,7 @@ describe('selectTooltipPayload', () => {
         stroke: 'red',
         fill: 'green',
         dataKey: 'x',
+        nameKey: 'y',
         name: 'foo',
         unit: 'bar',
       },
@@ -254,8 +258,9 @@ describe('selectTooltipPayload', () => {
       ],
     };
     const expectedEntry2: TooltipPayloadEntry = {
-      name: 'foo',
+      name: 11,
       dataKey: 'x',
+      nameKey: 'y',
       stroke: 'red',
       fill: 'green',
       payload: { x: 10, y: 11 },
@@ -279,6 +284,7 @@ describe('selectTooltipPayload', () => {
         stroke: 'red',
         fill: 'green',
         dataKey: 'y',
+        nameKey: 'x',
         name: 'foo',
         unit: 'bar',
       },
@@ -294,8 +300,9 @@ describe('selectTooltipPayload', () => {
     store.dispatch(setActiveMouseOverItemIndex({ activeIndex: '0', activeDataKey: 'y' }));
 
     const expectedEntry: TooltipPayloadEntry = {
-      name: 'foo',
+      name: 1,
       dataKey: 'y',
+      nameKey: 'x',
       stroke: 'red',
       fill: 'green',
       payload: { x: 1, y: 2 },
@@ -313,6 +320,7 @@ describe('selectTooltipPayload', () => {
         stroke: 'red',
         fill: 'green',
         dataKey: 'y',
+        nameKey: 'x',
         name: 'foo',
       },
       dataDefinedOnItem: [
@@ -331,8 +339,9 @@ describe('selectTooltipPayload', () => {
     store.dispatch(setActiveMouseOverItemIndex({ activeIndex: '0', activeDataKey: 'y' }));
     store.dispatch(setDataStartEndIndexes({ startIndex: 1, endIndex: 10 }));
     const expectedEntry: TooltipPayloadEntry = {
-      name: 'foo',
+      name: 3,
       dataKey: 'y',
+      nameKey: 'x',
       stroke: 'red',
       fill: 'green',
       payload: { x: 3, y: 4 },
@@ -355,6 +364,8 @@ describe('selectTooltipPayload', () => {
     );
     const expectedEntry1: TooltipPayloadEntry = {
       name: 'stature',
+      color: undefined,
+      fill: undefined,
       unit: 'cm',
       value: 100,
       payload: {
@@ -363,9 +374,12 @@ describe('selectTooltipPayload', () => {
         z: 200,
       },
       dataKey: 'x',
+      nameKey: 'nameKey1',
     };
     const expectedEntry2: TooltipPayloadEntry = {
       name: 'weight',
+      color: undefined,
+      fill: undefined,
       unit: 'kg',
       value: 200,
       payload: {
@@ -374,6 +388,7 @@ describe('selectTooltipPayload', () => {
         z: 200,
       },
       dataKey: 'y',
+      nameKey: 'nameKey1',
     };
     const expected: ReadonlyArray<TooltipPayloadEntry> = [expectedEntry1, expectedEntry2];
     expect(actual).toEqual(expected);
@@ -381,7 +396,7 @@ describe('selectTooltipPayload', () => {
 
   it('should use dataKey from tooltipAxis, if item dataKey is undefined', () => {
     const tooltipPayloadConfiguration: TooltipPayloadConfiguration = {
-      settings: {},
+      settings: { nameKey: undefined },
       dataDefinedOnItem: [],
     };
     const chartDataState: ChartDataState = initialChartDataState;

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -752,7 +752,7 @@ describe('selectContainerScale', () => {
   it('should return scale as the ratio of DOMRect / offsetWidth', () => {
     /*
      * This is a little bit of a case of "trust me" because:
-     8 jsdom returns zeroes everywhere so that doesn't test anything
+     * jsdom returns zeroes everywhere so that doesn't test anything
      * and the browser spec is everything, so I went and tested it in Firefox version 126.0
      * In a browser devtools I select arbitrary element and run:
      *


### PR DESCRIPTION
## Description

Now that all the tooltip data processing is in one place, it's a bit annoying to make sure the behaviour stays same as in 2.x (as in, each chart is different). We have an opportunity to unify behaviour across charts and make that another 3.x breaking change, what do you think? Stuff like: what does `name` do, what does `nameKey` do, etc.

## Related Issue

https://github.com/recharts/recharts/issues/4549

## Motivation and Context

Trying to get all charts data to Redux.

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
