### PR TITLE
selectAxisDomain now extends domain based on ErrorBar values

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -15,6 +15,7 @@
   "es6/util/tooltip",
   "es6/util/scale",
   "es6/util/payload",
+  "es6/util/isWellBehavedNumber.js",
   "es6/util/isDomainSpecifiedByUser.js",
   "es6/util/getLegendProps.js",
   "es6/util/getEveryNthWithCondition.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -15,6 +15,7 @@
   "lib/util/tooltip",
   "lib/util/scale",
   "lib/util/payload",
+  "lib/util/isWellBehavedNumber.js",
   "lib/util/isDomainSpecifiedByUser.js",
   "lib/util/getLegendProps.js",
   "lib/util/getEveryNthWithCondition.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -15,6 +15,7 @@
   "types/util/tooltip",
   "types/util/scale",
   "types/util/payload",
+  "types/util/isWellBehavedNumber.d.ts",
   "types/util/isDomainSpecifiedByUser.d.ts",
   "types/util/getLegendProps.d.ts",
   "types/util/getEveryNthWithCondition.d.ts",

--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -7,7 +7,7 @@ import Animate from 'react-smooth';
 import { Layer } from '../container/Layer';
 import { Props as XAxisProps } from './XAxis';
 import { Props as YAxisProps } from './YAxis';
-import { AnimationTiming, D3Scale, DataKey } from '../util/types';
+import { AnimationTiming, D3Scale, DataKey, LayoutType } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { BarRectangleItem } from './Bar';
 import { LinePointItem } from './Line';
@@ -63,6 +63,13 @@ interface ErrorBarProps extends InternalErrorBarProps {
 }
 
 export type Props = SVGProps<SVGLineElement> & ErrorBarProps;
+
+export function getRealDirection(
+  directionFromProps: ErrorBarDirection | undefined,
+  layout: LayoutType,
+): ErrorBarDirection {
+  return directionFromProps ?? (layout === 'horizontal' ? 'y' : 'x');
+}
 
 export function ErrorBar(props: Props) {
   const {
@@ -170,9 +177,11 @@ export function ErrorBar(props: Props) {
     );
   });
 
+  const realDirection: ErrorBarDirection = getRealDirection(props.direction, layout);
+
   return (
     <Layer className="recharts-errorBars">
-      <ReportErrorBarSettings dataKey={props.dataKey} direction={props.direction} />
+      <ReportErrorBarSettings dataKey={props.dataKey} direction={realDirection} />
       {errorBars}
     </Layer>
   );

--- a/src/state/axisMapSlice.ts
+++ b/src/state/axisMapSlice.ts
@@ -65,9 +65,15 @@ const axisMapSlice = createSlice({
     removeXAxis(state, action: PayloadAction<XAxisSettings>) {
       delete state.xAxis[action.payload.id];
     },
+    addYAxis(state, action: PayloadAction<YAxisSettings>) {
+      state.yAxis[action.payload.id] = castDraft(action.payload);
+    },
+    removeYAxis(state, action: PayloadAction<YAxisSettings>) {
+      delete state.yAxis[action.payload.id];
+    },
   },
 });
 
-export const { addXAxis, removeXAxis } = axisMapSlice.actions;
+export const { addXAxis, removeXAxis, addYAxis, removeYAxis } = axisMapSlice.actions;
 
 export const axisMapReducer = axisMapSlice.reducer;

--- a/src/state/chartDataSlice.ts
+++ b/src/state/chartDataSlice.ts
@@ -16,7 +16,7 @@ export type ChartData = unknown[];
  * We still don't know what the type is - that depends on what exactly it was before the dataKey application,
  * and the dataKey can return whatever anyway - but let's keep it separate as a form of documentation.
  *
- * TL;DR: ChartData after dataKey
+ * TL;DR: ChartData after dataKey.
  */
 export type AppliedChartData = ReadonlyArray<{ value: unknown }>;
 

--- a/src/util/isDomainSpecifiedByUser.ts
+++ b/src/util/isDomainSpecifiedByUser.ts
@@ -2,6 +2,7 @@ import { MAX_VALUE_REG, MIN_VALUE_REG } from './ChartUtils';
 import { isNumber } from './DataUtils';
 import { getNiceTickValues } from './scale';
 import { AxisDomain, AxisDomainType, NumberDomain } from './types';
+import { isWellBehavedNumber } from './isWellBehavedNumber';
 
 /**
  * @deprecated instead use `numericalDomainSpecifiedWithoutRequiringData`
@@ -31,10 +32,6 @@ export function isDomainSpecifiedByUser(
   }
 
   return false;
-}
-
-function isWellBehavedNumber(n: unknown): n is number {
-  return Number.isFinite(n);
 }
 
 function isWellFormedNumberDomain(v: unknown): v is NumberDomain {

--- a/src/util/isWellBehavedNumber.ts
+++ b/src/util/isWellBehavedNumber.ts
@@ -1,0 +1,3 @@
+export function isWellBehavedNumber(n: unknown): n is number {
+  return Number.isFinite(n);
+}

--- a/test/state/axisSelectors.spec.tsx
+++ b/test/state/axisSelectors.spec.tsx
@@ -206,6 +206,25 @@ describe('selectAxisDomain', () => {
     expect(axisDomainSpy).toHaveBeenCalledTimes(3);
   });
 
+  it.fails('should be stable', () => {
+    // TODO make selectAxisDomain stable
+    expect.assertions(1);
+    const Comp = (): null => {
+      const result1 = useAppSelector(state => selectAxisDomain(state, 'xAxis', defaultAxisId));
+      const result2 = useAppSelector(state => selectAxisDomain(state, 'xAxis', defaultAxisId));
+      expect(result1).toBe(result2);
+      return null;
+    };
+    render(
+      <LineChart width={100} height={100}>
+        <Line data={data1} />
+        <Line data={data2} />
+        <XAxis dataKey="y" />
+        <Customized component={Comp} />
+      </LineChart>,
+    );
+  });
+
   it('should return nothing for graphical items that do not have any explicit data prop on them', () => {
     const domainSpy = vi.fn();
     const { container } = render(
@@ -2200,8 +2219,8 @@ describe('selectErrorBarsSettings', () => {
     render(
       <LineChart width={100} height={100} data={pageData}>
         <Line isAnimationActive={false}>
-          <ErrorBar dataKey="x" direction="x" />
-          <ErrorBar dataKey="y" direction="y" />
+          <ErrorBar dataKey="data-x" direction="x" />
+          <ErrorBar dataKey="data-y" direction="y" />
         </Line>
         <XAxis type="number" />
         <Customized component={Comp} />
@@ -2225,8 +2244,8 @@ describe('selectErrorBarsSettings', () => {
     render(
       <BarChart width={100} height={100}>
         <Bar data={[{ x: 1 }, { x: 2 }, { x: 3 }]} isAnimationActive={false}>
-          <ErrorBar dataKey="x" direction="x" />
-          <ErrorBar dataKey="y" direction="y" />
+          <ErrorBar dataKey="data-x" direction="x" />
+          <ErrorBar dataKey="data-y" direction="y" />
         </Bar>
         <Customized component={Comp} />
         <XAxis type="number" />
@@ -2234,13 +2253,13 @@ describe('selectErrorBarsSettings', () => {
     );
     expect(xAxisSpy).toHaveBeenLastCalledWith([
       {
-        dataKey: 'x',
+        dataKey: 'data-x',
         direction: 'x',
       },
     ]);
     expect(yAxisSpy).toHaveBeenLastCalledWith([
       {
-        dataKey: 'y',
+        dataKey: 'data-y',
         direction: 'y',
       },
     ]);
@@ -2260,8 +2279,8 @@ describe('selectErrorBarsSettings', () => {
       <LineChart width={100} height={100}>
         <Line data={[{ x: 1 }, { x: 2 }, { x: 3 }]} />
         <Line data={[{ x: 10 }, { x: 20 }, { x: 30 }]} isAnimationActive={false}>
-          <ErrorBar dataKey="x" direction="x" />
-          <ErrorBar dataKey="y" direction="y" />
+          <ErrorBar dataKey="data-x" direction="x" />
+          <ErrorBar dataKey="data-y" direction="y" />
         </Line>
         <Customized component={Comp} />
         <XAxis type="number" />
@@ -2269,13 +2288,48 @@ describe('selectErrorBarsSettings', () => {
     );
     expect(xAxisSpy).toHaveBeenLastCalledWith([
       {
-        dataKey: 'x',
+        dataKey: 'data-x',
         direction: 'x',
       },
     ]);
     expect(yAxisSpy).toHaveBeenLastCalledWith([
       {
-        dataKey: 'y',
+        dataKey: 'data-y',
+        direction: 'y',
+      },
+    ]);
+    expect(xAxisSpy).toHaveBeenCalledTimes(4);
+    expect(yAxisSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('should return bars settings if present in vertical LineChart', () => {
+    const xAxisSpy = vi.fn();
+    const yAxisSpy = vi.fn();
+    const Comp = (): null => {
+      xAxisSpy(useAppSelector(state => selectErrorBarsSettings(state, 'xAxis', defaultAxisId)));
+      yAxisSpy(useAppSelector(state => selectErrorBarsSettings(state, 'yAxis', defaultAxisId)));
+      return null;
+    };
+    render(
+      <LineChart width={100} height={100} layout="vertical">
+        <Line data={[{ x: 1 }, { x: 2 }, { x: 3 }]} />
+        <Line data={[{ x: 10 }, { x: 20 }, { x: 30 }]} isAnimationActive={false}>
+          <ErrorBar dataKey="data-x" direction="x" />
+          <ErrorBar dataKey="data-y" direction="y" />
+        </Line>
+        <Customized component={Comp} />
+        <XAxis type="number" />
+      </LineChart>,
+    );
+    expect(xAxisSpy).toHaveBeenLastCalledWith([
+      {
+        dataKey: 'data-x',
+        direction: 'x',
+      },
+    ]);
+    expect(yAxisSpy).toHaveBeenLastCalledWith([
+      {
+        dataKey: 'data-y',
         direction: 'y',
       },
     ]);

--- a/test/util/errorValue.spec.ts
+++ b/test/util/errorValue.spec.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect } from 'vitest';
+import { ErrorBarsSettings } from '../../src/state/graphicalItemsSlice';
+import { fromMainValueToError, getErrorDomainByDataKey } from '../../src/state/axisSelectors';
+
+describe('fromMainValueToError', () => {
+  const invalidValues: ReadonlyArray<unknown> = [
+    null,
+    undefined,
+    'a',
+    NaN,
+    Symbol('a'),
+    [],
+    {},
+    () => {},
+    new Date(),
+    new Map(),
+    new Set(),
+    Infinity,
+  ];
+
+  test.each(invalidValues)('should return undefined when the input is %s', value => {
+    expect(fromMainValueToError(value)).toBeUndefined();
+  });
+
+  const validValues = [
+    { value: [1, 2], expected: [1, 2] },
+    { value: [2, 1], expected: [1, 2] },
+    { value: [1, 2, 3], expected: [1, 3] },
+    { value: [3, 2, 1], expected: [1, 3] },
+    { value: 3, expected: [3, 3] },
+    { value: -3, expected: [-3, -3] },
+  ];
+
+  test.each(validValues)('should return %s when the input is %s', ({ value, expected }) => {
+    expect(fromMainValueToError(value)).toEqual(expected);
+  });
+});
+
+describe('getErrorDomainByDataKey', () => {
+  describe.each([null, undefined])('when entry = %s', entry => {
+    it('should return empty array when errorBar.dataKey is string', () => {
+      const errorBars: ReadonlyArray<ErrorBarsSettings> = [{ dataKey: 'uv', direction: 'x' }];
+      expect(getErrorDomainByDataKey(entry, 1, errorBars)).toEqual([]);
+    });
+
+    it(`should return empty array even when errorBars.dataKey returns a number anyway;
+              this behaviour is inherited from getValueByDataKey and is not technically required here but here we are`, () => {
+      const errorBars: ReadonlyArray<ErrorBarsSettings> = [{ dataKey: () => 7, direction: 'x' }];
+      expect(getErrorDomainByDataKey(entry, 1, errorBars)).toEqual([]);
+    });
+  });
+
+  it('should return empty array when errorBars is empty', () => {
+    expect(getErrorDomainByDataKey(1, 1, [])).toEqual([]);
+  });
+
+  it.each([null, undefined])('should return empty array when errorBars.dataKey is %s', dataKey => {
+    const errorBars: ReadonlyArray<ErrorBarsSettings> = [{ dataKey, direction: 'x' }];
+    expect(getErrorDomainByDataKey(1, 1, errorBars)).toEqual([]);
+  });
+
+  it('should return all ErrorValues in a single array when the errorBar.dataKey results in a number', () => {
+    const entry = {
+      val: 2,
+      errX: 3,
+      errY: 7,
+    };
+    const errorBars: ReadonlyArray<ErrorBarsSettings> = [
+      { dataKey: 'errX', direction: 'x' },
+      { dataKey: 'errY', direction: 'y' },
+    ];
+    expect(getErrorDomainByDataKey(entry, 2, errorBars)).toEqual([-1, 5, -5, 9]);
+  });
+
+  it('should return array of all errors when the errorBar.dataKey results in an array', () => {
+    const entry = {
+      val: 2,
+      errX: [3, 7],
+      errY: [11, 13],
+    };
+    const errorBars: ReadonlyArray<ErrorBarsSettings> = [
+      { dataKey: 'errX', direction: 'x' },
+      { dataKey: 'errY', direction: 'y' },
+    ];
+    expect(getErrorDomainByDataKey(entry, 2, errorBars)).toEqual([-1, 9, -9, 15]);
+  });
+});

--- a/test/util/isWellBehavedNumber.spec.ts
+++ b/test/util/isWellBehavedNumber.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { isWellBehavedNumber } from '../../src/util/isWellBehavedNumber';
+
+describe('isWellBehavedNumber', () => {
+  it.each([
+    [null, false],
+    [undefined, false],
+    ['a', false],
+    ['1', false],
+    [NaN, false],
+    [Symbol('a'), false],
+    [[], false],
+    [{}, false],
+    [() => {}, false],
+    [new Date(), false],
+    [new Map(), false],
+    [new Set(), false],
+    [Infinity, false],
+    [-Infinity, false],
+    [-0, true],
+    [3, true],
+    [-3, true],
+  ])('should return %s when the input is %s', (value, expected) => {
+    expect(isWellBehavedNumber(value)).toBe(expected);
+  });
+});


### PR DESCRIPTION
this works for both YAxis and XAxis - unlike in 2.x where the domain extension only works on YAxis

## Related Issue

https://github.com/recharts/recharts/issues/4583

Next, the margin diff from previous PR, then domain of stacked items, then we can use domain+range+scale from redux.