### PR TITLE
Consider null as 0 in stacked area chart with connectNulls (v3)

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -242,6 +242,7 @@ export class Area extends PureComponent<Props, State> {
     dataKey: Props['dataKey'];
   }): AreaComposedData => {
     const { layout } = props;
+    const { connectNulls } = item.props;
     const hasStack = stackedData && stackedData.length;
     const baseValue = Area.getBaseValue(props, item, xAxis, yAxis);
     const isHorizontalLayout = layout === 'horizontal';
@@ -262,7 +263,7 @@ export class Area extends PureComponent<Props, State> {
         }
       }
 
-      const isBreakPoint = value[1] == null || (hasStack && getValueByDataKey(entry, dataKey) == null);
+      const isBreakPoint = value[1] == null || (hasStack && !connectNulls && getValueByDataKey(entry, dataKey) == null);
 
       if (isHorizontalLayout) {
         return {

--- a/storybook/stories/Examples/AreaChart.stories.tsx
+++ b/storybook/stories/Examples/AreaChart.stories.tsx
@@ -263,6 +263,96 @@ export const AreaChartConnectNulls = {
   },
 };
 
+export const StackedAreaChartConnectNulls = {
+  render: () => {
+    const data = [
+      {
+        name: 'Page A',
+        uv: 4000,
+        pv: 2400,
+        amt: 2400,
+      },
+      {
+        name: 'Page B',
+        uv: 3000,
+        pv: 1398,
+        amt: 2210,
+      },
+      {
+        name: 'Page C',
+        uv: 2000,
+      },
+      {
+        name: 'Page D',
+        pv: 3908,
+        amt: 2000,
+      },
+      {
+        name: 'Page E',
+        uv: 1890,
+        pv: 4800,
+        amt: 2181,
+      },
+      {
+        name: 'Page F',
+        uv: 2390,
+        pv: 3800,
+        amt: 2500,
+      },
+      {
+        name: 'Page G',
+      },
+    ];
+
+    return (
+      <div style={{ width: '100%' }}>
+        <ResponsiveContainer width="100%" height={200}>
+          <AreaChart
+            width={500}
+            height={200}
+            data={data}
+            margin={{
+              top: 10,
+              right: 30,
+              left: 0,
+              bottom: 0,
+            }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Area type="monotone" dataKey="uv" stackId="1" stroke="#8884d8" fill="#8884d8" />
+            <Area type="monotone" dataKey="pv" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
+            <Area type="monotone" dataKey="amt" stackId="1" stroke="#ffc658" fill="#ffc658" />
+          </AreaChart>
+        </ResponsiveContainer>
+        <ResponsiveContainer width="100%" height={200}>
+          <AreaChart
+            width={500}
+            height={200}
+            data={data}
+            margin={{
+              top: 10,
+              right: 30,
+              left: 0,
+              bottom: 0,
+            }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip />
+            <Area connectNulls type="monotone" dataKey="uv" stackId="1" stroke="#8884d8" fill="#8884d8" />
+            <Area connectNulls type="monotone" dataKey="pv" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
+            <Area connectNulls type="monotone" dataKey="amt" stackId="1" stroke="#ffc658" fill="#ffc658" />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    );
+  },
+};
+
 export const SynchronisedAreaChart = {
   render: () => {
     return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
https://github.com/recharts/recharts/pull/4656 for v3

<!--- Describe your changes in detail -->

## Related Issue
#4656 
#2176 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
(I captured screenshot again, with this branch.)
<img width="605" alt="image" src="https://github.com/recharts/recharts/assets/20365512/87f94b9b-0291-4550-bde4-c957a565fd16">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
