### PR TITLE
Improve `Text` story

### DIFF
--- a/storybook/stories/API/component/Text.stories.tsx
+++ b/storybook/stories/API/component/Text.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ResponsiveContainer, Text } from '../../../../src';
+import { Surface, Text } from '../../../../src';
 import { TextProps } from '../props/TextProps';
 
 export default {
@@ -10,22 +10,27 @@ export default {
 };
 
 export const API = {
-  render: (args: Record<string, any>) => {
+  render: ({ containerWidth, containerHeight, ...args }: Record<string, any>) => {
     return (
-      <ResponsiveContainer width="100%" height={80}>
+      <Surface width={containerWidth} height={containerHeight}>
         <Text {...args}>{args.content}</Text>
-      </ResponsiveContainer>
+      </Surface>
     );
   },
   args: {
+    width: 250,
+    content:
+      'This is really long text to showcase how line wrapping as well as other properties from the `Text` component work',
     breakAll: false,
     lineHeight: '1em',
     maxLines: 3,
     scaleToFit: false,
     textAnchor: 'start',
-    verticalAnchor: 'end',
+    verticalAnchor: 'start',
     angle: 0,
-    width: 200,
-    content: 'This is really long text',
+    containerWidth: '100%',
+    containerHeight: 100,
+    fontSize: '1rem',
+    letterSpacing: '0px',
   },
 };

--- a/storybook/stories/API/props/TextProps.ts
+++ b/storybook/stories/API/props/TextProps.ts
@@ -1,6 +1,12 @@
 import { StorybookArgs } from '../../../StorybookArgs';
 
 export const TextProps: StorybookArgs = {
+  containerWidth: {
+    description: 'The width of the container. Can be configured to verify how overflow and wrapping work.',
+  },
+  containerHeight: {
+    description: 'The height of the container. Can be configured to verify how overflow and wrapping work.',
+  },
   content: {
     description: 'The content of text.',
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Improve `Text` story. 


<!--- Describe your changes in detail -->

## Related Issue

N/A

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Asked by @ckifer to replace `ResponsiveContainer` by `Surface`, so included a couple of improvements as well:
- Increased the text length to better test how line wrapping and ellipsis work
- Added `containerWidth` and `containerHeight` args to the story to allow users better test how `Text` works in constrained width and height environments
- Added `fontSize` and `letterSpacing` as args as they are valid properties of `Text`
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested it manually in Storybook.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://github.com/recharts/recharts/assets/12778398/4d4fb5b6-26e8-4432-916f-5caa09a67487)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

None of the above: refactor Storybook story. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
