### PR TITLE
fix: clipDot setting fails to take effect if set as the only DotProp

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -29,7 +29,7 @@ import {
   TickItem,
   AnimationDuration,
 } from '../util/types';
-import { filterProps, isDotProps } from '../util/ReactUtils';
+import { filterProps, hasClipDot } from '../util/ReactUtils';
 
 export type AreaDot = ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | DotProps | boolean;
 interface AreaPointItem extends CurvePoint {
@@ -558,7 +558,7 @@ export class Area extends PureComponent<Props, State> {
     const needClip = needClipX || needClipY;
     const clipPathId = isNil(id) ? this.id : id;
     const { r = 3, strokeWidth = 2 } = filterProps(dot, false) ?? { r: 3, strokeWidth: 2 };
-    const { clipDot = true } = isDotProps(dot) ? dot : {};
+    const { clipDot = true } = hasClipDot(dot) ? dot : {};
     const dotSize = r * 2 + strokeWidth;
 
     return (

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -15,7 +15,7 @@ import { ImplicitLabelType } from '../component/Label';
 import { LabelList } from '../component/LabelList';
 import { ErrorBar, ErrorBarDataPointFormatter, Props as ErrorBarProps } from './ErrorBar';
 import { uniqueId, interpolateNumber } from '../util/DataUtils';
-import { findAllByType, filterProps, isDotProps } from '../util/ReactUtils';
+import { findAllByType, filterProps, hasClipDot } from '../util/ReactUtils';
 import { Global } from '../util/Global';
 import { getCateCoordinateOfLine, getValueByDataKey } from '../util/ChartUtils';
 import { Props as XAxisProps } from './XAxis';
@@ -499,7 +499,7 @@ export class Line extends PureComponent<Props, State> {
     const needClip = needClipX || needClipY;
     const clipPathId = isNil(id) ? this.id : id;
     const { r = 3, strokeWidth = 2 } = filterProps(dot, false) ?? { r: 3, strokeWidth: 2 };
-    const { clipDot = true } = isDotProps(dot) ? dot : {};
+    const { clipDot = true } = hasClipDot(dot) ? dot : {};
     const dotSize = r * 2 + strokeWidth;
 
     return (

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -268,8 +268,8 @@ const SVG_TAGS: string[] = [
 
 const isSvgElement = (child: any) => child && child.type && isString(child.type) && SVG_TAGS.indexOf(child.type) >= 0;
 
-export const isDotProps = (dot: LineDot | AreaDot): dot is DotProps =>
-  dot && typeof dot === 'object' && 'cx' in dot && 'cy' in dot && 'r' in dot;
+export const hasClipDot = (dot: LineDot | AreaDot): dot is DotProps =>
+  dot && typeof dot === 'object' && 'clipDot' in dot;
 
 /**
  * Checks if the property is valid to spread onto an SVG element or onto a specific component

--- a/storybook/stories/Examples/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart.stories.tsx
@@ -366,7 +366,7 @@ export const ClipDot: StoryObj = {
             bottom: 20,
             left: 20,
           }}
-          data={pageData}
+          data={[...pageData, { name: 'Page H', pv: 0 }, { name: 'Page I', uv: 0 }]}
         >
           <Line
             isAnimationActive={false}
@@ -374,10 +374,10 @@ export const ClipDot: StoryObj = {
             {...args}
             dot={{ clipDot: args.clipDot, r: 4, strokeWidth: 2, fill: '#ffffff', fillOpacity: 1 }}
           />
-          <Line isAnimationActive={false} dataKey="pv" {...args} dot={{ clipDot: args.clipDot }} />
+          <Line isAnimationActive={false} dataKey="pv" {...args} dot={{ clipDot: args.clipDot, r: 10 }} />
           <Tooltip />
           <XAxis dataKey="name" allowDataOverflow />
-          <YAxis />
+          <YAxis allowDataOverflow />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -162,8 +162,6 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
       expect(container.querySelectorAll('.recharts-area-area')).toHaveLength(1);
       expect(container.querySelectorAll('.recharts-area-curve')).toHaveLength(1);
       expect(container.querySelectorAll('.recharts-area-dot')).toHaveLength(0);
-      // we don't have a clip path element
-      expect(container.querySelectorAll('clippath')).toHaveLength(0);
     });
 
     test('Does not render clip dot when clipDot is false', () => {
@@ -181,12 +179,11 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
     });
 
     test('Does render clip dot when clipDot is true', () => {
-      const { container, debug } = render(
+      const { container } = render(
         <ChartElement width={500} height={500} data={data}>
           <Area dataKey="value" dot={{ clipDot: true }} isAnimationActive={false} />
         </ChartElement>,
       );
-      debug();
 
       expect(container.querySelectorAll('.recharts-area-area')).toHaveLength(1);
       expect(container.querySelectorAll('.recharts-area-curve')).toHaveLength(1);

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -155,25 +155,44 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
         <ChartElement width={500} height={500} data={data}>
           {/* Test that the error Cannot read properties of null (reading 'clipDot') does not appear in JS projects */}
           {/* @ts-expect-error TypeScript correctly flags this as an error, but we want to have a test for it regardless */}
-          <Area dataKey="value" dot={null} />
+          <Area dataKey="value" dot={null} isAnimationActive={false} />
         </ChartElement>,
       );
 
       expect(container.querySelectorAll('.recharts-area-area')).toHaveLength(1);
       expect(container.querySelectorAll('.recharts-area-curve')).toHaveLength(1);
       expect(container.querySelectorAll('.recharts-area-dot')).toHaveLength(0);
+      // we don't have a clip path element
+      expect(container.querySelectorAll('clippath')).toHaveLength(0);
     });
 
-    test('Does not clip dot when clipDot false', () => {
+    test('Does not render clip dot when clipDot is false', () => {
       const { container } = render(
         <ChartElement width={500} height={500} data={data}>
-          <Area dataKey="value" dot={{ clipDot: false }} />
+          <Area dataKey="value" dot={{ clipDot: false }} isAnimationActive={false} />
         </ChartElement>,
       );
 
       expect(container.querySelectorAll('.recharts-area-area')).toHaveLength(1);
       expect(container.querySelectorAll('.recharts-area-curve')).toHaveLength(1);
-      expect(container.querySelectorAll('.recharts-area-dot')).toHaveLength(0);
+      const dots = container.querySelectorAll('.recharts-area-dot');
+      expect(dots).toHaveLength(5);
+      expect(dots[0].getAttribute('clip-path')).toBeNull();
+    });
+
+    test('Does render clip dot when clipDot is true', () => {
+      const { container, debug } = render(
+        <ChartElement width={500} height={500} data={data}>
+          <Area dataKey="value" dot={{ clipDot: true }} isAnimationActive={false} />
+        </ChartElement>,
+      );
+      debug();
+
+      expect(container.querySelectorAll('.recharts-area-area')).toHaveLength(1);
+      expect(container.querySelectorAll('.recharts-area-curve')).toHaveLength(1);
+      const dots = container.querySelectorAll('.recharts-area-dot');
+      expect(dots).toHaveLength(5);
+      expect(dots[0].getAttribute('clip-path')).toBeDefined();
     });
   });
 

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -163,6 +163,18 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
       expect(container.querySelectorAll('.recharts-area-curve')).toHaveLength(1);
       expect(container.querySelectorAll('.recharts-area-dot')).toHaveLength(0);
     });
+
+    test('Does not clip dot when clipDot false', () => {
+      const { container } = render(
+        <ChartElement width={500} height={500} data={data}>
+          <Area dataKey="value" dot={{ clipDot: false }} />
+        </ChartElement>,
+      );
+
+      expect(container.querySelectorAll('.recharts-area-area')).toHaveLength(1);
+      expect(container.querySelectorAll('.recharts-area-curve')).toHaveLength(1);
+      expect(container.querySelectorAll('.recharts-area-dot')).toHaveLength(0);
+    });
   });
 
   describe('baseValue', () => {

--- a/test/cartesian/Line.spec.tsx
+++ b/test/cartesian/Line.spec.tsx
@@ -47,6 +47,17 @@ describe('<Line />', () => {
     expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
   });
 
+  it('Does not clip dot when clipDot false', () => {
+    const { container } = render(
+      <Surface width={500} height={500}>
+        <Line isAnimationActive={false} points={data} dot={{ clipDot: false }} />
+      </Surface>,
+    );
+
+    expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
+    expect(container.querySelectorAll('.recharts-area-dot')).toHaveLength(0);
+  });
+
   it("Don't render any path when data is empty", () => {
     const { container } = render(
       <Surface width={500} height={500}>

--- a/test/cartesian/Line.spec.tsx
+++ b/test/cartesian/Line.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { expect } from 'vitest';
 import { Surface, Line } from '../../src';
 
 describe('<Line />', () => {
@@ -45,9 +46,10 @@ describe('<Line />', () => {
     );
 
     expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
+    expect(container.querySelectorAll('.recharts-line-dot')).toHaveLength(0);
   });
 
-  it('Does not clip dot when clipDot false', () => {
+  it('Does not render clip dot when clipDot is false', () => {
     const { container } = render(
       <Surface width={500} height={500}>
         <Line isAnimationActive={false} points={data} dot={{ clipDot: false }} />
@@ -55,7 +57,23 @@ describe('<Line />', () => {
     );
 
     expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
-    expect(container.querySelectorAll('.recharts-area-dot')).toHaveLength(0);
+    const dots = container.querySelectorAll('.recharts-line-dot');
+    expect(dots).toHaveLength(5);
+    expect(dots[0].getAttribute('clip-path')).toBeNull();
+  });
+
+  it('Does render clip dot when clipDot is true', () => {
+    const { container } = render(
+      <Surface width={500} height={500}>
+        <Line isAnimationActive={false} points={data} dot={{ clipDot: true }} />
+      </Surface>,
+    );
+
+    expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
+
+    const dots = container.querySelectorAll('.recharts-line-dot');
+    expect(dots).toHaveLength(5);
+    expect(dots[0].getAttribute('clip-path')).toBeDefined();
   });
 
   it("Don't render any path when data is empty", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix clipDot not working when props are of the form `dot={{ clipDot: false }}` or similar

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4671

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix a bug

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See tests, see storybook

## Screenshots (if appropriate):
![image](https://github.com/recharts/recharts/assets/25180830/21822902-8111-4143-88b6-fce053da8b11)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] I have added a storybook story or extended an existing story to show my changes
