### PR TITLE
refactor: add selectors folder and containerSelectors for test files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,10 +32,13 @@
       }
     ],
     "import/extensions": "off",
-    "valid-jsdoc": ["error", {
-      "requireReturnType": false,
-      "requireParamType": false
-    }],
+    "valid-jsdoc": [
+      "error",
+      {
+        "requireReturnType": false,
+        "requireParamType": false
+      }
+    ],
     "react/no-did-update-set-state": "warn",
     "react/sort-comp": "off",
     "react/jsx-uses-react": "error",
@@ -119,7 +122,7 @@
       }
     },
     {
-      "files": ["src/state/*Slice.ts", "test/state/*.spec.tsx"],
+      "files": ["src/state/*Slice.ts", "test/state/**/*.spec.tsx"],
       // param-reassign is allowed in slices following Redux recommendation: https://redux-toolkit.js.org/usage/immer-reducers#linting-state-mutations
       "rules": { "no-param-reassign": ["error", { "props": false }] }
     }

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
-import { useAppSelector } from '../../src/state/hooks';
+import { useAppSelector } from '../../../src/state/hooks';
 import {
   mergeDomains,
   selectAllAppliedValues,
@@ -14,8 +14,8 @@ import {
   selectHasBar,
   selectNiceTicks,
   selectSmallestDistanceBetweenValues,
-} from '../../src/state/selectors/axisSelectors';
-import { createRechartsStore, RechartsRootState } from '../../src/state/store';
+} from '../../../src/state/selectors/axisSelectors';
+import { createRechartsStore, RechartsRootState } from '../../../src/state/store';
 import {
   Area,
   Bar,
@@ -34,14 +34,14 @@ import {
   ScatterChart,
   XAxis,
   YAxis,
-} from '../../src';
-import { misbehavedData, PageData } from '../_data';
-import { ExpectAxisDomain, expectXAxisTicks } from '../helper/expectAxisTicks';
-import { addCartesianGraphicalItem, CartesianGraphicalItemSettings } from '../../src/state/graphicalItemsSlice';
-import { generateMockData } from '../helper/generateMockData';
-import { AxisId } from '../../src/state/axisMapSlice';
-import { pageData } from '../../storybook/stories/data';
-import { AxisDomain } from '../../src/util/types';
+} from '../../../src';
+import { misbehavedData, PageData } from '../../_data';
+import { ExpectAxisDomain, expectXAxisTicks } from '../../helper/expectAxisTicks';
+import { addCartesianGraphicalItem, CartesianGraphicalItemSettings } from '../../../src/state/graphicalItemsSlice';
+import { generateMockData } from '../../helper/generateMockData';
+import { AxisId } from '../../../src/state/axisMapSlice';
+import { pageData } from '../../../storybook/stories/data';
+import { AxisDomain } from '../../../src/util/types';
 
 const defaultAxisId: AxisId = 0;
 

--- a/test/state/selectors/containerSelectors.spec.tsx
+++ b/test/state/selectors/containerSelectors.spec.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { getMockDomRect } from '../../helper/mockGetBoundingClientRect';
+import { useAppSelector } from '../../../src/state/hooks';
+import { RechartsHTMLContainer, setContainer } from '../../../src/state/layoutSlice';
+import { selectRootContainerDomRect, selectContainerScale } from '../../../src/state/selectors/containerSelectors';
+import { createRechartsStore } from '../../../src/state/store';
+
+describe('selectRootContainerDomRect', () => {
+  it('should return undefined when called outside of Redux context', () => {
+    expect.assertions(1);
+    const Comp = (): null => {
+      const rect = useAppSelector(selectRootContainerDomRect);
+      expect(rect).toBe(undefined);
+      return null;
+    };
+    render(<Comp />);
+  });
+
+  it('should return undefined for initial state', () => {
+    const store = createRechartsStore();
+    expect(selectRootContainerDomRect(store.getState())).toBe(undefined);
+  });
+
+  it('should return DOM rect of root container if set', () => {
+    const store = createRechartsStore();
+    const mockRect: DOMRect = getMockDomRect({
+      x: 1,
+      y: 2,
+      width: 3,
+      height: 4,
+    });
+    const mockElement: RechartsHTMLContainer = {
+      offsetWidth: 5,
+      getBoundingClientRect: () => mockRect,
+    };
+    store.dispatch(setContainer(mockElement));
+    expect(selectRootContainerDomRect(store.getState())).toEqual(mockRect);
+  });
+
+  it('should return updated DOM rect after browser window resize', () => {
+    const store = createRechartsStore();
+    const spy = vi.fn();
+    const mockRect: DOMRect = getMockDomRect({
+      x: 1,
+      y: 2,
+      width: 3,
+      height: 4,
+    });
+    const mockRectUpdated: DOMRect = getMockDomRect({
+      x: 5,
+      y: 6,
+      width: 7,
+      height: 8,
+    });
+    const mockElement: RechartsHTMLContainer = {
+      offsetWidth: 9,
+      getBoundingClientRect: spy,
+    };
+    spy.mockReturnValue(mockRect);
+    store.dispatch(setContainer(mockElement));
+    expect(selectRootContainerDomRect(store.getState())).toEqual(mockRect);
+    spy.mockReturnValue(mockRectUpdated);
+    expect(selectRootContainerDomRect(store.getState())).toEqual(mockRectUpdated);
+  });
+});
+
+describe('selectContainerScale', () => {
+  it('should return undefined when called outside of Redux context', () => {
+    expect.assertions(1);
+    const Comp = (): null => {
+      const scale = useAppSelector(selectContainerScale);
+      expect(scale).toBe(undefined);
+      return null;
+    };
+    render(<Comp />);
+  });
+
+  it('should return 1 for initial state', () => {
+    const store = createRechartsStore();
+    expect(selectContainerScale(store.getState())).toBe(1);
+  });
+
+  it('should return 1 when container is set and has width and DOMRect with matching widths', () => {
+    const store = createRechartsStore();
+    const mockRect: DOMRect = getMockDomRect({
+      x: 1,
+      y: 2,
+      width: 3,
+      height: 4,
+    });
+    const mockElement: RechartsHTMLContainer = {
+      offsetWidth: 3,
+      getBoundingClientRect: () => mockRect,
+    };
+    store.dispatch(setContainer(mockElement));
+    expect(selectContainerScale(store.getState())).toBe(1);
+  });
+
+  it('should return scale as the ratio of DOMRect / offsetWidth', () => {
+    /*
+     * This is a little bit of a case of "trust me" because:
+     * jsdom returns zeroes everywhere so that doesn't test anything
+     * and the browser spec is everything, so I went and tested it in Firefox version 126.0
+     * In a browser devtools I select arbitrary element and run:
+     *
+        console.table({
+         'getBoundingClientRect().width': $0.getBoundingClientRect().width,
+         offsetWidth: $0.offsetWidth,
+         scale: $0.getBoundingClientRect().width / $0.offsetWidth
+        })
+     *
+     * This shows rect: 100, offsetWidth: 100, scale: 1
+     * Then I went and changed the `scale` CSS property to 1.5 using devtools and
+     * run the console.log again, and this time it shows
+     * rect: 150, offsetWidth: 100, scale: 1.5
+     * So there we go.
+     */
+    const store = createRechartsStore();
+    const mockRect: DOMRect = getMockDomRect({
+      x: 1,
+      y: 2,
+      width: 3,
+      height: 4,
+    });
+    const mockElement: RechartsHTMLContainer = {
+      offsetWidth: 5,
+      getBoundingClientRect: () => mockRect,
+    };
+    store.dispatch(setContainer(mockElement));
+    expect(selectContainerScale(store.getState())).toBe(3 / 5);
+  });
+
+  it('should return scale: 1 in jsdom because jsdom returns zeroes everywhere', () => {
+    /*
+     * This is a little bit of optimization for the test environment
+     * but without this fix, like half of the tests start throwing an error.
+     * Perhaps instead we should enforce mocking proper DOMRect
+     * on the container, in all tests,
+     * but for now this workaround is easier and doesn't hurt anyone.
+     */
+    const store = createRechartsStore();
+    const mockRect: DOMRect = getMockDomRect({
+      width: 0,
+    });
+    const mockElement: RechartsHTMLContainer = {
+      offsetWidth: 0,
+      getBoundingClientRect: () => mockRect,
+    };
+    store.dispatch(setContainer(mockElement));
+    expect(selectContainerScale(store.getState())).toBe(1);
+  });
+});

--- a/test/state/selectors/dataSelectors.spec.tsx
+++ b/test/state/selectors/dataSelectors.spec.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { useAppSelector } from '../../src/state/hooks';
-import { selectChartDataWithIndexes } from '../../src/state/selectors/dataSelectors';
-import { createRechartsStore } from '../../src/state/store';
-import { Area, BarChart, Brush, ComposedChart, Customized, Line, Scatter } from '../../src';
-import { PageData } from '../_data';
-import { ChartDataState } from '../../src/state/chartDataSlice';
-import { pageData } from '../../storybook/stories/data';
+import { useAppSelector } from '../../../src/state/hooks';
+import { selectChartDataWithIndexes } from '../../../src/state/selectors/dataSelectors';
+import { createRechartsStore } from '../../../src/state/store';
+import { Area, BarChart, Brush, ComposedChart, Customized, Line, Scatter } from '../../../src';
+import { PageData } from '../../_data';
+import { ChartDataState } from '../../../src/state/chartDataSlice';
+import { pageData } from '../../../storybook/stories/data';
 
 describe('selectChartDataWithIndexes', () => {
   it('should return undefined when called outside of Redux context', () => {

--- a/test/state/selectors/selectors.spec.tsx
+++ b/test/state/selectors/selectors.spec.tsx
@@ -11,11 +11,11 @@ import {
   selectTooltipPayloadConfigurations,
   selectTooltipState,
   useTooltipEventType,
-} from '../../src/state/selectors/selectors';
-import { createRechartsStore, RechartsRootState } from '../../src/state/store';
-import { RechartsStoreProvider } from '../../src/state/RechartsStoreProvider';
-import { BaseAxisProps, TooltipEventType } from '../../src/util/types';
-import { useAppSelector } from '../../src/state/hooks';
+} from '../../../src/state/selectors/selectors';
+import { createRechartsStore, RechartsRootState } from '../../../src/state/store';
+import { RechartsStoreProvider } from '../../../src/state/RechartsStoreProvider';
+import { BaseAxisProps, TooltipEventType } from '../../../src/util/types';
+import { useAppSelector } from '../../../src/state/hooks';
 import {
   addTooltipEntrySettings,
   mouseLeaveItem,
@@ -27,22 +27,19 @@ import {
   TooltipPayload,
   TooltipPayloadConfiguration,
   TooltipPayloadEntry,
-} from '../../src/state/tooltipSlice';
+} from '../../../src/state/tooltipSlice';
 import {
   ChartDataState,
   initialChartDataState,
   setChartData,
   setDataStartEndIndexes,
-} from '../../src/state/chartDataSlice';
-import { TooltipTrigger } from '../../src/chart/types';
-import { produceState } from './produceState';
-import { RechartsHTMLContainer, setContainer } from '../../src/state/layoutSlice';
-import { getMockDomRect } from '../helper/mockGetBoundingClientRect';
-import { arrayTooltipSearcher } from '../../src/state/optionsSlice';
-import { MousePointer } from '../../src/chart/generateCategoricalChart';
-import { Area, BarChart, ComposedChart, Customized, Line, Pie, PieChart, Scatter } from '../../src';
-import { PageData } from '../_data';
-import { selectRootContainerDomRect, selectContainerScale } from '../../src/state/selectors/containerSelectors';
+} from '../../../src/state/chartDataSlice';
+import { TooltipTrigger } from '../../../src/chart/types';
+import { produceState } from '../produceState';
+import { arrayTooltipSearcher } from '../../../src/state/optionsSlice';
+import { MousePointer } from '../../../src/chart/generateCategoricalChart';
+import { Area, BarChart, ComposedChart, Customized, Line, Pie, PieChart, Scatter } from '../../../src';
+import { PageData } from '../../_data';
 
 const exampleTooltipPayloadConfiguration1: TooltipPayloadConfiguration = {
   settings: {
@@ -685,152 +682,6 @@ describe('selectIsTooltipActive', () => {
         expect(selectIsTooltipActive(store.getState(), tooltipEventType, trigger)).toBe(true);
       });
     });
-  });
-});
-
-describe('selectRootContainerDomRect', () => {
-  it('should return undefined when called outside of Redux context', () => {
-    expect.assertions(1);
-    const Comp = (): null => {
-      const rect = useAppSelector(selectRootContainerDomRect);
-      expect(rect).toBe(undefined);
-      return null;
-    };
-    render(<Comp />);
-  });
-
-  it('should return undefined for initial state', () => {
-    const store = createRechartsStore();
-    expect(selectRootContainerDomRect(store.getState())).toBe(undefined);
-  });
-
-  it('should return DOM rect of root container if set', () => {
-    const store = createRechartsStore();
-    const mockRect: DOMRect = getMockDomRect({
-      x: 1,
-      y: 2,
-      width: 3,
-      height: 4,
-    });
-    const mockElement: RechartsHTMLContainer = {
-      offsetWidth: 5,
-      getBoundingClientRect: () => mockRect,
-    };
-    store.dispatch(setContainer(mockElement));
-    expect(selectRootContainerDomRect(store.getState())).toEqual(mockRect);
-  });
-
-  it('should return updated DOM rect after browser window resize', () => {
-    const store = createRechartsStore();
-    const spy = vi.fn();
-    const mockRect: DOMRect = getMockDomRect({
-      x: 1,
-      y: 2,
-      width: 3,
-      height: 4,
-    });
-    const mockRectUpdated: DOMRect = getMockDomRect({
-      x: 5,
-      y: 6,
-      width: 7,
-      height: 8,
-    });
-    const mockElement: RechartsHTMLContainer = {
-      offsetWidth: 9,
-      getBoundingClientRect: spy,
-    };
-    spy.mockReturnValue(mockRect);
-    store.dispatch(setContainer(mockElement));
-    expect(selectRootContainerDomRect(store.getState())).toEqual(mockRect);
-    spy.mockReturnValue(mockRectUpdated);
-    expect(selectRootContainerDomRect(store.getState())).toEqual(mockRectUpdated);
-  });
-});
-
-describe('selectContainerScale', () => {
-  it('should return undefined when called outside of Redux context', () => {
-    expect.assertions(1);
-    const Comp = (): null => {
-      const scale = useAppSelector(selectContainerScale);
-      expect(scale).toBe(undefined);
-      return null;
-    };
-    render(<Comp />);
-  });
-
-  it('should return 1 for initial state', () => {
-    const store = createRechartsStore();
-    expect(selectContainerScale(store.getState())).toBe(1);
-  });
-
-  it('should return 1 when container is set and has width and DOMRect with matching widths', () => {
-    const store = createRechartsStore();
-    const mockRect: DOMRect = getMockDomRect({
-      x: 1,
-      y: 2,
-      width: 3,
-      height: 4,
-    });
-    const mockElement: RechartsHTMLContainer = {
-      offsetWidth: 3,
-      getBoundingClientRect: () => mockRect,
-    };
-    store.dispatch(setContainer(mockElement));
-    expect(selectContainerScale(store.getState())).toBe(1);
-  });
-
-  it('should return scale as the ratio of DOMRect / offsetWidth', () => {
-    /*
-     * This is a little bit of a case of "trust me" because:
-     * jsdom returns zeroes everywhere so that doesn't test anything
-     * and the browser spec is everything, so I went and tested it in Firefox version 126.0
-     * In a browser devtools I select arbitrary element and run:
-     *
-        console.table({
-         'getBoundingClientRect().width': $0.getBoundingClientRect().width,
-         offsetWidth: $0.offsetWidth,
-         scale: $0.getBoundingClientRect().width / $0.offsetWidth
-        })
-     *
-     * This shows rect: 100, offsetWidth: 100, scale: 1
-     * Then I went and changed the `scale` CSS property to 1.5 using devtools and
-     * run the console.log again, and this time it shows
-     * rect: 150, offsetWidth: 100, scale: 1.5
-     * So there we go.
-     */
-    const store = createRechartsStore();
-    const mockRect: DOMRect = getMockDomRect({
-      x: 1,
-      y: 2,
-      width: 3,
-      height: 4,
-    });
-    const mockElement: RechartsHTMLContainer = {
-      offsetWidth: 5,
-      getBoundingClientRect: () => mockRect,
-    };
-    store.dispatch(setContainer(mockElement));
-    expect(selectContainerScale(store.getState())).toBe(3 / 5);
-  });
-
-  it('should return scale: 1 in jsdom because jsdom returns zeroes everywhere', () => {
-    /*
-     * This is a little bit of optimization for the test environment
-     * but without this fix, like half of the tests start throwing an error.
-     * Perhaps instead we should enforce mocking proper DOMRect
-     * on the container, in all tests,
-     * but for now this workaround is easier and doesn't hurt anyone.
-     */
-    const store = createRechartsStore();
-    const mockRect: DOMRect = getMockDomRect({
-      width: 0,
-    });
-    const mockElement: RechartsHTMLContainer = {
-      offsetWidth: 0,
-      getBoundingClientRect: () => mockRect,
-    };
-    store.dispatch(setContainer(mockElement));
-    expect(selectContainerScale(store.getState())).toBe(1);
   });
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactor only

I made changes to add a folder for selectors, I didn't change the test folder structure though. Do that.

Separate containerSelectors as well