### PR TITLE
fix typo: lineChart to LineChart

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All development is done on the `master` branch. The current latest release and s
 </LineChart>
 ```
 
-All the components of Recharts are clearly separated. The lineChart is composed of x axis, tooltip, grid, and line items, and each of them is an independent React Component. The clear separation and composition of components is one of the principle Recharts follows.
+All the components of Recharts are clearly separated. The LineChart is composed of x axis, tooltip, grid, and line items, and each of them is an independent React Component. The clear separation and composition of components is one of the principle Recharts follows.
 
 ## Installation
 


### PR DESCRIPTION
## Description

Changed lineChart to LineChart in the examples section.

## Motivation and Context

A component name should be in PascalCase.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
