### PR TITLE
getStoryArgsFromArgsTypesObject should allow falsy values as defaults

### DIFF
--- a/storybook/stories/API/cartesian/Brush.stories.tsx
+++ b/storybook/stories/API/cartesian/Brush.stories.tsx
@@ -17,17 +17,14 @@ const GeneralProps: Args = {
   x: {
     description: 'The x-coordinate of brush.',
     table: { type: { summary: 'number' }, category: 'General' },
-    defaultValue: 0,
   },
   y: {
     description: 'The y-coordinate of brush.',
     table: { type: { summary: 'number' }, category: 'General' },
-    defaultValue: 0,
   },
   width: {
     description: 'The width of brush.',
     table: { type: { summary: 'number' }, category: 'General' },
-    defaultValue: 0,
   },
   height: {
     description: 'The height of brush.',

--- a/storybook/stories/API/props/utils.ts
+++ b/storybook/stories/API/props/utils.ts
@@ -4,10 +4,10 @@ import { StorybookArgs } from '../../../StorybookArgs';
 export const getStoryArgsFromArgsTypesObject = (argsTypes: StorybookArgs): Record<string, unknown> => {
   const args: Record<string, unknown> = {};
   Object.keys(argsTypes).forEach((key: string) => {
-    const defaultValue = argsTypes[key]?.defaultValue ?? argsTypes[key]?.table?.defaultValue;
-    // TODO this erases zeroes and `False` values, perhaps it should check for undefined instead?
-    if (defaultValue) {
-      args[key] = defaultValue;
+    if ('defaultValue' in argsTypes[key]) {
+      args[key] = argsTypes[key].defaultValue;
+    } else if ('table' in argsTypes[key] && 'defaultValue' in argsTypes[key].table) {
+      args[key] = argsTypes[key].table.defaultValue;
     }
   });
   return args;


### PR DESCRIPTION
zero, false, null, and undefined are all perfectly acceptable default props

## Motivation and Context

With the old code, storybook does not render controls when the default value is falsy. With new one it does.

<img width="691" alt="image" src="https://github.com/recharts/recharts/assets/1100170/bbdf70f6-a875-4e4c-bd2f-b32913c28c8f">

## How Has This Been Tested?

There were some visual diffs due to incorrect defaults so I fixed that too.