### PR TITLE
Improve z axis test

### DIFF
--- a/test/cartesian/ZAxis.spec.tsx
+++ b/test/cartesian/ZAxis.spec.tsx
@@ -1,8 +1,24 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import { Surface, ZAxis } from '../../src';
+import userEvent from '@testing-library/user-event';
+import { expect } from 'vitest';
+import { CartesianGrid, Scatter, ScatterChart, Surface, Tooltip, XAxis, YAxis, ZAxis } from '../../src';
 
 describe('<ZAxis />', () => {
+  const data = [
+    {
+      name: 'Page A',
+      xAxis: 590,
+      zAxis: 800,
+      yAxis: 1000,
+    },
+    {
+      name: 'Page B',
+      xAxis: 490,
+      zAxis: 100,
+      yAxis: 1400,
+    },
+  ];
   it("Don't render anything", () => {
     render(
       <Surface width={500} height={500}>
@@ -13,5 +29,50 @@ describe('<ZAxis />', () => {
 
     expect(svg).toBeInTheDocument();
     expect(svg?.children).toHaveLength(2);
+  });
+
+  it('Renders Scatters symbols and tooltips with Z axis data', async () => {
+    const { container } = render(
+      <ScatterChart height={400} width={400}>
+        <XAxis dataKey="xAxis" type="number" />
+        <YAxis dataKey="yAxis" />
+        <ZAxis dataKey="zAxis" name="test name" range={[0, 2000]} unit="km" />
+        <CartesianGrid />
+        <Scatter data={data} name="pageData" />
+        <Tooltip />
+      </ScatterChart>,
+    );
+
+    const svg = document.querySelector('svg');
+    const gContainers = svg.querySelectorAll('.recharts-layer.recharts-scatter-symbol');
+
+    expect(gContainers).toHaveLength(data.length);
+
+    const firstShape = gContainers[0].querySelector('path');
+    const firstShapeName = firstShape.getAttribute('name');
+    expect(firstShapeName).toBe(data[0].name);
+
+    const secondShape = gContainers[1].querySelector('path');
+    const secondShapeName = secondShape.getAttribute('name');
+    expect(secondShapeName).toBe(data[1].name);
+
+    const firstShapeWidth = Number(firstShape.getAttribute('width'));
+    const secondShapeWidth = Number(secondShape.getAttribute('width'));
+
+    expect(firstShapeWidth).toBeGreaterThan(secondShapeWidth);
+
+    const tooltip = container.querySelector('.recharts-tooltip-wrapper');
+    expect(tooltip).not.toBeVisible();
+
+    await userEvent.hover(firstShape);
+    expect(tooltip).toBeVisible();
+    expect(tooltip).toHaveTextContent(`xAxis : ${data[0].xAxis}yAxis : ${data[0].yAxis}test name : ${data[0].zAxis}km`);
+
+    await userEvent.unhover(firstShape);
+    expect(tooltip).not.toBeVisible();
+
+    await userEvent.hover(secondShape);
+    expect(tooltip).toBeVisible();
+    expect(tooltip).toHaveTextContent(`xAxis : ${data[1].xAxis}yAxis : ${data[1].yAxis}test name : ${data[1].zAxis}km`);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added test verifying tooltip content, dots size enriched with z axis.
## Related Issue

[#4591](https://github.com/recharts/recharts/issues/4591
)<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Lack of test for ZAxis component
## How Has This Been Tested?

Test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Test

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
