### PR TITLE
Fix stacked bar default props 2x

### DIFF
--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -180,7 +180,10 @@ export const getMainColorOfGraphicItem = (item: ReactElement) => {
   const {
     type: { displayName },
   } = item as any; // TODO: check if displayName is valid.
-  const { stroke, fill } = item.props;
+  const defaultedProps = (item.type as any)?.defaultProps
+    ? { ...(item.type as any).defaultProps, ...item.props }
+    : item.props;
+  const { stroke, fill } = defaultedProps;
   let result;
 
   switch (displayName) {
@@ -996,13 +999,16 @@ export const getStackGroupsByAxisId = (
   const parentStackGroupsInitialValue: Record<AxisId, ParentStackGroup> = {};
 
   const stackGroups: Record<AxisId, ParentStackGroup> = items.reduce((result, item) => {
-    const { stackId, hide } = item.props;
+    const defaultedProps = (item.type as any)?.defaultProps
+      ? { ...(item.type as any).defaultProps, ...item.props }
+      : item.props;
+    const { stackId, hide } = defaultedProps;
 
     if (hide) {
       return result;
     }
 
-    const axisId: AxisId = item.props[numericAxisId];
+    const axisId: AxisId = defaultedProps[numericAxisId];
     const parentGroup: ParentStackGroup = result[axisId] || { hasStack: false, stackGroups: {} };
 
     if (isNumOrStr(stackId)) {
@@ -1186,7 +1192,10 @@ export const getStackedDataOfItem = <StackedData>(
   item: ReactElement,
   stackGroups: Record<StackId, GenericChildStackGroup<StackedData>>,
 ): StackedData | null => {
-  const { stackId } = item.props;
+  const defaultedProps = (item.type as any)?.defaultProps
+    ? { ...(item.type as any).defaultProps, ...item.props }
+    : item.props;
+  const { stackId } = defaultedProps;
 
   if (isNumOrStr(stackId)) {
     const group = stackGroups[stackId];
@@ -1338,7 +1347,10 @@ export const parseDomainOfCategoryAxis = <T>(
 };
 
 export const getTooltipItem = (graphicalItem: ReactElement, payload: any) => {
-  const { dataKey, name, unit, formatter, tooltipType, chartType, hide } = graphicalItem.props;
+  const defaultedProps = (graphicalItem.type as any).defaultProps
+    ? { ...(graphicalItem.type as any).defaultProps, ...graphicalItem.props }
+    : graphicalItem.props;
+  const { dataKey, name, unit, formatter, tooltipType, chartType, hide } = defaultedProps;
 
   return {
     ...filterProps(graphicalItem, false),

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -100,6 +100,17 @@ describe('<BarChart />', () => {
       </BarChart>,
     );
 
+    const yAxis = container.querySelector('.recharts-yAxis');
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const tickValues = yAxis!.querySelectorAll('.recharts-cartesian-axis-tick-value');
+
+    const firstTick = tickValues[0].textContent;
+    const lastTick = tickValues[tickValues.length - 1].textContent;
+
+    expect(firstTick).toEqual('0');
+    expect(lastTick).toEqual('12000');
+
     expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(8);
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Safely re-add defaultProps to places where props are being read directly from graphical items to fix issues with current alpha release

Fixes stacked bars and stacked areas. maybe more

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4558

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
support react 19 in 2.x. Lots of defaultProps issues

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See tests added. These now pass in R19 and 18

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
