### PR TITLE
test: add test that will break if Legend defaultProps change

### DIFF
--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -821,6 +821,24 @@ describe('<Legend />', () => {
         screen.getByText(/My Other Line Data/i);
       });
 
+      test('Legend defaults are read correctly', () => {
+        const { container } = render(
+          <LineChart width={500} height={500} data={categoricalData}>
+            <Legend />
+            <Line dataKey={row => row.value} name="My Line Data" />
+            <Line dataKey={row => row.color} name="My Other Line Data" />
+          </LineChart>,
+        );
+
+        const legendWrapper = container.getElementsByClassName('recharts-legend-wrapper')[0];
+        expect(legendWrapper).not.toHaveStyle({ width: 'auto' });
+        expect(legendWrapper).toHaveStyle({ height: 'auto' });
+        const legendItem = container.getElementsByClassName('legend-item-0')[0];
+        const surface = legendItem.getElementsByClassName('recharts-surface')[0];
+        expect(surface.getAttribute('height')).toBe('14');
+        expect(surface.getAttribute('width')).toBe('14');
+      });
+
       test(`Renders '' if sibling's dataKey is a function and name is not provided`, () => {
         // Warning should be logged. Spy on it so we can confirm it was called.
         const consoleWarn = vi.spyOn(console, 'warn');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Porting over a test written in 2.x  https://github.com/recharts/recharts/pull/4589 that will break if Legend defaultProps are read incorrectly as what happens when using R19 in the current state of 3.x

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
So we know we break rather than not

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
