### PR TITLE
Fixing CartesianAxis ticks prop type

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -20,7 +20,7 @@ import {
 } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { getTicks } from './getTicks';
-import { AxisPropsNeededForTicksGenerator, ScaleForTicksGenerator } from '../util/ChartUtils';
+import { ScaleForTicksGenerator } from '../util/ChartUtils';
 
 /** The orientation of the axis in correspondence to the chart */
 export type Orientation = 'top' | 'bottom' | 'left' | 'right';
@@ -41,17 +41,16 @@ export interface CartesianAxisProps {
   viewBox?: CartesianViewBox;
   tick?: SVGProps<SVGTextElement> | ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | boolean;
   axisLine?: boolean | SVGProps<SVGLineElement>;
-  tickLine?: boolean | SVGProps<SVGLineElement>;
+  tickLine?: boolean | SVGProps<SVGElement>;
   mirror?: boolean;
   tickMargin?: number;
   hide?: boolean;
   label?: any;
 
   minTickGap?: number;
-  ticks?: ReadonlyArray<CartesianTickItem>;
+  cartesianTickItems?: ReadonlyArray<CartesianTickItem>;
   tickSize?: number;
   tickFormatter?: TickFormatter;
-  ticksGenerator?: (props?: AxisPropsNeededForTicksGenerator) => ReadonlyArray<CartesianTickItem>;
   interval?: AxisInterval;
   /** Angle in which ticks will be rendered. */
   angle?: number;
@@ -59,7 +58,7 @@ export interface CartesianAxisProps {
    * This is NOT SVG scale attribute;
    * this is Recharts scale, based on d3-scale.
    */
-  scale?: ScaleForTicksGenerator;
+  scale: ScaleForTicksGenerator;
 }
 
 interface IState {
@@ -78,7 +77,7 @@ export type Props = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>,
 export class CartesianAxis extends Component<Props, IState> {
   static displayName = 'CartesianAxis';
 
-  static defaultProps = {
+  static defaultProps: Partial<Props> = {
     x: 0,
     y: 0,
     width: 0,
@@ -87,7 +86,7 @@ export class CartesianAxis extends Component<Props, IState> {
     // The orientation of axis
     orientation: 'bottom',
     // The ticks
-    ticks: [] as CartesianAxisProps['ticks'],
+    cartesianTickItems: [] as CartesianAxisProps['cartesianTickItems'],
 
     stroke: '#666',
     tickLine: true,
@@ -334,26 +333,13 @@ export class CartesianAxis extends Component<Props, IState> {
   }
 
   render() {
-    const { axisLine, width, height, ticksGenerator, className, hide } = this.props;
+    const { axisLine, width, height, className, hide } = this.props;
 
     if (hide) {
       return null;
     }
 
-    const { ticks, ...noTicksProps } = this.props;
-    let finalTicks: ReadonlyArray<CartesianTickItem> = ticks;
-
-    if (isFunction(ticksGenerator)) {
-      /*
-       * ticksGenerator says it accepts different ticks type than this.props provide.
-       * Somehow this is not a problem in any charts because it just so happens that
-       * the ticksGenerator and props.ticks are never actually set at the same time:
-       * Either the generator is null, or the ticks are null, never both.
-       * So it kinda works.
-       */
-      // @ts-expect-error ticks type does not match
-      finalTicks = ticks && ticks.length > 0 ? ticksGenerator(this.props) : ticksGenerator(noTicksProps);
-    }
+    const { cartesianTickItems } = this.props;
 
     if (width <= 0 || height <= 0) {
       return null;
@@ -367,7 +353,7 @@ export class CartesianAxis extends Component<Props, IState> {
         }}
       >
         {axisLine && this.renderAxisLine()}
-        {this.renderTicks(finalTicks, this.state.fontSize, this.state.letterSpacing)}
+        {this.renderTicks(cartesianTickItems, this.state.fontSize, this.state.letterSpacing)}
         {Label.renderCallByParent(this.props)}
       </Layer>
     );

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import type { FunctionComponent, SVGProps } from 'react';
 import clsx from 'clsx';
-import { BaseAxisProps, AxisInterval, AxisTick } from '../util/types';
+import { BaseAxisProps, AxisInterval, AxisTick, CartesianTickItem } from '../util/types';
 import { useChartHeight, useChartWidth, useYAxisOrThrow } from '../context/chartLayoutContext';
 import { CartesianAxis } from './CartesianAxis';
 import { AxisPropsNeededForTicksGenerator, getTicksOfAxis } from '../util/ChartUtils';
@@ -36,21 +36,45 @@ interface YAxisProps extends BaseAxisProps {
 
 export type Props = Omit<SVGProps<SVGElement>, 'scale'> & YAxisProps;
 
-export const YAxis: FunctionComponent<Props> = ({ yAxisId }: Props) => {
+export const YAxis: FunctionComponent<Props> = (props: Props) => {
+  const { yAxisId, className } = props;
   const width = useChartWidth();
   const height = useChartHeight();
+  const axisType = 'yAxis';
+
   const axisOptions = useYAxisOrThrow(yAxisId);
   if (axisOptions == null) {
     return null;
   }
 
+  const tickGeneratorInput: AxisPropsNeededForTicksGenerator = {
+    axisType,
+    categoricalDomain: axisOptions.categoricalDomain,
+    duplicateDomain: axisOptions.duplicateDomain,
+    isCategorical: axisOptions.isCategorical,
+    niceTicks: axisOptions.niceTicks,
+    range: axisOptions.range,
+    realScaleType: axisOptions.realScaleType,
+    scale: axisOptions.scale,
+    tickCount: props.tickCount,
+    ticks: props.ticks,
+    type: props.type,
+  };
+  const cartesianTickItems: ReadonlyArray<CartesianTickItem> = getTicksOfAxis(tickGeneratorInput, true);
+
+  const { ref, dangerouslySetInnerHTML, ticks, ...allOtherProps } = props;
+
   return (
-    // @ts-expect-error the axisOptions type is not exactly what CartesianAxis is expecting.
     <CartesianAxis
-      {...axisOptions}
-      className={clsx(`recharts-${axisOptions.axisType} ${axisOptions.axisType}`, axisOptions.className)}
+      {...allOtherProps}
+      scale={axisOptions.scale}
+      x={axisOptions.x}
+      y={axisOptions.y}
+      width={axisOptions.width}
+      height={axisOptions.height}
+      className={clsx(`recharts-${axisType} ${axisType}`, className)}
       viewBox={{ x: 0, y: 0, width, height }}
-      ticksGenerator={(axis: AxisPropsNeededForTicksGenerator) => getTicksOfAxis(axis, true)}
+      cartesianTickItems={cartesianTickItems}
     />
   );
 };

--- a/src/cartesian/getTicks.ts
+++ b/src/cartesian/getTicks.ts
@@ -119,8 +119,15 @@ function getTicksStart(
   return result;
 }
 
+type GetTicksInput = Pick<
+  CartesianAxisProps,
+  'tick' | 'viewBox' | 'minTickGap' | 'orientation' | 'interval' | 'tickFormatter' | 'unit' | 'angle'
+> & {
+  ticks: ReadonlyArray<CartesianTickItem>;
+};
+
 export function getTicks(
-  props: CartesianAxisProps,
+  props: GetTicksInput,
   fontSize?: string,
   letterSpacing?: string,
 ): ReadonlyArray<CartesianTickItem> {

--- a/src/chart/types.ts
+++ b/src/chart/types.ts
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 import {
+  AxisTick,
   AxisType,
   BaseAxisProps,
   ChartCoordinate,
@@ -100,6 +101,14 @@ export type AxisPropsWithExtraComputedData = Omit<BaseAxisProps, 'scale'> & {
   mirror: boolean;
   reversed: boolean;
   scale: ScaleForTicksGenerator;
+  categoricalDomain?: ReadonlyArray<AxisTick>;
+  duplicateDomain?: ReadonlyArray<AxisTick>;
+  niceTicks?: ReadonlyArray<AxisTick>;
+  isCategorical: boolean;
+  range?: Array<number>;
+  realScaleType?: 'scaleBand' | 'band' | 'point' | 'linear';
+  x: number;
+  y: number;
 };
 
 export type XAxisWithExtraData = AxisPropsWithExtraComputedData & {

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -659,14 +659,14 @@ export type ScaleForTicksGenerator = {
 };
 
 export type AxisPropsNeededForTicksGenerator = {
-  duplicateDomain?: ReadonlyArray<any>;
+  duplicateDomain?: ReadonlyArray<AxisTick>;
   realScaleType?: 'scaleBand' | 'band' | 'point' | 'linear';
   scale: ScaleForTicksGenerator;
   axisType?: AxisType;
   ticks?: ReadonlyArray<AxisTick>;
   niceTicks?: ReadonlyArray<AxisTick>;
   isCategorical?: boolean;
-  categoricalDomain?: ReadonlyArray<any>;
+  categoricalDomain?: ReadonlyArray<AxisTick>;
   type?: 'number' | 'category';
   range?: Array<number>;
   tickCount?: number;

--- a/src/util/TickUtils.ts
+++ b/src/util/TickUtils.ts
@@ -41,6 +41,9 @@ export function isVisible(
   return sign * (tickPosition - (sign * size) / 2 - start) >= 0 && sign * (tickPosition + (sign * size) / 2 - end) <= 0;
 }
 
-export function getNumberIntervalTicks(ticks: ReadonlyArray<CartesianTickItem>, interval: number) {
+export function getNumberIntervalTicks(
+  ticks: ReadonlyArray<CartesianTickItem>,
+  interval: number,
+): ReadonlyArray<CartesianTickItem> {
   return getEveryNthWithCondition(ticks, interval + 1);
 }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1128,7 +1128,7 @@ export interface BaseAxisProps {
   /** The option for axisLine */
   axisLine?: boolean | SVGProps<SVGLineElement>;
   /** The option for tickLine */
-  tickLine?: boolean | SVGProps<SVGTextElement>;
+  tickLine?: boolean | SVGProps<SVGElement>;
   /** The size of tick line */
   tickSize?: number;
   /** The formatter function of tick */

--- a/test/cartesian/CartesianAxis.spec.tsx
+++ b/test/cartesian/CartesianAxis.spec.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { scaleLinear } from 'victory-vendor/d3-scale';
 import { Surface, CartesianAxis } from '../../src';
+import { CartesianTickItem } from '../../src/util/types';
 
 const CustomizeLabel = ({ x, y }: any) => (
   <text data-testid="customized-label" x={x} y={y}>
@@ -15,8 +17,10 @@ const CustomizedTick = ({ x, y }: any) => (
   </text>
 );
 
+const exampleScale = scaleLinear();
+
 describe('<CartesianAxis />', () => {
-  const ticks = [
+  const ticks: ReadonlyArray<CartesianTickItem> = [
     { value: 10, coordinate: 50 },
     { value: 1000, coordinate: 100 },
     { value: 20, coordinate: 150 },
@@ -33,8 +37,9 @@ describe('<CartesianAxis />', () => {
           width={400}
           height={50}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={ticks}
+          cartesianTickItems={ticks}
           label="test"
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -52,8 +57,9 @@ describe('<CartesianAxis />', () => {
           width={400}
           height={50}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={[]}
+          cartesianTickItems={[]}
           label="test"
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -70,9 +76,10 @@ describe('<CartesianAxis />', () => {
           width={400}
           height={50}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={ticks}
+          cartesianTickItems={ticks}
           label="test"
           interval="preserveStartEnd"
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -94,9 +101,10 @@ describe('<CartesianAxis />', () => {
           width={400}
           height={50}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={ticks}
+          cartesianTickItems={ticks}
           label="test"
           interval="preserveStartEnd"
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -115,9 +123,10 @@ describe('<CartesianAxis />', () => {
           width={400}
           height={50}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={ticks}
+          cartesianTickItems={ticks}
           label="test"
           interval="preserveStart"
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -134,8 +143,9 @@ describe('<CartesianAxis />', () => {
           width={400}
           height={50}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={ticks}
+          cartesianTickItems={ticks}
           label="top"
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -153,8 +163,9 @@ describe('<CartesianAxis />', () => {
           width={50}
           height={400}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={ticks}
+          cartesianTickItems={ticks}
           label="left"
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -172,8 +183,9 @@ describe('<CartesianAxis />', () => {
           width={50}
           height={400}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={ticks}
+          cartesianTickItems={ticks}
           label="right"
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -191,8 +203,9 @@ describe('<CartesianAxis />', () => {
           width={50}
           height={400}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={ticks}
+          cartesianTickItems={ticks}
           label={CustomizeLabel}
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -210,8 +223,9 @@ describe('<CartesianAxis />', () => {
           width={50}
           height={400}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={ticks}
+          cartesianTickItems={ticks}
           label={<CustomizeLabel />}
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -229,9 +243,10 @@ describe('<CartesianAxis />', () => {
           width={400}
           height={50}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={ticks}
+          cartesianTickItems={ticks}
           tick={<CustomizedTick />}
           interval={0}
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -248,9 +263,10 @@ describe('<CartesianAxis />', () => {
           width={400}
           height={50}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={ticks}
+          cartesianTickItems={ticks}
           tick={<CustomizedTick />}
           interval={0}
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -267,9 +283,10 @@ describe('<CartesianAxis />', () => {
           width={400}
           height={50}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
-          ticks={ticks}
+          cartesianTickItems={ticks}
           tick={CustomizedTick}
           interval={0}
+          scale={exampleScale}
         />
       </Surface>,
     );
@@ -287,6 +304,7 @@ describe('<CartesianAxis />', () => {
           height={50}
           viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
           tick={false}
+          scale={exampleScale}
         />
       </Surface>,
     );


### PR DESCRIPTION
## Description

individual axes now compute the ticks before passing the result down.

This is a breaking change since I renamed the `ticks` prop. I can undo this part - but I am more inclined to un-export the `CartesianAxis` component and offer only the trio of XAxis + YAxis + ZAxis instead.

## Related Issue

https://github.com/recharts/recharts/issues/4583

## Motivation and Context

Type safety

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
