### PR TITLE
XAxis uses niceTicks from redux instead of generator

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -11,7 +11,7 @@ import { AxisPropsNeededForTicksGenerator, getTicksOfAxis } from '../util/ChartU
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { addXAxis, removeXAxis, XAxisPadding, XAxisSettings } from '../state/axisMapSlice';
 import { XAxisWithExtraData } from '../chart/types';
-import { selectAxisScale } from '../state/axisSelectors';
+import { selectAxisScale, selectNiceTicks } from '../state/axisSelectors';
 
 interface XAxisProps extends BaseAxisProps {
   /** The unique id of x-axis */
@@ -57,6 +57,7 @@ const XAxisImpl = (props: Props) => {
   const axisOptions: XAxisWithExtraData = useXAxisOrThrow(xAxisId);
   const axisType = 'xAxis';
   const scaleObj = useAppSelector(state => selectAxisScale(state, 'xAxis', xAxisId));
+  const niceTicks = useAppSelector(state => selectNiceTicks(state, 'xAxis', xAxisId));
 
   if (axisOptions == null || scaleObj == null) {
     return null;
@@ -67,7 +68,7 @@ const XAxisImpl = (props: Props) => {
     categoricalDomain: axisOptions.categoricalDomain,
     duplicateDomain: axisOptions.duplicateDomain,
     isCategorical: axisOptions.isCategorical,
-    niceTicks: axisOptions.niceTicks,
+    niceTicks,
     range: axisOptions.range,
     realScaleType: scaleObj.realScaleType,
     scale: scaleObj.scale,

--- a/src/state/axisSelectors.ts
+++ b/src/state/axisSelectors.ts
@@ -34,7 +34,7 @@ import { AppliedChartData, ChartData } from './chartDataSlice';
 import { getPercentValue, hasDuplicate } from '../util/DataUtils';
 import { CartesianGraphicalItemSettings, ErrorBarsSettings } from './graphicalItemsSlice';
 import { isWellBehavedNumber } from '../util/isWellBehavedNumber';
-import { getNiceTickValues } from '../util/scale';
+import { getNiceTickValues, getTickValuesFixedDomain } from '../util/scale';
 import { ReferenceAreaSettings, ReferenceDotSettings, ReferenceLineSettings } from './referenceElementsSlice';
 
 export const selectXAxisSettings = (state: RechartsRootState, axisId: AxisId): XAxisSettings => {
@@ -620,6 +620,11 @@ export const selectNiceTicks = createSelector(
     ) {
       return getNiceTickValues(axisDomain, axisSettings.tickCount, axisSettings.allowDecimals);
     }
+
+    if (axisSettings != null && axisSettings.tickCount && axisSettings.type === 'number') {
+      return getTickValuesFixedDomain(axisDomain, axisSettings.tickCount, axisSettings.allowDecimals);
+    }
+
     return undefined;
   },
 );

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -6,7 +6,7 @@ import { mockAnimation, cleanupMockAnimation } from '../helper/animation-frame-h
 import { expectXAxisTicks, expectYAxisTicks } from '../helper/expectAxisTicks';
 import { AxisDomainType } from '../../src/util/types';
 import { useAppSelector } from '../../src/state/hooks';
-import { selectAxisDomain, selectAxisDomainIncludingNiceTicks } from '../../src/state/axisSelectors';
+import { selectAxisDomainIncludingNiceTicks } from '../../src/state/axisSelectors';
 import { getRealDirection } from '../../src/cartesian/ErrorBar';
 
 // asserts an error bar has both a start and end position
@@ -279,10 +279,10 @@ describe('<ErrorBar />', () => {
   });
 
   describe('ErrorBar and axis domain interaction', () => {
-    test('ErrorBar should extend YAxis domain', () => {
+    it('should extend YAxis domain', () => {
       const axisDomainSpy = vi.fn();
       const Comp = (): null => {
-        axisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'yAxis', 0)));
+        axisDomainSpy(useAppSelector(state => selectAxisDomainIncludingNiceTicks(state, 'yAxis', 0)));
         return null;
       };
       const { container, rerender } = render(
@@ -321,7 +321,7 @@ describe('<ErrorBar />', () => {
           y: '5',
         },
       ]);
-      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3300]);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3400]);
       expect(axisDomainSpy).toHaveBeenCalledTimes(3);
       rerender(
         <BarChart data={dataWithError} width={500} height={500}>
@@ -361,14 +361,14 @@ describe('<ErrorBar />', () => {
           y: '5',
         },
       ]);
-      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3440]);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3600]);
       expect(axisDomainSpy).toHaveBeenCalledTimes(6);
     });
 
-    test('ErrorBar should extend YAxis domain when data is defined on the graphical item', () => {
+    it('should extend YAxis domain when data is defined on the graphical item', () => {
       const axisDomainSpy = vi.fn();
       const Comp = (): null => {
-        axisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'yAxis', 0)));
+        axisDomainSpy(useAppSelector(state => selectAxisDomainIncludingNiceTicks(state, 'yAxis', 0)));
         return null;
       };
       const { container, rerender } = render(
@@ -407,7 +407,7 @@ describe('<ErrorBar />', () => {
           y: '5',
         },
       ]);
-      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3300]);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3400]);
       expect(axisDomainSpy).toHaveBeenCalledTimes(3);
 
       rerender(
@@ -448,11 +448,11 @@ describe('<ErrorBar />', () => {
           y: '5',
         },
       ]);
-      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3440]);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3600]);
       expect(axisDomainSpy).toHaveBeenCalledTimes(6);
     });
 
-    test('ErrorBar not extend XAxis domain - this looks like a bug to me!', () => {
+    it('should extend XAxis domain', () => {
       const xAxisSpy = vi.fn();
       const Comp = (): null => {
         xAxisSpy(useAppSelector(state => selectAxisDomainIncludingNiceTicks(state, 'xAxis', 0)));
@@ -507,8 +507,52 @@ describe('<ErrorBar />', () => {
         </BarChart>,
       );
       assertErrorBars(container, 4);
-      // IMHO the same extension should happen here, but it does not. The ticks are the exact same.
-      // Perhaps the Redux refactor can fix it?
+      expectXAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '5',
+          y: '473',
+        },
+        {
+          textContent: '900',
+          x: '127.5',
+          y: '473',
+        },
+        {
+          textContent: '1800',
+          x: '250',
+          y: '473',
+        },
+        {
+          textContent: '2700',
+          x: '372.5',
+          y: '473',
+        },
+        {
+          textContent: '3600',
+          x: '495',
+          y: '473',
+        },
+      ]);
+      expect(xAxisSpy).toHaveBeenLastCalledWith([0, 3600]);
+      expect(xAxisSpy).toHaveBeenCalledTimes(6);
+    });
+
+    it('should extend XAxis domain when data is defined on the graphical item', () => {
+      const xAxisSpy = vi.fn();
+      const Comp = (): null => {
+        xAxisSpy(useAppSelector(state => selectAxisDomainIncludingNiceTicks(state, 'xAxis', 0)));
+        return null;
+      };
+      const { container, rerender } = render(
+        <LineChart width={500} height={500}>
+          <XAxis dataKey="uv" type="number" />
+          <Line isAnimationActive={false} dataKey="uv" data={dataWithError} />
+          <Customized component={<Comp />} />
+        </LineChart>,
+      );
+
+      assertErrorBars(container, 0);
       expectXAxisTicks(container, [
         {
           textContent: '0',
@@ -517,29 +561,66 @@ describe('<ErrorBar />', () => {
         },
         {
           textContent: '850',
-          x: '120.69444444444444',
+          x: '127.5',
           y: '473',
         },
         {
           textContent: '1700',
-          x: '236.38888888888889',
+          x: '250',
           y: '473',
         },
         {
           textContent: '2550',
-          x: '352.0833333333333',
+          x: '372.5',
           y: '473',
         },
         {
           textContent: '3400',
-          x: '467.77777777777777',
+          x: '495',
           y: '473',
         },
       ]);
-      // Yep look at this - the selector has fixed this bug and is now extending XAxis domain too.
-      // Once we switch from generateCategoricalChart domain to redux domain, then the axis will be fixed too
+      expect(xAxisSpy).toHaveBeenLastCalledWith([0, 3400]);
+      expect(xAxisSpy).toHaveBeenCalledTimes(3);
+
+      rerender(
+        <LineChart width={500} height={500}>
+          <XAxis dataKey="uv" type="number" />
+          <Line isAnimationActive={false} dataKey="uv" data={dataWithError}>
+            <ErrorBar dataKey="uvError" direction="x" />
+          </Line>
+          <Customized component={<Comp />} />
+        </LineChart>,
+      );
+      assertErrorBars(container, 4);
+      expectXAxisTicks(container, [
+        {
+          textContent: '0',
+          x: '5',
+          y: '473',
+        },
+        {
+          textContent: '900',
+          x: '127.5',
+          y: '473',
+        },
+        {
+          textContent: '1800',
+          x: '250',
+          y: '473',
+        },
+        {
+          textContent: '2700',
+          x: '372.5',
+          y: '473',
+        },
+        {
+          textContent: '3600',
+          x: '495',
+          y: '473',
+        },
+      ]);
       expect(xAxisSpy).toHaveBeenLastCalledWith([0, 3600]);
-      expect(xAxisSpy).toHaveBeenCalledTimes(6);
     });
   });
 });

--- a/test/chart/AreaChart.spec.tsx
+++ b/test/chart/AreaChart.spec.tsx
@@ -178,14 +178,14 @@ describe('AreaChart', () => {
       const { container } = render(chart);
 
       spies.forEach(el => expect(el.mock.calls.length).toBe(1));
-      expect(axisSpy.mock.calls.length).toBe(4);
+      expect(axisSpy).toHaveBeenCalledTimes(3);
 
       fireEvent.mouseEnter(container, { clientX: 30, clientY: 200 });
       fireEvent.mouseMove(container, { clientX: 200, clientY: 200 });
       fireEvent.mouseLeave(container);
 
       spies.forEach(el => expect(el.mock.calls.length).toBe(1));
-      expect(axisSpy.mock.calls.length).toBe(4);
+      expect(axisSpy).toHaveBeenCalledTimes(3);
     });
 
     // protect against the future where someone might mess up our clean rendering
@@ -193,7 +193,7 @@ describe('AreaChart', () => {
       const { container } = render(chart);
 
       spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-      expect(axisSpy).toHaveBeenCalledTimes(4);
+      expect(axisSpy).toHaveBeenCalledTimes(3);
 
       const brushSlide = container.querySelector('.recharts-brush-slide');
       assertNotNull(brushSlide);
@@ -202,7 +202,7 @@ describe('AreaChart', () => {
       fireEvent.mouseUp(window);
 
       spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-      expect(axisSpy).toHaveBeenCalledTimes(6);
+      expect(axisSpy).toHaveBeenCalledTimes(3);
     });
 
     test('should only show the last data when the brush travelers all moved to the right', () => {

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -1042,14 +1042,14 @@ describe('<LineChart /> - Pure Rendering', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
 
     fireEvent.mouseEnter(container, { clientX: 30, clientY: 200, bubbles: true, cancelable: true });
     fireEvent.mouseMove(container, { clientX: 200, clientY: 200, bubbles: true, cancelable: true });
     fireEvent.mouseLeave(container);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
   });
 
   // protect against the future where someone might mess up our clean rendering
@@ -1057,7 +1057,7 @@ describe('<LineChart /> - Pure Rendering', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
 
     const leftCursor = container.querySelector('.recharts-brush-traveller');
     assertNotNull(leftCursor);
@@ -1068,7 +1068,7 @@ describe('<LineChart /> - Pure Rendering', () => {
     fireEvent.mouseUp(window);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -1102,7 +1102,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
 
     fireEvent.mouseEnter(container, { clientX: 30, clientY: 200, bubbles: true, cancelable: true });
 
@@ -1111,7 +1111,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     fireEvent.mouseLeave(container);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
   });
 
   // protect against the future where someone might mess up our clean rendering
@@ -1119,7 +1119,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
 
     const leftCursor = container.querySelector('.recharts-brush-traveller');
     assertNotNull(leftCursor);
@@ -1128,7 +1128,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     fireEvent.mouseUp(window);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/test/state/axisSelectors.spec.tsx
+++ b/test/state/axisSelectors.spec.tsx
@@ -244,47 +244,47 @@ describe('selectAxisDomain', () => {
     );
     expectXAxisTicks(container, [
       {
-        textContent: '70',
+        textContent: '10',
         x: '5',
         y: '73',
       },
       {
-        textContent: '80',
+        textContent: '20',
         x: '16.25',
         y: '73',
       },
       {
-        textContent: '90',
+        textContent: '30',
         x: '27.5',
         y: '73',
       },
       {
-        textContent: '10',
+        textContent: '40',
         x: '38.75',
         y: '73',
       },
       {
-        textContent: '20',
+        textContent: '50',
         x: '50',
         y: '73',
       },
       {
-        textContent: '30',
+        textContent: '60',
         x: '61.25',
         y: '73',
       },
       {
-        textContent: '40',
+        textContent: '70',
         x: '72.5',
         y: '73',
       },
       {
-        textContent: '50',
+        textContent: '80',
         x: '83.75',
         y: '73',
       },
       {
-        textContent: '60',
+        textContent: '90',
         x: '95',
         y: '73',
       },


### PR DESCRIPTION
## Description

Following up from problems in https://github.com/recharts/recharts/pull/4730 here I am fixing two of them:

1. nice ticks in generator were excluded for scale=time, but included in redux
2. axis domain (and therefore ticks) were extended for XAxis in redux, but not extended in generator

I found that while trying to read niceTicks from redux and then I figured I might just as well commit that part.

## Related Issue

https://github.com/recharts/recharts/pull/4730
