### PR TITLE
Add data selectors, use them in the domain calculator

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -60,6 +60,7 @@
   "es6/state/layoutSlice.js",
   "es6/state/hooks.js",
   "es6/state/graphicalItemsSlice.js",
+  "es6/state/dataSelectors.js",
   "es6/state/chartDataSlice.js",
   "es6/state/axisSlice.js",
   "es6/state/axisSelectors.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -60,6 +60,7 @@
   "lib/state/layoutSlice.js",
   "lib/state/hooks.js",
   "lib/state/graphicalItemsSlice.js",
+  "lib/state/dataSelectors.js",
   "lib/state/chartDataSlice.js",
   "lib/state/axisSlice.js",
   "lib/state/axisSelectors.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -60,6 +60,7 @@
   "types/state/layoutSlice.d.ts",
   "types/state/hooks.d.ts",
   "types/state/graphicalItemsSlice.d.ts",
+  "types/state/dataSelectors.d.ts",
   "types/state/chartDataSlice.d.ts",
   "types/state/axisSlice.d.ts",
   "types/state/axisSelectors.d.ts",

--- a/src/state/axisSelectors.ts
+++ b/src/state/axisSelectors.ts
@@ -1,13 +1,13 @@
 import { createSelector } from '@reduxjs/toolkit';
-import isNil from 'lodash/isNil';
 import { selectChartLayout } from '../context/chartLayoutContext';
-import { ParsedScaleReturn, getValueByDataKey, parseScale } from '../util/ChartUtils';
+import { ParsedScaleReturn, parseScale } from '../util/ChartUtils';
 import { AxisType, CategoricalDomain, LayoutType, NumberDomain } from '../util/types';
 import { AxisId, AxisSettings } from './axisMapSlice';
-import { selectAllGraphicalItemsData, selectChartDataWithIndexes, selectChartName } from './selectors';
+import { selectChartName } from './selectors';
 import { RechartsRootState } from './store';
+import { selectAllDataSquished } from './dataSelectors';
 
-export const selectAxisSettings = (state: RechartsRootState, axisType: AxisType, axisId: string): AxisSettings =>
+export const selectAxisSettings = (state: RechartsRootState, axisType: AxisType, axisId: AxisId): AxisSettings =>
   state.axisMap[axisType][axisId];
 
 export const selectHasBar = (state: RechartsRootState): boolean => state.graphicalItems.countOfBars > 0;
@@ -19,15 +19,6 @@ const unknownScale: ParsedScaleReturn = {
 
 export function getDefaultDomainByAxisType(axisType: 'number' | string) {
   return axisType === 'number' ? [0, 'auto'] : undefined;
-}
-
-function nilPredicate(filterNil: boolean) {
-  return function predicate<T>(item: T): boolean {
-    if (filterNil) {
-      return !isNil(item);
-    }
-    return true;
-  };
 }
 
 function makeUniq<T>(arr: ReadonlyArray<T>, allowDuplicates: boolean): ReadonlyArray<T> {
@@ -44,37 +35,27 @@ function onlyAllowNumbersAndStringsAndDates<T>(item: T): string | number | Date 
   return '';
 }
 
-export const selectDomainOfDataByKey: (
+export const selectDomainOfDataByKey = (
   state: RechartsRootState,
   axisType: AxisType,
   axisId: AxisId,
-) => NumberDomain | CategoricalDomain = createSelector(
-  selectChartDataWithIndexes,
-  selectAllGraphicalItemsData,
-  selectAxisSettings,
-  (chartData, graphicalItemsData, axisSettings: AxisSettings): NumberDomain | CategoricalDomain => {
-    if (axisSettings == null) {
-      return undefined;
-    }
-    // Array.prototype.flat has good support everywhere except IE11: https://caniuse.com/?search=flat
-    const allDataSquished = graphicalItemsData
-      .flat(1)
-      .concat(chartData.chartData)
-      .map(entry => getValueByDataKey(entry, axisSettings.dataKey));
+): NumberDomain | CategoricalDomain => {
+  const axisSettings = selectAxisSettings(state, axisType, axisId);
+  if (axisSettings == null) {
+    return undefined;
+  }
+  const allDataSquished = selectAllDataSquished(state, axisSettings.dataKey);
 
-    if (axisSettings.type === 'number') {
-      const onlyNumbers = allDataSquished
-        .filter(v => typeof v === 'number' || typeof v === 'string')
-        .map(Number)
-        .filter(n => Number.isNaN(n) === false);
-      return [Math.min(...onlyNumbers), Math.max(...onlyNumbers)];
-    }
+  if (axisSettings.type === 'number') {
+    const onlyNumbers = allDataSquished
+      .filter(v => typeof v === 'number' || typeof v === 'string')
+      .map(Number)
+      .filter(n => Number.isNaN(n) === false);
+    return [Math.min(...onlyNumbers), Math.max(...onlyNumbers)];
+  }
 
-    return makeUniq(allDataSquished.filter(nilPredicate(true)), axisSettings.allowDuplicatedCategory).map(
-      onlyAllowNumbersAndStringsAndDates,
-    );
-  },
-);
+  return makeUniq(allDataSquished.map(onlyAllowNumbersAndStringsAndDates), axisSettings.allowDuplicatedCategory);
+};
 
 export const selectAxisScale: (state: RechartsRootState, axisType: AxisType, axisId: string) => ParsedScaleReturn =
   createSelector(

--- a/src/state/dataSelectors.ts
+++ b/src/state/dataSelectors.ts
@@ -1,0 +1,44 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { RechartsRootState } from './store';
+import { ChartData, ChartDataState } from './chartDataSlice';
+import { DataKey } from '../util/types';
+import { getValueByDataKey } from '../util/ChartUtils';
+
+/**
+ * This is a "cheap" selector - it returns the data but doesn't iterate them, so it is not sensitive on the array length.
+ * @param state RechartsRootState
+ * @returns data defined on the chart root element, such as BarChart or ScatterChart
+ */
+export const selectChartDataWithIndexes = (state: RechartsRootState): ChartDataState => state.chartData;
+
+/**
+ * This is a "cheap" selector - it returns the data but doesn't iterate them, so it is not sensitive on the array length.
+ * @param state RechartsRootState
+ * @returns data defined on the chart graphical items, such as Line or Scatter or Pie
+ */
+export const selectAllGraphicalItemsData: (state: RechartsRootState) => ReadonlyArray<ChartData> = (
+  state: RechartsRootState,
+) => state.graphicalItems.graphicalItemData;
+
+/**
+ * This selector will return all data there is in the chart: graphical items, chart root, all together
+ * and all processed by a single DataKey.
+ * Useful for figuring out an axis domain (because that needs to know of everything),
+ * not useful for rendering individual graphical elements (because they need to know which data is theirs and which is not).
+ *
+ * This function will discard the original indexes, so it is also not useful for anything that depends on ordering.
+ *
+ * This is an expensive selector - it will iterate all data and compute their value using the provided dataKey.
+ */
+export const selectAllDataSquished: (state: RechartsRootState, dataKey: DataKey<any>) => ChartData | undefined =
+  createSelector(
+    selectAllGraphicalItemsData,
+    selectChartDataWithIndexes,
+    (_: RechartsRootState, dataKey: DataKey<any>) => dataKey,
+    (graphicalItemsData, { chartData = [] }, dataKey) => {
+      return graphicalItemsData
+        .flat(1)
+        .concat(chartData)
+        .map(entry => getValueByDataKey(entry, dataKey));
+    },
+  );

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -20,7 +20,7 @@ import {
   getValueByDataKey,
   inRange,
 } from '../util/ChartUtils';
-import { ChartData, ChartDataState } from './chartDataSlice';
+import { ChartDataState } from './chartDataSlice';
 import { selectTooltipAxis } from '../context/useTooltipAxis';
 import { BaseAxisProps, ChartOffset, DataKey, LayoutType, TickItem, TooltipEventType } from '../util/types';
 import { findEntryInArray } from '../util/DataUtils';
@@ -36,6 +36,7 @@ import {
   selectYAxisMap,
 } from '../context/chartLayoutContext';
 import { ChartPointer, MousePointer } from '../chart/generateCategoricalChart';
+import { selectChartDataWithIndexes } from './dataSelectors';
 
 export const selectChartName = (state: RechartsRootState) => state.options.chartName;
 
@@ -70,7 +71,6 @@ function getSliced<T>(
 }
 
 export const selectTooltipState = (state: RechartsRootState) => state.tooltip;
-export const selectChartDataWithIndexes = (state: RechartsRootState) => state.chartData;
 
 const selectTooltipTicks = createSelector(selectTooltipAxis, (tooltipAxis: AxisPropsNeededForTicksGenerator) =>
   getTicksOfAxis(tooltipAxis, false, true),
@@ -330,7 +330,3 @@ export const selectActiveIndexFromMousePointer: (state: RechartsRootState, mouse
     selectChartOffset,
     combineActiveIndex,
   );
-
-export const selectAllGraphicalItemsData: (state: RechartsRootState) => ReadonlyArray<ChartData> = (
-  state: RechartsRootState,
-) => state.graphicalItems.graphicalItemData;

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -40,6 +40,7 @@ import { TooltipEntrySettings, TooltipPayloadEntry } from '../state/tooltipSlice
 import { getLegendProps } from './getLegendProps';
 import { getNiceTickValues, getTickValuesFixedDomain } from './scale';
 import {
+  AxisDomainType,
   AxisTick,
   AxisType,
   BaseAxisProps,
@@ -89,7 +90,7 @@ export function getValueByDataKey<T>(obj: T, dataKey: DataKey<T>, defaultValue?:
 export function getDomainOfDataByKey<T>(
   data: Array<T>,
   key: DataKey<T>,
-  type: BaseAxisProps['type'],
+  type: AxisDomainType,
   filterNil?: boolean,
 ): NumberDomain | CategoricalDomain {
   const flattenData: unknown[] = flatMap(data, (entry: T): unknown => getValueByDataKey(entry, key));
@@ -674,6 +675,9 @@ export type AxisPropsNeededForTicksGenerator = {
   isCategorical?: boolean;
   categoricalDomain?: ReadonlyArray<AxisTick>;
   type?: 'number' | 'category';
+  /**
+   * The range appears to be only used in Angle Axis - needs further investigation
+   */
   range?: Array<number>;
   tickCount?: number;
 };
@@ -1295,6 +1299,13 @@ export const getDomainOfStackGroups = (
 export const MIN_VALUE_REG = /^dataMin[\s]*-[\s]*([0-9]+([.]{1}[0-9]+){0,1})$/;
 export const MAX_VALUE_REG = /^dataMax[\s]*\+[\s]*([0-9]+([.]{1}[0-9]+){0,1})$/;
 
+/**
+ * @deprecated instead use `parseNumericalUserDomain`
+ * @param specifiedDomain do not use
+ * @param dataDomain do not use
+ * @param allowDataOverflow do not use
+ * @returns do not use
+ */
 export const parseSpecifiedDomain = (
   specifiedDomain: /* AxisDomain */ any,
   dataDomain: any,

--- a/src/util/DataUtils.ts
+++ b/src/util/DataUtils.ts
@@ -75,7 +75,7 @@ export const getAnyElementOfObject = (obj: any) => {
   return null;
 };
 
-export const hasDuplicate = (ary: Array<any>) => {
+export const hasDuplicate = (ary: ReadonlyArray<unknown>) => {
   if (!Array.isArray(ary)) {
     return false;
   }

--- a/src/util/isDomainSpecifiedByUser.ts
+++ b/src/util/isDomainSpecifiedByUser.ts
@@ -4,6 +4,8 @@ import { getNiceTickValues } from './scale';
 import { AxisDomain, AxisDomainType, NumberDomain } from './types';
 
 /**
+ * @deprecated instead use `numericalDomainSpecifiedWithoutRequiringData`
+ *
  * Takes a domain and user props to determine whether he provided the domain via props or if we need to calculate it.
  * @param   {AxisDomain}  domain              The potential domain from props
  * @param   {Boolean}     allowDataOverflow   from props

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1111,7 +1111,7 @@ export type AxisDomain =
  */
 export type NumberDomain = [min: number, max: number];
 
-export type CategoricalDomain = (number | string | Date)[];
+export type CategoricalDomain = ReadonlyArray<number | string | Date>;
 
 /** The props definition of base axis */
 export interface BaseAxisProps {

--- a/test/state/dataSelectors.spec.tsx
+++ b/test/state/dataSelectors.spec.tsx
@@ -1,0 +1,326 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useAppSelector } from '../../src/state/hooks';
+import {
+  selectAllDataSquished,
+  selectAllGraphicalItemsData,
+  selectChartDataWithIndexes,
+} from '../../src/state/dataSelectors';
+import { createRechartsStore } from '../../src/state/store';
+import { Area, BarChart, Brush, ComposedChart, Customized, Line, LineChart, Pie, PieChart, Scatter } from '../../src';
+import { PageData } from '../_data';
+import { ChartDataState } from '../../src/state/chartDataSlice';
+import { pageData } from '../../storybook/stories/data';
+import { generateMockData } from '../helper/generateMockData';
+
+describe('selectChartDataWithIndexes', () => {
+  it('should return undefined when called outside of Redux context', () => {
+    expect.assertions(1);
+    const Comp = (): null => {
+      const payload = useAppSelector(selectChartDataWithIndexes);
+      expect(payload).toBe(undefined);
+      return null;
+    };
+    render(<Comp />);
+  });
+
+  it('should return undefined for initial state', () => {
+    const store = createRechartsStore();
+    const expected: ChartDataState = { chartData: undefined, dataEndIndex: 0, dataStartIndex: 0 };
+    expect(selectChartDataWithIndexes(store.getState())).toEqual(expected);
+  });
+
+  it('should return undefined in an empty chart', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const tooltipData = useAppSelector(selectChartDataWithIndexes);
+      spy(tooltipData);
+      return null;
+    };
+    render(
+      <BarChart width={100} height={100}>
+        <Customized component={Comp} />
+      </BarChart>,
+    );
+    expect(spy).toHaveBeenCalledTimes(2);
+    const expected: ChartDataState = { chartData: undefined, dataEndIndex: 0, dataStartIndex: 0 };
+    expect(spy).toHaveBeenLastCalledWith(expected);
+  });
+
+  it('should return none of the data defined on graphical items', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const tooltipData = useAppSelector(selectChartDataWithIndexes);
+      spy(tooltipData);
+      return null;
+    };
+    render(
+      <ComposedChart data={PageData} width={100} height={100}>
+        <Area dataKey="" data={[1, 2, 3]} />
+        <Area dataKey="" data={[10, 20, 30]} />
+        <Line data={[4, 5, 6]} />
+        <Line data={[40, 50, 60]} />
+        <Scatter data={[7, 8, 9]} />
+        <Scatter data={[70, 80, 90]} />
+        <Customized component={Comp} />
+      </ComposedChart>,
+    );
+    const expected: ChartDataState = { chartData: undefined, dataEndIndex: 0, dataStartIndex: 0 };
+    expect(spy).toHaveBeenCalledWith(expected);
+  });
+
+  it('should return all data defined on the root chart element, and set default endIndex based on the data length', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const tooltipData = useAppSelector(selectChartDataWithIndexes);
+      spy(tooltipData);
+      return null;
+    };
+    render(
+      <BarChart data={PageData} width={100} height={100}>
+        <Customized component={Comp} />
+      </BarChart>,
+    );
+    expect(pageData.length).toBeGreaterThan(1);
+    const expected: ChartDataState = { chartData: PageData, dataEndIndex: PageData.length - 1, dataStartIndex: 0 };
+    expect(spy).toHaveBeenLastCalledWith(expected);
+  });
+
+  it('should return indexes from Brush element', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const tooltipData = useAppSelector(selectChartDataWithIndexes);
+      spy(tooltipData);
+      return null;
+    };
+    render(
+      <BarChart data={PageData} width={100} height={100}>
+        <Brush startIndex={3} endIndex={4} />
+        <Customized component={Comp} />
+      </BarChart>,
+    );
+    const expected: ChartDataState = { chartData: PageData, dataEndIndex: 4, dataStartIndex: 3 };
+    expect(spy).toHaveBeenLastCalledWith(expected);
+  });
+});
+
+describe('selectAllGraphicalItemsData', () => {
+  it('should return undefined when called outside of Redux context', () => {
+    expect.assertions(1);
+    const Comp = (): null => {
+      const payload = useAppSelector(selectAllGraphicalItemsData);
+      expect(payload).toBe(undefined);
+      return null;
+    };
+    render(<Comp />);
+  });
+
+  it('should return empty array for initial state', () => {
+    const store = createRechartsStore();
+    expect(selectAllGraphicalItemsData(store.getState())).toEqual([]);
+  });
+
+  it('should return empty array in an empty chart', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const tooltipData = useAppSelector(selectAllGraphicalItemsData);
+      spy(tooltipData);
+      return null;
+    };
+    render(
+      <BarChart data={PageData} width={100} height={100}>
+        <Customized component={Comp} />
+      </BarChart>,
+    );
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith([]);
+  });
+
+  it('should return all tooltip payloads defined on graphical items', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const tooltipData = useAppSelector(selectAllGraphicalItemsData);
+      spy(tooltipData);
+      return null;
+    };
+    render(
+      <ComposedChart data={PageData} width={100} height={100}>
+        <Area dataKey="" data={[1, 2, 3]} />
+        <Area dataKey="" data={[10, 20, 30]} />
+        <Line data={[4, 5, 6]} />
+        <Line data={[40, 50, 60]} />
+        <Scatter data={[7, 8, 9]} />
+        <Scatter data={[70, 80, 90]} />
+        <Customized component={Comp} />
+      </ComposedChart>,
+    );
+    // as opposed to the tooltip data selector - this one stores all original data without transformation.
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        [1, 2, 3],
+        [10, 20, 30],
+        [4, 5, 6],
+        [40, 50, 60],
+        [7, 8, 9],
+        [70, 80, 90],
+      ]),
+    );
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return nothing for graphical items that do not have any explicit data prop on them', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const tooltipData = useAppSelector(selectAllGraphicalItemsData);
+      spy(tooltipData);
+      return null;
+    };
+    render(
+      <ComposedChart data={PageData} width={100} height={100}>
+        <Area dataKey="" />
+        <Area dataKey="" data={[10, 20, 30]} />
+        <Line />
+        <Line data={[40, 50, 60]} />
+        <Scatter />
+        <Scatter data={[70, 80, 90]} />
+        <Customized component={Comp} />
+      </ComposedChart>,
+    );
+    // Scatter - surprises again - and provides empty array instead of proper undefined like the other elements!
+    expect(spy).toHaveBeenLastCalledWith([undefined, [10, 20, 30], undefined, [40, 50, 60], [], [70, 80, 90]]);
+  });
+
+  it('should return all data defined on Pies', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const tooltipData = useAppSelector(selectAllGraphicalItemsData);
+      spy(tooltipData);
+      return null;
+    };
+    render(
+      <PieChart width={100} height={100}>
+        <Customized component={Comp} />
+        <Pie data={[{ x: 1 }, { x: 2 }, { x: 3 }]} dataKey="x" />
+        <Pie data={[{ y: 10 }, { y: 20 }, { y: 30 }]} dataKey="y" />
+      </PieChart>,
+    );
+    /*
+     * okay Pie surprises again - it adds ton of extra other properties to the original array
+     * and then it pretends it was there from the start.
+     * Well in this test let's pretend that's not happening and assume it provides the original array instead.
+     */
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        [expect.objectContaining({ x: 1 }), expect.objectContaining({ x: 2 }), expect.objectContaining({ x: 3 })],
+        [expect.objectContaining({ y: 10 }), expect.objectContaining({ y: 20 }), expect.objectContaining({ y: 30 })],
+      ]),
+    );
+  });
+});
+
+describe('selectAllDataSquished', () => {
+  const mockData = generateMockData(10, 982347);
+  const data1 = mockData.slice(0, 5);
+  const data2 = mockData.slice(5);
+  it('should return undefined when called outside of Redux context', () => {
+    expect.assertions(1);
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectAllDataSquished(state, 'x'));
+      expect(result).toBe(undefined);
+      return null;
+    };
+    render(<Comp />);
+  });
+
+  it('should return empty array for initial state', () => {
+    const store = createRechartsStore();
+    expect(selectAllDataSquished(store.getState(), 'x')).toEqual([]);
+  });
+
+  it('should return empty array in an empty chart', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectAllDataSquished(state, 'x'));
+      spy(result);
+      return null;
+    };
+    render(
+      <BarChart width={100} height={100}>
+        <Customized component={Comp} />
+      </BarChart>,
+    );
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith([]);
+  });
+
+  it('should return data defined in all graphical items based on the input dataKey', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectAllDataSquished(state, 'x'));
+      spy(result);
+      return null;
+    };
+    render(
+      <LineChart width={100} height={100}>
+        <Line data={data1} />
+        <Line data={data2} />
+        <Customized component={Comp} />
+      </LineChart>,
+    );
+    expect(spy).toHaveBeenLastCalledWith([211, 245, 266, 140, 131, 280, 294, 239, 293, 244]);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return different data with different dataKey', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectAllDataSquished(state, 'y'));
+      spy(result);
+      return null;
+    };
+    render(
+      <LineChart width={100} height={100}>
+        <Line data={data1} />
+        <Line data={data2} />
+        <Customized component={Comp} />
+      </LineChart>,
+    );
+    expect(spy).toHaveBeenLastCalledWith([481, 672, 721, 446, 598, 774, 687, 762, 439, 569]);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return data defined in the chart root, with one undefined from the empty Line', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectAllDataSquished(state, 'x'));
+      spy(result);
+      return null;
+    };
+    render(
+      <LineChart data={data1} width={100} height={100}>
+        <Line />
+        <Customized component={Comp} />
+      </LineChart>,
+    );
+    expect(spy).toHaveBeenLastCalledWith([undefined, 211, 245, 266, 140, 131]);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return array full of undefined when the dataKey does not match anything in the data', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectAllDataSquished(state, 'invalid datakey'));
+      spy(result);
+      return null;
+    };
+    render(
+      <LineChart data={data1} width={100} height={100}>
+        <Line />
+        <Customized component={Comp} />
+      </LineChart>,
+    );
+    expect(spy).toHaveBeenLastCalledWith([undefined, undefined, undefined, undefined, undefined, undefined]);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { describe, it, test, expect, beforeEach, vi } from 'vitest';
+import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { Store } from '@reduxjs/toolkit';
 import {
   combineTooltipPayload,
   selectActiveIndex,
   selectActiveIndexFromMousePointer,
-  selectAllGraphicalItemsData,
   selectContainerScale,
   selectIsTooltipActive,
   selectRootContainerDomRect,
@@ -1151,119 +1150,5 @@ describe('selectTooltipState.tooltipItemPayloads', () => {
         ],
       ],
     ]);
-  });
-});
-
-describe('selectAllGraphicalItemsData', () => {
-  it('should return undefined when called outside of Redux context', () => {
-    expect.assertions(1);
-    const Comp = (): null => {
-      const payload = useAppSelector(selectAllGraphicalItemsData);
-      expect(payload).toBe(undefined);
-      return null;
-    };
-    render(<Comp />);
-  });
-
-  it('should return empty array for initial state', () => {
-    const store = createRechartsStore();
-    expect(selectAllGraphicalItemsData(store.getState())).toEqual([]);
-  });
-
-  it('should return empty array in an empty chart', () => {
-    const spy = vi.fn();
-    const Comp = (): null => {
-      const tooltipData = useAppSelector(selectAllGraphicalItemsData);
-      spy(tooltipData);
-      return null;
-    };
-    render(
-      <BarChart data={PageData} width={100} height={100}>
-        <Customized component={Comp} />
-      </BarChart>,
-    );
-    expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy).toHaveBeenLastCalledWith([]);
-  });
-
-  it('should return all tooltip payloads defined on graphical items', () => {
-    const spy = vi.fn();
-    const Comp = (): null => {
-      const tooltipData = useAppSelector(selectAllGraphicalItemsData);
-      spy(tooltipData);
-      return null;
-    };
-    render(
-      <ComposedChart data={PageData} width={100} height={100}>
-        <Area dataKey="" data={[1, 2, 3]} />
-        <Area dataKey="" data={[10, 20, 30]} />
-        <Line data={[4, 5, 6]} />
-        <Line data={[40, 50, 60]} />
-        <Scatter data={[7, 8, 9]} />
-        <Scatter data={[70, 80, 90]} />
-        <Customized component={Comp} />
-      </ComposedChart>,
-    );
-    // as opposed to the tooltip data selector - this one stores all original data without transformation.
-    expect(spy).toHaveBeenLastCalledWith(
-      expect.arrayContaining([
-        [1, 2, 3],
-        [10, 20, 30],
-        [4, 5, 6],
-        [40, 50, 60],
-        [7, 8, 9],
-        [70, 80, 90],
-      ]),
-    );
-    expect(spy).toHaveBeenCalledTimes(3);
-  });
-
-  it('should return undefined for graphical items that do not have any explicit data prop on them', () => {
-    const spy = vi.fn();
-    const Comp = (): null => {
-      const tooltipData = useAppSelector(selectAllGraphicalItemsData);
-      spy(tooltipData);
-      return null;
-    };
-    render(
-      <ComposedChart data={PageData} width={100} height={100}>
-        <Area dataKey="" />
-        <Area dataKey="" data={[10, 20, 30]} />
-        <Line />
-        <Line data={[40, 50, 60]} />
-        <Scatter />
-        <Scatter data={[70, 80, 90]} />
-        <Customized component={Comp} />
-      </ComposedChart>,
-    );
-    // Scatter - surprises again - and provides empty array instead of proper undefined like the other elements!
-    expect(spy).toHaveBeenLastCalledWith([undefined, [10, 20, 30], undefined, [40, 50, 60], [], [70, 80, 90]]);
-  });
-
-  it('should return all data defined on Pies', () => {
-    const spy = vi.fn();
-    const Comp = (): null => {
-      const tooltipData = useAppSelector(selectAllGraphicalItemsData);
-      spy(tooltipData);
-      return null;
-    };
-    render(
-      <PieChart width={100} height={100}>
-        <Customized component={Comp} />
-        <Pie data={[{ x: 1 }, { x: 2 }, { x: 3 }]} dataKey="x" />
-        <Pie data={[{ y: 10 }, { y: 20 }, { y: 30 }]} dataKey="y" />
-      </PieChart>,
-    );
-    /*
-     * okay Pie surprises again - it adds ton of extra other properties to the original array
-     * and then it pretends it was there from the start.
-     * Well in this test let's pretend that's not happening and assume it provides the original array instead.
-     */
-    expect(spy).toHaveBeenLastCalledWith(
-      expect.arrayContaining([
-        [expect.objectContaining({ x: 1 }), expect.objectContaining({ x: 2 }), expect.objectContaining({ x: 3 })],
-        [expect.objectContaining({ y: 10 }), expect.objectContaining({ y: 20 }), expect.objectContaining({ y: 30 })],
-      ]),
-    );
   });
 });


### PR DESCRIPTION
## Description

Getting closer to replacing XAxis data with redux store

## Related Issue

https://github.com/recharts/recharts/issues/4583

## Motivation and Context

No DOM access

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
