### PR TITLE
Add default for nameKey in Treemap

### DIFF
--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -504,6 +504,7 @@ export class Treemap extends PureComponent<Props, State> {
   static defaultProps = {
     aspectRatio: 0.5 * (1 + Math.sqrt(5)),
     dataKey: 'value',
+    nameKey: 'name',
     type: 'flat',
     isAnimationActive: !Global.isSsr,
     isUpdateAnimationActive: !Global.isSsr,


### PR DESCRIPTION
## Description

Treemap does not have a default value for nameKey. This pull request adds it

## Related Issue

https://github.com/recharts/recharts/issues/4648

## Motivation and Context

Tooltips are not displayed by default. See https://github.com/recharts/recharts/issues/4648
This changes should be follow by an editing of documentation. 

## How Has This Been Tested?

npm test

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly: https://github.com/recharts/recharts.org/pull/297
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
