### PR TITLE
test(Bar): add to stacked bar test, fails in react 19

### DIFF
--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -100,6 +100,17 @@ describe('<BarChart />', () => {
       </BarChart>,
     );
 
+    const yAxis = container.querySelector('.recharts-yAxis');
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const tickValues = yAxis!.querySelectorAll('.recharts-cartesian-axis-tick-value');
+
+    const firstTick = tickValues[0].textContent;
+    const lastTick = tickValues[tickValues.length - 1].textContent;
+
+    expect(firstTick).toEqual('0');
+    expect(lastTick).toEqual('12000');
+
     expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(8);
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This test fails in react 19 because stackIds are no longer respected (defaultProps issue). Add to help find where the regression is

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4558

## Motivation and Context

<!--- Why is this change required? What problem does it solve? --

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
