### PR TITLE
refactor: simplify validateHeightWidth

### DIFF
--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -697,7 +697,7 @@ export class Sankey extends PureComponent<Props, State> {
   }
 
   render() {
-    if (!validateWidthHeight(this)) {
+    if (!validateWidthHeight({ width: this.props.width, height: this.props.height })) {
       return null;
     }
 

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -865,7 +865,7 @@ export class Treemap extends PureComponent<Props, State> {
   }
 
   render() {
-    if (!validateWidthHeight(this)) {
+    if (!validateWidthHeight({ width: this.props.width, height: this.props.height })) {
       return null;
     }
 

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -946,7 +946,7 @@ export const generateCategoricalChart = ({
     },
     prevState?: CategoricalChartState,
   ): any => {
-    if (!validateWidthHeight({ props })) {
+    if (!validateWidthHeight({ width: props.width, height: props.height })) {
       return null;
     }
 
@@ -1818,7 +1818,7 @@ export const generateCategoricalChart = ({
     };
 
     render() {
-      if (!validateWidthHeight(this)) {
+      if (!validateWidthHeight({ width: this.props.width, height: this.props.height })) {
         return null;
       }
 

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -147,12 +147,7 @@ export function findChildByType<ComponentType extends React.ComponentType>(
  * @param  {Object} el A chart element
  * @return {Boolean}   true If the props width and height are number, and greater than 0
  */
-export const validateWidthHeight = (el: any): boolean => {
-  if (!el || !el.props) {
-    return false;
-  }
-  const { width, height } = el.props;
-
+export const validateWidthHeight = ({ width, height }: { width: number; height: number }): boolean => {
   if (!isNumber(width) || width <= 0 || !isNumber(height) || height <= 0) {
     return false;
   }

--- a/test/util/ReactUtils.spec.tsx
+++ b/test/util/ReactUtils.spec.tsx
@@ -149,7 +149,7 @@ describe('ReactUtils untest tests', () => {
   });
 
   describe('validateWidthHeight', () => {
-    test('validateWidthHeight return false when a react element has width or height smaller than 0', () => {
+    test('validateWidthHeight return false when input is not of the correct form', () => {
       const { container } = render(
         <LineChart width={0} height={0}>
           <Line dataKey="a" />
@@ -157,12 +157,15 @@ describe('ReactUtils untest tests', () => {
           <Bar dataKey="c" />
         </LineChart>,
       );
-      expect(validateWidthHeight(container)).toEqual(false);
+      expect(validateWidthHeight(container as any)).toEqual(false);
     });
 
-    test('validateWidthHeight return false when input is not a react element', () => {
-      expect(validateWidthHeight({ a: 1 })).toEqual(false);
-      expect(validateWidthHeight(vi.fn())).toEqual(false);
+    test('validateWidthHeight return false when input is 0s', () => {
+      expect(validateWidthHeight({ width: 0, height: 0 })).toEqual(false);
+    });
+
+    test('validateWidthHeight returns true when height and width are positive numbers', () => {
+      expect(validateWidthHeight({ width: 5, height: 10 })).toEqual(true);
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Tiny refactor. Remove an `any`

Imo its less intuitive to pass `this` or `props` to `validateWidthHeight` than it is to just pass the things that it wants

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Selfish refactoring

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm test`

Fix tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
