### PR TITLE
Avoid adding ellipsis if text does not overflow

### DIFF
--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -167,7 +167,7 @@ const getWordsWithoutCalculate = (children: React.ReactNode): Array<Words> => {
 
 type GetWordsByLinesProps = Pick<Props, 'width' | 'scaleToFit' | 'children' | 'style' | 'breakAll' | 'maxLines'>;
 
-const getWordsByLines = ({ width, scaleToFit, children, style, breakAll, maxLines }: GetWordsByLinesProps) => {
+export const getWordsByLines = ({ width, scaleToFit, children, style, breakAll, maxLines }: GetWordsByLinesProps) => {
   // Only perform calculations if using features that require them (multiline, scaleToFit)
   if ((width || scaleToFit) && !Global.isSsr) {
     let wordsWithComputedWidth: Array<WordWithComputedWidth>, spaceWidth: number;

--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -103,6 +103,11 @@ const calculateWordsByLines = (
     return originalResult;
   }
 
+  const overflows = originalResult.length > maxLines || findLongestLine(originalResult).width > Number(lineWidth);
+  if (!overflows) {
+    return originalResult;
+  }
+
   const suffix = '…';
 
   const checkOverflow = (index: number): [boolean, Words[]] => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Avoid adding an ellipsis (`...`) if the text does not overflow. This should not only fix an issue, but also improve performance slightly as we don't need to check for overflow for tick labels that we know will fit. 
<!--- Describe your changes in detail -->

## Related Issue

https://github.com/recharts/recharts/issues/4735
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

There seems to be a small bug in the ellipsis logic for the `Text` component, more specifically in `calculateWordsByLines`. 

The bug happens because sometimes adding a new character creates a narrower string than adding the suffix `…`. In that case, Recharts is adding a suffix, but adding the last character would not overflow. I tested this suspicion with the code below:

```ts
const suffix = '…';
console.log(
  'March',
  getStringSize('March', style).width,
  '|',
  'Marc' + suffix,
  getStringSize('Marc' + suffix, style).width,
);
// March 32.328125 | Marc… 38.328125
```
This can be replicated by running the `Text` Storybook story and setting the arguments below: 

<details>
<summary>Storybook Story Arguments</summary>

```js
{
  maxLines: 1,
  textAnchor: 'start',
  verticalAnchor: 'start',
  angle: 0,
  width: 33,
  y: 50,
  x: 50,
  fontSize: '12px',
  letterSpacing: '0.2px',
  content: 'March',
  style: {
    fontSize: '12px',
    letterSpacing: '0.2px',
  },
}
```

</details>

The algorithm should checking if the initial content doesn't overflow, and if it doesn't then return that value immediately. 
Instead, it's always running the `while` loop to check where to trim, and it is actually running code that the following comment says it shouldn't: 

https://github.com/recharts/recharts/blob/0179beddc1070d0723cedc290c6dcb09122bc0e6/src/component/Text.tsx#L153-L155

This happens because if text doesn't overflow, `trimmedResult` will be `undefined`, so `originalResult` will be returned. 
If we check for overflow early, we can avoid running the `while` loop altogether. 

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Added unit tests and tested manually in Storybook `Text` story, using the following arguments:

<details>
<summary>Storybook Story Arguments</summary>

```js
{
  maxLines: 1,
  textAnchor: 'start',
  verticalAnchor: 'start',
  angle: 0,
  width: 33,
  y: 50,
  x: 50,
  fontSize: '12px',
  letterSpacing: '0.2px',
  content: 'March',
  style: {
    fontSize: '12px',
    letterSpacing: '0.2px',
  },
}
```

</details>
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:

![image](https://github.com/recharts/recharts/assets/12778398/7da0b06c-f844-4789-b16a-ce2bb0c849b0)

After:

![image](https://github.com/recharts/recharts/assets/12778398/c33a0118-18c8-4776-b97e-793cc7f6adc7)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
