### PR TITLE
Use forced UTC when formatting date in storybook

### DIFF
--- a/storybook/stories/API/chart/ComposedChart.stories.tsx
+++ b/storybook/stories/API/chart/ComposedChart.stories.tsx
@@ -130,6 +130,16 @@ export const LineBarHorizontal = {
 
 export const LineBarAreaScatterTimeScale = {
   render: (args: Record<string, any>) => {
+    const tickFormatter = (tick: Date) => {
+      return tick.toLocaleString('en-GB', {
+        /*
+         * Forced timezone so that our visual diff renders the same for all contributors.
+         * In real app you will probably leave timeZone undefined
+         */
+        timeZone: 'UTC',
+        dateStyle: 'medium',
+      });
+    };
     return (
       <ResponsiveContainer width="100%" height={500}>
         <div style={{ width: '600px', margin: 'auto' }}>
@@ -153,6 +163,7 @@ export const LineBarAreaScatterTimeScale = {
                 scale="time"
                 type="number"
                 tick={{ fontSize: 10, fill: 'red' }}
+                tickFormatter={tickFormatter}
               />
               <YAxis />
               <Legend />


### PR DESCRIPTION
## Description

I considered forcing it across all storybooks by overwriting Date.prototype but decided against it - this way we can also show it off as an example of date formatting.

## Motivation and Context

Storybook renders depending on timezone. Because I am in Australian timezone and the CI is in GMT, I couldn't reproduce some bugs.

Now, this doesn't help me reproduce it either 😬 but it makes sure it won't happen again. Also it produces some more reasonable looking chart than a single tick with full timezone info.

This will create visual diff.