### PR TITLE
Add ReferenceLine Props annotation

### DIFF
--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -193,7 +193,7 @@ function ReferenceLineImpl(props: Props) {
 }
 
 // eslint-disable-next-line react/prefer-stateless-function -- requires static defaultProps
-export class ReferenceLine extends React.Component {
+export class ReferenceLine extends React.Component<Props> {
   static displayName = 'ReferenceLine';
 
   static defaultProps = {


### PR DESCRIPTION
Fix for #4608 missing Props type annotation

## Description

Missing Props type annotation in ReferenceLine.tsx causing Typescript to reject documents props. 

## Related Issue

Fixes [#4608](https://github.com/recharts/recharts/issues/4608)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
