### PR TITLE
refactor: start moving defaultIndex functionality to selectors

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1056,7 +1056,7 @@ export const generateCategoricalChart = ({
         // Check all (0+) <XAxis /> elements to see if ANY have reversed={true}. If so, this will be treated as an RTL chart
         ltr: isAxisLTR(this.state.xAxisMap),
       });
-      this.displayDefaultTooltip();
+      // this.displayDefaultTooltip();
     }
 
     displayDefaultTooltip() {

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -144,7 +144,9 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
     selectIsTooltipActive(state, tooltipEventType, trigger, defaultIndex),
   );
 
-  const coordinateFromRedux = useAppSelector(state => selectActiveCoordinate(state, tooltipEventType, trigger));
+  const coordinateFromRedux = useAppSelector(state =>
+    selectActiveCoordinate(state, tooltipEventType, trigger, defaultIndex),
+  );
   // TODO remove the payloadFromContext fallback
   const payload: TooltipPayload = payloadFromRedux?.length > 0 ? payloadFromRedux : payloadFromContext;
   const tooltipPortalFromContext = useTooltipPortal();

--- a/storybook/stories/Examples/ScatterChart.stories.tsx
+++ b/storybook/stories/Examples/ScatterChart.stories.tsx
@@ -53,7 +53,7 @@ export const Simple: Meta<ScatterProps> = {
           <XAxis type="number" dataKey="x" name="stature" unit="cm" />
           <YAxis type="number" dataKey="y" name="weight" unit="kg" />
           <Scatter activeShape={args.activeShape} name="A school" data={data} fill="#8884d8" />
-          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} defaultIndex={1} />
         </ScatterChart>
       </ResponsiveContainer>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
I want to move this defaultIndex init to redux to remove DOM access of `Tooltip` and this function from the generator. However, how do we support this for Scatter and other charts?

Hunting for some ideas before continuing

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
remove dom access and move to redux

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
it hasn't yet!

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Refactor

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
