### PR TITLE
Domain selector for XAxis in vertical chart

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -588,6 +588,7 @@ export class Bar extends PureComponent<Props, State> {
 
     const offset = layout === 'vertical' ? data[0].height / 2 : data[0].width / 2;
 
+    // @ts-expect-error getValueByDataKey does not validate the output type
     const dataPointFormatter: ErrorBarDataPointFormatter = (dataPoint: BarRectangleItem, dataKey) => {
       /**
        * if the value coming from `getComposedData` is an array then this is a stacked bar chart.

--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -182,6 +182,7 @@ function getTextOfTick(props: TextOfTickProps): ReactText {
   const { index, data, tickFormatter, dataKey } = props;
   const text = getValueByDataKey(data[index], dataKey, index);
 
+  // @ts-expect-error getValueByDataKey does not validate the output type
   return isFunction(tickFormatter) ? tickFormatter(text, index) : text;
 }
 

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -198,6 +198,7 @@ export class Line extends PureComponent<Props, State> {
       if (layout === 'horizontal') {
         return {
           x: getCateCoordinateOfLine({ axis: xAxis, ticks: xAxisTicks, bandSize, entry, index }),
+          // @ts-expect-error getValueByDataKey does not validate the output type
           y: isNil(value) ? null : yAxis.scale(value),
           value,
           payload: entry,
@@ -205,6 +206,7 @@ export class Line extends PureComponent<Props, State> {
       }
 
       return {
+        // @ts-expect-error getValueByDataKey does not validate the output type
         x: isNil(value) ? null : xAxis.scale(value),
         y: getCateCoordinateOfLine({ axis: yAxis, ticks: yAxisTicks, bandSize, entry, index }),
         value,
@@ -212,6 +214,7 @@ export class Line extends PureComponent<Props, State> {
       };
     });
 
+    // @ts-expect-error getValueByDataKey does not validate the output type
     return { points, layout, ...offset };
   };
 
@@ -343,6 +346,7 @@ export class Line extends PureComponent<Props, State> {
       return null;
     }
 
+    // @ts-expect-error getValueByDataKey does not validate the output type
     const dataPointFormatter: ErrorBarDataPointFormatter = (dataPoint: LinePointItem, dataKey) => {
       return {
         x: dataPoint.x,

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -281,6 +281,7 @@ export class Scatter extends PureComponent<Props, State> {
           // @ts-expect-error name prop should not have dataKey in it
           name: isNil(xAxis.dataKey) ? item.props.name : xAxis.name || xAxis.dataKey,
           unit: xAxis.unit || '',
+          // @ts-expect-error getValueByDataKey does not validate the output type
           value: x,
           payload: entry,
           dataKey: xAxisDataKey,
@@ -290,6 +291,7 @@ export class Scatter extends PureComponent<Props, State> {
           // @ts-expect-error name prop should not have dataKey in it
           name: isNil(yAxis.dataKey) ? item.props.name : yAxis.name || yAxis.dataKey,
           unit: yAxis.unit || '',
+          // @ts-expect-error getValueByDataKey does not validate the output type
           value: y,
           payload: entry,
           dataKey: yAxisDataKey,
@@ -302,6 +304,7 @@ export class Scatter extends PureComponent<Props, State> {
           // @ts-expect-error name prop should not have dataKey in it
           name: zAxis.name || zAxis.dataKey,
           unit: zAxis.unit || '',
+          // @ts-expect-error getValueByDataKey does not validate the output type
           value: z,
           payload: entry,
           dataKey: zAxisDataKey,
@@ -324,6 +327,7 @@ export class Scatter extends PureComponent<Props, State> {
         index,
         dataKey: yAxisDataKey,
       });
+      // @ts-expect-error getValueByDataKey does not validate the output type
       const size = z !== '-' ? zAxis.scale(z) : defaultZ;
       const radius = Math.sqrt(Math.max(size, 0) / Math.PI);
 
@@ -462,6 +466,7 @@ export class Scatter extends PureComponent<Props, State> {
         xAxis,
         yAxis,
         layout: direction === 'x' ? 'vertical' : 'horizontal',
+        // @ts-expect-error getValueByDataKey does not validate the output type
         dataPointFormatter: (dataPoint: ScatterPointItem, dataKey: Props['dataKey']) => {
           return {
             x: dataPoint.cx,

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -127,6 +127,7 @@ export const computeNode = ({
   return {
     ...node,
     children: computedChildren,
+    // @ts-expect-error getValueByDataKey does not validate the output type
     name: getValueByDataKey(node, nameKey, ''),
     [NODE_VALUE_KEY]: nodeValue,
     depth,

--- a/src/numberAxis/Funnel.tsx
+++ b/src/numberAxis/Funnel.tsx
@@ -256,8 +256,10 @@ export class Funnel extends PureComponent<FunnelProps, State> {
         nextVal = 0;
       }
 
+      // @ts-expect-error getValueByDataKey does not validate the output type
       const x = ((maxValue - val) * realWidth) / (2 * maxValue) + top + 25 + offsetX;
       const y = rowHeight * i + left + offsetY;
+      // @ts-expect-error getValueByDataKey does not validate the output type
       const upperWidth = (val / maxValue) * realWidth;
       const lowerWidth = (nextVal / maxValue) * realWidth;
 
@@ -274,13 +276,13 @@ export class Funnel extends PureComponent<FunnelProps, State> {
         upperWidth,
         lowerWidth,
         height: rowHeight,
+        // @ts-expect-error getValueByDataKey does not validate the output type
         name,
         val,
         tooltipPayload,
         tooltipPosition,
         ...omit(entry, 'width'),
         payload: entry,
-        // @ts-expect-error parentViewBox property does not exist on type FunnelTrapezoidItem
         parentViewBox,
         labelViewBox: {
           x: x + (upperWidth - lowerWidth) / 4,

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -388,7 +388,9 @@ export class Pie extends PureComponent<Props, State> {
         const middleRadius = (coordinate.innerRadius + coordinate.outerRadius) / 2;
         const tooltipPayload: TooltipPayload = [
           {
+            // @ts-expect-error getValueByDataKey does not validate the output type
             name,
+            // @ts-expect-error getValueByDataKey does not validate the output type
             value: val,
             payload: entry,
             dataKey,

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -181,7 +181,9 @@ export class Radar extends PureComponent<Props, State> {
 
       points.push({
         ...polarToCartesian(cx, cy, radius, angle),
+        // @ts-expect-error getValueByDataKey does not validate the output type
         name,
+        // @ts-expect-error getValueByDataKey does not validate the output type
         value,
         cx,
         cy,

--- a/src/state/chartDataSlice.ts
+++ b/src/state/chartDataSlice.ts
@@ -4,8 +4,21 @@ import { BrushStartEndIndex } from '../context/brushUpdateContext';
 /**
  * This is the data that's coming through main chart `data` prop
  * Recharts is very flexible in what it accepts so the type is very flexible too.
+ * This will typically be an object, and various components will provide various `dataKey`
+ * that dictates how to pull data from that object.
+ *
+ * TL;DR: before dataKey
  */
 export type ChartData = unknown[];
+
+/**
+ * So this is the same unknown type as ChartData but this is after the dataKey has been applied.
+ * We still don't know what the type is - that depends on what exactly it was before the dataKey application,
+ * and the dataKey can return whatever anyway - but let's keep it separate as a form of documentation.
+ *
+ * TL;DR: ChartData after dataKey
+ */
+export type AppliedChartData = ReadonlyArray<{ value: unknown }>;
 
 export type ChartDataState = {
   chartData: ChartData | undefined;

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -231,6 +231,7 @@ export const combineTooltipPayload = (
             tooltipEntrySettings: newSettings,
             dataKey: item.dataKey,
             payload: item.payload,
+            // @ts-expect-error getValueByDataKey does not validate the output type
             value: getValueByDataKey(item.payload, item.dataKey),
             name: item.name,
           }),
@@ -243,7 +244,9 @@ export const combineTooltipPayload = (
           tooltipEntrySettings: settings,
           dataKey: finalDataKey,
           payload: tooltipPayload,
+          // @ts-expect-error getValueByDataKey does not validate the output type
           value: getValueByDataKey(tooltipPayload, finalDataKey),
+          // @ts-expect-error getValueByDataKey does not validate the output type
           name: getValueByDataKey(tooltipPayload, finalNameKey) ?? settings?.name,
         }),
       );

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -64,7 +64,7 @@ import { inRangeOfSector, polarToCartesian } from './PolarUtils';
 // Exported for backwards compatibility
 export { getLegendProps };
 
-export function getValueByDataKey<T>(obj: T, dataKey: DataKey<T>, defaultValue?: any) {
+export function getValueByDataKey<T>(obj: T, dataKey: DataKey<T>, defaultValue?: any): unknown {
   if (isNil(obj) || isNil(dataKey)) {
     return defaultValue;
   }
@@ -1195,6 +1195,7 @@ export function getCateCoordinateOfLine<T extends Record<string, unknown>>({
 
   const value = getValueByDataKey(entry, !isNil(dataKey) ? dataKey : axis.dataKey);
 
+  // @ts-expect-error getValueByDataKey does not validate the output type
   return !isNil(value) ? axis.scale(value) : null;
 }
 

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -414,10 +414,11 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
       );
       expect(spy).toHaveBeenLastCalledWith(
         expect.arrayContaining([
-          expect.objectContaining({
+          {
             data: data2,
+            dataKey: 'value',
             xAxisId: 7,
-          }),
+          },
         ]),
       );
 
@@ -427,6 +428,32 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
         </ChartElement>,
       );
       expect(spy).toHaveBeenLastCalledWith([]);
+    });
+
+    it('should report default props to redux state', () => {
+      const spy = vi.fn();
+      const Comp = (): null => {
+        const cartesianItems = useAppSelector(state => state.graphicalItems.cartesianItems);
+        spy(cartesianItems);
+        return null;
+      };
+      const data2 = [1, 2, 3];
+
+      render(
+        <ChartElement data={data}>
+          <Area dataKey="value" data={data2} />
+          <Customized component={<Comp />} />
+        </ChartElement>,
+      );
+      expect(spy).toHaveBeenLastCalledWith(
+        expect.arrayContaining([
+          {
+            data: data2,
+            dataKey: 'value',
+            xAxisId: 0,
+          },
+        ]),
+      );
     });
   });
 

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -16,7 +16,11 @@ import {
   XAxis,
   YAxis,
 } from '../../src';
-import { selectAxisSettings } from '../../src/state/axisSelectors';
+import {
+  selectAxisSettings,
+  selectCartesianGraphicalItemsData,
+  selectDisplayedData,
+} from '../../src/state/axisSelectors';
 import { useAppSelector } from '../../src/state/hooks';
 import { ExpectAxisDomain, expectXAxisTicks } from '../helper/expectAxisTicks';
 import { XAxisSettings } from '../../src/state/axisMapSlice';
@@ -152,11 +156,11 @@ describe('<XAxis />', () => {
   });
 
   it('should render array indexes when dataKey is not specified', () => {
-    const spy = vi.fn();
+    const axisDomainSpy = vi.fn();
     const { container } = render(
       <LineChart width={400} height={400} data={lineData}>
         <XAxis />
-        <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
+        <Customized component={<ExpectAxisDomain assert={axisDomainSpy} axisType="xAxis" />} />
       </LineChart>,
     );
 
@@ -193,7 +197,7 @@ describe('<XAxis />', () => {
         y: '373',
       },
     ]);
-    expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+    expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
   });
 
   it('should return empty strings when dataKey is specified but does not match the data', () => {
@@ -3172,10 +3176,14 @@ describe('<XAxis />', () => {
     });
 
     it('should render with in LineChart VerticalWithSpecifiedDomain', () => {
-      // const axisDomainSpy = vi.fn();
+      const axisDomainSpy = vi.fn();
       const axisSettingsSpy = vi.fn();
+      const displayedDataSpy = vi.fn();
+      const itemDataSpy = vi.fn();
       const Comp = (): null => {
         axisSettingsSpy(useAppSelector(state => selectAxisSettings(state, 'xAxis', 0)));
+        displayedDataSpy(useAppSelector(state => selectDisplayedData(state, 'xAxis', 0)));
+        itemDataSpy(useAppSelector(state => selectCartesianGraphicalItemsData(state, 'xAxis', 0)));
         return null;
       };
       const { container } = render(
@@ -3199,6 +3207,7 @@ describe('<XAxis />', () => {
           <Line dataKey="uv" stroke="#82ca9d" />
           <Tooltip />
           <Customized component={<Comp />} />
+          <Customized component={<ExpectAxisDomain assert={axisDomainSpy} axisType="xAxis" />} />
         </LineChart>,
       );
       expectXAxisTicks(container, [
@@ -3238,8 +3247,15 @@ describe('<XAxis />', () => {
         tickCount: 5,
         type: 'number',
       });
-      // TODO this fails because the redux selectors do not yet implement what `getDomainOfItemsWithSameAxis` does.
-      // expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 2520]);
+      expect(itemDataSpy).toHaveBeenLastCalledWith([]);
+      expect(itemDataSpy).toHaveBeenCalledTimes(3);
+      expect(displayedDataSpy).toHaveBeenLastCalledWith(pageData);
+      // oof
+      expect(axisDomainSpy).toHaveBeenCalledTimes(20);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 2520]);
     });
   });
+
+  describe.todo('in vertical stacked BarChart');
+  describe.todo('with custom tickFormatter');
 });

--- a/test/state/axisSelectors.spec.tsx
+++ b/test/state/axisSelectors.spec.tsx
@@ -1,33 +1,34 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { useAppSelector } from '../../src/state/hooks';
 import {
-  selectAxisScale,
+  selectAllAppliedValues,
   selectAxisDomain,
-  selectHasBar,
+  selectAxisScale,
   selectCalculatedXAxisPadding,
-  selectSmallestDistanceBetweenValues,
   selectCartesianGraphicalItemsData,
-  selectAllDataSquished,
+  selectDisplayedData,
+  selectHasBar,
+  selectSmallestDistanceBetweenValues,
 } from '../../src/state/axisSelectors';
 import { createRechartsStore, RechartsRootState } from '../../src/state/store';
 import {
+  Area,
   Bar,
   BarChart,
-  XAxis,
-  Customized,
-  ComposedChart,
-  Area,
-  Line,
-  Scatter,
-  YAxis,
-  RadialBarChart,
-  RadialBar,
-  PieChart,
-  Pie,
-  LineChart,
   Brush,
+  ComposedChart,
+  Customized,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  RadialBar,
+  RadialBarChart,
+  Scatter,
+  XAxis,
+  YAxis,
 } from '../../src';
 import { misbehavedData, PageData } from '../_data';
 import { ExpectAxisDomain, expectXAxisTicks } from '../helper/expectAxisTicks';
@@ -36,6 +37,10 @@ import { generateMockData } from '../helper/generateMockData';
 import { AxisId } from '../../src/state/axisMapSlice';
 
 const defaultAxisId: AxisId = 0;
+
+const mockData = generateMockData(10, 982347);
+const data1 = mockData.slice(0, 5);
+const data2 = mockData.slice(5);
 
 describe('selectAxisScale', () => {
   it('should return undefined when called outside of Redux context', () => {
@@ -179,6 +184,156 @@ describe('selectAxisDomain', () => {
     expectXAxisTicks(container, []);
   });
 
+  it('should gather data from all graphical items that match the axis ID', () => {
+    const axisDomainSpy = vi.fn();
+    const Comp = (): null => {
+      axisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'xAxis', defaultAxisId)));
+      return null;
+    };
+    render(
+      <LineChart width={100} height={100}>
+        <Line data={data1} />
+        <Line data={data2} />
+        <XAxis dataKey="y" />
+        <Customized component={Comp} />
+      </LineChart>,
+    );
+    expect(axisDomainSpy).toHaveBeenLastCalledWith([481, 672, 721, 446, 598, 774, 687, 762, 439, 569]);
+    expect(axisDomainSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return nothing for graphical items that do not have any explicit data prop on them', () => {
+    const domainSpy = vi.fn();
+    const { container } = render(
+      <ComposedChart data={PageData} width={100} height={100}>
+        <Area dataKey="" />
+        <Area dataKey="" data={[{ x: 10 }, { x: 20 }, { x: 30 }]} />
+        <Line />
+        <Line data={[{ x: 40 }, { x: 50 }, { x: 60 }]} />
+        <Scatter />
+        <Scatter data={[{ x: 70 }, { x: 80 }, { x: 90 }]} />
+        <XAxis dataKey="x" />
+        <Customized component={<ExpectAxisDomain axisType="xAxis" assert={domainSpy} />} />
+      </ComposedChart>,
+    );
+    expectXAxisTicks(container, [
+      {
+        textContent: '10',
+        x: '5',
+        y: '73',
+      },
+      {
+        textContent: '20',
+        x: '16.25',
+        y: '73',
+      },
+      {
+        textContent: '30',
+        x: '27.5',
+        y: '73',
+      },
+      {
+        textContent: '40',
+        x: '38.75',
+        y: '73',
+      },
+      {
+        textContent: '50',
+        x: '50',
+        y: '73',
+      },
+      {
+        textContent: '60',
+        x: '61.25',
+        y: '73',
+      },
+      {
+        textContent: '70',
+        x: '72.5',
+        y: '73',
+      },
+      {
+        textContent: '80',
+        x: '83.75',
+        y: '73',
+      },
+      {
+        textContent: '90',
+        x: '95',
+        y: '73',
+      },
+    ]);
+    expect(domainSpy).toHaveBeenLastCalledWith([70, 80, 90, 10, 20, 30, 40, 50, 60]);
+    // big oof
+    expect(domainSpy).toHaveBeenCalledTimes(28);
+  });
+
+  it('should return array indexes if there are multiple graphical items, and no explicit dataKey on the matching XAxis', () => {
+    const domainSpy = vi.fn();
+    const { container } = render(
+      <ComposedChart data={PageData} width={100} height={100}>
+        <Area dataKey="" />
+        <Area dataKey="" data={[{ x: 10 }, { x: 20 }, { x: 30 }]} />
+        <Line />
+        <Line data={[{ x: 40 }, { x: 50 }, { x: 60 }]} />
+        <Scatter />
+        <Scatter data={[{ x: 70 }, { x: 80 }, { x: 90 }]} />
+        <XAxis />
+        <Customized component={<ExpectAxisDomain axisType="xAxis" assert={domainSpy} />} />
+      </ComposedChart>,
+    );
+    expectXAxisTicks(container, [
+      {
+        textContent: '0',
+        x: '5',
+        y: '73',
+      },
+      {
+        textContent: '1',
+        x: '16.25',
+        y: '73',
+      },
+      {
+        textContent: '2',
+        x: '27.5',
+        y: '73',
+      },
+      {
+        textContent: '3',
+        x: '38.75',
+        y: '73',
+      },
+      {
+        textContent: '4',
+        x: '50',
+        y: '73',
+      },
+      {
+        textContent: '5',
+        x: '61.25',
+        y: '73',
+      },
+      {
+        textContent: '6',
+        x: '72.5',
+        y: '73',
+      },
+      {
+        textContent: '7',
+        x: '83.75',
+        y: '73',
+      },
+      {
+        textContent: '8',
+        x: '95',
+        y: '73',
+      },
+    ]);
+    expect(domainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+    // big oof
+    expect(domainSpy).toHaveBeenCalledTimes(28);
+  });
+
   describe('XAxis with type = number', () => {
     it('should return highest and lowest number of the chart root data based on the axis dataKey', () => {
       const spy = vi.fn();
@@ -314,7 +469,8 @@ describe('selectAxisDomain', () => {
       ]);
     });
 
-    it('should squish all data defined on all items, ignore chart root data, compute min, max of the combination, and then readjust it based on nice ticks', () => {
+    it(`should squish all data defined on all items, ignore chart root data,
+        compute min, max of the combination, and then readjust it based on nice ticks`, () => {
       const axisDomainSpy = vi.fn();
       const Comp = (): null => {
         const result = useAppSelector(state => selectAxisDomain(state, 'xAxis', 0));
@@ -1203,8 +1359,26 @@ describe('selectCartesianGraphicalItemsData', () => {
         <Customized component={Comp} />
       </BarChart>,
     );
-    expect(spy).toHaveBeenCalledTimes(2);
     expect(spy).toHaveBeenLastCalledWith([]);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return empty array in a chart with root data', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const tooltipData = useAppSelector(state => selectCartesianGraphicalItemsData(state, 'xAxis', defaultAxisId));
+      spy(tooltipData);
+      return null;
+    };
+    render(
+      <BarChart data={PageData} width={100} height={100}>
+        <Customized component={Comp} />
+        <Bar dataKey="pv" />
+        <Bar dataKey="uv" />
+      </BarChart>,
+    );
+    expect(spy).toHaveBeenLastCalledWith([]);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 
   it('should return all data defined on graphical items', () => {
@@ -1229,45 +1403,48 @@ describe('selectCartesianGraphicalItemsData', () => {
     );
     // as opposed to the tooltip data selector - this one stores all original data without transformation.
     expect(spy).toHaveBeenLastCalledWith(
-      expect.arrayContaining([
-        [1, 2, 3],
-        [10, 20, 30],
-        [4, 5, 6],
-        [40, 50, 60],
-        [7, 8, 9],
-        [70, 80, 90],
-      ]),
+      // the arrayContaining is there because it ignores elements order.
+      expect.arrayContaining([7, 8, 9, 70, 80, 90, 1, 2, 3, 10, 20, 30, 4, 5, 6, 40, 50, 60]),
     );
     expect(spy).toHaveBeenCalledTimes(3);
   });
 
   it('should return nothing for graphical items that do not have any explicit data prop on them', () => {
-    const spy = vi.fn();
+    const graphicalItemsDataSpy = vi.fn();
     const domainSpy = vi.fn();
     const Comp = (): null => {
       const tooltipData = useAppSelector(state => selectCartesianGraphicalItemsData(state, 'xAxis', defaultAxisId));
-      spy(tooltipData);
+      graphicalItemsDataSpy(tooltipData);
       return null;
     };
     const { container } = render(
       <ComposedChart data={PageData} width={100} height={100}>
         <Area dataKey="" />
-        <Area dataKey="" data={[10, 20, 30]} />
+        <Area dataKey="" data={[{ x: 10 }, { x: 20 }, { x: 30 }]} />
         <Line />
-        <Line data={[40, 50, 60]} />
+        <Line data={[{ x: 40 }, { x: 50 }, { x: 60 }]} />
         <Scatter />
-        <Scatter data={[70, 80, 90]} />
+        <Scatter data={[{ x: 70 }, { x: 80 }, { x: 90 }]} />
         <XAxis />
         <Customized component={Comp} />
         <Customized component={<ExpectAxisDomain axisType="xAxis" assert={domainSpy} />} />
       </ComposedChart>,
     );
     // Scatter - surprises again - and provides empty array instead of proper undefined like the other elements! Coincidentally that makes no difference
-    expect(spy).toHaveBeenLastCalledWith(
+    expect(graphicalItemsDataSpy).toHaveBeenLastCalledWith(
       // the order is arbitrary
-      expect.arrayContaining([[10, 20, 30], [40, 50, 60], [], [70, 80, 90]]),
+      expect.arrayContaining([
+        { x: 70 },
+        { x: 80 },
+        { x: 90 },
+        { x: 10 },
+        { x: 20 },
+        { x: 30 },
+        { x: 40 },
+        { x: 50 },
+        { x: 60 },
+      ]),
     );
-    expect(domainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8]);
     expectXAxisTicks(container, [
       {
         textContent: '0',
@@ -1315,6 +1492,7 @@ describe('selectCartesianGraphicalItemsData', () => {
         y: '73',
       },
     ]);
+    expect(domainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
   it('should not return any data defined on Pies - that one will have its own independent selector', () => {
@@ -1340,30 +1518,26 @@ describe('selectCartesianGraphicalItemsData', () => {
   });
 });
 
-describe('selectAllDataSquished', () => {
-  const mockData = generateMockData(10, 982347);
-  const data1 = mockData.slice(0, 5);
-  const data2 = mockData.slice(5);
-
+describe('selectDisplayedData', () => {
   it('should return undefined when called outside of Redux context', () => {
     expect.assertions(1);
     const Comp = (): null => {
-      const result = useAppSelector(state => selectAllDataSquished(state, 'xAxis', defaultAxisId));
+      const result = useAppSelector(state => selectDisplayedData(state, 'xAxis', defaultAxisId));
       expect(result).toBe(undefined);
       return null;
     };
     render(<Comp />);
   });
 
-  it('should return undefined for initial state', () => {
+  it('should return empty array for initial state', () => {
     const store = createRechartsStore();
-    expect(selectAllDataSquished(store.getState(), 'xAxis', defaultAxisId)).toEqual(undefined);
+    expect(selectDisplayedData(store.getState(), 'xAxis', defaultAxisId)).toEqual([]);
   });
 
-  it('should return undefined in an empty chart', () => {
+  it('should return empty in an empty chart', () => {
     const spy = vi.fn();
     const Comp = (): null => {
-      const result = useAppSelector(state => selectAllDataSquished(state, 'xAxis', defaultAxisId));
+      const result = useAppSelector(state => selectDisplayedData(state, 'xAxis', defaultAxisId));
       spy(result);
       return null;
     };
@@ -1372,14 +1546,14 @@ describe('selectAllDataSquished', () => {
         <Customized component={Comp} />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(undefined);
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith([]);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 
-  it('should return undefined if there is no axis with matching ID', () => {
+  it('should return the original data if there is no axis with matching ID', () => {
     const spy = vi.fn();
     const Comp = (): null => {
-      const result = useAppSelector(state => selectAllDataSquished(state, 'xAxis', defaultAxisId));
+      const result = useAppSelector(state => selectDisplayedData(state, 'xAxis', defaultAxisId));
       spy(result);
       return null;
     };
@@ -1390,14 +1564,154 @@ describe('selectAllDataSquished', () => {
         <Customized component={Comp} />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(undefined);
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith([
+      {
+        label: 'Iter: 0',
+        x: 211,
+        y: 481,
+        z: 1798,
+      },
+      {
+        label: 'Iter: 1',
+        x: 245,
+        y: 672,
+        z: 1087,
+      },
+      {
+        label: 'Iter: 2',
+        x: 266,
+        y: 721,
+        z: 1631,
+      },
+      {
+        label: 'Iter: 3',
+        x: 140,
+        y: 446,
+        z: 1932,
+      },
+      {
+        label: 'Iter: 4',
+        x: 131,
+        y: 598,
+        z: 1184,
+      },
+      {
+        label: 'Iter: 5',
+        x: 280,
+        y: 774,
+        z: 1811,
+      },
+      {
+        label: 'Iter: 6',
+        x: 294,
+        y: 687,
+        z: 1229,
+      },
+      {
+        label: 'Iter: 7',
+        x: 239,
+        y: 762,
+        z: 1410,
+      },
+      {
+        label: 'Iter: 8',
+        x: 293,
+        y: 439,
+        z: 1557,
+      },
+      {
+        label: 'Iter: 9',
+        x: 244,
+        y: 569,
+        z: 1305,
+      },
+    ]);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return the original data if there is no axis with matching ID but graphical items have dataKeys', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectDisplayedData(state, 'xAxis', defaultAxisId));
+      spy(result);
+      return null;
+    };
+    render(
+      <LineChart width={100} height={100}>
+        <Line dataKey="x" data={data1} />
+        <Line dataKey="y" data={data2} />
+        <Customized component={Comp} />
+      </LineChart>,
+    );
+    expect(spy).toHaveBeenLastCalledWith([
+      {
+        label: 'Iter: 0',
+        x: 211,
+        y: 481,
+        z: 1798,
+      },
+      {
+        label: 'Iter: 1',
+        x: 245,
+        y: 672,
+        z: 1087,
+      },
+      {
+        label: 'Iter: 2',
+        x: 266,
+        y: 721,
+        z: 1631,
+      },
+      {
+        label: 'Iter: 3',
+        x: 140,
+        y: 446,
+        z: 1932,
+      },
+      {
+        label: 'Iter: 4',
+        x: 131,
+        y: 598,
+        z: 1184,
+      },
+      {
+        label: 'Iter: 5',
+        x: 280,
+        y: 774,
+        z: 1811,
+      },
+      {
+        label: 'Iter: 6',
+        x: 294,
+        y: 687,
+        z: 1229,
+      },
+      {
+        label: 'Iter: 7',
+        x: 239,
+        y: 762,
+        z: 1410,
+      },
+      {
+        label: 'Iter: 8',
+        x: 293,
+        y: 439,
+        z: 1557,
+      },
+      {
+        label: 'Iter: 9',
+        x: 244,
+        y: 569,
+        z: 1305,
+      },
+    ]);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 
   it('should return data defined in all graphical items based on the input dataKey, and default axis ID', () => {
     const spy = vi.fn();
     const Comp = (): null => {
-      const result = useAppSelector(state => selectAllDataSquished(state, 'xAxis', defaultAxisId));
+      const result = useAppSelector(state => selectAllAppliedValues(state, 'xAxis', defaultAxisId));
       spy(result);
       return null;
     };
@@ -1425,13 +1739,18 @@ describe('selectAllDataSquished', () => {
   });
 
   it('should return data defined in graphical items with matching axis ID', () => {
-    const spy = vi.fn();
+    const displayedDataSpy1 = vi.fn();
+    const displayedDataSpy2 = vi.fn();
+    const axisDomainSpy1 = vi.fn();
+    const axisDomainSpy2 = vi.fn();
     const Comp = (): null => {
-      const result = useAppSelector(state => selectAllDataSquished(state, 'xAxis', 'my axis id'));
-      spy(result);
+      displayedDataSpy1(useAppSelector(state => selectDisplayedData(state, 'xAxis', 'my axis id')));
+      displayedDataSpy2(useAppSelector(state => selectDisplayedData(state, 'xAxis', 'some other ID')));
+      axisDomainSpy1(useAppSelector(state => selectAxisDomain(state, 'xAxis', 'my axis id')));
+      axisDomainSpy2(useAppSelector(state => selectAxisDomain(state, 'xAxis', 'some other ID')));
       return null;
     };
-    render(
+    const { container } = render(
       <LineChart width={100} height={100}>
         <Line data={data2} xAxisId="my axis id" />
         <XAxis dataKey="x" xAxisId="my axis id" />
@@ -1440,21 +1759,76 @@ describe('selectAllDataSquished', () => {
         <Customized component={Comp} />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([
-      { value: 280 },
-      { value: 294 },
-      { value: 239 },
-      { value: 293 },
-      { value: 244 },
+    const allAxes = container.querySelectorAll('.recharts-xAxis');
+    expect(allAxes).toHaveLength(2);
+    expectXAxisTicks(allAxes[0], [
+      {
+        textContent: '280',
+        x: '5',
+        y: '43',
+      },
+      {
+        textContent: '294',
+        x: '27.5',
+        y: '43',
+      },
+      {
+        textContent: '239',
+        x: '50',
+        y: '43',
+      },
+      {
+        textContent: '293',
+        x: '72.5',
+        y: '43',
+      },
+      {
+        textContent: '244',
+        x: '95',
+        y: '43',
+      },
     ]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expectXAxisTicks(allAxes[1], [
+      {
+        textContent: '481',
+        x: '5',
+        y: '73',
+      },
+      {
+        textContent: '672',
+        x: '27.5',
+        y: '73',
+      },
+      {
+        textContent: '721',
+        x: '50',
+        y: '73',
+      },
+      {
+        textContent: '446',
+        x: '72.5',
+        y: '73',
+      },
+      {
+        textContent: '598',
+        x: '95',
+        y: '73',
+      },
+    ]);
+    expect(axisDomainSpy1).toHaveBeenLastCalledWith([280, 294, 239, 293, 244]);
+    expect(axisDomainSpy2).toHaveBeenLastCalledWith([481, 672, 721, 446, 598]);
+    expect(axisDomainSpy1).toHaveBeenCalledTimes(3);
+    expect(axisDomainSpy2).toHaveBeenCalledTimes(3);
+    expect(displayedDataSpy1).toHaveBeenLastCalledWith(data2);
+    expect(displayedDataSpy2).toHaveBeenLastCalledWith(data1);
+    expect(displayedDataSpy1).toHaveBeenCalledTimes(3);
+    expect(displayedDataSpy2).toHaveBeenCalledTimes(3);
   });
 
-  it('should return different data with different dataKey', () => {
-    const spy = vi.fn();
+  it('should gather data from all graphical items that match the axis ID', () => {
+    const displayedDataSpy = vi.fn();
     const Comp = (): null => {
-      const result = useAppSelector(state => selectAllDataSquished(state, 'xAxis', defaultAxisId));
-      spy(result);
+      displayedDataSpy(useAppSelector(state => selectDisplayedData(state, 'xAxis', defaultAxisId)));
       return null;
     };
     render(
@@ -1465,17 +1839,223 @@ describe('selectAllDataSquished', () => {
         <Customized component={Comp} />
       </LineChart>,
     );
+    expect(displayedDataSpy).toHaveBeenLastCalledWith(mockData);
+    expect(displayedDataSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return data defined in the chart root', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectDisplayedData(state, 'xAxis', defaultAxisId));
+      spy(result);
+      return null;
+    };
+    render(
+      <LineChart data={data1} width={100} height={100}>
+        <Line />
+        <XAxis dataKey="x" />
+        <Customized component={Comp} />
+      </LineChart>,
+    );
     expect(spy).toHaveBeenLastCalledWith([
-      { value: 481 },
-      { value: 672 },
-      { value: 721 },
-      { value: 446 },
-      { value: 598 },
-      { value: 774 },
-      { value: 687 },
-      { value: 762 },
-      { value: 439 },
-      { value: 569 },
+      {
+        label: 'Iter: 0',
+        x: 211,
+        y: 481,
+        z: 1798,
+      },
+      {
+        label: 'Iter: 1',
+        x: 245,
+        y: 672,
+        z: 1087,
+      },
+      {
+        label: 'Iter: 2',
+        x: 266,
+        y: 721,
+        z: 1631,
+      },
+      {
+        label: 'Iter: 3',
+        x: 140,
+        y: 446,
+        z: 1932,
+      },
+      {
+        label: 'Iter: 4',
+        x: 131,
+        y: 598,
+        z: 1184,
+      },
+    ]);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return data defined in the chart root regardless of the axis ID match', () => {
+    const displayedDataSpy = vi.fn();
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectDisplayedData(state, 'xAxis', 'axis with this ID is not present'));
+      displayedDataSpy(result);
+      return null;
+    };
+    render(
+      <LineChart data={data1} width={100} height={100}>
+        <Customized component={Comp} />
+        <XAxis dataKey="x" />
+      </LineChart>,
+    );
+    expect(displayedDataSpy).toHaveBeenLastCalledWith([
+      {
+        label: 'Iter: 0',
+        x: 211,
+        y: 481,
+        z: 1798,
+      },
+      {
+        label: 'Iter: 1',
+        x: 245,
+        y: 672,
+        z: 1087,
+      },
+      {
+        label: 'Iter: 2',
+        x: 266,
+        y: 721,
+        z: 1631,
+      },
+      {
+        label: 'Iter: 3',
+        x: 140,
+        y: 446,
+        z: 1932,
+      },
+      {
+        label: 'Iter: 4',
+        x: 131,
+        y: 598,
+        z: 1184,
+      },
+    ]);
+    expect(displayedDataSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should slice chart root data by dataStartIndex and dataEndIndex', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectDisplayedData(state, 'xAxis', defaultAxisId));
+      spy(result);
+      return null;
+    };
+    render(
+      <LineChart data={mockData} width={100} height={100}>
+        <Line />
+        <Brush startIndex={1} endIndex={4} />
+        <XAxis dataKey="x" />
+        <Customized component={Comp} />
+      </LineChart>,
+    );
+    expect(spy).toHaveBeenLastCalledWith([
+      {
+        label: 'Iter: 1',
+        x: 245,
+        y: 672,
+        z: 1087,
+      },
+      {
+        label: 'Iter: 2',
+        x: 266,
+        y: 721,
+        z: 1631,
+      },
+      {
+        label: 'Iter: 3',
+        x: 140,
+        y: 446,
+        z: 1932,
+      },
+      {
+        label: 'Iter: 4',
+        x: 131,
+        y: 598,
+        z: 1184,
+      },
+    ]);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('selectAllAppliedValues', () => {
+  it('should return undefined when called outside of Redux context', () => {
+    expect.assertions(1);
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectAllAppliedValues(state, 'xAxis', defaultAxisId));
+      expect(result).toBe(undefined);
+      return null;
+    };
+    render(<Comp />);
+  });
+
+  it('should return empty array for initial state', () => {
+    const store = createRechartsStore();
+    expect(selectAllAppliedValues(store.getState(), 'xAxis', defaultAxisId)).toEqual([]);
+  });
+
+  it('should return empty array in an empty chart', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectAllAppliedValues(state, 'xAxis', defaultAxisId));
+      spy(result);
+      return null;
+    };
+    render(
+      <BarChart width={100} height={100}>
+        <Customized component={Comp} />
+      </BarChart>,
+    );
+    expect(spy).toHaveBeenLastCalledWith([]);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return empty array if there is no axis with matching ID', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectAllAppliedValues(state, 'xAxis', defaultAxisId));
+      spy(result);
+      return null;
+    };
+    render(
+      <LineChart width={100} height={100}>
+        <Line />
+        <Customized component={Comp} />
+      </LineChart>,
+    );
+    expect(spy).toHaveBeenLastCalledWith([]);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('should return all data defined in all graphical items based on the input dataKey, and default axis ID', () => {
+    const spy = vi.fn();
+    const Comp = (): null => {
+      const result = useAppSelector(state => selectAllAppliedValues(state, 'xAxis', defaultAxisId));
+      spy(result);
+      return null;
+    };
+    render(
+      <LineChart width={100} height={100}>
+        <Line data={[{ x: 1 }, { x: 2 }, { x: 3 }]} />
+        <Line data={[{ x: 10 }, { x: 20 }, { x: 30 }]} />
+        <XAxis dataKey="x" />
+        <Customized component={Comp} />
+      </LineChart>,
+    );
+    expect(spy).toHaveBeenLastCalledWith([
+      { value: 1 },
+      { value: 2 },
+      { value: 3 },
+      { value: 10 },
+      { value: 20 },
+      { value: 30 },
     ]);
     expect(spy).toHaveBeenCalledTimes(3);
   });
@@ -1483,7 +2063,7 @@ describe('selectAllDataSquished', () => {
   it('should return data defined in the chart root', () => {
     const spy = vi.fn();
     const Comp = (): null => {
-      const result = useAppSelector(state => selectAllDataSquished(state, 'xAxis', defaultAxisId));
+      const result = useAppSelector(state => selectAllAppliedValues(state, 'xAxis', defaultAxisId));
       spy(result);
       return null;
     };
@@ -1504,66 +2084,63 @@ describe('selectAllDataSquished', () => {
     expect(spy).toHaveBeenCalledTimes(3);
   });
 
-  it('should not return data defined in the chart root if the axis ID does not match', () => {
-    const spy = vi.fn();
+  it('should return values as full input objects if the axis ID does not match anything in the data', () => {
+    const displayedDataSpy = vi.fn();
     const Comp = (): null => {
-      const result = useAppSelector(state => selectAllDataSquished(state, 'xAxis', 'axis with this ID is not present'));
-      spy(result);
+      const result = useAppSelector(state =>
+        selectAllAppliedValues(state, 'xAxis', 'axis with this ID is not present'),
+      );
+      displayedDataSpy(result);
       return null;
     };
     render(
       <LineChart data={data1} width={100} height={100}>
         <Customized component={Comp} />
-        <XAxis dataKey="x" />
+        <XAxis dataKey="this dataKey is not present in the input data" />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(undefined);
-    expect(spy).toHaveBeenCalledTimes(2);
-  });
-
-  it('should return array full of undefined when the dataKey does not match anything in the data', () => {
-    const dataSpy = vi.fn();
-    const domainSpy = vi.fn();
-    const Comp = (): null => {
-      const result = useAppSelector(state => selectAllDataSquished(state, 'xAxis', defaultAxisId));
-      dataSpy(result);
-      return null;
-    };
-    render(
-      <LineChart data={data1} width={100} height={100}>
-        <Line />
-        <XAxis dataKey="invalid dataKey" />
-        <Customized component={Comp} />
-        <Customized component={<ExpectAxisDomain axisType="xAxis" assert={domainSpy} />} />
-      </LineChart>,
-    );
-    expect(dataSpy).toHaveBeenLastCalledWith([
-      { value: undefined },
-      { value: undefined },
-      { value: undefined },
-      { value: undefined },
-      { value: undefined },
+    expect(displayedDataSpy).toHaveBeenLastCalledWith([
+      {
+        value: {
+          label: 'Iter: 0',
+          x: 211,
+          y: 481,
+          z: 1798,
+        },
+      },
+      {
+        value: {
+          label: 'Iter: 1',
+          x: 245,
+          y: 672,
+          z: 1087,
+        },
+      },
+      {
+        value: {
+          label: 'Iter: 2',
+          x: 266,
+          y: 721,
+          z: 1631,
+        },
+      },
+      {
+        value: {
+          label: 'Iter: 3',
+          x: 140,
+          y: 446,
+          z: 1932,
+        },
+      },
+      {
+        value: {
+          label: 'Iter: 4',
+          x: 131,
+          y: 598,
+          z: 1184,
+        },
+      },
     ]);
-    expect(domainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4]);
-    expect(dataSpy).toHaveBeenCalledTimes(3);
-  });
-
-  it('should slice chart root data by dataStartIndex and dataEndIndex', () => {
-    const spy = vi.fn();
-    const Comp = (): null => {
-      const result = useAppSelector(state => selectAllDataSquished(state, 'xAxis', defaultAxisId));
-      spy(result);
-      return null;
-    };
-    render(
-      <LineChart data={mockData} width={100} height={100}>
-        <Line />
-        <Brush startIndex={1} endIndex={4} />
-        <XAxis dataKey="x" />
-        <Customized component={Comp} />
-      </LineChart>,
-    );
-    expect(spy).toHaveBeenLastCalledWith([{ value: 245 }, { value: 266 }, { value: 140 }, { value: 131 }]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(displayedDataSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/test/state/axisSelectors.spec.tsx
+++ b/test/state/axisSelectors.spec.tsx
@@ -95,10 +95,10 @@ describe('selectAxisScale', () => {
   });
 
   it('should set the scale domain and range based on the axis type, and data', () => {
-    const spy = vi.fn();
+    const scaleDomainSpy = vi.fn();
     const Comp = (): null => {
       const result = useAppSelector(state => selectAxisScale(state, 'xAxis', '0'));
-      spy(result.scale?.domain());
+      scaleDomainSpy(result.scale?.domain());
       return null;
     };
     const { container } = render(
@@ -140,7 +140,7 @@ describe('selectAxisScale', () => {
         y: '73',
       },
     ]);
-    expect(spy).toHaveBeenLastCalledWith(['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
+    expect(scaleDomainSpy).toHaveBeenLastCalledWith(['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
   });
 });
 
@@ -1409,7 +1409,18 @@ describe('selectAllDataSquished', () => {
         <Customized component={Comp} />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([211, 245, 266, 140, 131, 280, 294, 239, 293, 244]);
+    expect(spy).toHaveBeenLastCalledWith([
+      { value: 211 },
+      { value: 245 },
+      { value: 266 },
+      { value: 140 },
+      { value: 131 },
+      { value: 280 },
+      { value: 294 },
+      { value: 239 },
+      { value: 293 },
+      { value: 244 },
+    ]);
     expect(spy).toHaveBeenCalledTimes(3);
   });
 
@@ -1429,7 +1440,13 @@ describe('selectAllDataSquished', () => {
         <Customized component={Comp} />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([280, 294, 239, 293, 244]);
+    expect(spy).toHaveBeenLastCalledWith([
+      { value: 280 },
+      { value: 294 },
+      { value: 239 },
+      { value: 293 },
+      { value: 244 },
+    ]);
     expect(spy).toHaveBeenCalledTimes(3);
   });
 
@@ -1448,7 +1465,18 @@ describe('selectAllDataSquished', () => {
         <Customized component={Comp} />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([481, 672, 721, 446, 598, 774, 687, 762, 439, 569]);
+    expect(spy).toHaveBeenLastCalledWith([
+      { value: 481 },
+      { value: 672 },
+      { value: 721 },
+      { value: 446 },
+      { value: 598 },
+      { value: 774 },
+      { value: 687 },
+      { value: 762 },
+      { value: 439 },
+      { value: 569 },
+    ]);
     expect(spy).toHaveBeenCalledTimes(3);
   });
 
@@ -1466,7 +1494,13 @@ describe('selectAllDataSquished', () => {
         <Customized component={Comp} />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([211, 245, 266, 140, 131]);
+    expect(spy).toHaveBeenLastCalledWith([
+      { value: 211 },
+      { value: 245 },
+      { value: 266 },
+      { value: 140 },
+      { value: 131 },
+    ]);
     expect(spy).toHaveBeenCalledTimes(3);
   });
 
@@ -1503,7 +1537,13 @@ describe('selectAllDataSquished', () => {
         <Customized component={<ExpectAxisDomain axisType="xAxis" assert={domainSpy} />} />
       </LineChart>,
     );
-    expect(dataSpy).toHaveBeenLastCalledWith([undefined, undefined, undefined, undefined, undefined]);
+    expect(dataSpy).toHaveBeenLastCalledWith([
+      { value: undefined },
+      { value: undefined },
+      { value: undefined },
+      { value: undefined },
+      { value: undefined },
+    ]);
     expect(domainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4]);
     expect(dataSpy).toHaveBeenCalledTimes(3);
   });
@@ -1523,7 +1563,7 @@ describe('selectAllDataSquished', () => {
         <Customized component={Comp} />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([245, 266, 140, 131]);
+    expect(spy).toHaveBeenLastCalledWith([{ value: 245 }, { value: 266 }, { value: 140 }, { value: 131 }]);
     expect(spy).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Description

This was as much fun as getting my teeth pulled but I got the behaviour to be the same as generateCategoricalCharts, but in Redux.

Next, ErrorBars, then stacking, and then we can replace `scale` in XAxis.

## Related Issue

https://github.com/recharts/recharts/issues/4583