### PR TITLE
Fix: show all series data on tooltip when multiple X-Axis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,12 +42,14 @@
         "@storybook/source-loader": "^8.1.2",
         "@storybook/test-runner": "^0.18.0",
         "@storybook/theming": "^8.1.2",
+        "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.4.5",
         "@testing-library/react": "^15.0.7",
         "@testing-library/user-event": "^14.5.2",
         "@types/d3-interpolate": "^3.0.1",
         "@types/d3-shape": "^3.1.0",
         "@types/d3-time-format": "^4.0.0",
+        "@types/jest": "^29.5.12",
         "@types/lodash": "^4.14.144",
         "@types/node": "^14.18.34",
         "@types/react": "^18.3.3",
@@ -6334,9 +6336,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.1.0.tgz",
-      "integrity": "sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -6883,6 +6885,42 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "chromatic": "npx chromatic",
     "test-storybook": "test-storybook --config-dir storybook",
     "test-storybook:url": "test-storybook --url http://127.0.0.1:9009 --config-dir storybook",
+    "prettier": "prettier --write \"./{src,test}/**/*.{ts,tsx}\"",
     "test-storybook:ci": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"npm run build-storybook --quiet && npx http-server storybook/public --port 9009 --silent\" \"wait-on tcp:127.0.0.1:9009 && npm run test-storybook:url --maxWorkers=2\""
   },
   "lint-staged": {
@@ -99,12 +100,14 @@
     "@storybook/source-loader": "^8.1.2",
     "@storybook/test-runner": "^0.18.0",
     "@storybook/theming": "^8.1.2",
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/react": "^15.0.7",
     "@testing-library/user-event": "^14.5.2",
     "@types/d3-interpolate": "^3.0.1",
     "@types/d3-shape": "^3.1.0",
     "@types/d3-time-format": "^4.0.0",
+    "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.144",
     "@types/node": "^14.18.34",
     "@types/react": "^18.3.3",

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -285,8 +285,19 @@ const getTooltipData = (state: CategoricalChartState, chartData: any[], layout: 
   const activeIndex = calculateActiveTickIndex(pos, ticks, tooltipTicks, axis);
 
   if (activeIndex >= 0 && tooltipTicks) {
-    const activeLabel = tooltipTicks[activeIndex] && tooltipTicks[activeIndex].value;
-    const activePayload = getTooltipContent(state, chartData, activeIndex, activeLabel);
+    const activeLabel = tooltipTicks[activeIndex] && tooltipTicks[activeIndex].value; // for backward compatibility
+    let activePayload: any[];
+    if (state.xAxisMap) {
+      activePayload = Object.values(state.xAxisMap).reduce<any[]>((acc, xAxis) => {
+        const label: TickItem['value'] | undefined = Array.isArray(xAxis.domain)
+          ? xAxis.domain[activeIndex]
+          : tooltipTicks[activeIndex]?.value;
+        const tooltipContent: any[] | null = getTooltipContent(state, chartData, activeIndex, label);
+        return [...acc, ...(tooltipContent ?? [])];
+      }, []);
+    } else {
+      activePayload = getTooltipContent(state, chartData, activeIndex, activeLabel);
+    }
     const activeCoordinate = getActiveCoordinate(layout, ticks, activeIndex, rangeData);
 
     return {

--- a/storybook/stories/Examples/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart.stories.tsx
@@ -2,7 +2,7 @@
 import { expect, userEvent, within } from '@storybook/test';
 import { StoryObj } from '@storybook/react';
 import React, { PureComponent, useState } from 'react';
-import { Impressions, impressionsData, pageData } from '../data';
+import { Impressions, impressionsData, pageData, finDataOverTime } from '../data';
 import {
   Line,
   LineChart,
@@ -982,6 +982,75 @@ export const HideOnLegendClick: StoryObj = {
 
           <Line hide={activeSeries.includes('uv')} type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
           <Line hide={activeSeries.includes('pv')} type="monotone" dataKey="pv" stroke="#987" fill="#8884d8" />
+        </LineChart>
+      </ResponsiveContainer>
+    );
+  },
+};
+
+export const MultipleXandYAxisAreaChart = {
+  render: () => {
+    const dataKey = 'month';
+    const colors = ['green', 'red'];
+    const xAxisOrientations = ['top', 'bottom'];
+    const yAxisOrientations = ['left', 'right'];
+    const categories = ['Revenue', 'Cost'];
+    return (
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart width={500} height={300}>
+          <CartesianGrid strokeDasharray="3 3" />
+
+          <Tooltip />
+          <Legend />
+          {finDataOverTime.map((s, sIdx) => {
+            return (
+              <>
+                <XAxis
+                  key={s.name}
+                  dataKey={dataKey}
+                  orientation={xAxisOrientations[sIdx]}
+                  xAxisId={sIdx}
+                  allowDuplicatedCategory={false}
+                />
+                {categories.map((category, cIdx) => {
+                  const dataRange = [].concat(
+                    ...s.data.map(d =>
+                      d[category]
+                        ? [
+                            {
+                              [dataKey]: d[dataKey],
+                              [category]: d[category],
+                            },
+                          ]
+                        : [],
+                    ),
+                  );
+                  return (
+                    <>
+                      <YAxis
+                        key={`yaxis-${s.name}-${category}`}
+                        domain={['auto', 'auto']}
+                        orientation={yAxisOrientations[cIdx]}
+                        yAxisId={cIdx}
+                        stroke={colors[cIdx]}
+                      />
+                      <Line
+                        key={`line-${s.name}-${category}`}
+                        dataKey={category}
+                        data={dataRange}
+                        name={`${s.name}: ${category}`}
+                        xAxisId={sIdx}
+                        yAxisId={cIdx}
+                        stroke={colors[cIdx]}
+                        fill={colors[cIdx]}
+                        strokeDasharray={`5 ${sIdx > 0 ? 5 : ''}`}
+                      />
+                    </>
+                  );
+                })}
+              </>
+            );
+          })}
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart.stories.tsx
@@ -988,16 +988,16 @@ export const HideOnLegendClick: StoryObj = {
   },
 };
 
-export const MultipleXandYAxisAreaChart = {
+export const MultipleXandYAxisLineChartHorizontalLayout = {
   render: () => {
     const dataKey = 'month';
     const colors = ['green', 'red'];
-    const xAxisOrientations = ['top', 'bottom'];
-    const yAxisOrientations = ['left', 'right'];
+    const xAxisOrientations = ['top', 'bottom'] as const;
+    const yAxisOrientations = ['left', 'right'] as const;
     const categories = ['Revenue', 'Cost'];
     return (
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart width={500} height={300}>
+        <LineChart width={500} height={300} layout="horizontal">
           <CartesianGrid strokeDasharray="3 3" />
 
           <Tooltip />
@@ -1041,6 +1041,78 @@ export const MultipleXandYAxisAreaChart = {
                         name={`${s.name}: ${category}`}
                         xAxisId={sIdx}
                         yAxisId={cIdx}
+                        stroke={colors[cIdx]}
+                        fill={colors[cIdx]}
+                        strokeDasharray={`5 ${sIdx > 0 ? 5 : ''}`}
+                      />
+                    </>
+                  );
+                })}
+              </>
+            );
+          })}
+        </LineChart>
+      </ResponsiveContainer>
+    );
+  },
+};
+
+export const MultipleXandYAxisLineChartVerticalLayout = {
+  render: () => {
+    const dataKey = 'month';
+    const colors = ['green', 'red'];
+    const xAxisOrientations = ['top', 'bottom'] as const;
+    const yAxisOrientations = ['left', 'right'] as const;
+    const categories = ['Revenue', 'Cost'];
+    return (
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart width={500} height={300} layout="vertical">
+          <CartesianGrid strokeDasharray="3 3" />
+
+          <Tooltip />
+          <Legend />
+          {finDataOverTime.map((s, sIdx) => {
+            return (
+              <>
+                <YAxis
+                  key={`yaxis-${s.name}-`}
+                  // domain={['auto', 'auto']}
+                  orientation={yAxisOrientations[sIdx]}
+                  dataKey={dataKey}
+                  allowDuplicatedCategory={false}
+                  yAxisId={sIdx}
+                  type="category"
+                />
+                {categories.map((category, cIdx) => {
+                  const dataRange = [].concat(
+                    ...s.data.map(d =>
+                      d[category]
+                        ? [
+                            {
+                              [dataKey]: d[dataKey],
+                              [category]: d[category],
+                            },
+                          ]
+                        : [],
+                    ),
+                  );
+                  return (
+                    <>
+                      <XAxis
+                        key={s.name}
+                        // dataKey={dataKey}
+                        orientation={xAxisOrientations[cIdx]}
+                        xAxisId={cIdx}
+                        type="number"
+                        domain={['auto', 'auto']}
+                      />
+                      <Line
+                        key={`line-${s.name}-${category}`}
+                        dataKey={category}
+                        data={dataRange}
+                        name={`${s.name}: ${category}`}
+                        xAxisId={cIdx}
+                        yAxisId={sIdx}
                         stroke={colors[cIdx]}
                         fill={colors[cIdx]}
                         strokeDasharray={`5 ${sIdx > 0 ? 5 : ''}`}

--- a/storybook/stories/data/FinDataOverTime.ts
+++ b/storybook/stories/data/FinDataOverTime.ts
@@ -1,0 +1,126 @@
+export const finDataOverTime: Array<{
+  name: string;
+  data: Array<Record<string, string | number>>;
+}> = [
+  {
+    name: '2021',
+    data: [
+      {
+        month: 'Jan 21',
+        Revenue: 4400,
+        Cost: 0.1,
+      },
+      {
+        month: 'Feb 21',
+        Revenue: 3612,
+        Cost: 0.2,
+      },
+      {
+        month: 'Mar 21',
+        Revenue: 145,
+        Cost: 0.15,
+      },
+      {
+        month: 'Apr 21',
+        Revenue: 5142,
+        Cost: 0.25,
+      },
+      {
+        month: 'May 21',
+        Revenue: 1234,
+        Cost: 0.11,
+      },
+      {
+        month: 'Jun 21',
+        Revenue: 2345,
+        Cost: 0.3,
+      },
+      {
+        month: 'Jul 21',
+        Revenue: 3456,
+        Cost: 0.5,
+      },
+      {
+        month: 'Aug 21',
+        Revenue: 4567,
+        Cost: 0.2,
+      },
+      {
+        month: 'Sep 21',
+        Revenue: 5678,
+        Cost: 0.1,
+      },
+      {
+        month: 'Oct 21',
+        Revenue: 6789,
+        Cost: 0.35,
+      },
+      {
+        month: 'Nov 21',
+        Revenue: 7890,
+        Cost: 0.16,
+      },
+      {
+        month: 'Dec 21',
+        Revenue: 8901,
+        Cost: 0.2,
+      },
+    ],
+  },
+  {
+    name: '2022',
+    data: [
+      {
+        month: 'Jan 22',
+        Revenue: 571,
+      },
+      {
+        month: 'Feb 22',
+        Revenue: 234,
+      },
+      {
+        month: 'Mar 22',
+        Revenue: 2345,
+      },
+      {
+        month: 'Apr 22',
+        Revenue: 3456,
+      },
+      {
+        month: 'May 22',
+        Revenue: 4567,
+      },
+      {
+        month: 'Jun 22',
+        Revenue: 5678,
+      },
+      {
+        month: 'Jul 22',
+        Revenue: 6789,
+      },
+      {
+        month: 'Aug 22',
+        Revenue: 7890,
+      },
+      {
+        month: 'Sep 22',
+        Revenue: 8901,
+      },
+      {
+        month: 'Oct 22',
+        Revenue: 9012,
+        Cost: 0.9,
+      },
+      {
+        month: 'Nov 22',
+        Revenue: 1234,
+        Cost: 0.82,
+      },
+      {
+        month: 'Dec 22',
+        Revenue: 2345,
+        Cost: 0.62,
+      },
+    ],
+  },
+];

--- a/storybook/stories/data/index.ts
+++ b/storybook/stories/data/index.ts
@@ -9,3 +9,4 @@ export * from './Time';
 export * from './BoxPlot';
 export * from './Impression';
 export * from './Error';
+export * from './FinDataOverTime';

--- a/test/chart/AreaChart.spec.tsx
+++ b/test/chart/AreaChart.spec.tsx
@@ -1,3 +1,4 @@
+import { screen, waitFor } from '@testing-library/dom';
 import { fireEvent, render } from '@testing-library/react';
 import React, { ComponentProps, FC } from 'react';
 import { vi, SpyInstance } from 'vitest';
@@ -147,6 +148,182 @@ describe('AreaChart', () => {
       </AreaChart>,
     );
     expect(container.querySelectorAll('.recharts-area')).toHaveLength(0);
+  });
+
+  test('Renders tooltip when Tooltip item is added', () => {
+    const { container } = render(
+      <AreaChart width={100} height={50} data={data}>
+        <Area type="monotone" dot label dataKey="uv" stroke="#ff7300" fill="#ff7300" />
+        <Area type="monotone" dot label dataKey="pv" stroke="#ff7300" fill="#387908" />
+        <Tooltip />
+      </AreaChart>,
+    );
+    // Both the default Tooltip as well as the Tooltip wrapper are rendered even if not visible
+    expect(container.querySelectorAll('.recharts-default-tooltip')).toHaveLength(1);
+    expect(container.querySelectorAll('.recharts-tooltip-wrapper')).toHaveLength(1);
+  });
+
+  describe('<AreaChart /> - Series data', () => {
+    const seriesData = [
+      {
+        name: '2021',
+        data: [
+          { month: 'Jan 21', Revenue: 4400, Cost: 0.1 },
+          { month: 'Feb 21', Revenue: 3612, Cost: 0.2 },
+          { month: 'Mar 21', Revenue: 145, Cost: 0.15 },
+        ],
+      },
+      {
+        name: '2022',
+        data: [
+          { month: 'Jan 22', Revenue: 571, Cost: 0.5 },
+          { month: 'Feb 22', Revenue: 234, Cost: 0.3 },
+          { month: 'Mar 22', Revenue: 2345, Cost: 0.7 },
+        ],
+      },
+    ];
+
+    test('Renders tooltip when Tooltip item is added and layout is horizontal', async () => {
+      const { container } = render(
+        <AreaChart width={100} height={50}>
+          <Area
+            type="monotone"
+            dot
+            label
+            dataKey="Revenue"
+            stroke="#ff7300"
+            fill="#ff7300"
+            data={seriesData[0].data}
+            yAxisId={0}
+            xAxisId={0}
+          />
+          <Area
+            type="monotone"
+            dot
+            label
+            dataKey="Cost"
+            stroke="#387908"
+            fill="#387908"
+            data={seriesData[0].data}
+            yAxisId={1}
+            xAxisId={0}
+          />
+          <Area
+            type="monotone"
+            dot
+            label
+            dataKey="Revenue"
+            stroke="#ff7300"
+            fill="#ff7300"
+            data={seriesData[1].data}
+            strokeDasharray="5 5"
+            yAxisId={0}
+            xAxisId={1}
+          />
+          <Area
+            type="monotone"
+            dot
+            label
+            dataKey="Cost"
+            stroke="#387908"
+            fill="#387908"
+            data={seriesData[1].data}
+            strokeDasharray="5 5"
+            yAxisId={1}
+            xAxisId={1}
+          />
+
+          <XAxis type="number" xAxisId={0} />
+          <XAxis type="number" xAxisId={1} />
+          <YAxis type="category" dataKey="month" allowDuplicatedCategory={false} yAxisId={0} />
+          <YAxis type="category" dataKey="month" allowDuplicatedCategory={false} yAxisId={1} />
+          <Tooltip />
+        </AreaChart>,
+      );
+
+      const tooltipWrapper = container.querySelectorAll('.recharts-tooltip-wrapper');
+      const tooltip = container.querySelectorAll('.recharts-default-tooltip');
+      const area = container.querySelectorAll('.recharts-surface')[0];
+
+      expect(tooltip).toHaveLength(1);
+      expect(tooltipWrapper).toHaveLength(1);
+
+      await waitFor(() => {
+        fireEvent.mouseOver(area);
+        expect(tooltipWrapper).toBeVisible();
+        screen.debug();
+      });
+    });
+
+    test('Renders tooltip when Tooltip item is added and layout is vertical', async () => {
+      const { container } = render(
+        <AreaChart width={100} height={50} layout="vertical">
+          <Area
+            type="monotone"
+            dot
+            label
+            dataKey="Revenue"
+            stroke="#ff7300"
+            fill="#ff7300"
+            data={seriesData[0].data}
+            yAxisId={0}
+            xAxisId={0}
+          />
+          <Area
+            type="monotone"
+            dot
+            label
+            dataKey="Cost"
+            stroke="#387908"
+            fill="#387908"
+            data={seriesData[0].data}
+            yAxisId={1}
+            xAxisId={0}
+          />
+          <Area
+            type="monotone"
+            dot
+            label
+            dataKey="Revenue"
+            stroke="#ff7300"
+            fill="#ff7300"
+            data={seriesData[1].data}
+            strokeDasharray="5 5"
+            yAxisId={0}
+            xAxisId={1}
+          />
+          <Area
+            type="monotone"
+            dot
+            label
+            dataKey="Cost"
+            stroke="#387908"
+            fill="#387908"
+            data={seriesData[1].data}
+            strokeDasharray="5 5"
+            yAxisId={1}
+            xAxisId={1}
+          />
+          <XAxis type="number" xAxisId={0} />
+          <XAxis type="number" xAxisId={1} />
+          <YAxis type="category" dataKey="month" allowDuplicatedCategory={false} yAxisId={0} />
+          <YAxis type="category" dataKey="month" allowDuplicatedCategory={false} yAxisId={1} />
+          <Tooltip />
+        </AreaChart>,
+      );
+      const tooltipWrapper = container.querySelectorAll('.recharts-tooltip-wrapper');
+      const tooltip = container.querySelectorAll('.recharts-default-tooltip');
+      const area = container.querySelectorAll('.recharts-area')[0];
+
+      expect(tooltip).toHaveLength(1);
+      expect(tooltipWrapper).toHaveLength(1);
+
+      await waitFor(() => {
+        fireEvent.mouseOver(area);
+        expect(tooltipWrapper).toBeVisible();
+        screen.debug();
+      });
+    });
   });
 
   describe('<AreaChart /> - Pure Rendering', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes https://github.com/recharts/recharts/issues/4757

<!--- Describe your changes in detail -->
I am using the state xAxisMap to access the domain of each x axis and create the missing payloads.
Not sure that's the best solution but it works and I couldn't really find a more elegant solution without major refactoring.

## How Has This Been Tested?
I have added a story for the line chart. Also, all automated tests are passing.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before the fix:
![Screenshot from 2024-07-12 12-58-46](https://github.com/user-attachments/assets/334f3bad-a1c0-4f9c-9184-7eed51365370)

After the fix:
![Screenshot from 2024-07-12 13-00-02](https://github.com/user-attachments/assets/c57ea53d-046e-4419-893a-551e8ac30b2a)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
