### PR TITLE
fix(polar): set paddingAngle 0 when pie data length <= 1

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -352,11 +352,12 @@ export class Pie extends PureComponent<Props, State> {
       return null;
     }
 
-    const { cornerRadius, startAngle, endAngle, paddingAngle, dataKey, nameKey, tooltipType } = item.props;
+    const { cornerRadius, startAngle, endAngle, dataKey, nameKey, tooltipType } = item.props;
     const minAngle = Math.abs(item.props.minAngle);
     const coordinate = Pie.parseCoordinateOfPie(item, offset);
     const deltaAngle = Pie.parseDeltaAngle(startAngle, endAngle);
     const absDeltaAngle = Math.abs(deltaAngle);
+    const paddingAngle = pieData.length <= 1 ? 0 : item.props.paddingAngle ?? 0;
 
     const notZeroItemCount = pieData.filter(entry => getValueByDataKey(entry, dataKey, 0) !== 0).length;
     const totalPadingAngle = (absDeltaAngle >= 360 ? notZeroItemCount : notZeroItemCount - 1) * paddingAngle;

--- a/test/polar/Pie.spec.tsx
+++ b/test/polar/Pie.spec.tsx
@@ -709,4 +709,14 @@ describe('<Pie />', () => {
       expect(document.activeElement).toBe(document.body);
     });
   });
+
+  test('when data.length <= 1 set force paddingAngle to zero', async () => {
+    const { container } = render(
+      <PieChart width={500} height={500}>
+        <Pie isAnimationActive={false} data={[{ uv: 1 }]} dataKey="uv" paddingAngle={360} />
+      </PieChart>,
+    );
+
+    await waitFor(() => expect(container.querySelector('path')).not.toBeNull());
+  });
 });


### PR DESCRIPTION
# Set paddingAngle 0 when pie data length <= 1

## Description
If datas length is less or equal then 1 in props, set force paddingAngle to 0.

## Motivation and Context
In my project using recharts's pie chart. I expected that setting paddingAngle would not create a gap when there was 1 data, but it did not.
According to https://recharts.org/en-US/api/Pie#paddingAngle. paddingAngle is "The angle between two sectors.", So when there was just 1 data, it should not create gap.

## How Has This Been Tested?
recharts has no e2e test. So i tested on storybook.

## Screenshots (if appropriate):
### before
![Screenshot 2024-07-04 at 9 39 34 PM](https://github.com/recharts/recharts/assets/66503450/db193072-db7b-4b5b-a1c9-156ccda98884)
### after
![Screenshot 2024-07-04 at 9 53 51 PM](https://github.com/recharts/recharts/assets/66503450/e243becc-6fa0-4b7c-baa3-ba2f0dcd83c0)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
