### PR TITLE
Stacked data domains in Redux

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -616,6 +616,7 @@ export class Area extends PureComponent<Props, State> {
             dataKey={this.props.dataKey}
             errorBars={noErrorBars}
             stackId={this.props.stackId}
+            hide={this.props.hide}
           />
           <SetAreaLegend {...this.props} />
           <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
@@ -641,6 +642,7 @@ export class Area extends PureComponent<Props, State> {
         dataKey={this.props.dataKey}
         yAxisId={this.props.yAxisId}
         stackId={this.props.stackId}
+        hide={this.props.hide}
       >
         <Layer className={layerClass}>
           <SetAreaLegend {...this.props} />

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -615,6 +615,7 @@ export class Area extends PureComponent<Props, State> {
             yAxisId={this.props.yAxisId}
             dataKey={this.props.dataKey}
             errorBars={noErrorBars}
+            stackId={this.props.stackId}
           />
           <SetAreaLegend {...this.props} />
           <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
@@ -639,6 +640,7 @@ export class Area extends PureComponent<Props, State> {
         xAxisId={this.props.xAxisId}
         dataKey={this.props.dataKey}
         yAxisId={this.props.yAxisId}
+        stackId={this.props.stackId}
       >
         <Layer className={layerClass}>
           <SetAreaLegend {...this.props} />

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -666,6 +666,7 @@ export class Bar extends PureComponent<Props, State> {
         xAxisId={this.props.xAxisId}
         yAxisId={this.props.yAxisId}
         dataKey={this.props.dataKey}
+        stackId={this.props.stackId}
       >
         <Layer className={layerClass}>
           <ReportBar />

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -55,6 +55,7 @@ import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 import { ReportBar } from '../state/ReportBar';
 import { CartesianGraphicalItemContext } from '../context/CartesianGraphicalItemContext';
+import { SetCartesianGraphicalItem } from '../state/SetCartesianGraphicalItem';
 
 export interface BarRectangleItem extends RectangleProps {
   value?: number | [number, number];
@@ -646,6 +647,16 @@ export class Bar extends PureComponent<Props, State> {
     if (hide || !data || !data.length) {
       return (
         <>
+          <SetCartesianGraphicalItem
+            // Bar does not allow setting data directly on the graphical item (why?)
+            data={null}
+            xAxisId={this.props.xAxisId}
+            yAxisId={this.props.yAxisId}
+            dataKey={this.props.dataKey}
+            errorBars={emptyArray}
+            stackId={this.props.stackId}
+            hide={this.props.hide}
+          />
           <ReportBar />
           <SetBarLegend {...this.props} />
           <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
@@ -662,7 +673,8 @@ export class Bar extends PureComponent<Props, State> {
 
     return (
       <CartesianGraphicalItemContext
-        data={emptyArray}
+        // Bar does not allow setting data directly on the graphical item (why?)
+        data={null}
         xAxisId={this.props.xAxisId}
         yAxisId={this.props.yAxisId}
         dataKey={this.props.dataKey}

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -667,6 +667,7 @@ export class Bar extends PureComponent<Props, State> {
         yAxisId={this.props.yAxisId}
         dataKey={this.props.dataKey}
         stackId={this.props.stackId}
+        hide={this.props.hide}
       >
         <Layer className={layerClass}>
           <ReportBar />

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -549,6 +549,8 @@ export class Line extends PureComponent<Props, State> {
             yAxisId={this.props.yAxisId}
             dataKey={this.props.dataKey}
             errorBars={noErrorBars}
+            // line doesn't stack
+            stackId={undefined}
           />
           <SetLineLegend {...this.props} />
           <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
@@ -573,6 +575,8 @@ export class Line extends PureComponent<Props, State> {
         xAxisId={this.props.xAxisId}
         yAxisId={this.props.yAxisId}
         dataKey={this.props.dataKey}
+        // line doesn't stack
+        stackId={undefined}
       >
         <Layer className={layerClass}>
           <SetLineLegend {...this.props} />

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -551,6 +551,7 @@ export class Line extends PureComponent<Props, State> {
             errorBars={noErrorBars}
             // line doesn't stack
             stackId={undefined}
+            hide={this.props.hide}
           />
           <SetLineLegend {...this.props} />
           <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
@@ -577,6 +578,7 @@ export class Line extends PureComponent<Props, State> {
         dataKey={this.props.dataKey}
         // line doesn't stack
         stackId={undefined}
+        hide={this.props.hide}
       >
         <Layer className={layerClass}>
           <SetLineLegend {...this.props} />

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -534,6 +534,7 @@ export class Scatter extends PureComponent<Props, State> {
             errorBars={noErrorBars}
             // scatter doesn't stack
             stackId={undefined}
+            hide={this.props.hide}
           />
           <SetScatterLegend {...this.props} />
           <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
@@ -555,6 +556,7 @@ export class Scatter extends PureComponent<Props, State> {
         dataKey={this.props.dataKey}
         // scatter doesn't stack
         stackId={undefined}
+        hide={this.props.hide}
       >
         <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
           <SetScatterLegend {...this.props} />

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -532,6 +532,8 @@ export class Scatter extends PureComponent<Props, State> {
             yAxisId={this.props.yAxisId}
             dataKey={this.props.dataKey}
             errorBars={noErrorBars}
+            // scatter doesn't stack
+            stackId={undefined}
           />
           <SetScatterLegend {...this.props} />
           <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
@@ -551,6 +553,8 @@ export class Scatter extends PureComponent<Props, State> {
         xAxisId={this.props.xAxisId}
         yAxisId={this.props.yAxisId}
         dataKey={this.props.dataKey}
+        // scatter doesn't stack
+        stackId={undefined}
       >
         <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
           <SetScatterLegend {...this.props} />

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -106,6 +106,7 @@ const XAxisSettingsDispatcher = (props: Props) => {
         allowDuplicatedCategory={props.allowDuplicatedCategory}
         allowDecimals={props.allowDecimals}
         tickCount={props.tickCount}
+        includeHidden={props.includeHidden ?? false}
       />
       <XAxisImpl {...props} />
     </>

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -102,6 +102,7 @@ const YAxisSettingsDispatcher = (props: Props) => {
         allowDecimals={props.allowDecimals}
         tickCount={props.tickCount}
         padding={props.padding}
+        includeHidden={props.includeHidden ?? false}
       />
       <YAxisImpl {...props} />
     </>

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -77,6 +77,7 @@ export const addToTreemapNodeIndex = (
 };
 
 const options: ChartOptions = {
+  stackOffset: 'none',
   barCategoryGap: '10%',
   chartName: 'Treemap',
   defaultTooltipEventType: 'item',

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1940,6 +1940,7 @@ export const generateCategoricalChart = ({
       validateTooltipEventTypes,
       tooltipPayloadSearcher,
       barCategoryGap: props.barCategoryGap ?? '10%',
+      stackOffset: props.stackOffset ?? 'none',
     };
     return (
       <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={props.id ?? chartName}>

--- a/src/context/CartesianGraphicalItemContext.tsx
+++ b/src/context/CartesianGraphicalItemContext.tsx
@@ -25,6 +25,7 @@ type GraphicalItemContextProps = {
   dataKey: DataKey<any>;
   children: React.ReactNode;
   stackId: StackId | undefined;
+  hide: boolean;
 };
 
 export const CartesianGraphicalItemContext = ({
@@ -34,6 +35,7 @@ export const CartesianGraphicalItemContext = ({
   dataKey,
   data,
   stackId,
+  hide,
 }: GraphicalItemContextProps) => {
   const [errorBars, updateErrorBars] = React.useState<ReadonlyArray<ErrorBarsSettings>>([]);
   // useCallback is necessary in these two because without it, the new function reference causes an infinite render loop
@@ -58,6 +60,7 @@ export const CartesianGraphicalItemContext = ({
         dataKey={dataKey}
         errorBars={errorBars}
         stackId={stackId}
+        hide={hide}
       />
       {children}
     </ErrorBarDirectionDispatchContext.Provider>

--- a/src/context/CartesianGraphicalItemContext.tsx
+++ b/src/context/CartesianGraphicalItemContext.tsx
@@ -4,6 +4,7 @@ import { SetCartesianGraphicalItem } from '../state/SetCartesianGraphicalItem';
 import { ChartData } from '../state/chartDataSlice';
 import { AxisId } from '../state/axisMapSlice';
 import { DataKey } from '../util/types';
+import { StackId } from '../util/ChartUtils';
 
 const noop = () => {};
 
@@ -23,6 +24,7 @@ type GraphicalItemContextProps = {
   yAxisId: AxisId;
   dataKey: DataKey<any>;
   children: React.ReactNode;
+  stackId: StackId | undefined;
 };
 
 export const CartesianGraphicalItemContext = ({
@@ -31,6 +33,7 @@ export const CartesianGraphicalItemContext = ({
   yAxisId,
   dataKey,
   data,
+  stackId,
 }: GraphicalItemContextProps) => {
   const [errorBars, updateErrorBars] = React.useState<ReadonlyArray<ErrorBarsSettings>>([]);
   // useCallback is necessary in these two because without it, the new function reference causes an infinite render loop
@@ -54,6 +57,7 @@ export const CartesianGraphicalItemContext = ({
         yAxisId={yAxisId}
         dataKey={dataKey}
         errorBars={errorBars}
+        stackId={stackId}
       />
       {children}
     </ErrorBarDirectionDispatchContext.Provider>

--- a/src/state/axisMapSlice.ts
+++ b/src/state/axisMapSlice.ts
@@ -9,7 +9,7 @@ export type YAxisPadding = { top?: number; bottom?: number } | 'gap' | 'no-gap';
 
 /**
  * These are the external props, visible for users as they set them using our public API.
- * There is all sorts of internal computed things based on these but they will come through selectors.
+ * There is all sorts of internal computed things based on these, but they will come through selectors.
  */
 export type AxisSettings = {
   id: AxisId;
@@ -27,6 +27,7 @@ export type AxisSettings = {
   allowDuplicatedCategory: boolean;
   allowDecimals: boolean;
   tickCount: number;
+  includeHidden: boolean;
 };
 
 export type XAxisSettings = AxisSettings & {

--- a/src/state/axisSelectors.ts
+++ b/src/state/axisSelectors.ts
@@ -253,6 +253,7 @@ export const selectAllAppliedNumericalValuesIncludingErrorValues = createSelecto
     items: ReadonlyArray<CartesianGraphicalItemSettings>,
     axisType: AxisType,
   ): ReadonlyArray<AppliedChartDataWithErrorDomain> => {
+    // TODO add stacks
     if (items.length > 0) {
       return data
         .flatMap(entry => {
@@ -369,8 +370,6 @@ export const selectAxisDomain = (
     const allDataSquished = selectAllAppliedValues(state, axisType, axisId);
     return computeCategoricalDomain(allDataSquished, axisSettings);
   }
-
-  // TODO getDomainOfStackGroups here
 
   return selectNumericalDomain(state, axisSettings, axisType, axisId);
 };

--- a/src/state/axisSelectors.ts
+++ b/src/state/axisSelectors.ts
@@ -38,6 +38,7 @@ export const selectAxisSettings = (state: RechartsRootState, axisType: AxisType,
 export const selectHasBar = (state: RechartsRootState): boolean => state.graphicalItems.countOfBars > 0;
 
 const pickAxisType = (_state: RechartsRootState, axisType: AxisType): AxisType => axisType;
+const pickAxisId = (_state: RechartsRootState, _axisType: AxisType, axisId: AxisId): AxisId => axisId;
 
 /**
  * Filters CartesianGraphicalItemSettings by the relevant axis ID
@@ -61,12 +62,25 @@ function itemAxisPredicate(axisType: AxisType, axisId: AxisId) {
   };
 }
 
+const selectUnfilteredCartesianItems = (state: RechartsRootState) => state.graphicalItems.cartesianItems;
+
 const selectCartesianItemsSettings: (
   state: RechartsRootState,
   axisType: AxisType,
   axisId: AxisId,
-) => ReadonlyArray<CartesianGraphicalItemSettings> = (state: RechartsRootState, axisType: AxisType, axisId: AxisId) =>
-  state.graphicalItems.cartesianItems.filter(itemAxisPredicate(axisType, axisId));
+) => ReadonlyArray<CartesianGraphicalItemSettings> = createSelector(
+  selectUnfilteredCartesianItems,
+  selectAxisSettings,
+  pickAxisType,
+  pickAxisId,
+  (cartesianItems, axisSettings, axisType: AxisType, axisId: AxisId) =>
+    cartesianItems.filter(itemAxisPredicate(axisType, axisId)).filter(item => {
+      if (axisSettings?.includeHidden === true) {
+        return true;
+      }
+      return !item.hide;
+    }),
+);
 
 /**
  * This is a "cheap" selector - it returns the data but doesn't iterate them, so it is not sensitive on the array length.

--- a/src/state/axisSelectors.ts
+++ b/src/state/axisSelectors.ts
@@ -1,10 +1,28 @@
 import { createSelector } from '@reduxjs/toolkit';
 import range from 'lodash/range';
+import { Series } from 'victory-vendor/d3-shape';
 import { selectChartLayout, selectChartOffset } from '../context/chartLayoutContext';
-import { getValueByDataKey, isCategoricalAxis, ParsedScaleReturn, parseScale } from '../util/ChartUtils';
-import { AxisDomain, AxisType, CategoricalDomain, ChartOffset, LayoutType, NumberDomain } from '../util/types';
+import {
+  getDomainOfStackGroups,
+  getStackedData,
+  getValueByDataKey,
+  isCategoricalAxis,
+  ParsedScaleReturn,
+  parseScale,
+  StackId,
+} from '../util/ChartUtils';
+import {
+  AxisDomain,
+  AxisType,
+  CategoricalDomain,
+  ChartOffset,
+  DataKey,
+  LayoutType,
+  NumberDomain,
+  StackOffsetType,
+} from '../util/types';
 import { AxisId, AxisSettings, XAxisSettings, YAxisSettings } from './axisMapSlice';
-import { selectBarCategoryGap, selectChartName } from './selectors';
+import { selectBarCategoryGap, selectChartName, selectStackOffsetType } from './selectors';
 import { RechartsRootState } from './store';
 import { selectChartDataWithIndexes } from './dataSelectors';
 import {
@@ -15,6 +33,7 @@ import { AppliedChartData, ChartData } from './chartDataSlice';
 import { getPercentValue, hasDuplicate } from '../util/DataUtils';
 import { CartesianGraphicalItemSettings, ErrorBarsSettings } from './graphicalItemsSlice';
 import { isWellBehavedNumber } from '../util/isWellBehavedNumber';
+import { getNiceTickValues } from '../util/scale';
 
 export const selectXAxisSettings = (state: RechartsRootState, axisId: AxisId): XAxisSettings => {
   return state.axisMap.xAxis[axisId];
@@ -80,6 +99,14 @@ const selectCartesianItemsSettings: (
       }
       return !item.hide;
     }),
+);
+
+const selectCartesianItemsSettingsExceptStacked: (
+  state: RechartsRootState,
+  axisType: AxisType,
+  axisId: AxisId,
+) => ReadonlyArray<CartesianGraphicalItemSettings> = createSelector(selectCartesianItemsSettings, cartesianItems =>
+  cartesianItems.filter(item => item.stackId === undefined),
 );
 
 /**
@@ -256,10 +283,58 @@ export function getErrorDomainByDataKey(
   );
 }
 
+export type StackGroup = { readonly stackedData: ReadonlyArray<Series<Record<string, unknown>, DataKey<any>>> };
+
+export const selectStackGroups: (
+  state: RechartsRootState,
+  axisType: AxisType,
+  axisId: AxisId,
+) => Record<StackId, StackGroup> = createSelector(
+  selectDisplayedData,
+  selectCartesianItemsSettings,
+  selectStackOffsetType,
+  (
+    displayedData,
+    items: ReadonlyArray<CartesianGraphicalItemSettings>,
+    stackOffsetType: StackOffsetType,
+  ): Record<StackId, StackGroup> => {
+    const initialItemsGroups: Record<StackId, Array<DataKey<any>>> = {};
+    const itemsGroup: Record<StackId, ReadonlyArray<DataKey<any>>> = items.reduce(
+      (acc: Record<StackId, Array<DataKey<any>>>, item: CartesianGraphicalItemSettings) => {
+        if (item.stackId == null) {
+          return acc;
+        }
+        if (acc[item.stackId] == null) {
+          acc[item.stackId] = [];
+        }
+        acc[item.stackId].push(item.dataKey);
+        return acc;
+      },
+      initialItemsGroups,
+    );
+
+    return Object.fromEntries(
+      Object.entries(itemsGroup).map(([stackId, dataKeys]) => {
+        // @ts-expect-error getStackedData requires that the input is array of objects, Recharts does not test for that
+        return [stackId, { stackedData: getStackedData(displayedData, dataKeys, stackOffsetType) }];
+      }),
+    );
+  },
+);
+
+export const selectDomainOfStackGroups = createSelector(
+  selectStackGroups,
+  selectChartDataWithIndexes,
+  (stackGroups, { dataStartIndex, dataEndIndex }): NumberDomain => {
+    // @ts-expect-error typescript is unhappy with the two different types of StackGroups
+    return getDomainOfStackGroups(stackGroups, dataStartIndex, dataEndIndex);
+  },
+);
+
 export const selectAllAppliedNumericalValuesIncludingErrorValues = createSelector(
   selectDisplayedData,
   selectAxisSettings,
-  selectCartesianItemsSettings,
+  selectCartesianItemsSettingsExceptStacked,
   pickAxisType,
   (
     data: ChartData,
@@ -267,7 +342,6 @@ export const selectAllAppliedNumericalValuesIncludingErrorValues = createSelecto
     items: ReadonlyArray<CartesianGraphicalItemSettings>,
     axisType: AxisType,
   ): ReadonlyArray<AppliedChartDataWithErrorDomain> => {
-    // TODO add stacks
     if (items.length > 0) {
       return data
         .flatMap(entry => {
@@ -331,13 +405,17 @@ const computeCategoricalDomain = (allDataSquished: AppliedChartData, axisSetting
   return Array.from(new Set(categoricalDomain));
 };
 
+const defaultNumericDomain: AxisDomain = [0, 'auto'];
+
+const getDomainDefinition = (axisSettings: AxisSettings): AxisDomain => axisSettings?.domain ?? defaultNumericDomain;
+
 const selectNumericalDomain = (
   state: RechartsRootState,
   axisSettings: AxisSettings,
   axisType: AxisType,
   axisId: AxisId,
 ): NumberDomain => {
-  const domainDefinition: AxisDomain = axisSettings.domain ?? [0, 'auto'];
+  const domainDefinition: AxisDomain = getDomainDefinition(axisSettings);
 
   const domainFromUserPreference: NumberDomain | undefined = numericalDomainSpecifiedWithoutRequiringData(
     domainDefinition,
@@ -348,18 +426,25 @@ const selectNumericalDomain = (
     return domainFromUserPreference;
   }
 
-  const allDataWithErrorDomains: ReadonlyArray<AppliedChartDataWithErrorDomain> =
-    selectAllAppliedNumericalValuesIncludingErrorValues(state, axisType, axisId);
-  const domainFromData = computeNumericalDomain(allDataWithErrorDomains);
+  let domainFromData: NumberDomain;
+  const domainOfStackGroups = selectDomainOfStackGroups(state, axisType, axisId);
+  if (domainOfStackGroups[0] !== 0 || domainOfStackGroups[1] !== 0) {
+    domainFromData = domainOfStackGroups;
+  } else {
+    const allDataWithErrorDomains: ReadonlyArray<AppliedChartDataWithErrorDomain> =
+      selectAllAppliedNumericalValuesIncludingErrorValues(state, axisType, axisId);
+    domainFromData = computeNumericalDomain(allDataWithErrorDomains);
+  }
 
-  return parseNumericalUserDomain(
-    domainDefinition,
-    domainFromData,
-    axisSettings.allowDataOverflow,
-    axisSettings.allowDecimals,
-    axisSettings.tickCount,
-  );
+  return parseNumericalUserDomain(domainDefinition, domainFromData, axisSettings.allowDataOverflow);
 };
+
+/**
+ * Expand by design maps everything between 0 and 1,
+ * there is nothing to compute.
+ * See https://d3js.org/d3-shape/stack#stack-offsets
+ */
+const expandDomain: NumberDomain = [0, 1];
 
 export const selectAxisDomain = (
   state: RechartsRootState,
@@ -385,8 +470,28 @@ export const selectAxisDomain = (
     return computeCategoricalDomain(allDataSquished, axisSettings);
   }
 
+  if (selectStackOffsetType(state) === 'expand') {
+    return expandDomain;
+  }
+
   return selectNumericalDomain(state, axisSettings, axisType, axisId);
 };
+
+export const selectNiceTicks = createSelector(
+  selectAxisDomain,
+  selectAxisSettings,
+  (axisDomain, axisSettings): ReadonlyArray<number> | undefined => {
+    const domainDefinition: AxisDomain = getDomainDefinition(axisSettings);
+    if (
+      axisSettings != null &&
+      Array.isArray(domainDefinition) &&
+      (domainDefinition[0] === 'auto' || domainDefinition[1] === 'auto')
+    ) {
+      return getNiceTickValues(axisDomain, axisSettings.tickCount, axisSettings.allowDecimals);
+    }
+    return undefined;
+  },
+);
 
 /**
  * Returns the smallest gap, between two numbers in the data, as a ratio of the whole range (max - min).

--- a/src/state/graphicalItemsSlice.ts
+++ b/src/state/graphicalItemsSlice.ts
@@ -4,6 +4,7 @@ import { ChartData } from './chartDataSlice';
 import { AxisId } from './axisMapSlice';
 import { DataKey } from '../util/types';
 import { ErrorBarDirection } from '../cartesian/ErrorBar';
+import { StackId } from '../util/ChartUtils';
 
 /**
  * ErrorBars have lot more settings but all the others are scoped to the component itself.
@@ -42,6 +43,7 @@ export type CartesianGraphicalItemSettings = {
    * One graphical item can have multiple error bars. This probably only makes sense in Scatter.
    */
   errorBars: ReadonlyArray<ErrorBarsSettings> | undefined;
+  stackId: StackId | undefined;
 };
 
 export type GraphicalItemsState = {

--- a/src/state/graphicalItemsSlice.ts
+++ b/src/state/graphicalItemsSlice.ts
@@ -44,6 +44,13 @@ export type CartesianGraphicalItemSettings = {
    */
   errorBars: ReadonlyArray<ErrorBarsSettings> | undefined;
   stackId: StackId | undefined;
+  /**
+   * Why not just stop pushing the graphical items to state when they are hidden?
+   * Well some components decide to continue showing them anyway.
+   * Legend for example will keep showing a record for hidden graphical items.
+   * Stacks for example will ignore them.
+   */
+  hide: boolean;
 };
 
 export type GraphicalItemsState = {

--- a/src/state/optionsSlice.ts
+++ b/src/state/optionsSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { TooltipEventType } from '../util/types';
+import { StackOffsetType, TooltipEventType } from '../util/types';
 import { TooltipPayloadSearcher } from './tooltipSlice';
 
 export type ChartOptions = {
@@ -9,6 +9,7 @@ export type ChartOptions = {
   // Should this instead be a property of a graphical item? Do we want to mix items with different data types in one chart?
   tooltipPayloadSearcher: TooltipPayloadSearcher | undefined;
   barCategoryGap: number | string;
+  stackOffset: StackOffsetType;
 };
 
 export const arrayTooltipSearcher: TooltipPayloadSearcher = (
@@ -23,6 +24,7 @@ export const arrayTooltipSearcher: TooltipPayloadSearcher = (
 };
 
 const initialState: ChartOptions = {
+  stackOffset: 'none',
   chartName: '',
   tooltipPayloadSearcher: undefined,
   barCategoryGap: '10%',

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -30,6 +30,7 @@ import {
   ChartOffset,
   DataKey,
   LayoutType,
+  StackOffsetType,
   TickItem,
   TooltipEventType,
 } from '../util/types';
@@ -51,6 +52,8 @@ import { selectChartDataWithIndexes } from './dataSelectors';
 export const selectChartName = (state: RechartsRootState) => state.options.chartName;
 
 export const selectBarCategoryGap = (state: RechartsRootState) => state.options.barCategoryGap;
+
+export const selectStackOffsetType = (state: RechartsRootState): StackOffsetType => state.options.stackOffset;
 
 export const useChartName = (): string => {
   return useAppSelector(selectChartName);

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1014,10 +1014,9 @@ const STACK_OFFSET_MAP: Record<string, OffsetAccessor> = {
 
 export const getStackedData = (
   data: ReadonlyArray<Record<string, unknown>>,
-  stackItems: ReadonlyArray<{ props: { dataKey?: DataKey<any> } }>,
+  dataKeys: ReadonlyArray<DataKey<any>>,
   offsetType: StackOffsetType,
 ): ReadonlyArray<Series<Record<string, unknown>, string>> => {
-  const dataKeys = stackItems.map(item => item.props.dataKey);
   const offsetAccessor: OffsetAccessor = STACK_OFFSET_MAP[offsetType];
   const stack = shapeStack<Record<string, unknown>>()
     // @ts-expect-error stack.keys type wants an array of strings, but we provide array of DataKeys
@@ -1115,7 +1114,11 @@ export const getStackGroupsByAxisId = (
             numericAxisId,
             cateAxisId,
             items: g.items,
-            stackedData: getStackedData(data, g.items, offsetType),
+            stackedData: getStackedData(
+              data,
+              g.items.map(item => item.props.dataKey),
+              offsetType,
+            ),
           },
         };
       }, stackGroupsInitialValue);

--- a/src/util/isDomainSpecifiedByUser.ts
+++ b/src/util/isDomainSpecifiedByUser.ts
@@ -1,6 +1,5 @@
 import { MAX_VALUE_REG, MIN_VALUE_REG } from './ChartUtils';
 import { isNumber } from './DataUtils';
-import { getNiceTickValues } from './scale';
 import { AxisDomain, AxisDomainType, NumberDomain } from './types';
 import { isWellBehavedNumber } from './isWellBehavedNumber';
 
@@ -44,7 +43,7 @@ function isWellFormedNumberDomain(v: unknown): v is NumberDomain {
   return false;
 }
 
-function extendDomain(
+export function extendDomain(
   providedDomain: NumberDomain,
   boundaryDomain: NumberDomain,
   allowDataOverflow: boolean,
@@ -150,8 +149,6 @@ export function numericalDomainSpecifiedWithoutRequiringData(
  * @param userDomain external prop, user provided, before validation. Can have various shapes: array, function, special magical strings inside too.
  * @param dataDomain calculated from data. Can be undefined, as an option for performance optimization
  * @param allowDataOverflow provided by users. If true then the data domain wins
- * @param allowDecimals if true then recharts is allowed to generate domain with decimal numbers; if false the numbers are always integers
- * @param tickCount if the automatic "nice" ticks land outside of domain, the domain will be extended
  *
  * @return [min, max] domain if it's well-formed; undefined if the domain is invalid
  */
@@ -159,8 +156,6 @@ export function parseNumericalUserDomain(
   userDomain: AxisDomain | undefined,
   dataDomain: NumberDomain | undefined,
   allowDataOverflow: boolean,
-  allowDecimals: boolean,
-  tickCount: number,
 ): NumberDomain | undefined {
   if (!allowDataOverflow && dataDomain == null) {
     // Cannot compute data overflow if the data is not provided
@@ -178,12 +173,11 @@ export function parseNumericalUserDomain(
   }
   if (Array.isArray(userDomain) && userDomain.length === 2) {
     const [providedMin, providedMax] = userDomain;
-    let finalMin, finalMax: number, niceTicks: ReadonlyArray<number>;
+    let finalMin, finalMax: number;
 
     if (providedMin === 'auto') {
       if (dataDomain != null) {
-        niceTicks = getNiceTickValues(dataDomain, tickCount, allowDecimals);
-        finalMin = Math.min(...niceTicks);
+        finalMin = Math.min(...dataDomain);
       }
     } else if (typeof providedMin === 'number' && !Number.isNaN(providedMin)) {
       finalMin = providedMin;
@@ -202,10 +196,7 @@ export function parseNumericalUserDomain(
 
     if (providedMax === 'auto') {
       if (dataDomain != null) {
-        if (niceTicks == null) {
-          niceTicks = getNiceTickValues([finalMin, dataDomain[1]], tickCount, allowDecimals);
-        }
-        finalMax = Math.max(...niceTicks);
+        finalMax = Math.max(...dataDomain);
       }
     } else if (typeof providedMax === 'number' && !Number.isNaN(providedMax)) {
       finalMax = providedMax;

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -445,7 +445,7 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
 
       const { rerender } = render(
         <ChartElement data={data}>
-          <Area dataKey="value" data={data2} xAxisId={7} yAxisId={9} />
+          <Area dataKey="value" data={data2} xAxisId={7} yAxisId={9} stackId="q" />
           <Customized component={<Comp />} />
         </ChartElement>,
       );
@@ -456,6 +456,7 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
           xAxisId: 7,
           yAxisId: 9,
           errorBars: [],
+          stackId: 'q',
         },
       ];
       expect(spy).toHaveBeenLastCalledWith(expected);
@@ -490,6 +491,7 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
           xAxisId: 0,
           yAxisId: 0,
           errorBars: [],
+          stackId: undefined,
         },
       ];
       expect(spy).toHaveBeenLastCalledWith(expected);

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -445,7 +445,7 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
 
       const { rerender } = render(
         <ChartElement data={data}>
-          <Area dataKey="value" data={data2} xAxisId={7} yAxisId={9} stackId="q" />
+          <Area dataKey="value" data={data2} xAxisId={7} yAxisId={9} stackId="q" hide />
           <Customized component={<Comp />} />
         </ChartElement>,
       );
@@ -457,6 +457,7 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
           yAxisId: 9,
           errorBars: [],
           stackId: 'q',
+          hide: true,
         },
       ];
       expect(spy).toHaveBeenLastCalledWith(expected);
@@ -492,6 +493,7 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
           yAxisId: 0,
           errorBars: [],
           stackId: undefined,
+          hide: false,
         },
       ];
       expect(spy).toHaveBeenLastCalledWith(expected);

--- a/test/cartesian/Bar.spec.tsx
+++ b/test/cartesian/Bar.spec.tsx
@@ -399,7 +399,7 @@ describe.each(includingCompact(chartsThatSupportBar))('<Bar /> as a child of $te
       );
       const expected: ReadonlyArray<CartesianGraphicalItemSettings> = [
         {
-          data: [],
+          data: null,
           dataKey: 'value',
           xAxisId: 0,
           yAxisId: 0,

--- a/test/cartesian/Bar.spec.tsx
+++ b/test/cartesian/Bar.spec.tsx
@@ -2,13 +2,15 @@ import React, { ComponentType, ReactNode } from 'react';
 import { describe, expect, it, test, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import uniqueId from 'lodash/uniqueId';
-import { Bar, Legend, LegendType, XAxis, YAxis } from '../../src';
+import { Bar, Customized, Legend, LegendType, XAxis, YAxis } from '../../src';
 import {
   allCategoricalsChartsExcept,
   BarChartCase,
   ComposedChartCase,
   includingCompact,
 } from '../helper/parameterizedTestCases';
+import { useAppSelector } from '../../src/state/hooks';
+import { CartesianGraphicalItemSettings } from '../../src/state/graphicalItemsSlice';
 
 type TestCase = {
   ChartElement: ComponentType<{ children?: ReactNode; width?: number; height?: number; data?: any[] }>;
@@ -342,6 +344,71 @@ describe.each(includingCompact(chartsThatSupportBar))('<Bar /> as a child of $te
           expect.soft(l).not.toHaveAttribute('fill', '#808080');
         });
       });
+    });
+  });
+
+  describe('state integration', () => {
+    it('should report its props to redux state, and remove them when removed from DOM', () => {
+      const spy = vi.fn();
+      const Comp = (): null => {
+        const cartesianItems = useAppSelector(state => state.graphicalItems.cartesianItems);
+        spy(cartesianItems);
+        return null;
+      };
+
+      const { rerender } = render(
+        <ChartElement data={data}>
+          <Bar dataKey="value" xAxisId={7} yAxisId={9} stackId="q" hide />
+          <Customized component={<Comp />} />
+        </ChartElement>,
+      );
+      const expected: ReadonlyArray<CartesianGraphicalItemSettings> = [
+        {
+          data: null,
+          dataKey: 'value',
+          xAxisId: 7,
+          yAxisId: 9,
+          errorBars: [],
+          stackId: 'q',
+          hide: true,
+        },
+      ];
+      expect(spy).toHaveBeenLastCalledWith(expected);
+
+      rerender(
+        <ChartElement data={data}>
+          <Customized component={<Comp />} />
+        </ChartElement>,
+      );
+      expect(spy).toHaveBeenLastCalledWith([]);
+    });
+
+    it('should report default props to redux state', () => {
+      const spy = vi.fn();
+      const Comp = (): null => {
+        const cartesianItems = useAppSelector(state => state.graphicalItems.cartesianItems);
+        spy(cartesianItems);
+        return null;
+      };
+
+      render(
+        <ChartElement data={data}>
+          <Bar dataKey="value" />
+          <Customized component={<Comp />} />
+        </ChartElement>,
+      );
+      const expected: ReadonlyArray<CartesianGraphicalItemSettings> = [
+        {
+          data: [],
+          dataKey: 'value',
+          xAxisId: 0,
+          yAxisId: 0,
+          errorBars: [],
+          stackId: undefined,
+          hide: false,
+        },
+      ];
+      expect(spy).toHaveBeenLastCalledWith(expected);
     });
   });
 });

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -321,7 +321,7 @@ describe('<ErrorBar />', () => {
           y: '5',
         },
       ]);
-      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3400]);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3300]);
       expect(axisDomainSpy).toHaveBeenCalledTimes(3);
       rerender(
         <BarChart data={dataWithError} width={500} height={500}>
@@ -361,7 +361,7 @@ describe('<ErrorBar />', () => {
           y: '5',
         },
       ]);
-      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3600]);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3440]);
       expect(axisDomainSpy).toHaveBeenCalledTimes(6);
     });
 
@@ -407,7 +407,7 @@ describe('<ErrorBar />', () => {
           y: '5',
         },
       ]);
-      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3400]);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3300]);
       expect(axisDomainSpy).toHaveBeenCalledTimes(3);
 
       rerender(
@@ -448,7 +448,7 @@ describe('<ErrorBar />', () => {
           y: '5',
         },
       ]);
-      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3600]);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3440]);
       expect(axisDomainSpy).toHaveBeenCalledTimes(6);
     });
 
@@ -494,7 +494,7 @@ describe('<ErrorBar />', () => {
           y: '473',
         },
       ]);
-      expect(xAxisSpy).toHaveBeenLastCalledWith([0, 3400]);
+      expect(xAxisSpy).toHaveBeenLastCalledWith([0, 3300]);
       expect(xAxisSpy).toHaveBeenCalledTimes(3);
 
       rerender(
@@ -538,7 +538,7 @@ describe('<ErrorBar />', () => {
       ]);
       // Yep look at this - the selector has fixed this bug and is now extending XAxis domain too.
       // Once we switch from generateCategoricalChart domain to redux domain, then the axis will be fixed too
-      expect(xAxisSpy).toHaveBeenLastCalledWith([0, 3600]);
+      expect(xAxisSpy).toHaveBeenLastCalledWith([0, 3440]);
       expect(xAxisSpy).toHaveBeenCalledTimes(6);
     });
   });

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -743,7 +743,7 @@ describe('<XAxis />', () => {
     const axisLine = container.getElementsByClassName('recharts-cartesian-axis-line');
     expect(axisLine).toHaveLength(1);
     expectXAxisTicks(container, []);
-    expect(spy).toHaveBeenLastCalledWith([0, 0]);
+    expect(spy).toHaveBeenLastCalledWith(undefined);
   });
 
   it('Render Bars for a single data point with barSize=50%', () => {
@@ -1065,7 +1065,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expect(spy).toHaveBeenLastCalledWith([0, 170]);
       });
 
       describe.each([true, false, undefined])('auto domain with allowDataOverflow = %s', allowDataOverflow => {
@@ -1104,7 +1104,7 @@ describe('<XAxis />', () => {
               y: '273',
             },
           ]);
-          expect(spy).toHaveBeenLastCalledWith([100, 180]);
+          expect(spy).toHaveBeenLastCalledWith([100, 170]);
         });
 
         it('should render ticks from number, auto', () => {
@@ -1142,7 +1142,7 @@ describe('<XAxis />', () => {
               y: '273',
             },
           ]);
-          expect(spy).toHaveBeenLastCalledWith([-55, 180]);
+          expect(spy).toHaveBeenLastCalledWith([-55, 170]);
         });
 
         it('should render ticks from auto, number', () => {
@@ -1487,7 +1487,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expect(spy).toHaveBeenLastCalledWith([0, 170]);
       });
 
       it('should allow providing less tickCount', () => {
@@ -1793,7 +1793,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expect(spy).toHaveBeenLastCalledWith([0, 170]);
       });
 
       it('should only display domain of data with matching xAxisId', () => {
@@ -1868,8 +1868,8 @@ describe('<XAxis />', () => {
           },
         ]);
         expect(reduxDefaultDomainSpy).toHaveBeenLastCalledWith(undefined);
-        expect(reduxDomainSpyA).toHaveBeenLastCalledWith([0, 180]);
-        expect(reduxDomainSpyB).toHaveBeenLastCalledWith([0, 160]);
+        expect(reduxDomainSpyA).toHaveBeenLastCalledWith([0, 170]);
+        expect(reduxDomainSpyB).toHaveBeenLastCalledWith([0, 150]);
       });
 
       it('should only display domain of data with matching xAxisId, and dataMin dataMax domains', () => {
@@ -1980,7 +1980,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 1]);
+        expect(spy).toHaveBeenLastCalledWith([0, 0.9]);
       });
 
       it('should not allow decimals in small numbers if allowDecimals is false', () => {
@@ -2018,7 +2018,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 4]);
+        expect(spy).toHaveBeenLastCalledWith([0, 0.9]);
       });
 
       it.each([true, false, undefined])(
@@ -2058,7 +2058,7 @@ describe('<XAxis />', () => {
               y: '273',
             },
           ]);
-          expect(spy).toHaveBeenLastCalledWith([0, 16]);
+          expect(spy).toHaveBeenLastCalledWith([0, 12.5]);
         },
       );
     });
@@ -2099,7 +2099,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expect(spy).toHaveBeenLastCalledWith([0, 170]);
       });
 
       it('should display every second tick with interval = 1', () => {
@@ -2127,7 +2127,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expect(spy).toHaveBeenLastCalledWith([0, 170]);
       });
 
       it('should display every third tick with interval = 2', () => {
@@ -2150,7 +2150,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expect(spy).toHaveBeenLastCalledWith([0, 170]);
       });
 
       it('should add more ticks with tickCount and then reduce them again with interval', () => {
@@ -2198,7 +2198,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 171]);
+        expect(spy).toHaveBeenLastCalledWith([0, 170]);
       });
 
       it('should attempt to show the ticks start with interval = preserveStart', () => {
@@ -3177,7 +3177,7 @@ describe('<XAxis />', () => {
           y: '273',
         },
       ]);
-      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 600]);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 500]);
     });
 
     it('should render with in LineChart VerticalWithSpecifiedDomain', () => {

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -859,13 +859,14 @@ describe('<XAxis />', () => {
       };
       const { container } = render(
         <BarChart width={100} height={100}>
-          <XAxis xAxisId="foo" scale="log" type="number" />
+          <XAxis xAxisId="foo" scale="log" type="number" includeHidden />
           <Customized component={Comp} />
         </BarChart>,
       );
       expect(container.querySelector('.xAxis')).toBeVisible();
       expect(spy).toHaveBeenCalledTimes(3);
       const expectedSettings: XAxisSettings = {
+        includeHidden: true,
         tickCount: 5,
         allowDecimals: true,
         id: 'foo',
@@ -898,6 +899,7 @@ describe('<XAxis />', () => {
         </BarChart>,
       );
       const expectedSettings1: XAxisSettings = {
+        includeHidden: false,
         tickCount: 5,
         allowDecimals: true,
         id: 'foo',
@@ -928,6 +930,7 @@ describe('<XAxis />', () => {
         foo: XAxisSettings;
       } = {
         foo: {
+          includeHidden: false,
           id: 'foo',
           scale: 'log',
           type: 'number',
@@ -943,6 +946,7 @@ describe('<XAxis />', () => {
           tickCount: 5,
         },
         bar: {
+          includeHidden: false,
           id: 'bar',
           scale: 'utc',
           type: 'category',
@@ -967,6 +971,7 @@ describe('<XAxis />', () => {
       );
 
       const expectedSettings3: XAxisSettings = {
+        includeHidden: false,
         tickCount: 5,
         id: 'bar',
         scale: 'utc',
@@ -3232,7 +3237,8 @@ describe('<XAxis />', () => {
           y: '273',
         },
       ]);
-      expect(axisSettingsSpy).toHaveBeenLastCalledWith({
+      const expectedSettings: XAxisSettings = {
+        includeHidden: false,
         allowDataOverflow: false,
         allowDecimals: true,
         allowDuplicatedCategory: true,
@@ -3246,7 +3252,8 @@ describe('<XAxis />', () => {
         scale: 'auto',
         tickCount: 5,
         type: 'number',
-      });
+      };
+      expect(axisSettingsSpy).toHaveBeenLastCalledWith(expectedSettings);
       expect(itemDataSpy).toHaveBeenLastCalledWith([]);
       expect(itemDataSpy).toHaveBeenCalledTimes(3);
       expect(displayedDataSpy).toHaveBeenLastCalledWith(pageData);

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -310,13 +310,14 @@ describe('<YAxis />', () => {
       };
       const { container } = render(
         <BarChart width={100} height={100}>
-          <YAxis yAxisId="foo" scale="log" type="number" />
+          <YAxis yAxisId="foo" scale="log" type="number" includeHidden />
           <Customized component={Comp} />
         </BarChart>,
       );
       expect(container.querySelector('.yAxis')).toBeVisible();
       expect(spy).toHaveBeenCalledTimes(3);
       const expectedSettings: YAxisSettings = {
+        includeHidden: true,
         tickCount: 5,
         allowDecimals: true,
         id: 'foo',
@@ -349,6 +350,7 @@ describe('<YAxis />', () => {
         </BarChart>,
       );
       const expectedSettings1: YAxisSettings = {
+        includeHidden: false,
         tickCount: 5,
         allowDecimals: true,
         id: 'foo',
@@ -379,6 +381,7 @@ describe('<YAxis />', () => {
         foo: YAxisSettings;
       } = {
         foo: {
+          includeHidden: false,
           id: 'foo',
           scale: 'log',
           type: 'number',
@@ -394,6 +397,7 @@ describe('<YAxis />', () => {
           tickCount: 5,
         },
         bar: {
+          includeHidden: false,
           id: 'bar',
           scale: 'utc',
           type: 'category',
@@ -418,6 +422,7 @@ describe('<YAxis />', () => {
       );
 
       const expectedSettings3: YAxisSettings = {
+        includeHidden: false,
         tickCount: 5,
         id: 'bar',
         scale: 'utc',

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -539,7 +539,7 @@ describe('<YAxis />', () => {
       },
     );
 
-    it('should ignore domain of hidden items', () => {
+    it.each([undefined, false])('should ignore domain of hidden items when includeHidden=%s', includeHidden => {
       const stackedData = [
         {
           x: 100,
@@ -554,7 +554,7 @@ describe('<YAxis />', () => {
       };
       const { container } = render(
         <BarChart width={100} height={100} data={stackedData}>
-          <YAxis />
+          <YAxis includeHidden={includeHidden} />
           <Bar dataKey="x" stackId="a" />
           <Bar dataKey="y" stackId="a" hide />
           <Customized component={<Comp />} />
@@ -603,7 +603,6 @@ describe('<YAxis />', () => {
         domainSpy(domain);
         return null;
       };
-      // includeHidden does not work with stacked data, why?
       const { container, rerender } = render(
         <BarChart width={100} height={100} data={stackedData}>
           <YAxis includeHidden />
@@ -612,6 +611,7 @@ describe('<YAxis />', () => {
           <Customized component={<Comp />} />
         </BarChart>,
       );
+      // includeHidden does not work with stacked data, why?
       expectYAxisTicks(container, [
         {
           textContent: '0',
@@ -639,7 +639,7 @@ describe('<YAxis />', () => {
           y: '5',
         },
       ]);
-      expect(domainSpy).toHaveBeenLastCalledWith([0, 12]);
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 200]);
 
       // the same data, when not stacked, are included when includeHidden is true.
       rerender(

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -5,8 +5,9 @@ import { AreaChart, Area, BarChart, Bar, LineChart, Line, CartesianGrid, Tooltip
 import { AxisDomain } from '../../src/util/types';
 import { pageData } from '../../storybook/stories/data';
 import { useAppSelector } from '../../src/state/hooks';
-import { selectAxisSettings } from '../../src/state/axisSelectors';
+import { selectAxisDomain, selectAxisSettings } from '../../src/state/axisSelectors';
 import { YAxisSettings } from '../../src/state/axisMapSlice';
+import { expectYAxisTicks } from '../helper/expectAxisTicks';
 
 describe('<YAxis />', () => {
   const data = [
@@ -445,6 +446,94 @@ describe('<YAxis />', () => {
         foo: undefined,
         bar: undefined,
       });
+    });
+  });
+
+  describe('in stacked BarChart', () => {
+    it('should render sum of stacked values', () => {
+      const stackedData = [
+        {
+          x: 100,
+          y: 200,
+        },
+      ];
+      const domainSpy = vi.fn();
+      const Comp = (): null => {
+        const domain = useAppSelector(state => selectAxisDomain(state, 'yAxis', 0));
+        domainSpy(domain);
+        return null;
+      };
+      const { container, rerender } = render(
+        <BarChart width={100} height={100} data={stackedData}>
+          <YAxis />
+          <Bar dataKey="x" stackId="a" />
+          <Customized component={<Comp />} />
+        </BarChart>,
+      );
+      expectYAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '57',
+          y: '95',
+        },
+        {
+          textContent: '25',
+          x: '57',
+          y: '72.5',
+        },
+        {
+          textContent: '50',
+          x: '57',
+          y: '50',
+        },
+        {
+          textContent: '75',
+          x: '57',
+          y: '27.5',
+        },
+        {
+          textContent: '100',
+          x: '57',
+          y: '5',
+        },
+      ]);
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 100]);
+      rerender(
+        <BarChart width={100} height={100} data={stackedData}>
+          <YAxis />
+          <Bar dataKey="x" stackId="a" />
+          <Bar dataKey="y" stackId="a" />
+          <Customized component={<Comp />} />
+        </BarChart>,
+      );
+      expectYAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '57',
+          y: '95',
+        },
+        {
+          textContent: '75',
+          x: '57',
+          y: '72.5',
+        },
+        {
+          textContent: '150',
+          x: '57',
+          y: '50',
+        },
+        {
+          textContent: '225',
+          x: '57',
+          y: '27.5',
+        },
+        {
+          textContent: '300',
+          x: '57',
+          y: '5',
+        },
+      ]);
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 300]);
     });
   });
 });

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -238,7 +238,7 @@ describe('<YAxis />', () => {
           y: '5',
         },
       ]);
-      expect(domainSpy).toHaveBeenLastCalledWith([0, 10000]);
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 9800]);
     });
 
     it.each([false, undefined])('should exclude hidden items domain when includeHidden=%s', includeHidden => {
@@ -328,7 +328,7 @@ describe('<YAxis />', () => {
           y: '5',
         },
       ]);
-      expect(domainSpy).toHaveBeenLastCalledWith([0, 10000]);
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 9800]);
     });
   });
 
@@ -732,7 +732,7 @@ describe('<YAxis />', () => {
           y: '5',
         },
       ]);
-      expect(domainSpy).toHaveBeenLastCalledWith([0, 200]);
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 210]);
 
       // the same data, when not stacked, are included when includeHidden is true.
       rerender(
@@ -822,6 +822,7 @@ describe('<YAxis />', () => {
           y: '5',
         },
       ]);
+      // -2000, 100 is the correct domain - the tick generator decides to extend it beyond, to 700. But the domain ends at 100.
       expect(domainSpy).toHaveBeenLastCalledWith([-2000, 100]);
     });
 
@@ -1029,4 +1030,6 @@ describe('<YAxis />', () => {
       expect(domainSpy).toHaveBeenLastCalledWith([0, 100]);
     });
   });
+
+  describe.todo('Reference elements should expand domain');
 });

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -590,6 +590,97 @@ describe('<YAxis />', () => {
       expect(domainSpy).toHaveBeenLastCalledWith([0, 100]);
     });
 
+    it('should ignore domain of hidden items with includeHidden! this feels like a bug to me - why does this not work for stacked data?', () => {
+      const stackedData = [
+        {
+          x: 10,
+          y: 200,
+        },
+      ];
+      const domainSpy = vi.fn();
+      const Comp = (): null => {
+        const domain = useAppSelector(state => selectAxisDomain(state, 'yAxis', 0));
+        domainSpy(domain);
+        return null;
+      };
+      // includeHidden does not work with stacked data, why?
+      const { container, rerender } = render(
+        <BarChart width={100} height={100} data={stackedData}>
+          <YAxis includeHidden />
+          <Bar dataKey="x" stackId="a" />
+          <Bar dataKey="y" stackId="a" hide />
+          <Customized component={<Comp />} />
+        </BarChart>,
+      );
+      expectYAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '57',
+          y: '95',
+        },
+        {
+          textContent: '3',
+          x: '57',
+          y: '72.5',
+        },
+        {
+          textContent: '6',
+          x: '57',
+          y: '50',
+        },
+        {
+          textContent: '9',
+          x: '57',
+          y: '27.5',
+        },
+        {
+          textContent: '12',
+          x: '57',
+          y: '5',
+        },
+      ]);
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 12]);
+
+      // the same data, when not stacked, are included when includeHidden is true.
+      rerender(
+        <BarChart width={100} height={100} data={stackedData}>
+          <YAxis includeHidden />
+          <Bar dataKey="x" />
+          <Bar dataKey="y" hide />
+          <Customized component={<Comp />} />
+        </BarChart>,
+      );
+
+      expectYAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '57',
+          y: '95',
+        },
+        {
+          textContent: '50',
+          x: '57',
+          y: '72.5',
+        },
+        {
+          textContent: '100',
+          x: '57',
+          y: '50',
+        },
+        {
+          textContent: '150',
+          x: '57',
+          y: '27.5',
+        },
+        {
+          textContent: '200',
+          x: '57',
+          y: '5',
+        },
+      ]);
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 200]);
+    });
+
     it('should render positive and negative ticks with stackOffset = "sign"', () => {
       const stackedSignedData = [
         {

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -195,53 +195,141 @@ describe('<YAxis />', () => {
     );
   });
 
-  it('Render identical ticks when data is hidden and includeHidden is true', () => {
-    const wrapperBothShowing = render(
-      <BarChart width={600} height={400} data={data}>
-        <YAxis type="number" stroke="#ff7300" includeHidden />
-        <Bar dataKey="pv" stroke="#ff7300" fill="#ff7300" isAnimationActive={false} />
-        <Bar dataKey="amt" stroke="#ff7300" fill="#ff7300" isAnimationActive={false} />
-      </BarChart>,
-    );
+  describe('includeHidden', () => {
+    it.each([undefined, true, false])('should show ticks for visibleData when includeHidden=%s', includeHidden => {
+      const domainSpy = vi.fn();
+      const Comp = (): null => {
+        const domain = useAppSelector(state => selectAxisDomain(state, 'yAxis', 0));
+        domainSpy(domain);
+        return null;
+      };
+      const { container } = render(
+        <BarChart width={600} height={400} data={data}>
+          <YAxis includeHidden={includeHidden} />
+          <Bar dataKey="pv" />
+          <Bar dataKey="uv" />
+          <Customized component={<Comp />} />
+        </BarChart>,
+      );
+      expectYAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '57',
+          y: '395',
+        },
+        {
+          textContent: '2500',
+          x: '57',
+          y: '297.5',
+        },
+        {
+          textContent: '5000',
+          x: '57',
+          y: '200',
+        },
+        {
+          textContent: '7500',
+          x: '57',
+          y: '102.5',
+        },
+        {
+          textContent: '10000',
+          x: '57',
+          y: '5',
+        },
+      ]);
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 10000]);
+    });
 
-    const wrapperFirstHidden = render(
-      <BarChart width={600} height={400} data={data}>
-        <YAxis type="number" stroke="#ff7300" includeHidden />
-        <Bar dataKey="pv" stroke="#ff7300" fill="#ff7300" isAnimationActive={false} hide />
-        <Bar dataKey="amt" stroke="#ff7300" fill="#ff7300" isAnimationActive={false} />
-      </BarChart>,
-    );
+    it.each([false, undefined])('should exclude hidden items domain when includeHidden=%s', includeHidden => {
+      const domainSpy = vi.fn();
+      const Comp = (): null => {
+        const domain = useAppSelector(state => selectAxisDomain(state, 'yAxis', 0));
+        domainSpy(domain);
+        return null;
+      };
+      const { container } = render(
+        <BarChart width={600} height={400} data={data}>
+          <YAxis includeHidden={includeHidden} />
+          <Bar dataKey="pv" hide />
+          <Bar dataKey="uv" />
+          <Customized component={<Comp />} />
+        </BarChart>,
+      );
+      expectYAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '57',
+          y: '395',
+        },
+        {
+          textContent: '100',
+          x: '57',
+          y: '297.5',
+        },
+        {
+          textContent: '200',
+          x: '57',
+          y: '200',
+        },
+        {
+          textContent: '300',
+          x: '57',
+          y: '102.5',
+        },
+        {
+          textContent: '400',
+          x: '57',
+          y: '5',
+        },
+      ]);
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 400]);
+    });
 
-    const wrapperSecondHidden = render(
-      <BarChart width={600} height={400} data={data}>
-        <YAxis type="number" stroke="#ff7300" includeHidden />
-        <Bar dataKey="pv" stroke="#ff7300" fill="#ff7300" isAnimationActive={false} />
-        <Bar dataKey="amt" stroke="#ff7300" fill="#ff7300" isAnimationActive={false} hide />
-      </BarChart>,
-    );
-
-    const ticksBothShowing = wrapperBothShowing.container.querySelectorAll('text');
-    const ticksFirstHidden = wrapperFirstHidden.container.querySelectorAll('text');
-    const ticksSecondHidden = wrapperSecondHidden.container.querySelectorAll('text');
-
-    expect(ticksFirstHidden.length).toBe(ticksBothShowing.length);
-    expect(ticksFirstHidden[0].getAttribute('y')).toBe(ticksBothShowing[0].getAttribute('y'));
-    expect(ticksFirstHidden[3].getAttribute('y')).toBe(ticksBothShowing[3].getAttribute('y'));
-
-    expect(ticksSecondHidden.length).toBe(ticksBothShowing.length);
-    expect(ticksSecondHidden[0].getAttribute('y')).toBe(ticksBothShowing[0].getAttribute('y'));
-    expect(ticksSecondHidden[3].getAttribute('y')).toBe(ticksBothShowing[3].getAttribute('y'));
-
-    const barsBothShowing = wrapperBothShowing.container.querySelectorAll('recharts-bar-rectangle > path');
-    const barsFirstHidden = wrapperFirstHidden.container.querySelectorAll('recharts-bar-rectangle > path');
-    const barsSecondHidden = wrapperSecondHidden.container.querySelectorAll('recharts-bar-rectangle > path');
-
-    // spreading to match indices, as barsBothShowing will get Rectangles from the first Bar, then the second
-    expect(
-      [...Array.from(barsSecondHidden), ...Array.from(barsFirstHidden)].every((bar, i) => {
-        return bar.getAttribute('height') === barsBothShowing[i].getAttribute('height');
-      }),
-    ).toBe(true);
+    it('should include hidden data domain when includeHidden=true', () => {
+      const domainSpy = vi.fn();
+      const Comp = (): null => {
+        const domain = useAppSelector(state => selectAxisDomain(state, 'yAxis', 0));
+        domainSpy(domain);
+        return null;
+      };
+      const { container } = render(
+        <BarChart width={600} height={400} data={data}>
+          <YAxis includeHidden />
+          <Bar dataKey="pv" hide />
+          <Bar dataKey="uv" />
+          <Customized component={<Comp />} />
+        </BarChart>,
+      );
+      expectYAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '57',
+          y: '395',
+        },
+        {
+          textContent: '2500',
+          x: '57',
+          y: '297.5',
+        },
+        {
+          textContent: '5000',
+          x: '57',
+          y: '200',
+        },
+        {
+          textContent: '7500',
+          x: '57',
+          y: '102.5',
+        },
+        {
+          textContent: '10000',
+          x: '57',
+          y: '5',
+        },
+      ]);
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 10000]);
+    });
   });
 
   it('should render all labels in an example', () => {

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -539,6 +539,57 @@ describe('<YAxis />', () => {
       },
     );
 
+    it('should ignore domain of hidden items', () => {
+      const stackedData = [
+        {
+          x: 100,
+          y: 200,
+        },
+      ];
+      const domainSpy = vi.fn();
+      const Comp = (): null => {
+        const domain = useAppSelector(state => selectAxisDomain(state, 'yAxis', 0));
+        domainSpy(domain);
+        return null;
+      };
+      const { container } = render(
+        <BarChart width={100} height={100} data={stackedData}>
+          <YAxis />
+          <Bar dataKey="x" stackId="a" />
+          <Bar dataKey="y" stackId="a" hide />
+          <Customized component={<Comp />} />
+        </BarChart>,
+      );
+      expectYAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '57',
+          y: '95',
+        },
+        {
+          textContent: '25',
+          x: '57',
+          y: '72.5',
+        },
+        {
+          textContent: '50',
+          x: '57',
+          y: '50',
+        },
+        {
+          textContent: '75',
+          x: '57',
+          y: '27.5',
+        },
+        {
+          textContent: '100',
+          x: '57',
+          y: '5',
+        },
+      ]);
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 100]);
+    });
+
     it('should render positive and negative ticks with stackOffset = "sign"', () => {
       const stackedSignedData = [
         {

--- a/test/component/Cursor.spec.tsx
+++ b/test/component/Cursor.spec.tsx
@@ -46,6 +46,7 @@ const preloadedState: Partial<RechartsRootState> = {
     chartName: '',
     tooltipPayloadSearcher: arrayTooltipSearcher,
     barCategoryGap: '',
+    stackOffset: 'none',
   },
 };
 
@@ -178,6 +179,7 @@ describe('Cursor', () => {
           chartName: 'ScatterChart',
           tooltipPayloadSearcher: arrayTooltipSearcher,
           barCategoryGap: '',
+          stackOffset: 'none',
         },
         tooltip: {
           ...initialTooltipState,

--- a/test/state/axisSelectors.spec.tsx
+++ b/test/state/axisSelectors.spec.tsx
@@ -1365,6 +1365,7 @@ describe('selectCartesianGraphicalItemsData', () => {
   it('should be stable', () => {
     const store = createRechartsStore();
     const settings: CartesianGraphicalItemSettings = {
+      hide: false,
       stackId: 's-id',
       errorBars: [],
       dataKey: 'dataKey',
@@ -2440,6 +2441,7 @@ describe('selectErrorBarsSettings', () => {
   it('should be stable with data', () => {
     const store = createRechartsStore();
     const settings: CartesianGraphicalItemSettings = {
+      hide: false,
       stackId: 'q',
       dataKey: 'x',
       data: [],

--- a/test/state/axisSelectors.spec.tsx
+++ b/test/state/axisSelectors.spec.tsx
@@ -1365,8 +1365,9 @@ describe('selectCartesianGraphicalItemsData', () => {
   it('should be stable', () => {
     const store = createRechartsStore();
     const settings: CartesianGraphicalItemSettings = {
-      errorBars: undefined,
-      dataKey: undefined,
+      stackId: 's-id',
+      errorBars: [],
+      dataKey: 'dataKey',
       data: PageData,
       xAxisId: 'x',
       yAxisId: 'y',
@@ -2439,6 +2440,7 @@ describe('selectErrorBarsSettings', () => {
   it('should be stable with data', () => {
     const store = createRechartsStore();
     const settings: CartesianGraphicalItemSettings = {
+      stackId: 'q',
       dataKey: 'x',
       data: [],
       xAxisId: '',

--- a/test/state/axisSelectors.spec.tsx
+++ b/test/state/axisSelectors.spec.tsx
@@ -1392,7 +1392,7 @@ describe('selectCartesianGraphicalItemsData', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith([]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should return empty array in a chart with root data', () => {
@@ -1579,7 +1579,7 @@ describe('selectDisplayedData', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith([]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should return the original data if there is no axis with matching ID', () => {
@@ -2046,7 +2046,7 @@ describe('selectAllAppliedValues', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith([]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should return empty array if there is no axis with matching ID', () => {

--- a/test/state/graphicalItemsSlice.spec.ts
+++ b/test/state/graphicalItemsSlice.spec.ts
@@ -19,6 +19,7 @@ describe('graphicalItemsSlice', () => {
       data: PageData,
       xAxisId: 'x',
       yAxisId: 'y',
+      hide: false,
     };
     store.dispatch(addCartesianGraphicalItem(item));
     expect(store.getState().graphicalItems.cartesianItems).toHaveLength(1);

--- a/test/state/graphicalItemsSlice.spec.ts
+++ b/test/state/graphicalItemsSlice.spec.ts
@@ -13,6 +13,7 @@ describe('graphicalItemsSlice', () => {
     expect(store.getState().graphicalItems.cartesianItems).toHaveLength(0);
 
     const item: CartesianGraphicalItemSettings = {
+      stackId: undefined,
       errorBars: undefined,
       dataKey: undefined,
       data: PageData,

--- a/test/state/selectors.spec.tsx
+++ b/test/state/selectors.spec.tsx
@@ -131,6 +131,7 @@ const preloadedState: Partial<RechartsRootState> = {
     tooltipPayloadSearcher: arrayTooltipSearcher,
     chartName: '',
     barCategoryGap: '',
+    stackOffset: 'none',
   },
 };
 
@@ -207,6 +208,7 @@ describe('useTooltipEventType', () => {
           tooltipPayloadSearcher: arrayTooltipSearcher,
           chartName: '',
           barCategoryGap: '',
+          stackOffset: 'none',
         },
       };
       render(

--- a/test/util/ChartUtils/getStackedData.spec.ts
+++ b/test/util/ChartUtils/getStackedData.spec.ts
@@ -297,4 +297,30 @@ describe('getStackedData', () => {
     offsetSign(data, []);
     expect(data).toEqual(expected);
   });
+
+  test('stacking numbers encoded as strings produces numbers', () => {
+    const data = [
+      { name: 'A', uv: '1', pv: '2' },
+      { name: 'B', uv: '3', pv: '4' },
+    ];
+    const result = getStackedData(data, ['uv', 'pv'], 'none');
+    const expected = [
+      createSeries('uv', 0, [createSeriesPoint(0, 1, data[0]), createSeriesPoint(0, 3, data[1])]),
+      createSeries('pv', 1, [createSeriesPoint(1, 3, data[0]), createSeriesPoint(3, 7, data[1])]),
+    ];
+    expect(result).toEqual(expected);
+  });
+
+  test('stacking strings that are not numbers produces NaN - this is a bug if you ask me, we should reject non-numerical data', () => {
+    const data = [
+      { name: 'A', uv: 'a', pv: 'b' },
+      { name: 'B', uv: 'c', pv: 'd' },
+    ];
+    const result = getStackedData(data, ['uv', 'pv'], 'none');
+    const expected = [
+      createSeries('uv', 0, [createSeriesPoint(0, NaN, data[0]), createSeriesPoint(0, NaN, data[1])]),
+      createSeries('pv', 1, [createSeriesPoint(0, NaN, data[0]), createSeriesPoint(0, NaN, data[1])]),
+    ];
+    expect(result).toEqual(expected);
+  });
 });

--- a/test/util/ChartUtils/getStackedData.spec.ts
+++ b/test/util/ChartUtils/getStackedData.spec.ts
@@ -1,10 +1,6 @@
 import { Series, SeriesPoint } from 'victory-vendor/d3-shape';
 import { getStackedData, offsetSign } from '../../../src/util/ChartUtils';
-import { DataKey, StackOffsetType } from '../../../src/util/types';
-
-function createDataKeyProps(dataKey: DataKey<any>) {
-  return { props: { dataKey } };
-}
+import { StackOffsetType } from '../../../src/util/types';
 
 export function createSeries(
   key: string,
@@ -84,12 +80,12 @@ const dataWithNegativeNumbers = [
 
 /**
  * If you see one of these tests failing with a message "serializes to the same string",
- * that is because the d3-shape library assigns abitrary property keys to an array.
+ * that is because the d3-shape library assigns arbitrary property keys to an array.
  *
  * Jest doesn't like that. When it compares the two arrays it can see that it has extra property,
  * and if that extra property is different then it fails.
  * But when printing the array, it only prints the usual array elements, and ignores the extra properties.
- * Therefore the "serializes to the same string" problem.
+ * Therefore, the "serializes to the same string" problem.
  *
  * So when you see that error, try to compare the other properties, like `Series.key` and `SeriesPoint.data`.
  * Or print them with console.log, that will show the difference.
@@ -104,21 +100,13 @@ describe('getStackedData', () => {
   });
 
   it('should return one empty array for each dataKey even if it is not part of the data', () => {
-    const result = getStackedData(
-      [],
-      [createDataKeyProps('x'), createDataKeyProps('y'), createDataKeyProps('z')],
-      'none',
-    );
+    const result = getStackedData([], ['x', 'y', 'z'], 'none');
     const expected = [createSeries('x', 0), createSeries('y', 1), createSeries('z', 2)];
     expect(result).toEqual(expected);
   });
 
   it('should return one empty array for each data key even if it is not part of the data', () => {
-    const result = getStackedData(
-      [],
-      [createDataKeyProps('x'), createDataKeyProps('y'), createDataKeyProps('z')],
-      'none',
-    );
+    const result = getStackedData([], ['x', 'y', 'z'], 'none');
     const expected = [createSeries('x', 0), createSeries('y', 1), createSeries('z', 2)];
     expect(result).toEqual(expected);
   });
@@ -126,7 +114,7 @@ describe('getStackedData', () => {
   const allOffsets: StackOffsetType[] = ['expand', 'none', 'positive', 'sign', 'silhouette', 'wiggle'];
   describe.each(allOffsets)('with offset %s', offset => {
     it('should stack numerical data', () => {
-      const dataKeys = [createDataKeyProps('uv'), createDataKeyProps('pv')];
+      const dataKeys = ['uv', 'pv'];
       const result = getStackedData(mockData, dataKeys, offset);
       expect(result).toHaveLength(dataKeys.length);
       result.forEach(series => {
@@ -141,7 +129,7 @@ describe('getStackedData', () => {
     });
 
     it('should stack data when dataKey is a function', () => {
-      const dataKeys = [createDataKeyProps(o => o.uv + 100), createDataKeyProps(o => o.pv - 100)];
+      const dataKeys = [(o: any) => o.uv + 100, (o: any) => o.pv - 100];
       const result = getStackedData(mockData, dataKeys, offset);
       expect(result).toHaveLength(dataKeys.length);
       result.forEach(series => {
@@ -157,7 +145,7 @@ describe('getStackedData', () => {
   });
 
   it('should stack numerical data with offset: none', () => {
-    const result = getStackedData(mockData, [createDataKeyProps('uv'), createDataKeyProps('pv')], 'none');
+    const result = getStackedData(mockData, ['uv', 'pv'], 'none');
     const firstSeries = createSeries('uv', 0, [
       createSeriesPoint(0, 590, mockData[0]),
       createSeriesPoint(0, 868, mockData[1]),
@@ -171,11 +159,7 @@ describe('getStackedData', () => {
   });
 
   it('should stack numerical data with offset: sign', () => {
-    const result = getStackedData(
-      dataWithNegativeNumbers,
-      [createDataKeyProps('uv'), createDataKeyProps('pv')],
-      'sign',
-    );
+    const result = getStackedData(dataWithNegativeNumbers, ['uv', 'pv'], 'sign');
     const uvSeries = createSeries('uv', 0, [
       createSeriesPoint(0, 4000, dataWithNegativeNumbers[0]),
       createSeriesPoint(0, -3000, dataWithNegativeNumbers[1]),
@@ -199,7 +183,7 @@ describe('getStackedData', () => {
   });
 
   it('with offset: positive should ignore all negative data points', () => {
-    const dataKeys = [createDataKeyProps('uv'), createDataKeyProps('pv')];
+    const dataKeys = ['uv', 'pv'];
     const result = getStackedData(dataWithNegativeNumbers, dataKeys, 'positive');
     const uvSeries = createSeries('uv', 0, [
       createSeriesPoint(0, 4000, dataWithNegativeNumbers[0]),
@@ -224,11 +208,7 @@ describe('getStackedData', () => {
   });
 
   it('should stack data when dataKey is a function with offset: none', () => {
-    const result = getStackedData(
-      mockData,
-      [createDataKeyProps(o => o.uv + 100), createDataKeyProps(o => o.pv - 100)],
-      'none',
-    );
+    const result = getStackedData(mockData, [o => o.uv + 100, o => o.pv - 100], 'none');
     const firstSeries = createSeries('uv', 0, [
       createSeriesPoint(0, 690, mockData[0]),
       createSeriesPoint(0, 968, mockData[1]),
@@ -265,7 +245,7 @@ describe('getStackedData', () => {
         name: 'z',
       },
     ];
-    const result = getStackedData(mockCategoryData, [createDataKeyProps('x')], 'positive');
+    const result = getStackedData(mockCategoryData, ['x'], 'positive');
     const expected = [
       createSeries('x', 0, [
         createSeriesPoint(0, 0, mockCategoryData[0]),
@@ -293,7 +273,7 @@ describe('getStackedData', () => {
         },
       },
     ];
-    const result = getStackedData(mockCategoryData, [createDataKeyProps('x')], 'sign');
+    const result = getStackedData(mockCategoryData, ['x'], 'sign');
     const expected = [
       createSeries('x', 0, [
         createSeriesPoint(0, 0, mockCategoryData[0]),

--- a/test/util/isDomainSpecifiedByUser.spec.ts
+++ b/test/util/isDomainSpecifiedByUser.spec.ts
@@ -150,7 +150,7 @@ describe('parsing axis domain provided by user', () => {
     { domain: ['auto', 1], expected: [-100, 1] },
     { domain: [0, 'dataMax'], expected: [0, 100] },
     { domain: ['dataMin', 'dataMax'], expected: [-100, 100] },
-    { domain: ['auto', 'auto'], expected: [-100, 150] },
+    { domain: ['auto', 'auto'], expected: [-100, 100] },
     { domain: ['dataMin - 11.2', 'dataMax + 7.3'], expected: [-111.2, 107.3] },
     { domain: d => [Math.min(...d), 999], expected: [-100, 999] },
     { domain: d => [d[0] - 21, d[1] + 23], expected: [-121, 123] },
@@ -209,106 +209,59 @@ describe('parsing axis domain provided by user', () => {
     );
   });
 
-  describe.each([true, false])('parseNumericalUserDomain with allowDecimals = %s', allowDecimals => {
-    const tickCount = 6;
+  describe('parseNumericalUserDomain', () => {
     it.each([true, false])(
       'should return undefined when user input is undefined and allowDataOverflow = %s',
       allowDataOverflow => {
-        expect(
-          parseNumericalUserDomain(undefined, numericalDataDomain, allowDataOverflow, allowDecimals, tickCount),
-        ).toBeUndefined();
-        expect(
-          parseNumericalUserDomain(undefined, numericalDataDomain, allowDataOverflow, allowDecimals, tickCount),
-        ).toBeUndefined();
+        expect(parseNumericalUserDomain(undefined, numericalDataDomain, allowDataOverflow)).toBeUndefined();
+        expect(parseNumericalUserDomain(undefined, numericalDataDomain, allowDataOverflow)).toBeUndefined();
       },
     );
 
     it.each(validCases)(
       'should return $expected when domain = $domain and allowDataOverflow = true',
       ({ domain, expected }) => {
-        expect(parseNumericalUserDomain(domain, undefined, true, allowDecimals, tickCount)).toEqual(expected);
+        expect(parseNumericalUserDomain(domain, undefined, true)).toEqual(expected);
       },
     );
 
     it.each(casesValidOnlyWhenDataDomainIsGiven)(
       'should return $expected when domain = $domain',
       ({ domain, expected }) => {
-        expect(parseNumericalUserDomain(domain, numericalDataDomain, true, true, tickCount)).toEqual(expected);
+        expect(parseNumericalUserDomain(domain, numericalDataDomain, true)).toEqual(expected);
       },
     );
 
     it.each(casesValidOnlyWhenDataDomainIsGiven)(
       'should return undefined when domain = $domain and data is undefined',
       ({ domain }) => {
-        expect(parseNumericalUserDomain(domain, undefined, true, true, tickCount)).toEqual(undefined);
-        expect(parseNumericalUserDomain(domain, undefined, false, true, tickCount)).toEqual(undefined);
+        expect(parseNumericalUserDomain(domain, undefined, true)).toEqual(undefined);
+        expect(parseNumericalUserDomain(domain, undefined, false)).toEqual(undefined);
       },
     );
 
     it.each(casesWithDomainSmallerThanData)(
       'should extend the domain to $expected when domain = $domain and allowDataOverflow = false',
       ({ domain, expected }) => {
-        expect(parseNumericalUserDomain(domain, numericalDataDomain, false, true, tickCount)).toEqual(expected);
+        expect(parseNumericalUserDomain(domain, numericalDataDomain, false)).toEqual(expected);
       },
     );
 
     it.each(invalidCases)('should return undefined when domain = $domain', ({ domain }) => {
-      expect(parseNumericalUserDomain(domain, numericalDataDomain, true, true, tickCount)).toBeUndefined();
-      expect(parseNumericalUserDomain(domain, numericalDataDomain, false, true, tickCount)).toBeUndefined();
-      expect(parseNumericalUserDomain(domain, undefined, true, true, tickCount)).toBeUndefined();
-      expect(parseNumericalUserDomain(domain, undefined, false, true, tickCount)).toBeUndefined();
+      expect(parseNumericalUserDomain(domain, numericalDataDomain, true)).toBeUndefined();
+      expect(parseNumericalUserDomain(domain, numericalDataDomain, false)).toBeUndefined();
+      expect(parseNumericalUserDomain(domain, undefined, true)).toBeUndefined();
+      expect(parseNumericalUserDomain(domain, undefined, false)).toBeUndefined();
     });
 
     it.each(casesThatDefaultToDataMinDataMax)(
       'should return data min, data max when domain = $domain',
       ({ domain }) => {
-        expect(parseNumericalUserDomain(domain, numericalDataDomain, true, true, tickCount)).toEqual([-100, 100]);
-        expect(parseNumericalUserDomain(domain, numericalDataDomain, false, true, tickCount)).toEqual([-100, 100]);
-        expect(parseNumericalUserDomain(domain, undefined, true, true, tickCount)).toBeUndefined();
-        expect(parseNumericalUserDomain(domain, undefined, false, true, tickCount)).toBeUndefined();
+        expect(parseNumericalUserDomain(domain, numericalDataDomain, true)).toEqual([-100, 100]);
+        expect(parseNumericalUserDomain(domain, numericalDataDomain, false)).toEqual([-100, 100]);
+        expect(parseNumericalUserDomain(domain, undefined, true)).toBeUndefined();
+        expect(parseNumericalUserDomain(domain, undefined, false)).toBeUndefined();
       },
     );
-
-    describe('allowDecimals', () => {
-      const domainSmallerThan1: NumberDomain = [0.3, 0.5];
-      const domainWithDecimalNumbers: NumberDomain = [4.1, 7.9];
-
-      it('should auto-generate domain with decimals with allowDecimals: true', () => {
-        expect(parseNumericalUserDomain(['auto', 'auto'], domainSmallerThan1, false, true, tickCount)).toEqual([
-          0.3, 0.55,
-        ]);
-      });
-
-      it('should use integers with allowDecimals: false', () => {
-        expect(parseNumericalUserDomain(['auto', 'auto'], domainSmallerThan1, false, false, tickCount)).toEqual([0, 5]);
-      });
-
-      it('should extend the domain a little for numbers larger than 1! This is very unexpected to me but okay', () => {
-        expect(parseNumericalUserDomain(['auto', 'auto'], domainWithDecimalNumbers, false, true, tickCount)).toEqual([
-          4, 8,
-        ]);
-        expect(parseNumericalUserDomain(['auto', 'auto'], domainWithDecimalNumbers, false, false, tickCount)).toEqual([
-          4, 9,
-        ]);
-      });
-
-      it('should have no affect for domain settings other than "auto"', () => {
-        expect(parseNumericalUserDomain(domainSmallerThan1, domainSmallerThan1, false, true, tickCount)).toEqual(
-          domainSmallerThan1,
-        );
-        expect(parseNumericalUserDomain(domainSmallerThan1, domainSmallerThan1, false, false, tickCount)).toEqual(
-          domainSmallerThan1,
-        );
-      });
-    });
-  });
-
-  describe('parseNumericalUserDomain with tickCount', () => {
-    it('should extend the domain to whatever getNiceTickValues decides', () => {
-      const userDomain: AxisDomain = [0, 'auto'];
-      expect(parseNumericalUserDomain(userDomain, numericalDataDomain, false, true, 3)).toEqual([-100, 100]);
-      expect(parseNumericalUserDomain(userDomain, numericalDataDomain, false, true, 6)).toEqual([-100, 100]);
-      expect(parseNumericalUserDomain(userDomain, numericalDataDomain, false, true, 12)).toEqual([-100, 110]);
-    });
   });
 });


### PR DESCRIPTION
## Description

Couple of changes here:
- selectAxisDomain no longer considers niceTicks
- new separate selector for niceTicks
- selectAxisDomain now uses stack groups to get the right domain
- selectCartesianItemsSettings now uses hide+includeHidden props
- hidden Bar now reports its settings too
- and a bunch of tests

## Related Issue

https://github.com/recharts/recharts/issues/4583
