### PR TITLE
Move Tooltip state redux

### DIFF
--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -18,7 +18,7 @@ import { Global } from '../util/Global';
 import { findChildByType, validateWidthHeight, filterProps } from '../util/ReactUtils';
 import { AnimationDuration, AnimationTiming, DataKey } from '../util/types';
 import { ViewBoxContext } from '../context/chartLayoutContext';
-import { TooltipContextProvider, TooltipContextValue } from '../context/tooltipContext';
+import { SetTooltipInfo, TooltipContextValue } from '../context/tooltipContext';
 import { CursorPortalContext, TooltipPortalContext } from '../context/tooltipPortalContext';
 import { RechartsWrapper } from './RechartsWrapper';
 import {
@@ -868,6 +868,7 @@ export class Treemap extends PureComponent<Props, State> {
     const { width, height, className, style, children, type, ...others } = this.props;
     const attrs = filterProps(others, false);
     const viewBox = { x: 0, y: 0, width, height };
+    const ttContext = this.getTooltipContext();
 
     return (
       <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={this.props.className ?? 'Treemap'}>
@@ -878,33 +879,36 @@ export class Treemap extends PureComponent<Props, State> {
               args={{ props: this.props, currentRoot: this.state.currentRoot }}
             />
             <ViewBoxContext.Provider value={viewBox}>
-              <TooltipContextProvider value={this.getTooltipContext()}>
-                <RechartsWrapper
-                  className={className}
-                  style={style}
-                  width={width}
-                  height={height}
-                  ref={(node: HTMLDivElement) => {
-                    if (this.state.tooltipPortal == null) {
-                      this.setState({ tooltipPortal: node });
-                    }
-                  }}
-                >
-                  <Surface {...attrs} width={width} height={type === 'nest' ? height - 30 : height}>
-                    <g
-                      className="recharts-cursor-portal"
-                      ref={(node: SVGElement) => {
-                        if (this.state.cursorPortal == null) {
-                          this.setState({ cursorPortal: node });
-                        }
-                      }}
-                    />
-                    {this.renderAllNodes()}
-                    {children}
-                  </Surface>
-                  {type === 'nest' && this.renderNestIndex()}
-                </RechartsWrapper>
-              </TooltipContextProvider>
+              <SetTooltipInfo
+                active={ttContext.active}
+                activeCoordinate={ttContext.coordinate}
+                activeLabel={ttContext.label}
+              />
+              <RechartsWrapper
+                className={className}
+                style={style}
+                width={width}
+                height={height}
+                ref={(node: HTMLDivElement) => {
+                  if (this.state.tooltipPortal == null) {
+                    this.setState({ tooltipPortal: node });
+                  }
+                }}
+              >
+                <Surface {...attrs} width={width} height={type === 'nest' ? height - 30 : height}>
+                  <g
+                    className="recharts-cursor-portal"
+                    ref={(node: SVGElement) => {
+                      if (this.state.cursorPortal == null) {
+                        this.setState({ cursorPortal: node });
+                      }
+                    }}
+                  />
+                  {this.renderAllNodes()}
+                  {children}
+                </Surface>
+                {type === 'nest' && this.renderNestIndex()}
+              </RechartsWrapper>
             </ViewBoxContext.Provider>
           </TooltipPortalContext.Provider>
         </CursorPortalContext.Provider>

--- a/src/component/Cursor.tsx
+++ b/src/component/Cursor.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, cloneElement, createElement, isValidElement, SVGProps } from 'react';
 import clsx from 'clsx';
+import { useAppSelector } from '../state/hooks';
 import { ChartCoordinate, ChartOffset, LayoutType, TooltipEventType } from '../util/types';
 import { Curve } from '../shape/Curve';
 import { Cross } from '../shape/Cross';
@@ -98,14 +99,17 @@ export function CursorInternal(props: CursorConnectedProps) {
  */
 export function Cursor(props: CursorProps) {
   const tooltipAxisBandSize = useTooltipAxisBandSize();
-  const { coordinate, payload, index } = useTooltipContext();
+  // TODO: move index to redux. Not sure about payload...?
+  const { payload, index, coordinate: coordFromContext } = useTooltipContext();
+  const tooltipPropsFromRedux = useAppSelector(state => state.tooltip);
+  console.log(tooltipPropsFromRedux);
   const offset = useOffset();
   const layout = useChartLayout();
   const chartName = useChartName();
   return (
     <CursorInternal
       {...props}
-      coordinate={coordinate}
+      coordinate={tooltipPropsFromRedux?.activeCoordinate ?? coordFromContext}
       index={index}
       payload={payload}
       offset={offset}

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -123,7 +123,14 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
   const tooltipEventType = useTooltipEventType(shared);
 
   // TODO swap the other properties from generateCategoricalChart context, to redux
-  const { active: activeFromContext, payload: payloadFromContext, coordinate, label } = useTooltipContext();
+  const {
+    active: activeFromContext,
+    payload: payloadFromContext,
+    coordinate: coordFromContext,
+    label: labelFromContext,
+  } = useTooltipContext();
+
+  const activeProps = useAppSelector(state => state.tooltip);
   const payloadFromRedux = useAppSelector(state =>
     selectTooltipPayload(state, tooltipEventType, trigger, defaultIndex),
   );
@@ -136,7 +143,7 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
    *
    * If the `active` prop is not defined then it will show and hide based on mouse or keyboard activity.
    */
-  const finalIsActive = activeFromProps ?? activeFromContext;
+  const finalIsActive = activeFromProps ?? activeProps?.active ?? activeFromContext;
   const [lastBoundingBox, updateBoundingBox] = useGetBoundingClientRect(undefined, [payload, finalIsActive]);
 
   const tooltipPortal = portalFromProps ?? tooltipPortalFromContext;
@@ -157,6 +164,8 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
       defaultUniqBy,
     );
   }
+  const finalCoord = activeProps?.activeCoordinate ?? coordFromContext;
+  const finalLabel = activeProps?.activeLabel ?? labelFromContext;
 
   const hasPayload = finalPayload.length > 0;
 
@@ -167,7 +176,7 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
       animationEasing={animationEasing}
       isAnimationActive={isAnimationActive}
       active={finalIsActive}
-      coordinate={coordinate}
+      coordinate={finalCoord}
       hasPayload={hasPayload}
       offset={offset}
       position={position}
@@ -182,9 +191,9 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
         ...props,
         // @ts-expect-error renderContent method expects the payload to be mutable, TODO make it immutable
         payload: finalPayload,
-        label,
+        label: finalLabel,
         active: finalIsActive,
-        coordinate,
+        coordinate: finalCoord,
         accessibilityLayer,
       })}
     </TooltipBoundingBox>

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -24,6 +24,7 @@ import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { setPolarAngleAxisMap, setPolarRadiusAxisMap, setXAxisMap, setYAxisMap } from '../state/axisSlice';
 import { RechartsRootState } from '../state/store';
 import { setLayout, setOffset } from '../state/layoutSlice';
+import { setActiveProps } from '../state/tooltipSlice';
 
 export const ViewBoxContext = createContext<CartesianViewBox | undefined>(undefined);
 export const ClipPathIdContext = createContext<string | undefined>(undefined);
@@ -88,6 +89,13 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
   };
 
   const dispatch = useAppDispatch();
+  /**
+   * This throws an error no matter where I put it (here, useEffect here, separate component)
+   * How is this fixed? Eventually we'll get rud of the chart context provider altogether but...
+   *
+   * Warning: Cannot update a component (`TooltipInternal`) while rendering a different component (`ChartLayoutContextProvider`).
+   */
+  dispatch(setActiveProps({ active: isTooltipActive, activeCoordinate, activeLabel }));
   dispatch(setXAxisMap(xAxisMap));
   dispatch(setYAxisMap(yAxisMap));
   dispatch(setPolarAngleAxisMap(angleAxisMap));

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -1,7 +1,12 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useEffect } from 'react';
 import { ChartCoordinate, Coordinate, DataKey } from '../util/types';
 import { useAppDispatch } from '../state/hooks';
-import { mouseLeaveItem, setActiveClickItemIndex, setActiveMouseOverItemIndex } from '../state/tooltipSlice';
+import {
+  mouseLeaveItem,
+  setActiveClickItemIndex,
+  setActiveProps,
+  setActiveMouseOverItemIndex,
+} from '../state/tooltipSlice';
 
 export type TooltipContextValue = {
   label: string;
@@ -39,6 +44,22 @@ export type ActivateTooltipAction<T extends TooltipPayloadType> = (
   index: number,
   event: React.MouseEvent<SVGElement>,
 ) => void;
+
+export const SetTooltipInfo = (props: {
+  active: boolean;
+  activeCoordinate: ChartCoordinate;
+  activeLabel?: string;
+}): null => {
+  const { active, activeCoordinate, activeLabel } = props;
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    dispatch(setActiveProps({ active, activeCoordinate, activeLabel }));
+    return () => {
+      dispatch(setActiveProps({ active: false, activeCoordinate: { x: 0, y: 0 }, activeLabel: '' }));
+    };
+  }, [active, activeCoordinate, activeLabel, dispatch]);
+  return null;
+};
 
 export const MouseEnterItemDispatchContext = createContext<ActivateTooltipAction<TooltipPayloadType> | null>(null);
 export const MouseLeaveItemDispatchContext = createContext<ActivateTooltipAction<TooltipPayloadType> | null>(null);

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, current, PayloadAction } from '@reduxjs/toolkit';
 import { NameType, Payload, ValueType } from '../component/DefaultTooltipContent';
-import { DataKey } from '../util/types';
+import { ChartCoordinate, DataKey } from '../util/types';
 
 /**
  * One Tooltip can display multiple TooltipPayloadEntries at a time.
@@ -131,9 +131,16 @@ export type TooltipState = {
    * may render multiple tooltip payloads.
    */
   tooltipItemPayloads: ReadonlyArray<TooltipPayloadConfiguration>;
+  // whether or not the Tooltip is active (from Redux' perspective)
+  active: boolean;
+  // the chart coordinate the tooltip is rendered
+  activeCoordinate: ChartCoordinate;
+  // the label rendered in the Tooltip
+  // TODO: find this the same way we find payload
+  activeLabel?: string;
 };
 
-const initialState: TooltipState = {
+export const initialState: TooltipState = {
   itemInteraction: {
     activeClick: false,
     activeHover: false,
@@ -151,6 +158,9 @@ const initialState: TooltipState = {
     activeClickAxisDataKey: undefined,
   },
   tooltipItemPayloads: [],
+  activeCoordinate: { x: 0, y: 0 },
+  active: false,
+  activeLabel: '',
 };
 
 const tooltipSlice = createSlice({
@@ -201,6 +211,17 @@ const tooltipSlice = createSlice({
       state.axisInteraction.activeClickAxisIndex = action.payload.activeIndex;
       state.axisInteraction.activeClickAxisDataKey = action.payload.activeDataKey;
     },
+    setActive(state, action: PayloadAction<boolean>) {
+      state.active = action.payload;
+    },
+    setActiveProps(
+      state,
+      action: PayloadAction<{ activeCoordinate: ChartCoordinate; active: boolean; activeLabel: string }>,
+    ) {
+      state.activeCoordinate = action.payload.activeCoordinate;
+      state.active = action.payload.active;
+      state.activeLabel = action.payload.activeLabel;
+    },
   },
 });
 
@@ -212,6 +233,8 @@ export const {
   setActiveClickItemIndex,
   setMouseOverAxisIndex,
   setMouseClickAxisIndex,
+  setActive,
+  setActiveProps,
 } = tooltipSlice.actions;
 
 export const tooltipReducer = tooltipSlice.reducer;

--- a/storybook/stories/API/chart/LineChart.stories.tsx
+++ b/storybook/stories/API/chart/LineChart.stories.tsx
@@ -30,13 +30,13 @@ export const SynchronizedTooltip = {
   render: (args: Args) => {
     return (
       <div>
-        <LineChart {...args}>
-          <Line isAnimationActive={false} type="monotone" dataKey="uv" stroke="#ff7300" />
+        <LineChart {...args} id="BookOne">
+          <Line isAnimationActive={false} name="BookOne" type="monotone" dataKey="uv" stroke="#111" />
           <XAxis dataKey="name" />
-          <Tooltip />
+          <Tooltip active />
         </LineChart>
-        <LineChart {...args}>
-          <Line isAnimationActive={false} type="monotone" dataKey="uv" stroke="#ff7300" />
+        <LineChart {...args} id="BookTwo">
+          <Line isAnimationActive={false} name="BookTwo" type="monotone" dataKey="uv" stroke="#ff7300" />
           <XAxis dataKey="name" />
           <Tooltip />
         </LineChart>

--- a/test/component/Cursor.spec.tsx
+++ b/test/component/Cursor.spec.tsx
@@ -7,6 +7,7 @@ import { RechartsRootState } from '../../src/state/store';
 import { RechartsStoreProvider } from '../../src/state/RechartsStoreProvider';
 import { TooltipContextProvider, TooltipContextValue } from '../../src/context/tooltipContext';
 import { arrayTooltipSearcher } from '../../src/state/optionsSlice';
+import { initialState as initialTooltipState } from '../../src/state/tooltipSlice';
 
 const defaultProps: CursorProps = {
   cursor: true,
@@ -46,6 +47,18 @@ const preloadedRadialState: Partial<RechartsRootState> = {
     layoutType: 'radial',
     offset: undefined,
     container: undefined,
+  },
+  tooltip: {
+    ...initialTooltipState,
+    activeCoordinate: {
+      endAngle: 2,
+      radius: 1,
+      startAngle: 1,
+      x: 0,
+      y: 0,
+    },
+    active: true,
+    activeLabel: '',
   },
 };
 

--- a/test/component/Tooltip/Tooltip.sync.spec.tsx
+++ b/test/component/Tooltip/Tooltip.sync.spec.tsx
@@ -36,11 +36,12 @@ import {
   radialBarChartMouseHoverTooltipSelector,
 } from './tooltipMouseHoverSelectors';
 
-type TooltipVisibilityTestCase = {
+type TooltipSyncTestCase = {
   // For identifying which test is running
   name: string;
   mouseHoverSelector: MouseHoverTooltipTriggerSelector;
-  Wrapper: ComponentType<{ children: ReactNode; syncId: string }>;
+  Wrapper: ComponentType<{ children: ReactNode; syncId: string; dataKey: string }>;
+  tooltipContent: { chartOne: { name: string; value: string }; chartTwo: { name: string; value: string } };
 };
 
 const commonChartProps = {
@@ -49,46 +50,49 @@ const commonChartProps = {
   data: PageData,
 };
 
-const AreaChartTestCase: TooltipVisibilityTestCase = {
+const AreaChartTestCase: TooltipSyncTestCase = {
   name: 'AreaChart',
-  Wrapper: ({ children, syncId }) => (
+  Wrapper: ({ children, syncId, dataKey }) => (
     <AreaChart {...commonChartProps} syncId={syncId}>
-      <Area dataKey="uv" />
+      <Area dataKey={dataKey} />
       {children}
     </AreaChart>
   ),
   mouseHoverSelector: areaChartMouseHoverTooltipSelector,
+  tooltipContent: { chartOne: { name: 'uv', value: '300' }, chartTwo: { name: 'pv', value: '1398' } },
 };
 
-const BarChartTestCase: TooltipVisibilityTestCase = {
+const BarChartTestCase: TooltipSyncTestCase = {
   name: 'BarChart',
-  Wrapper: ({ children, syncId }) => (
+  Wrapper: ({ children, syncId, dataKey }) => (
     <BarChart {...commonChartProps} syncId={syncId}>
-      <Bar dataKey="uv" />
+      <Bar dataKey={dataKey} />
       {children}
     </BarChart>
   ),
   mouseHoverSelector: barChartMouseHoverTooltipSelector,
+  tooltipContent: { chartOne: { name: 'uv', value: '300' }, chartTwo: { name: 'pv', value: '1398' } },
 };
 
-const LineChartHorizontalTestCase: TooltipVisibilityTestCase = {
+const LineChartHorizontalTestCase: TooltipSyncTestCase = {
   name: 'horizontal LineChart',
-  Wrapper: ({ children, syncId }) => (
+  Wrapper: ({ children, syncId, dataKey }) => (
     <LineChart {...commonChartProps} syncId={syncId}>
       <XAxis dataKey="name" />
       <YAxis />
       <CartesianGrid strokeDasharray="3 3" />
       {children}
       <Legend />
-      <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+      <Line type="monotone" dataKey={dataKey} stroke="#82ca9d" />
     </LineChart>
   ),
   mouseHoverSelector: lineChartMouseHoverTooltipSelector,
+  tooltipContent: { chartOne: { name: 'uv', value: '300' }, chartTwo: { name: 'pv', value: '1398' } },
 };
 
-const LineChartVerticalTestCase: TooltipVisibilityTestCase = {
+const LineChartVerticalTestCase: TooltipSyncTestCase = {
   name: 'vertical LineChart',
-  Wrapper: ({ children, syncId }) => (
+  Wrapper: ({ children, syncId, dataKey }) => (
     <LineChart
       layout="vertical"
       {...commonChartProps}
@@ -105,77 +109,83 @@ const LineChartVerticalTestCase: TooltipVisibilityTestCase = {
       <YAxis dataKey="name" type="category" />
       {children}
       <Legend />
-      <Line dataKey="uv" stroke="#82ca9d" />
+      <Line dataKey={dataKey} stroke="#82ca9d" />
     </LineChart>
   ),
   mouseHoverSelector: lineChartMouseHoverTooltipSelector,
+  tooltipContent: { chartOne: { name: 'uv', value: '200' }, chartTwo: { name: 'pv', value: '9800' } },
 };
 
-const ComposedChartWithAreaTestCase: TooltipVisibilityTestCase = {
+const ComposedChartWithAreaTestCase: TooltipSyncTestCase = {
   name: 'ComposedChart with Area',
-  Wrapper: ({ children, syncId }) => (
+  Wrapper: ({ children, syncId, dataKey }) => (
     <ComposedChart {...commonChartProps} syncId={syncId}>
       <XAxis dataKey="name" type="category" />
       <YAxis dataKey="uv" />
       {children}
-      <Area dataKey="pv" />
+      <Area dataKey={dataKey} />
     </ComposedChart>
   ),
   mouseHoverSelector: composedChartMouseHoverTooltipSelector,
+  tooltipContent: { chartOne: { name: 'uv', value: '300' }, chartTwo: { name: 'pv', value: '1398' } },
 };
 
-const ComposedChartWithBarTestCase: TooltipVisibilityTestCase = {
+const ComposedChartWithBarTestCase: TooltipSyncTestCase = {
   name: 'ComposedChart with Bar',
-  Wrapper: ({ children, syncId }) => (
+  Wrapper: ({ children, syncId, dataKey }) => (
     <ComposedChart {...commonChartProps} syncId={syncId}>
       <XAxis dataKey="name" type="category" />
       <YAxis dataKey="uv" />
       {children}
-      <Bar dataKey="amt" />
+      <Bar dataKey={dataKey} />
     </ComposedChart>
   ),
   mouseHoverSelector: composedChartMouseHoverTooltipSelector,
+  tooltipContent: { chartOne: { name: 'uv', value: '300' }, chartTwo: { name: 'pv', value: '1398' } },
 };
 
-const ComposedChartWithLineTestCase: TooltipVisibilityTestCase = {
+const ComposedChartWithLineTestCase: TooltipSyncTestCase = {
   name: 'ComposedChart with Line',
-  Wrapper: ({ children, syncId }) => (
+  Wrapper: ({ children, syncId, dataKey }) => (
     <ComposedChart {...commonChartProps} syncId={syncId}>
       <XAxis dataKey="name" type="category" />
       <YAxis dataKey="amt" />
       {children}
-      <Line dataKey="pv" />
+      <Line dataKey={dataKey} />
     </ComposedChart>
   ),
   mouseHoverSelector: composedChartMouseHoverTooltipSelector,
+  tooltipContent: { chartOne: { name: 'uv', value: '300' }, chartTwo: { name: 'pv', value: '1398' } },
 };
 
-const RadarChartTestCase: TooltipVisibilityTestCase = {
+const RadarChartTestCase: TooltipSyncTestCase = {
   name: 'RadarChart',
-  Wrapper: ({ children, syncId }) => (
+  Wrapper: ({ children, syncId, dataKey }) => (
     <RadarChart height={600} width={600} data={PageData} syncId={syncId}>
       <PolarGrid />
       <PolarAngleAxis dataKey="name" />
       <PolarRadiusAxis />
-      <Radar name="Mike" dataKey="uv" stroke="#8884d8" fill="#8884d8" fillOpacity={0.6} />
+      <Radar name="Mike" dataKey={dataKey} stroke="#8884d8" fill="#8884d8" fillOpacity={0.6} />
       {children}
     </RadarChart>
   ),
   mouseHoverSelector: radarChartMouseHoverTooltipSelector,
+  tooltipContent: { chartOne: { name: 'Mike', value: '189' }, chartTwo: { name: 'Mike', value: '4800' } },
 };
 
-const RadialBarChartTestCase: TooltipVisibilityTestCase = {
+const RadialBarChartTestCase: TooltipSyncTestCase = {
   name: 'RadialBarChart',
-  Wrapper: ({ children, syncId }) => (
+  Wrapper: ({ children, syncId, dataKey }) => (
     <RadialBarChart height={600} width={600} data={PageData} syncId={syncId}>
       <PolarGrid />
       <PolarAngleAxis dataKey="name" />
       <PolarRadiusAxis />
-      <RadialBar name="Mike" dataKey="uv" stroke="#8884d8" fill="#8884d8" fillOpacity={0.6} />
+      <RadialBar name="Mike" dataKey={dataKey} stroke="#8884d8" fill="#8884d8" fillOpacity={0.6} />
       {children}
     </RadialBarChart>
   ),
   mouseHoverSelector: radialBarChartMouseHoverTooltipSelector,
+  tooltipContent: { chartOne: { name: 'Mike', value: '300' }, chartTwo: { name: 'Mike', value: '4567' } },
 };
 
 // TODO: fix synchronization in Pie, Scatter, Funnel. These currently accept syncId as a prop but do not work.
@@ -255,7 +265,7 @@ const RadialBarChartTestCase: TooltipVisibilityTestCase = {
 //   expectedTransform: 'transform: translate(94.5px, 58.5px);',
 // };
 
-const testCases: ReadonlyArray<TooltipVisibilityTestCase> = [
+const cartesianTestCases: ReadonlyArray<TooltipSyncTestCase> = [
   AreaChartTestCase,
   BarChartTestCase,
   LineChartHorizontalTestCase,
@@ -264,44 +274,63 @@ const testCases: ReadonlyArray<TooltipVisibilityTestCase> = [
   ComposedChartWithBarTestCase,
   ComposedChartWithLineTestCase,
   // FunnelChartTestCase,
+  // ScatterChartTestCase,
+];
+
+const radialTestCases: ReadonlyArray<TooltipSyncTestCase> = [
   // PieChartTestCase,
   RadarChartTestCase,
   RadialBarChartTestCase,
-  // ScatterChartTestCase,
 ];
 
 // Tooltip sync does not work for PieChart, ScatterChart, FunnelChart, SunburstChart, SankeyChart, Treemap
 describe('Tooltip synchronization', () => {
-  describe.each(testCases)('as a child of $name', ({ name, Wrapper, mouseHoverSelector }) => {
-    test(`${name} shows tooltip when synchronized with ${name}`, () => {
-      const { container, debug } = render(
-        <>
-          <Wrapper syncId="tooltipSync">
-            <Tooltip />
-          </Wrapper>
-          <Wrapper syncId="tooltipSync">
-            <Tooltip />
-          </Wrapper>
-        </>,
-      );
-      const wrappers = container.querySelectorAll('.recharts-wrapper');
-      const wrapperTwo = wrappers[1];
+  describe.each([...cartesianTestCases, ...radialTestCases])(
+    'as a child of $name',
+    ({ name, Wrapper, mouseHoverSelector, tooltipContent }) => {
+      test(`${name} shows tooltip when synchronized with ${name}`, () => {
+        const { chartOne: chartOneContent, chartTwo: chartTwoContent } = tooltipContent;
+        const { container, debug } = render(
+          <>
+            <div id="chartOne">
+              <Wrapper syncId="tooltipSync" dataKey="uv">
+                <Tooltip />
+              </Wrapper>
+            </div>
+            <div id="chartTwo">
+              <Wrapper syncId="tooltipSync" dataKey="pv">
+                <Tooltip />
+              </Wrapper>
+            </div>
+          </>,
+        );
+        // use ids to separate the charts so the `.recharts-wrapper` class can be used to activate the tooltip
+        const wrapperOne = container.querySelector('#chartOne');
+        const wrapperTwo = container.querySelector('#chartTwo');
 
-      // target the first chart to show the tooltip
-      showTooltip(container, mouseHoverSelector, debug);
+        // target the first chart to show the tooltip
+        showTooltip(wrapperOne, mouseHoverSelector, debug);
 
-      // target the second chart to see if it has the synchonized tooltip showing
-      const tooltip = getTooltip(wrapperTwo);
-      expect(tooltip).toBeVisible();
+        // target the second chart to see if it has the synchonized tooltip showing
+        const tooltip = getTooltip(wrapperTwo);
+        expect(tooltip).toBeVisible();
 
-      const tooltipContentName = wrapperTwo.querySelector('.recharts-tooltip-item-name');
-      const tooltipContentValue = wrapperTwo.querySelector('.recharts-tooltip-item-value');
-      expect(tooltipContentName).not.toBeNull();
-      expect(tooltipContentValue).not.toBeNull();
-      expect(tooltipContentName).toBeInTheDocument();
-      expect(tooltipContentValue).toBeInTheDocument();
-    });
-  });
+        [
+          { wrapper: wrapperOne, content: chartOneContent },
+          { wrapper: wrapperTwo, content: chartTwoContent },
+        ].forEach(({ wrapper, content }) => {
+          const tooltipContentName = wrapper.querySelector('.recharts-tooltip-item-name');
+          const tooltipContentValue = wrapper.querySelector('.recharts-tooltip-item-value');
+          expect(tooltipContentName).not.toBeNull();
+          expect(tooltipContentValue).not.toBeNull();
+          expect(tooltipContentName).toBeInTheDocument();
+          expect(tooltipContentValue).toBeInTheDocument();
+          expect(tooltipContentName.textContent).toEqual(content.name);
+          expect(tooltipContentValue.textContent).toEqual(content.value);
+        });
+      });
+    },
+  );
 });
 
 describe('brush synchronization', () => {
@@ -358,10 +387,10 @@ describe('Cursor synchronization', () => {
     it('should display cursor inside of the synchronized SVG', async () => {
       const { container, debug } = render(
         <>
-          <Wrapper syncId="cursorSync">
+          <Wrapper syncId="cursorSync" dataKey="uv">
             <Tooltip />
           </Wrapper>
-          <Wrapper syncId="cursorSync">
+          <Wrapper syncId="cursorSync" dataKey="amt">
             <Tooltip />
           </Wrapper>
         </>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In order to move synchronized to redux I need to move tooltip state to redux as opposed to context.

Everything renders as normal here... I will move Sankey as well before marking this ready. Sunburst is way behind so I'm not going to touch it.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4548

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Be able to access tt state via selectors

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
npm test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Refactor

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
