### PR TITLE
Add tests for xaxis tick positions

### DIFF
--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -285,8 +285,30 @@ describe('<XAxis />', () => {
 
     const bar = container.querySelector('.recharts-rectangle');
     assertNotNull(bar);
-    expect(parseInt(bar.getAttribute('x') as string, 10)).toEqual(70);
+    expect(bar.getAttribute('x')).toEqual('70.16326530612245');
     expect(spy).toHaveBeenLastCalledWith([100, 170]);
+    expectXAxisTicks(container, [
+      {
+        textContent: '100',
+        x: '81.42857142857143',
+        y: '273',
+      },
+      {
+        textContent: '120',
+        x: '137.75510204081633',
+        y: '273',
+      },
+      {
+        textContent: '140',
+        x: '194.0816326530612',
+        y: '273',
+      },
+      {
+        textContent: '170',
+        x: '278.57142857142856',
+        y: '273',
+      },
+    ]);
   });
 
   it('Render Bars with no gap', () => {
@@ -302,7 +324,7 @@ describe('<XAxis />', () => {
 
     const bar = container.querySelector('.recharts-rectangle');
     assertNotNull(bar);
-    expect(parseInt(bar.getAttribute('x') as string, 10)).toEqual(66);
+    expect(bar.getAttribute('x')).toEqual('66.2928279883382');
     expectXAxisTicks(container, [
       {
         textContent: '100',
@@ -322,6 +344,123 @@ describe('<XAxis />', () => {
       {
         textContent: '170',
         x: '282.0448979591837',
+        y: '273',
+      },
+    ]);
+    expect(spy).toHaveBeenLastCalledWith([100, 170]);
+  });
+
+  it('Render Bars with custom gap', () => {
+    const spy = vi.fn();
+    const { container } = render(
+      <BarChart width={300} height={300} data={data}>
+        <Bar dataKey="y" isAnimationActive={false} />
+        <XAxis dataKey="x" type="number" domain={['dataMin', 'dataMax']} padding={{ left: 11, right: 17 }} />
+        <YAxis dataKey="y" />
+        <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
+      </BarChart>,
+    );
+
+    const bar = container.querySelector('.recharts-rectangle');
+    assertNotNull(bar);
+    expect(bar.getAttribute('x')).toEqual('64.45714285714286');
+    expectXAxisTicks(container, [
+      {
+        textContent: '100',
+        x: '76',
+        y: '273',
+      },
+      {
+        textContent: '120',
+        x: '133.71428571428572',
+        y: '273',
+      },
+      {
+        textContent: '140',
+        x: '191.42857142857144',
+        y: '273',
+      },
+      {
+        textContent: '170',
+        x: '278',
+        y: '273',
+      },
+    ]);
+    expect(spy).toHaveBeenLastCalledWith([100, 170]);
+  });
+
+  it('Render Bars with padding on the left', () => {
+    const spy = vi.fn();
+    const { container } = render(
+      <BarChart width={300} height={300} data={data}>
+        <Bar dataKey="y" isAnimationActive={false} />
+        <XAxis dataKey="x" type="number" domain={['dataMin', 'dataMax']} padding={{ left: 19 }} />
+        <YAxis dataKey="y" />
+        <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
+      </BarChart>,
+    );
+
+    const bar = container.querySelector('.recharts-rectangle');
+    assertNotNull(bar);
+    expect(bar.getAttribute('x')).toEqual('71.94285714285715');
+    expectXAxisTicks(container, [
+      {
+        textContent: '100',
+        x: '84',
+        y: '273',
+      },
+      {
+        textContent: '120',
+        x: '144.28571428571428',
+        y: '273',
+      },
+      {
+        textContent: '140',
+        x: '204.57142857142856',
+        y: '273',
+      },
+      {
+        textContent: '170',
+        x: '295',
+        y: '273',
+      },
+    ]);
+    expect(spy).toHaveBeenLastCalledWith([100, 170]);
+  });
+
+  it('Render Bars with padding on the right', () => {
+    const spy = vi.fn();
+    const { container } = render(
+      <BarChart width={300} height={300} data={data}>
+        <Bar dataKey="y" isAnimationActive={false} />
+        <XAxis dataKey="x" type="number" domain={['dataMin', 'dataMax']} padding={{ right: 23 }} />
+        <YAxis dataKey="y" />
+        <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
+      </BarChart>,
+    );
+
+    const bar = container.querySelector('.recharts-rectangle');
+    assertNotNull(bar);
+    expect(bar.getAttribute('x')).toEqual('53.17142857142858');
+    expectXAxisTicks(container, [
+      {
+        textContent: '100',
+        x: '65',
+        y: '273',
+      },
+      {
+        textContent: '120',
+        x: '124.14285714285714',
+        y: '273',
+      },
+      {
+        textContent: '140',
+        x: '183.28571428571428',
+        y: '273',
+      },
+      {
+        textContent: '170',
+        x: '272',
         y: '273',
       },
     ]);

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -74,7 +74,18 @@ describe('<XAxis />', () => {
     );
 
     expect(container.querySelectorAll('.xAxis .recharts-cartesian-axis-tick')).toHaveLength(2);
-    expectXAxisTicks(container, ['0', '4']);
+    expectXAxisTicks(container, [
+      {
+        textContent: '0',
+        x: '20',
+        y: '358',
+      },
+      {
+        textContent: '4',
+        x: '308',
+        y: '358',
+      },
+    ]);
     expect(spy).toHaveBeenLastCalledWith(['', '', '', '', '', '', '']);
   });
 
@@ -89,7 +100,38 @@ describe('<XAxis />', () => {
     );
 
     expect(container.querySelectorAll('.xAxis .recharts-cartesian-axis-tick')[0]).toHaveTextContent('0');
-    expectXAxisTicks(container, ['0', '1', '2', '3', '4', '5']);
+    expectXAxisTicks(container, [
+      {
+        textContent: '0',
+        x: '20',
+        y: '358',
+      },
+      {
+        textContent: '1',
+        x: '92',
+        y: '358',
+      },
+      {
+        textContent: '2',
+        x: '164',
+        y: '358',
+      },
+      {
+        textContent: '3',
+        x: '236',
+        y: '358',
+      },
+      {
+        textContent: '4',
+        x: '308',
+        y: '358',
+      },
+      {
+        textContent: '5',
+        x: '380',
+        y: '358',
+      },
+    ]);
     expect(spy).toHaveBeenLastCalledWith(['', 'Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
   });
 
@@ -105,7 +147,38 @@ describe('<XAxis />', () => {
     );
 
     expect(container.querySelectorAll('.recharts-xAxis .recharts-cartesian-axis-tick')).toHaveLength(lineData.length);
-    expectXAxisTicks(container, ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
+    expectXAxisTicks(container, [
+      {
+        textContent: 'Page A',
+        x: '80',
+        y: '273',
+      },
+      {
+        textContent: 'Page B',
+        x: '178',
+        y: '273',
+      },
+      {
+        textContent: 'Page C',
+        x: '276',
+        y: '273',
+      },
+      {
+        textContent: 'Page D',
+        x: '374',
+        y: '273',
+      },
+      {
+        textContent: 'Page E',
+        x: '472',
+        y: '273',
+      },
+      {
+        textContent: 'Page F',
+        x: '570',
+        y: '273',
+      },
+    ]);
     expect(spy).toHaveBeenLastCalledWith(['', 'Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
   });
 
@@ -160,13 +233,41 @@ describe('<XAxis />', () => {
 
     expect(container.querySelectorAll('.recharts-xAxis .recharts-cartesian-axis-tick')).toHaveLength(timeData.length);
     expectXAxisTicks(container, [
-      'Thu Jul 04 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
-      'Fri Jul 05 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
-      'Sat Jul 06 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
-      'Sun Jul 07 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
-      'Mon Jul 08 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
-      'Tue Jul 09 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
-      'Wed Jul 10 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
+      {
+        textContent: 'Thu Jul 04 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
+        x: '80',
+        y: '273',
+      },
+      {
+        textContent: 'Fri Jul 05 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
+        x: '161.66666666666669',
+        y: '273',
+      },
+      {
+        textContent: 'Sat Jul 06 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
+        x: '243.33333333333334',
+        y: '273',
+      },
+      {
+        textContent: 'Sun Jul 07 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
+        x: '325',
+        y: '273',
+      },
+      {
+        textContent: 'Mon Jul 08 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
+        x: '406.6666666666667',
+        y: '273',
+      },
+      {
+        textContent: 'Tue Jul 09 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
+        x: '488.3333333333333',
+        y: '273',
+      },
+      {
+        textContent: 'Wed Jul 10 2019 00:00:00 GMT+0000 (Coordinated Universal Time)',
+        x: '570',
+        y: '273',
+      },
     ]);
     expect(spy).toHaveBeenLastCalledWith([1562198400000, 1562716800000]);
   });
@@ -202,7 +303,28 @@ describe('<XAxis />', () => {
     const bar = container.querySelector('.recharts-rectangle');
     assertNotNull(bar);
     expect(parseInt(bar.getAttribute('x') as string, 10)).toEqual(66);
-    expectXAxisTicks(container, ['100', '120', '140', '170']);
+    expectXAxisTicks(container, [
+      {
+        textContent: '100',
+        x: '77.95510204081633',
+        y: '273',
+      },
+      {
+        textContent: '120',
+        x: '136.266472303207',
+        y: '273',
+      },
+      {
+        textContent: '140',
+        x: '194.57784256559765',
+        y: '273',
+      },
+      {
+        textContent: '170',
+        x: '282.0448979591837',
+        y: '273',
+      },
+    ]);
     expect(spy).toHaveBeenLastCalledWith([100, 170]);
   });
 
@@ -227,7 +349,13 @@ describe('<XAxis />', () => {
     // This test merely confirms this known limitation.
     const bar = container.querySelector('.recharts-rectangle');
     expect(bar).not.toBeInTheDocument();
-    expectXAxisTicks(container, ['100']);
+    expectXAxisTicks(container, [
+      {
+        textContent: '100',
+        x: '180',
+        y: '273',
+      },
+    ]);
     expect(spy).toHaveBeenLastCalledWith([100, 100]);
   });
 
@@ -266,7 +394,33 @@ describe('<XAxis />', () => {
     expect(bar).toBeInTheDocument();
     expect(bar.getAttribute('x')).toEqual('123');
     expect(bar.getAttribute('width')).toEqual('115');
-    expectXAxisTicks(container, ['50', '75', '100', '125', '150']);
+    expectXAxisTicks(container, [
+      {
+        textContent: '50',
+        x: '65',
+        y: '273',
+      },
+      {
+        textContent: '75',
+        x: '122.5',
+        y: '273',
+      },
+      {
+        textContent: '100',
+        x: '180',
+        y: '273',
+      },
+      {
+        textContent: '125',
+        x: '237.5',
+        y: '273',
+      },
+      {
+        textContent: '150',
+        x: '295',
+        y: '273',
+      },
+    ]);
     expect(spy).toHaveBeenLastCalledWith([50, 150]);
   });
 
@@ -286,7 +440,28 @@ describe('<XAxis />', () => {
     expect(bar).toBeInTheDocument();
     expect(bar.getAttribute('x')).toEqual('42');
     expect(bar.getAttribute('width')).toEqual('46');
-    expectXAxisTicks(container, ['100', '115', '130', '150']);
+    expectXAxisTicks(container, [
+      {
+        textContent: '100',
+        x: '65',
+        y: '273',
+      },
+      {
+        textContent: '115',
+        x: '134',
+        y: '273',
+      },
+      {
+        textContent: '130',
+        x: '203',
+        y: '273',
+      },
+      {
+        textContent: '150',
+        x: '295',
+        y: '273',
+      },
+    ]);
     expect(spy).toHaveBeenLastCalledWith([100, 150]);
   });
 
@@ -485,7 +660,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['0', '45', '90', '135', '180']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '45',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '90',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '135',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '180',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([0, 200]);
       });
 
@@ -498,7 +699,33 @@ describe('<XAxis />', () => {
               <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
             </Component>,
           );
-          expectXAxisTicks(container, ['100', '120', '140', '160', '180']);
+          expectXAxisTicks(container, [
+            {
+              textContent: '100',
+              x: '5',
+              y: '273',
+            },
+            {
+              textContent: '120',
+              x: '77.5',
+              y: '273',
+            },
+            {
+              textContent: '140',
+              x: '150',
+              y: '273',
+            },
+            {
+              textContent: '160',
+              x: '222.5',
+              y: '273',
+            },
+            {
+              textContent: '180',
+              x: '295',
+              y: '273',
+            },
+          ]);
           expect(spy).toHaveBeenLastCalledWith([100, 200]);
         });
 
@@ -510,7 +737,33 @@ describe('<XAxis />', () => {
               <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
             </Component>,
           );
-          expectXAxisTicks(container, ['-60', '0', '60', '120', '180']);
+          expectXAxisTicks(container, [
+            {
+              textContent: '-60',
+              x: '5',
+              y: '273',
+            },
+            {
+              textContent: '0',
+              x: '77.5',
+              y: '273',
+            },
+            {
+              textContent: '60',
+              x: '150',
+              y: '273',
+            },
+            {
+              textContent: '120',
+              x: '222.5',
+              y: '273',
+            },
+            {
+              textContent: '180',
+              x: '295',
+              y: '273',
+            },
+          ]);
           expect(spy).toHaveBeenLastCalledWith([-55, 200]);
         });
 
@@ -522,7 +775,33 @@ describe('<XAxis />', () => {
               <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
             </Component>,
           );
-          expectXAxisTicks(container, ['0', '150', '300', '450', '600']);
+          expectXAxisTicks(container, [
+            {
+              textContent: '0',
+              x: '5',
+              y: '273',
+            },
+            {
+              textContent: '150',
+              x: '77.5',
+              y: '273',
+            },
+            {
+              textContent: '300',
+              x: '150',
+              y: '273',
+            },
+            {
+              textContent: '450',
+              x: '222.5',
+              y: '273',
+            },
+            {
+              textContent: '600',
+              x: '295',
+              y: '273',
+            },
+          ]);
           expect(spy).toHaveBeenLastCalledWith([100, 555]);
         });
       });
@@ -535,7 +814,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['-500', '-250', '0', '250', '500']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '-500',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '-250',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '0',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '250',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '500',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([-500, 500]);
       });
 
@@ -547,7 +852,28 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['-100', '-30', '40', '170']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '-100',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '-30',
+            x: '80.18518518518519',
+            y: '273',
+          },
+          {
+            textContent: '40',
+            x: '155.37037037037038',
+            y: '273',
+          },
+          {
+            textContent: '170',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([-100, 170]);
 
         rerender(
@@ -556,7 +882,28 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['100', '120', '140', '175']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '100',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '120',
+            x: '82.33333333333334',
+            y: '273',
+          },
+          {
+            textContent: '140',
+            x: '159.66666666666669',
+            y: '273',
+          },
+          {
+            textContent: '175',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([100, 175]);
 
         rerender(
@@ -565,7 +912,28 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['100', '120', '140', '170']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '100',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '120',
+            x: '87.85714285714285',
+            y: '273',
+          },
+          {
+            textContent: '140',
+            x: '170.7142857142857',
+            y: '273',
+          },
+          {
+            textContent: '170',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([100, 170]);
       });
 
@@ -577,7 +945,28 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['100', '120', '140', '170']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '100',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '120',
+            x: '87.85714285714285',
+            y: '273',
+          },
+          {
+            textContent: '140',
+            x: '170.7142857142857',
+            y: '273',
+          },
+          {
+            textContent: '170',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([100, 170]);
       });
 
@@ -589,7 +978,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['100', '75', '50', '25', '0']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '100',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '75',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '50',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '25',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '0',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([100, 0]);
       });
 
@@ -601,7 +1016,13 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['150']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '150',
+            x: '150',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([150, 150]);
       });
 
@@ -613,7 +1034,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['0', '25', '50', '75', '100']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '25',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '50',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '75',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '100',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([0, 100]);
       });
 
@@ -625,7 +1072,43 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['0', '30', '60', '90', '120', '150', '180']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '30',
+            x: '53.33333333333333',
+            y: '273',
+          },
+          {
+            textContent: '60',
+            x: '101.66666666666666',
+            y: '273',
+          },
+          {
+            textContent: '90',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '120',
+            x: '198.33333333333331',
+            y: '273',
+          },
+          {
+            textContent: '150',
+            x: '246.66666666666669',
+            y: '273',
+          },
+          {
+            textContent: '180',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([0, 200]);
       });
 
@@ -637,7 +1120,23 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['0', '85', '170']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '85',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '170',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([0, 200]);
       });
 
@@ -649,7 +1148,28 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['100', '120', '140', '170']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '100',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '120',
+            x: '87.85714285714285',
+            y: '273',
+          },
+          {
+            textContent: '140',
+            x: '170.7142857142857',
+            y: '273',
+          },
+          {
+            textContent: '170',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([100, 170]);
       });
 
@@ -666,7 +1186,28 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['100', '120', '140', '170']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '100',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '120',
+            x: '87.85714285714285',
+            y: '273',
+          },
+          {
+            textContent: '140',
+            x: '170.7142857142857',
+            y: '273',
+          },
+          {
+            textContent: '170',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([100, 170]);
       });
 
@@ -680,7 +1221,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={reduxDomainSpy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['-500', '-250', '0', '250', '500']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '-500',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '-250',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '0',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '250',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '500',
+            x: '295',
+            y: '273',
+          },
+        ]);
         // expect(domainPropSpy).toHaveBeenCalledTimes(12); // this is called 12 times with data defined on chart root and 14 times when data defined on graphical items
         expect(domainPropSpy).toHaveBeenCalledWith([100, 170], true);
 
@@ -690,7 +1257,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={reduxDomainSpy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['-500', '-250', '0', '250', '500']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '-500',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '-250',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '0',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '250',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '500',
+            x: '295',
+            y: '273',
+          },
+        ]);
         // hah that's quite a few calls isn't it. TODO let's see if it improves once we remove the old, generateCategoricalChart code path
         // expect(domainPropSpy).toHaveBeenCalledTimes(27); // TODO also not stable, sometimes 24 and sometimes 27 because of different code paths when data is defined on root vs graphical item
         expect(domainPropSpy).toHaveBeenLastCalledWith([100, 170], false);
@@ -709,7 +1302,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={reduxDomainSpy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['-500', '-250', '0', '250', '500']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '-500',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '-250',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '0',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '250',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '500',
+            x: '295',
+            y: '273',
+          },
+        ]);
         // expect(spyMin).toHaveBeenCalledTimes(12); // TODO this is not stable, sometimes it reports 12 and sometimes it reports 14, because of different code paths when data is defined on root vs graphical item
         // expect(spyMax).toHaveBeenCalledTimes(12); // TODO this is not stable, sometimes it reports 12 and sometimes it reports 14, because of different code paths when data is defined on root vs graphical item
         expect(spyMin).toHaveBeenCalledWith(100);
@@ -725,7 +1344,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </Component>,
         );
-        expectXAxisTicks(container, ['-500', '-250', '0', '250', '500']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '-500',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '-250',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '0',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '250',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '500',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([-500, 500]);
       });
     });
@@ -743,7 +1388,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </LineChart>,
         );
-        expectXAxisTicks(container, ['0', '45', '90', '135', '180']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '45',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '90',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '135',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '180',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([0, 200]);
       });
 
@@ -764,8 +1435,60 @@ describe('<XAxis />', () => {
         );
         const allXAxes = container.querySelectorAll('.recharts-xAxis');
         expect(allXAxes).toHaveLength(2);
-        expectXAxisTicks(allXAxes[0], ['0', '45', '90', '135', '180']);
-        expectXAxisTicks(allXAxes[1], ['0', '40', '80', '120', '160']);
+        expectXAxisTicks(allXAxes[0], [
+          {
+            textContent: '0',
+            x: '5',
+            y: '243',
+          },
+          {
+            textContent: '45',
+            x: '77.5',
+            y: '243',
+          },
+          {
+            textContent: '90',
+            x: '150',
+            y: '243',
+          },
+          {
+            textContent: '135',
+            x: '222.5',
+            y: '243',
+          },
+          {
+            textContent: '180',
+            x: '295',
+            y: '243',
+          },
+        ]);
+        expectXAxisTicks(allXAxes[1], [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '40',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '80',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '120',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '160',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(reduxDefaultDomainSpy).toHaveBeenLastCalledWith(undefined);
         expect(reduxDomainSpyA).toHaveBeenLastCalledWith([0, 200]);
         expect(reduxDomainSpyB).toHaveBeenLastCalledWith([0, 153]);
@@ -788,8 +1511,55 @@ describe('<XAxis />', () => {
         );
         const allXAxes = container.querySelectorAll('.recharts-xAxis');
         expect(allXAxes).toHaveLength(2);
-        expectXAxisTicks(allXAxes[0], ['100', '120', '140', '170']);
-        expectXAxisTicks(allXAxes[1], ['110', '120', '130', '140', '150']);
+        expectXAxisTicks(allXAxes[0], [
+          {
+            textContent: '100',
+            x: '5',
+            y: '243',
+          },
+          {
+            textContent: '120',
+            x: '87.85714285714285',
+            y: '243',
+          },
+          {
+            textContent: '140',
+            x: '170.7142857142857',
+            y: '243',
+          },
+          {
+            textContent: '170',
+            x: '295',
+            y: '243',
+          },
+        ]);
+        expectXAxisTicks(allXAxes[1], [
+          {
+            textContent: '110',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '120',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '130',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '140',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '150',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(reduxDefaultDomainSpy).toHaveBeenLastCalledWith(undefined);
         expect(reduxDomainSpyA).toHaveBeenLastCalledWith([100, 170]);
         expect(reduxDomainSpyB).toHaveBeenLastCalledWith([110, 150]);
@@ -805,7 +1575,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['0', '0.25', '0.5', '0.75', '1']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '0.25',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '0.5',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '0.75',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '1',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([0, 1]);
       });
 
@@ -817,7 +1613,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['0', '1', '2', '3', '4']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '1',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '2',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '3',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '4',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([0, 5]);
       });
 
@@ -831,7 +1653,33 @@ describe('<XAxis />', () => {
               <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
             </BarChart>,
           );
-          expectXAxisTicks(container, ['0', '4', '8', '12', '16']);
+          expectXAxisTicks(container, [
+            {
+              textContent: '0',
+              x: '5',
+              y: '273',
+            },
+            {
+              textContent: '4',
+              x: '77.5',
+              y: '273',
+            },
+            {
+              textContent: '8',
+              x: '150',
+              y: '273',
+            },
+            {
+              textContent: '12',
+              x: '222.5',
+              y: '273',
+            },
+            {
+              textContent: '16',
+              x: '295',
+              y: '273',
+            },
+          ]);
           expect(spy).toHaveBeenLastCalledWith([0, 18]);
         },
       );
@@ -846,7 +1694,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['0', '45', '90', '135', '180']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '45',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '90',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '135',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '180',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([0, 200]);
       });
 
@@ -858,7 +1732,23 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['0', '90', '180']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '90',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '180',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([0, 200]);
       });
 
@@ -870,7 +1760,18 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['0', '135']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '135',
+            x: '222.5',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([0, 200]);
       });
 
@@ -882,7 +1783,43 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['0', '27', '54', '81', '108', '135', '162']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '27',
+            x: '50.78947368421052',
+            y: '273',
+          },
+          {
+            textContent: '54',
+            x: '96.57894736842104',
+            y: '273',
+          },
+          {
+            textContent: '81',
+            x: '142.36842105263156',
+            y: '273',
+          },
+          {
+            textContent: '108',
+            x: '188.15789473684208',
+            y: '273',
+          },
+          {
+            textContent: '135',
+            x: '233.94736842105263',
+            y: '273',
+          },
+          {
+            textContent: '162',
+            x: '279.7368421052631',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([0, 200]);
       });
 
@@ -892,7 +1829,28 @@ describe('<XAxis />', () => {
             <XAxis dataKey="x" type="number" interval="preserveStart" tickCount={20} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['0', '45', '90', '135']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '45',
+            x: '10.263157894736842',
+            y: '273',
+          },
+          {
+            textContent: '90',
+            x: '15.526315789473683',
+            y: '273',
+          },
+          {
+            textContent: '135',
+            x: '20.789473684210527',
+            y: '273',
+          },
+        ]);
       });
 
       it('should attempt to show the ticks end with interval = preserveEnd', () => {
@@ -901,7 +1859,28 @@ describe('<XAxis />', () => {
             <XAxis dataKey="x" type="number" interval="preserveEnd" tickCount={20} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['36', '81', '126', '171']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '36',
+            x: '9.210526315789473',
+            y: '273',
+          },
+          {
+            textContent: '81',
+            x: '14.473684210526315',
+            y: '273',
+          },
+          {
+            textContent: '126',
+            x: '19.736842105263158',
+            y: '273',
+          },
+          {
+            textContent: '171',
+            x: '25',
+            y: '273',
+          },
+        ]);
       });
 
       it('should attempt to show the ticks start and end with interval = preserveStartEnd', () => {
@@ -910,7 +1889,28 @@ describe('<XAxis />', () => {
             <XAxis dataKey="x" type="number" interval="preserveStartEnd" tickCount={20} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['0', '45', '90', '171']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '45',
+            x: '10.263157894736842',
+            y: '273',
+          },
+          {
+            textContent: '90',
+            x: '15.526315789473683',
+            y: '273',
+          },
+          {
+            textContent: '171',
+            x: '25',
+            y: '273',
+          },
+        ]);
       });
 
       it('should do ... same thing as preserveStart? with interval = equidistantPreserveStart', () => {
@@ -919,7 +1919,28 @@ describe('<XAxis />', () => {
             <XAxis dataKey="x" type="number" interval="equidistantPreserveStart" tickCount={20} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['0', '45', '90', '135']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '45',
+            x: '10.263157894736842',
+            y: '273',
+          },
+          {
+            textContent: '90',
+            x: '15.526315789473683',
+            y: '273',
+          },
+          {
+            textContent: '135',
+            x: '20.789473684210527',
+            y: '273',
+          },
+        ]);
       });
     });
   });
@@ -933,7 +1954,38 @@ describe('<XAxis />', () => {
           <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
         </BarChart>,
       );
-      expectXAxisTicks(container, ['100', '120', '170', '140', '150', '110']);
+      expectXAxisTicks(container, [
+        {
+          textContent: '100',
+          x: '29.166666666666668',
+          y: '273',
+        },
+        {
+          textContent: '120',
+          x: '77.5',
+          y: '273',
+        },
+        {
+          textContent: '170',
+          x: '125.83333333333334',
+          y: '273',
+        },
+        {
+          textContent: '140',
+          x: '174.16666666666666',
+          y: '273',
+        },
+        {
+          textContent: '150',
+          x: '222.5',
+          y: '273',
+        },
+        {
+          textContent: '110',
+          x: '270.83333333333337',
+          y: '273',
+        },
+      ]);
       expect(spy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
     });
 
@@ -945,7 +1997,38 @@ describe('<XAxis />', () => {
           <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
         </BarChart>,
       );
-      expectXAxisTicks(container, ['200', '260', '400', '280', '500', '200']);
+      expectXAxisTicks(container, [
+        {
+          textContent: '200',
+          x: '29.166666666666668',
+          y: '273',
+        },
+        {
+          textContent: '260',
+          x: '77.5',
+          y: '273',
+        },
+        {
+          textContent: '400',
+          x: '125.83333333333334',
+          y: '273',
+        },
+        {
+          textContent: '280',
+          x: '174.16666666666666',
+          y: '273',
+        },
+        {
+          textContent: '500',
+          x: '222.5',
+          y: '273',
+        },
+        {
+          textContent: '200',
+          x: '270.83333333333337',
+          y: '273',
+        },
+      ]);
       expect(spy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500, 200]);
     });
 
@@ -957,7 +2040,33 @@ describe('<XAxis />', () => {
           <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
         </BarChart>,
       );
-      expectXAxisTicks(container, ['200', '260', '400', '280', '500']);
+      expectXAxisTicks(container, [
+        {
+          textContent: '200',
+          x: '34',
+          y: '273',
+        },
+        {
+          textContent: '260',
+          x: '92',
+          y: '273',
+        },
+        {
+          textContent: '400',
+          x: '150',
+          y: '273',
+        },
+        {
+          textContent: '280',
+          x: '208',
+          y: '273',
+        },
+        {
+          textContent: '500',
+          x: '266',
+          y: '273',
+        },
+      ]);
       expect(spy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500]);
     });
 
@@ -969,7 +2078,38 @@ describe('<XAxis />', () => {
           <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
         </BarChart>,
       );
-      expectXAxisTicks(container, ['200', '260', '400', '280', '500', '200']);
+      expectXAxisTicks(container, [
+        {
+          textContent: '200',
+          x: '29.166666666666668',
+          y: '273',
+        },
+        {
+          textContent: '260',
+          x: '77.5',
+          y: '273',
+        },
+        {
+          textContent: '400',
+          x: '125.83333333333334',
+          y: '273',
+        },
+        {
+          textContent: '280',
+          x: '174.16666666666666',
+          y: '273',
+        },
+        {
+          textContent: '500',
+          x: '222.5',
+          y: '273',
+        },
+        {
+          textContent: '200',
+          x: '270.83333333333337',
+          y: '273',
+        },
+      ]);
       expect(spy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500, 200]);
     });
 
@@ -989,7 +2129,38 @@ describe('<XAxis />', () => {
           <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
         </BarChart>,
       );
-      expectXAxisTicks(container, ['200', '260', '400', '280', '500', '200']);
+      expectXAxisTicks(container, [
+        {
+          textContent: '200',
+          x: '29.166666666666668',
+          y: '273',
+        },
+        {
+          textContent: '260',
+          x: '77.5',
+          y: '273',
+        },
+        {
+          textContent: '400',
+          x: '125.83333333333334',
+          y: '273',
+        },
+        {
+          textContent: '280',
+          x: '174.16666666666666',
+          y: '273',
+        },
+        {
+          textContent: '500',
+          x: '222.5',
+          y: '273',
+        },
+        {
+          textContent: '200',
+          x: '270.83333333333337',
+          y: '273',
+        },
+      ]);
       expect(spy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500, 200]);
     });
 
@@ -1002,7 +2173,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['0.1', '0.3', '0.5', '0.7', '0.9']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '0.1',
+            x: '34',
+            y: '273',
+          },
+          {
+            textContent: '0.3',
+            x: '92',
+            y: '273',
+          },
+          {
+            textContent: '0.5',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '0.7',
+            x: '208',
+            y: '273',
+          },
+          {
+            textContent: '0.9',
+            x: '266',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([0.1, 0.3, 0.5, 0.7, 0.9]);
       });
 
@@ -1014,7 +2211,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={reduxDomainSpy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['4.1', '6.3', '12.5', '3.7', '7.9']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '4.1',
+            x: '34',
+            y: '273',
+          },
+          {
+            textContent: '6.3',
+            x: '92',
+            y: '273',
+          },
+          {
+            textContent: '12.5',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '3.7',
+            x: '208',
+            y: '273',
+          },
+          {
+            textContent: '7.9',
+            x: '266',
+            y: '273',
+          },
+        ]);
         expect(reduxDomainSpy).toHaveBeenLastCalledWith([4.1, 6.3, 12.5, 3.7, 7.9]);
       });
     });
@@ -1033,7 +2256,38 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </LineChart>,
         );
-        expectXAxisTicks(container, ['200', '260', '400', '280', '500', '200']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '200',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '260',
+            x: '63',
+            y: '273',
+          },
+          {
+            textContent: '400',
+            x: '121',
+            y: '273',
+          },
+          {
+            textContent: '280',
+            x: '179',
+            y: '273',
+          },
+          {
+            textContent: '500',
+            x: '237',
+            y: '273',
+          },
+          {
+            textContent: '200',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500, 200]);
       });
 
@@ -1047,7 +2301,33 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </LineChart>,
         );
-        expectXAxisTicks(container, ['200', '260', '400', '280', '500']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '200',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '260',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '400',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '280',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '500',
+            x: '295',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500]);
       });
 
@@ -1070,12 +2350,43 @@ describe('<XAxis />', () => {
           );
           const allXAxes = container.querySelectorAll('.recharts-xAxis');
           expect(allXAxes).toHaveLength(2);
-          expectXAxisTicks(allXAxes[0], ['200', '260', '400']);
-          expectXAxisTicks(allXAxes[1], ['280', '500', '200']);
+          expectXAxisTicks(allXAxes[0], [
+            {
+              textContent: '200',
+              x: '5',
+              y: '243',
+            },
+            {
+              textContent: '260',
+              x: '150',
+              y: '243',
+            },
+            {
+              textContent: '400',
+              x: '295',
+              y: '243',
+            },
+          ]);
+          expectXAxisTicks(allXAxes[1], [
+            {
+              textContent: '280',
+              x: '5',
+              y: '273',
+            },
+            {
+              textContent: '500',
+              x: '150',
+              y: '273',
+            },
+            {
+              textContent: '200',
+              x: '295',
+              y: '273',
+            },
+          ]);
           expect(defaultReduxDomainSpy).toHaveBeenLastCalledWith(undefined);
-          // TODO regression - these two axes should have different domains
-          // expect(reduxDomainSpyA).toHaveBeenLastCalledWith([200, 260, 400, 280, 500, 200]); // TODO this is unstable - sometimes it returns the duplicates and sometimes it does not.
-          // expect(reduxDomainSpyB).toHaveBeenLastCalledWith([200, 260, 400, 280, 500, 200]); // TODO this is unstable - sometimes it returns the duplicates and sometimes it does not.
+          expect(reduxDomainSpyA).toHaveBeenLastCalledWith([200, 260, 400]);
+          expect(reduxDomainSpyB).toHaveBeenLastCalledWith([280, 500, 200]);
         },
       );
     });
@@ -1089,7 +2400,38 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['200', '260', '400', '280', '500', '200']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '200',
+            x: '29.166666666666668',
+            y: '273',
+          },
+          {
+            textContent: '260',
+            x: '77.5',
+            y: '273',
+          },
+          {
+            textContent: '400',
+            x: '125.83333333333334',
+            y: '273',
+          },
+          {
+            textContent: '280',
+            x: '174.16666666666666',
+            y: '273',
+          },
+          {
+            textContent: '500',
+            x: '222.5',
+            y: '273',
+          },
+          {
+            textContent: '200',
+            x: '270.83333333333337',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500, 200]);
       });
 
@@ -1101,7 +2443,23 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['200', '400', '500']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '200',
+            x: '29.166666666666668',
+            y: '273',
+          },
+          {
+            textContent: '400',
+            x: '125.83333333333334',
+            y: '273',
+          },
+          {
+            textContent: '500',
+            x: '222.5',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500, 200]);
       });
 
@@ -1113,7 +2471,18 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['200', '280']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '200',
+            x: '29.166666666666668',
+            y: '273',
+          },
+          {
+            textContent: '280',
+            x: '174.16666666666666',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500, 200]);
       });
 
@@ -1125,7 +2494,23 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['100', '170', '150']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '100',
+            x: '6.666666666666667',
+            y: '273',
+          },
+          {
+            textContent: '170',
+            x: '13.333333333333334',
+            y: '273',
+          },
+          {
+            textContent: '150',
+            x: '20.000000000000004',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
       });
 
@@ -1137,7 +2522,23 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['120', '140', '110']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '120',
+            x: '10',
+            y: '273',
+          },
+          {
+            textContent: '140',
+            x: '16.666666666666668',
+            y: '273',
+          },
+          {
+            textContent: '110',
+            x: '23.333333333333336',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
       });
 
@@ -1149,7 +2550,23 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['100', '170', '110']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '100',
+            x: '6.666666666666667',
+            y: '273',
+          },
+          {
+            textContent: '170',
+            x: '13.333333333333334',
+            y: '273',
+          },
+          {
+            textContent: '110',
+            x: '23.333333333333336',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
       });
 
@@ -1161,7 +2578,23 @@ describe('<XAxis />', () => {
             <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
           </BarChart>,
         );
-        expectXAxisTicks(container, ['100', '170', '150']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '100',
+            x: '6.666666666666667',
+            y: '273',
+          },
+          {
+            textContent: '170',
+            x: '13.333333333333334',
+            y: '273',
+          },
+          {
+            textContent: '150',
+            x: '20.000000000000004',
+            y: '273',
+          },
+        ]);
         expect(spy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
       });
     });

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -631,7 +631,33 @@ describe('<LineChart /> and various data sources', () => {
       </LineChart>,
     );
     expectLabels(container, ['258', '295', '193', '168', '117']);
-    expectXAxisTicks(container, ['Iter: 0', 'Iter: 1', 'Iter: 2', 'Iter: 3', 'Iter: 4']);
+    expectXAxisTicks(container, [
+      {
+        textContent: 'Iter: 0',
+        x: '5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 1',
+        x: '102.5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 2',
+        x: '200',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 3',
+        x: '297.5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 4',
+        x: '395',
+        y: '373',
+      },
+    ]);
   });
 
   it('should render chart with three lines and data on root chart', () => {
@@ -643,7 +669,33 @@ describe('<LineChart /> and various data sources', () => {
       </LineChart>,
     );
     expectLabels(container, ['258', '295', '193', '168', '117', '597', '745', '657', '538', '762']);
-    expectXAxisTicks(container, ['Iter: 0', 'Iter: 1', 'Iter: 2', 'Iter: 3', 'Iter: 4']);
+    expectXAxisTicks(container, [
+      {
+        textContent: 'Iter: 0',
+        x: '5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 1',
+        x: '102.5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 2',
+        x: '200',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 3',
+        x: '297.5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 4',
+        x: '395',
+        y: '373',
+      },
+    ]);
   });
 
   it('should render the chart when the same data are defined on Line elements and not on the chart', () => {
@@ -657,16 +709,56 @@ describe('<LineChart /> and various data sources', () => {
     expectLabels(container, ['258', '295', '193', '168', '117', '597', '745', '657', '538', '762']);
     // sic! the XAxis renders all ticks twice!
     expectXAxisTicks(container, [
-      'Iter: 0',
-      'Iter: 1',
-      'Iter: 2',
-      'Iter: 3',
-      'Iter: 4',
-      'Iter: 0',
-      'Iter: 1',
-      'Iter: 2',
-      'Iter: 3',
-      'Iter: 4',
+      {
+        textContent: 'Iter: 0',
+        x: '5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 1',
+        x: '48.333333333333336',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 2',
+        x: '91.66666666666667',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 3',
+        x: '135',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 4',
+        x: '178.33333333333334',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 0',
+        x: '221.66666666666669',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 1',
+        x: '265',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 2',
+        x: '308.33333333333337',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 3',
+        x: '351.6666666666667',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 4',
+        x: '395',
+        y: '373',
+      },
     ]);
   });
 
@@ -679,7 +771,33 @@ describe('<LineChart /> and various data sources', () => {
       </LineChart>,
     );
     expectLabels(container, ['258', '295', '193', '168', '117', '597', '745', '657', '538', '762']);
-    expectXAxisTicks(container, ['Iter: 0', 'Iter: 1', 'Iter: 2', 'Iter: 3', 'Iter: 4']);
+    expectXAxisTicks(container, [
+      {
+        textContent: 'Iter: 0',
+        x: '5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 1',
+        x: '102.5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 2',
+        x: '200',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 3',
+        x: '297.5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 4',
+        x: '395',
+        y: '373',
+      },
+    ]);
   });
 
   it('should render the chart when the same data are defined on Line elements and not on the chart - with a custom domain perhaps?', () => {
@@ -693,16 +811,56 @@ describe('<LineChart /> and various data sources', () => {
     expectLabels(container, ['258', '295', '193', '168', '117', '597', '745', '657', '538', '762']);
     // sic! the XAxis renders all ticks twice -anyway- and ignores my attempt at setting a domain
     expectXAxisTicks(container, [
-      'Iter: 0',
-      'Iter: 1',
-      'Iter: 2',
-      'Iter: 3',
-      'Iter: 4',
-      'Iter: 0',
-      'Iter: 1',
-      'Iter: 2',
-      'Iter: 3',
-      'Iter: 4',
+      {
+        textContent: 'Iter: 0',
+        x: '5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 1',
+        x: '48.333333333333336',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 2',
+        x: '91.66666666666667',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 3',
+        x: '135',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 4',
+        x: '178.33333333333334',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 0',
+        x: '221.66666666666669',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 1',
+        x: '265',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 2',
+        x: '308.33333333333337',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 3',
+        x: '351.6666666666667',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 4',
+        x: '395',
+        y: '373',
+      },
     ]);
   });
 
@@ -722,7 +880,33 @@ describe('<LineChart /> and various data sources', () => {
     );
     expectLabels(container, ['258', '295', '193', '168', '117', '597', '745', '657', '538', '762']);
     // so XAxis will filter the provided domain for duplicates, too
-    expectXAxisTicks(container, ['Iter: 0', 'Iter: 1', 'Iter: 2', 'Iter: 3', 'Iter: 4']);
+    expectXAxisTicks(container, [
+      {
+        textContent: 'Iter: 0',
+        x: '5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 1',
+        x: '102.5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 2',
+        x: '200',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 3',
+        x: '297.5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 4',
+        x: '395',
+        y: '373',
+      },
+    ]);
   });
 
   it('should render the same chart when the different data are defined on Line elements and not on the chart', () => {
@@ -736,16 +920,56 @@ describe('<LineChart /> and various data sources', () => {
     expectLabels(container, ['258', '295', '193', '168', '117', '770', '622', '670', '495', '603']);
     // okay this is reasonable
     expectXAxisTicks(container, [
-      'Iter: 0',
-      'Iter: 1',
-      'Iter: 2',
-      'Iter: 3',
-      'Iter: 4',
-      'Iter: 5',
-      'Iter: 6',
-      'Iter: 7',
-      'Iter: 8',
-      'Iter: 9',
+      {
+        textContent: 'Iter: 0',
+        x: '5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 1',
+        x: '48.333333333333336',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 2',
+        x: '91.66666666666667',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 3',
+        x: '135',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 4',
+        x: '178.33333333333334',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 5',
+        x: '221.66666666666669',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 6',
+        x: '265',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 7',
+        x: '308.33333333333337',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 8',
+        x: '351.6666666666667',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 9',
+        x: '395',
+        y: '373',
+      },
     ]);
   });
 
@@ -759,7 +983,33 @@ describe('<LineChart /> and various data sources', () => {
     );
     expectLabels(container, ['258', '295', '193', '168', '117', '770', '622', '670', '495', '603']);
     // this is bad - XAxis ignores ticks from the Chart root
-    expectXAxisTicks(container, ['Iter: 0', 'Iter: 1', 'Iter: 2', 'Iter: 3', 'Iter: 4']);
+    expectXAxisTicks(container, [
+      {
+        textContent: 'Iter: 0',
+        x: '5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 1',
+        x: '102.5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 2',
+        x: '200',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 3',
+        x: '297.5',
+        y: '373',
+      },
+      {
+        textContent: 'Iter: 4',
+        x: '395',
+        y: '373',
+      },
+    ]);
   });
 });
 
@@ -1021,7 +1271,7 @@ describe('<LineChart /> - Rendering two line charts with syncId', () => {
 
   /**
    * Tooltip tries to read payload from Redux but tooltip synchronisation is not in redux yet and so this test fails
-   * TODO implement tooltip sync in redux and then enable this test again
+   *  implement tooltip sync in redux and then enable this test again
    * https://github.com/recharts/recharts/issues/4548
    */
   test.fails(

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -1271,7 +1271,7 @@ describe('<LineChart /> - Rendering two line charts with syncId', () => {
 
   /**
    * Tooltip tries to read payload from Redux but tooltip synchronisation is not in redux yet and so this test fails
-   *  implement tooltip sync in redux and then enable this test again
+   * TODO implement tooltip sync in redux and then enable this test again
    * https://github.com/recharts/recharts/issues/4548
    */
   test.fails(

--- a/test/helper/expectAxisTicks.ts
+++ b/test/helper/expectAxisTicks.ts
@@ -4,10 +4,20 @@ import { AxisId } from '../../src/state/axisMapSlice';
 import { selectAxisDomain } from '../../src/state/axisSelectors';
 import { useAppSelector } from '../../src/state/hooks';
 
-export function expectXAxisTicks(container: Element, ticks: ReadonlyArray<string>) {
-  const allTicks = container.querySelectorAll('.recharts-xAxis .recharts-cartesian-axis-tick');
+export type ExpectedTick = {
+  textContent: string;
+  x: string;
+  y: string;
+};
+
+export function expectXAxisTicks(container: Element, ticks: ReadonlyArray<ExpectedTick>) {
+  const allTicks = container.querySelectorAll('.recharts-xAxis .recharts-cartesian-axis-tick-value');
   assertNotNull(allTicks);
-  const ticksContexts = Array.from(allTicks).map(tick => tick.textContent);
+  const ticksContexts = Array.from(allTicks).map(tick => ({
+    textContent: tick.textContent,
+    x: tick.getAttribute('x'),
+    y: tick.getAttribute('y'),
+  }));
   expect(ticksContexts).toEqual(ticks);
 }
 

--- a/test/state/axisSelectors.spec.tsx
+++ b/test/state/axisSelectors.spec.tsx
@@ -91,7 +91,38 @@ describe('selectAxisScale', () => {
         <Customized component={Comp} />
       </BarChart>,
     );
-    expectXAxisTicks(container, ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
+    expectXAxisTicks(container, [
+      {
+        textContent: 'Page A',
+        x: '12.5',
+        y: '73',
+      },
+      {
+        textContent: 'Page B',
+        x: '27.5',
+        y: '73',
+      },
+      {
+        textContent: 'Page C',
+        x: '42.5',
+        y: '73',
+      },
+      {
+        textContent: 'Page D',
+        x: '57.5',
+        y: '73',
+      },
+      {
+        textContent: 'Page E',
+        x: '72.5',
+        y: '73',
+      },
+      {
+        textContent: 'Page F',
+        x: '87.5',
+        y: '73',
+      },
+    ]);
     expect(spy).toHaveBeenLastCalledWith(['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
   });
 });
@@ -146,7 +177,33 @@ describe('selectAxisDomain', () => {
         </BarChart>,
       );
       expect(spy).toHaveBeenLastCalledWith([0, 405]);
-      expectXAxisTicks(container, ['0', '100', '200', '300', '400']);
+      expectXAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '5',
+          y: '73',
+        },
+        {
+          textContent: '100',
+          x: '27.5',
+          y: '73',
+        },
+        {
+          textContent: '200',
+          x: '50',
+          y: '73',
+        },
+        {
+          textContent: '300',
+          x: '72.5',
+          y: '73',
+        },
+        {
+          textContent: '400',
+          x: '95',
+          y: '73',
+        },
+      ]);
     });
 
     it('should return undefined if the data is not numerical', () => {
@@ -211,7 +268,33 @@ describe('selectAxisDomain', () => {
         </BarChart>,
       );
       expect(spy).toHaveBeenLastCalledWith([0, 10000]);
-      expectXAxisTicks(container, ['0', '2500', '5000', '7500', '10000']);
+      expectXAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '5',
+          y: '73',
+        },
+        {
+          textContent: '2500',
+          x: '27.5',
+          y: '73',
+        },
+        {
+          textContent: '5000',
+          x: '50',
+          y: '73',
+        },
+        {
+          textContent: '7500',
+          x: '72.5',
+          y: '73',
+        },
+        {
+          textContent: '10000',
+          x: '95',
+          y: '73',
+        },
+      ]);
     });
 
     it('should squish all data defined on all items and chart root and return min, max of the combination', () => {
@@ -283,7 +366,33 @@ describe('selectAxisDomain', () => {
         </ComposedChart>,
       );
       expect(spy).toHaveBeenLastCalledWith([0, 225]);
-      expectXAxisTicks(container, ['0', '55', '110', '165', '220']);
+      expectXAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '65',
+          y: '73',
+        },
+        {
+          textContent: '55',
+          x: '72.5',
+          y: '73',
+        },
+        {
+          textContent: '110',
+          x: '80',
+          y: '73',
+        },
+        {
+          textContent: '165',
+          x: '87.5',
+          y: '73',
+        },
+        {
+          textContent: '220',
+          x: '95',
+          y: '73',
+        },
+      ]);
     });
   });
 
@@ -302,7 +411,38 @@ describe('selectAxisDomain', () => {
         </BarChart>,
       );
       expect(spy).toHaveBeenLastCalledWith(['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
-      expectXAxisTicks(container, ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
+      expectXAxisTicks(container, [
+        {
+          textContent: 'Page A',
+          x: '12.5',
+          y: '73',
+        },
+        {
+          textContent: 'Page B',
+          x: '27.5',
+          y: '73',
+        },
+        {
+          textContent: 'Page C',
+          x: '42.5',
+          y: '73',
+        },
+        {
+          textContent: 'Page D',
+          x: '57.5',
+          y: '73',
+        },
+        {
+          textContent: 'Page E',
+          x: '72.5',
+          y: '73',
+        },
+        {
+          textContent: 'Page F',
+          x: '87.5',
+          y: '73',
+        },
+      ]);
     });
 
     it.each([true, undefined])(
@@ -321,7 +461,38 @@ describe('selectAxisDomain', () => {
           </BarChart>,
         );
         expect(spy).toHaveBeenLastCalledWith([400, 300, 300, 200, 278, 189]);
-        expectXAxisTicks(container, ['400', '300', '300', '200', '278', '189']);
+        expectXAxisTicks(container, [
+          {
+            textContent: '400',
+            x: '12.5',
+            y: '73',
+          },
+          {
+            textContent: '300',
+            x: '27.5',
+            y: '73',
+          },
+          {
+            textContent: '300',
+            x: '42.5',
+            y: '73',
+          },
+          {
+            textContent: '200',
+            x: '57.5',
+            y: '73',
+          },
+          {
+            textContent: '278',
+            x: '72.5',
+            y: '73',
+          },
+          {
+            textContent: '189',
+            x: '87.5',
+            y: '73',
+          },
+        ]);
       },
     );
 
@@ -339,7 +510,33 @@ describe('selectAxisDomain', () => {
         </BarChart>,
       );
       expect(spy).toHaveBeenLastCalledWith([400, 300, 200, 278, 189]);
-      expectXAxisTicks(container, ['400', '300', '200', '278', '189']);
+      expectXAxisTicks(container, [
+        {
+          textContent: '400',
+          x: '14',
+          y: '73',
+        },
+        {
+          textContent: '300',
+          x: '32',
+          y: '73',
+        },
+        {
+          textContent: '200',
+          x: '50',
+          y: '73',
+        },
+        {
+          textContent: '278',
+          x: '68',
+          y: '73',
+        },
+        {
+          textContent: '189',
+          x: '86',
+          y: '73',
+        },
+      ]);
     });
 
     it('should replace everything that is not a number, string, or Date, with empty string', () => {
@@ -397,24 +594,92 @@ describe('selectAxisDomain', () => {
         '',
       ]);
       expectXAxisTicks(container, [
-        '',
-        'Jan',
-        '',
-        'Feb',
-        'Mar',
-        '',
-        'Apr',
-        '',
-        'May',
-        '',
-        'Jun',
-        '',
-        'Jul',
-        '',
-        'Aug',
-        '',
-        // no idea where the string 'undefined' comes from - the new implementation doesn't have it, breaking or not.
-        'undefined',
+        {
+          textContent: '',
+          x: '7.647058823529411',
+          y: '73',
+        },
+        {
+          textContent: 'Jan',
+          x: '12.941176470588234',
+          y: '73',
+        },
+        {
+          textContent: '',
+          x: '18.235294117647058',
+          y: '73',
+        },
+        {
+          textContent: 'Feb',
+          x: '23.529411764705884',
+          y: '73',
+        },
+        {
+          textContent: 'Mar',
+          x: '28.823529411764707',
+          y: '73',
+        },
+        {
+          textContent: '',
+          x: '34.11764705882353',
+          y: '73',
+        },
+        {
+          textContent: 'Apr',
+          x: '39.411764705882355',
+          y: '73',
+        },
+        {
+          textContent: '',
+          x: '44.705882352941174',
+          y: '73',
+        },
+        {
+          textContent: 'May',
+          x: '50',
+          y: '73',
+        },
+        {
+          textContent: '',
+          x: '55.294117647058826',
+          y: '73',
+        },
+        {
+          textContent: 'Jun',
+          x: '60.588235294117645',
+          y: '73',
+        },
+        {
+          textContent: '',
+          x: '65.88235294117646',
+          y: '73',
+        },
+        {
+          textContent: 'Jul',
+          x: '71.17647058823529',
+          y: '73',
+        },
+        {
+          textContent: '',
+          x: '76.47058823529412',
+          y: '73',
+        },
+        {
+          textContent: 'Aug',
+          x: '81.76470588235293',
+          y: '73',
+        },
+        {
+          textContent: '',
+          x: '87.05882352941175',
+          y: '73',
+        },
+        {
+          // no idea where the string 'undefined' comes from - the new implementation doesn't have it, breaking or not.
+          textContent: 'undefined',
+          x: '92.35294117647058',
+          y: '73',
+        },
       ]);
     });
 
@@ -449,7 +714,28 @@ describe('selectAxisDomain', () => {
         </BarChart>,
       );
       expect(spy).toHaveBeenLastCalledWith(['', 'Monday', 'Tuesday', 'Wednesday']);
-      expectXAxisTicks(container, ['', 'Monday', 'Tuesday', 'Wednesday']);
+      expectXAxisTicks(container, [
+        {
+          textContent: '',
+          x: '16.25',
+          y: '73',
+        },
+        {
+          textContent: 'Monday',
+          x: '38.75',
+          y: '73',
+        },
+        {
+          textContent: 'Tuesday',
+          x: '61.25',
+          y: '73',
+        },
+        {
+          textContent: 'Wednesday',
+          x: '83.75',
+          y: '73',
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Description

Adding assertions to existing test cases, and added tests for padding defined as an object. The string constants were tested already.

## Related Issue

https://github.com/recharts/recharts/issues/4583

## Motivation and Context

I am going to change domain range next and I want it to be tested.

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
