### PR TITLE
YAxis uses scale (and domain and range) from redux instead of generator

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -56,8 +56,8 @@ const XAxisImpl = (props: Props) => {
   const height = useChartHeight();
   const axisOptions: XAxisWithExtraData = useXAxisOrThrow(xAxisId);
   const axisType = 'xAxis';
-  const scaleObj = useAppSelector(state => selectAxisScale(state, 'xAxis', xAxisId));
-  const niceTicks = useAppSelector(state => selectNiceTicks(state, 'xAxis', xAxisId));
+  const scaleObj = useAppSelector(state => selectAxisScale(state, axisType, xAxisId));
+  const niceTicks = useAppSelector(state => selectNiceTicks(state, axisType, xAxisId));
 
   if (axisOptions == null || scaleObj == null) {
     return null;
@@ -111,6 +111,7 @@ const XAxisSettingsDispatcher = (props: Props) => {
         tickCount={props.tickCount}
         includeHidden={props.includeHidden ?? false}
         reversed={props.reversed}
+        ticks={props.ticks}
       />
       <XAxisImpl {...props} />
     </>

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -5,7 +5,8 @@ import { useChartHeight, useChartWidth, useYAxisOrThrow } from '../context/chart
 import { CartesianAxis } from './CartesianAxis';
 import { AxisPropsNeededForTicksGenerator, getTicksOfAxis } from '../util/ChartUtils';
 import { addYAxis, removeYAxis, YAxisSettings } from '../state/axisMapSlice';
-import { useAppDispatch } from '../state/hooks';
+import { useAppDispatch, useAppSelector } from '../state/hooks';
+import { selectAxisScale, selectNiceTicks } from '../state/selectors/axisSelectors';
 
 interface YAxisProps extends BaseAxisProps {
   /** The unique id of y-axis */
@@ -50,9 +51,11 @@ const YAxisImpl: FunctionComponent<Props> = (props: Props) => {
   const width = useChartWidth();
   const height = useChartHeight();
   const axisType = 'yAxis';
-
   const axisOptions = useYAxisOrThrow(yAxisId);
-  if (axisOptions == null) {
+  const scaleObj = useAppSelector(state => selectAxisScale(state, axisType, yAxisId));
+  const niceTicks = useAppSelector(state => selectNiceTicks(state, axisType, yAxisId));
+
+  if (axisOptions == null || scaleObj == null) {
     return null;
   }
 
@@ -61,10 +64,10 @@ const YAxisImpl: FunctionComponent<Props> = (props: Props) => {
     categoricalDomain: axisOptions.categoricalDomain,
     duplicateDomain: axisOptions.duplicateDomain,
     isCategorical: axisOptions.isCategorical,
-    niceTicks: axisOptions.niceTicks,
     range: axisOptions.range,
-    realScaleType: axisOptions.realScaleType,
-    scale: axisOptions.scale,
+    realScaleType: scaleObj.realScaleType,
+    niceTicks,
+    scale: scaleObj.scale,
     tickCount: props.tickCount,
     ticks: props.ticks,
     type: props.type,
@@ -104,6 +107,7 @@ const YAxisSettingsDispatcher = (props: Props) => {
         padding={props.padding}
         includeHidden={props.includeHidden ?? false}
         reversed={props.reversed}
+        ticks={props.ticks}
       />
       <YAxisImpl {...props} />
     </>

--- a/src/state/axisMapSlice.ts
+++ b/src/state/axisMapSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { castDraft } from 'immer';
-import { AxisDomain, AxisDomainType, DataKey, ScaleType } from '../util/types';
+import { AxisDomain, AxisDomainType, AxisTick, DataKey, ScaleType } from '../util/types';
 import { RechartsScale } from '../util/ChartUtils';
 
 export type AxisId = string | number;
@@ -29,6 +29,11 @@ export type AxisSettings = {
   tickCount: number;
   includeHidden: boolean;
   reversed: boolean;
+  /**
+   * Ticks can be any type when the axis is the type of category
+   * Ticks must be numbers when the axis is the type of number
+   */
+  ticks: ReadonlyArray<AxisTick> | undefined;
 };
 
 export type XAxisSettings = AxisSettings & {

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -387,8 +387,15 @@ function onlyAllowNumbersAndStringsAndDates(item: { value: unknown }): string | 
 const computeNumericalDomain = (
   dataWithErrorDomains: ReadonlyArray<AppliedChartDataWithErrorDomain>,
 ): NumberDomain | undefined => {
-  const allDataSquished = dataWithErrorDomains.flatMap(d => [d.value, ...d.errorDomain]);
+  const allDataSquished = dataWithErrorDomains
+    // This flatMap has to be flat because we're creating a new array in the return value
+    .flatMap(d => [d.value, d.errorDomain])
+    // This flat is needed because a) errorDomain is an array, and b) value may be a number, or it may be a range (for Area, for example)
+    .flat(1);
   const onlyNumbers = onlyAllowNumbers(allDataSquished);
+  if (onlyNumbers.length === 0) {
+    return undefined;
+  }
   return [Math.min(...onlyNumbers), Math.max(...onlyNumbers)];
 };
 

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -200,7 +200,7 @@ describe('<XAxis />', () => {
     expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
   });
 
-  it('should return empty strings when dataKey is specified but does not match the data', () => {
+  it('should not render any ticks when dataKey is specified but does not match the data', () => {
     const spy = vi.fn();
     const { container } = render(
       <LineChart width={400} height={400} data={lineData}>
@@ -209,39 +209,8 @@ describe('<XAxis />', () => {
       </LineChart>,
     );
 
-    expectXAxisTicks(container, [
-      {
-        textContent: '',
-        x: '5',
-        y: '373',
-      },
-      {
-        textContent: '',
-        x: '83',
-        y: '373',
-      },
-      {
-        textContent: '',
-        x: '161',
-        y: '373',
-      },
-      {
-        textContent: '',
-        x: '239',
-        y: '373',
-      },
-      {
-        textContent: '',
-        x: '317',
-        y: '373',
-      },
-      {
-        textContent: '',
-        x: '395',
-        y: '373',
-      },
-    ]);
-    expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+    expectXAxisTicks(container, []);
+    expect(spy).toHaveBeenLastCalledWith([]);
   });
 
   it('Render duplicated ticks of XAxis', () => {
@@ -858,13 +827,14 @@ describe('<XAxis />', () => {
       };
       const { container } = render(
         <BarChart width={100} height={100}>
-          <XAxis xAxisId="foo" scale="log" type="number" includeHidden />
+          <XAxis xAxisId="foo" scale="log" type="number" includeHidden ticks={[4, 5, 6]} />
           <Customized component={Comp} />
         </BarChart>,
       );
       expect(container.querySelector('.xAxis')).toBeVisible();
       expect(spy).toHaveBeenCalledTimes(3);
       const expectedSettings: XAxisSettings = {
+        ticks: [4, 5, 6],
         includeHidden: true,
         tickCount: 5,
         allowDecimals: true,
@@ -899,6 +869,7 @@ describe('<XAxis />', () => {
         </BarChart>,
       );
       const expectedSettings1: XAxisSettings = {
+        ticks: undefined,
         includeHidden: false,
         tickCount: 5,
         allowDecimals: true,
@@ -931,6 +902,7 @@ describe('<XAxis />', () => {
         foo: XAxisSettings;
       } = {
         foo: {
+          ticks: undefined,
           includeHidden: false,
           id: 'foo',
           scale: 'log',
@@ -948,6 +920,7 @@ describe('<XAxis />', () => {
           reversed: false,
         },
         bar: {
+          ticks: undefined,
           includeHidden: false,
           id: 'bar',
           scale: 'utc',
@@ -974,6 +947,7 @@ describe('<XAxis />', () => {
       );
 
       const expectedSettings3: XAxisSettings = {
+        ticks: undefined,
         includeHidden: false,
         tickCount: 5,
         id: 'bar',
@@ -3361,6 +3335,7 @@ describe('<XAxis />', () => {
         },
       ]);
       const expectedSettings: XAxisSettings = {
+        ticks: undefined,
         includeHidden: false,
         allowDataOverflow: false,
         allowDecimals: true,

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -82,10 +82,10 @@ describe('<YAxis />', () => {
     expect(ticks[ticks.length - 1]).toHaveTextContent(textContent);
   });
 
-  it('Renders evenly distributed ticks when domain={[0, 1000]} and dataKey is "noExist"', () => {
+  it('Renders evenly distributed ticks when domain={[0, 1000]} and dataKey is "noExist", and allowDataOverflow', () => {
     const { container } = render(
       <AreaChart width={600} height={400} data={data}>
-        <YAxis stroke="#ff7300" domain={[0, 1000]} />
+        <YAxis stroke="#ff7300" domain={[0, 1000]} allowDataOverflow />
         <Area dataKey="noExist" stroke="#ff7300" fill="#ff7300" />
       </AreaChart>,
     );
@@ -116,6 +116,26 @@ describe('<YAxis />', () => {
         y: '5',
       },
     ]);
+  });
+
+  it('Renders no ticks when domain={[0, 1000]} and dataKey is "noExist", and allowDataOverflow=false', () => {
+    const { container } = render(
+      <AreaChart width={600} height={400} data={data}>
+        <YAxis stroke="#ff7300" domain={[0, 1000]} allowDataOverflow={false} />
+        <Area dataKey="noExist" stroke="#ff7300" fill="#ff7300" />
+      </AreaChart>,
+    );
+    expectYAxisTicks(container, []);
+  });
+
+  it('Renders no ticks when dataKey is "noExist"', () => {
+    const { container } = render(
+      <AreaChart width={600} height={400} data={data}>
+        <YAxis />
+        <Area dataKey="noExist" stroke="#ff7300" fill="#ff7300" />
+      </AreaChart>,
+    );
+    expectYAxisTicks(container, []);
   });
 
   const casesThatDoNotShowTicks: [AxisDomain][] = [[[0, 'dataMax + 100']], [[0, 'dataMax - 100']], [['auto', 'auto']]];
@@ -491,13 +511,14 @@ describe('<YAxis />', () => {
       };
       const { container } = render(
         <BarChart width={100} height={100}>
-          <YAxis yAxisId="foo" scale="log" type="number" includeHidden reversed />
+          <YAxis yAxisId="foo" scale="log" type="number" includeHidden reversed ticks={[1, 2, 3]} />
           <Customized component={Comp} />
         </BarChart>,
       );
       expect(container.querySelector('.yAxis')).toBeVisible();
       expect(spy).toHaveBeenCalledTimes(3);
       const expectedSettings: YAxisSettings = {
+        ticks: [1, 2, 3],
         includeHidden: true,
         tickCount: 5,
         allowDecimals: true,
@@ -532,6 +553,7 @@ describe('<YAxis />', () => {
         </BarChart>,
       );
       const expectedSettings1: YAxisSettings = {
+        ticks: undefined,
         includeHidden: false,
         tickCount: 5,
         allowDecimals: true,
@@ -579,6 +601,7 @@ describe('<YAxis />', () => {
           allowDecimals: true,
           tickCount: 5,
           reversed: false,
+          ticks: undefined,
         },
         bar: {
           includeHidden: false,
@@ -596,6 +619,7 @@ describe('<YAxis />', () => {
           allowDecimals: true,
           tickCount: 5,
           reversed: false,
+          ticks: undefined,
         },
       };
       expect(spy).toHaveBeenLastCalledWith(expectedSettings2);
@@ -607,6 +631,7 @@ describe('<YAxis />', () => {
       );
 
       const expectedSettings3: YAxisSettings = {
+        ticks: undefined,
         includeHidden: false,
         tickCount: 5,
         id: 'bar',
@@ -781,7 +806,7 @@ describe('<YAxis />', () => {
       expect(domainSpy).toHaveBeenLastCalledWith([0, 100]);
     });
 
-    it('should ignore domain of hidden items with includeHidden! this feels like a bug to me - why does this not work for stacked data?', () => {
+    it('should include domain of hidden items when includeHidden=true', () => {
       const stackedData = [
         {
           x: 10,
@@ -802,7 +827,6 @@ describe('<YAxis />', () => {
           <Customized component={<Comp />} />
         </BarChart>,
       );
-      // includeHidden does not work with stacked data, why?
       expectYAxisTicks(container, [
         {
           textContent: '0',
@@ -810,29 +834,29 @@ describe('<YAxis />', () => {
           y: '95',
         },
         {
-          textContent: '3',
+          textContent: '55',
           x: '57',
           y: '72.5',
         },
         {
-          textContent: '6',
+          textContent: '110',
           x: '57',
           y: '50',
         },
         {
-          textContent: '9',
+          textContent: '165',
           x: '57',
           y: '27.5',
         },
         {
-          textContent: '12',
+          textContent: '220',
           x: '57',
           y: '5',
         },
       ]);
       expect(domainSpy).toHaveBeenLastCalledWith([0, 210]);
 
-      // the same data, when not stacked, are included when includeHidden is true.
+      // the same data, not stacked
       rerender(
         <BarChart width={100} height={100} data={stackedData}>
           <YAxis includeHidden />

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -15,9 +15,11 @@ import {
   ReferenceDot,
   ReferenceArea,
   ReferenceLine,
+  XAxis,
+  ComposedChart,
 } from '../../src';
 import { AxisDomain, CategoricalDomain, NumberDomain, StackOffsetType } from '../../src/util/types';
-import { pageData } from '../../storybook/stories/data';
+import { pageData, rangeData } from '../../storybook/stories/data';
 import { useAppSelector } from '../../src/state/hooks';
 import { selectAxisDomain, selectAxisSettings } from '../../src/state/selectors/axisSelectors';
 import { YAxisSettings } from '../../src/state/axisMapSlice';
@@ -46,6 +48,63 @@ describe('<YAxis />', () => {
     );
 
     expect(container.querySelectorAll('.recharts-cartesian-axis-line')).toHaveLength(3);
+  });
+
+  it('should render ticks from Area with range', () => {
+    const domainSpy = vi.fn();
+    const Comp = (): null => {
+      const domain = useAppSelector(state => selectAxisDomain(state, 'yAxis', 0));
+      domainSpy(domain);
+      return null;
+    };
+    const { container } = render(
+      <AreaChart
+        width={500}
+        height={400}
+        data={rangeData}
+        margin={{
+          top: 10,
+          right: 30,
+          left: 0,
+          bottom: 0,
+        }}
+      >
+        <XAxis dataKey="day" />
+        <YAxis />
+        <Area dataKey="temperature" stroke="#d82428" fill="#8884d8" />
+        <Tooltip defaultIndex={4} active />
+        <Customized component={<Comp />} />
+      </AreaChart>,
+    );
+
+    expectYAxisTicks(container, [
+      {
+        textContent: '-6',
+        x: '52',
+        y: '370',
+      },
+      {
+        textContent: '0',
+        x: '52',
+        y: '280',
+      },
+      {
+        textContent: '6',
+        x: '52',
+        y: '190',
+      },
+      {
+        textContent: '12',
+        x: '52',
+        y: '100',
+      },
+      {
+        textContent: '18',
+        x: '52',
+        y: '10',
+      },
+    ]);
+    expect(domainSpy).toHaveBeenLastCalledWith([-3, 16]);
   });
 
   it('Should render 5 ticks', () => {
@@ -1377,6 +1436,72 @@ describe('<YAxis />', () => {
           },
         ]);
         expect(domainSpy).toHaveBeenLastCalledWith([-100, 5000]);
+      });
+    });
+
+    describe('ReferenceArea without any graphical elements', () => {
+      it('should render ticks following the domain of the area', () => {
+        const axisDomainSpy = vi.fn();
+        const Comp = (): null => {
+          const domain = useAppSelector(state => selectAxisDomain(state, 'yAxis', 0));
+          axisDomainSpy(domain);
+          return null;
+        };
+        const { container } = render(
+          <ComposedChart
+            width={500}
+            height={500}
+            data={pageData}
+            margin={{
+              top: 5,
+              right: 30,
+              left: 20,
+              bottom: 5,
+            }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis type="number" />
+            <ReferenceArea
+              x1="Page B"
+              x2="Page E"
+              y1={1890}
+              y2={-1000}
+              stroke="red"
+              strokeOpacity={0.3}
+              ifOverflow="extendDomain"
+            />
+            <Customized component={<Comp />} />
+          </ComposedChart>,
+        );
+        expect(axisDomainSpy).toHaveBeenLastCalledWith([-1000, 1890]);
+        expectYAxisTicks(container, [
+          {
+            textContent: '-1900',
+            x: '72',
+            y: '465',
+          },
+          {
+            textContent: '-950',
+            x: '72',
+            y: '350',
+          },
+          {
+            textContent: '0',
+            x: '72',
+            y: '235',
+          },
+          {
+            textContent: '950',
+            x: '72',
+            y: '120',
+          },
+          {
+            textContent: '1900',
+            x: '72',
+            y: '5',
+          },
+        ]);
       });
     });
 

--- a/test/chart/AreaChart.spec.tsx
+++ b/test/chart/AreaChart.spec.tsx
@@ -178,14 +178,14 @@ describe('AreaChart', () => {
       const { container } = render(chart);
 
       spies.forEach(el => expect(el.mock.calls.length).toBe(1));
-      expect(axisSpy).toHaveBeenCalledTimes(3);
+      expect(axisSpy).toHaveBeenCalledTimes(5);
 
       fireEvent.mouseEnter(container, { clientX: 30, clientY: 200 });
       fireEvent.mouseMove(container, { clientX: 200, clientY: 200 });
       fireEvent.mouseLeave(container);
 
       spies.forEach(el => expect(el.mock.calls.length).toBe(1));
-      expect(axisSpy).toHaveBeenCalledTimes(3);
+      expect(axisSpy).toHaveBeenCalledTimes(5);
     });
 
     // protect against the future where someone might mess up our clean rendering
@@ -193,7 +193,7 @@ describe('AreaChart', () => {
       const { container } = render(chart);
 
       spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-      expect(axisSpy).toHaveBeenCalledTimes(3);
+      expect(axisSpy).toHaveBeenCalledTimes(5);
 
       const brushSlide = container.querySelector('.recharts-brush-slide');
       assertNotNull(brushSlide);
@@ -202,7 +202,7 @@ describe('AreaChart', () => {
       fireEvent.mouseUp(window);
 
       spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-      expect(axisSpy).toHaveBeenCalledTimes(3);
+      expect(axisSpy).toHaveBeenCalledTimes(7);
     });
 
     test('should only show the last data when the brush travelers all moved to the right', () => {

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -1042,14 +1042,14 @@ describe('<LineChart /> - Pure Rendering', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(3);
+    expect(axisSpy).toHaveBeenCalledTimes(5);
 
     fireEvent.mouseEnter(container, { clientX: 30, clientY: 200, bubbles: true, cancelable: true });
     fireEvent.mouseMove(container, { clientX: 200, clientY: 200, bubbles: true, cancelable: true });
     fireEvent.mouseLeave(container);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(3);
+    expect(axisSpy).toHaveBeenCalledTimes(5);
   });
 
   // protect against the future where someone might mess up our clean rendering
@@ -1057,7 +1057,7 @@ describe('<LineChart /> - Pure Rendering', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(3);
+    expect(axisSpy).toHaveBeenCalledTimes(5);
 
     const leftCursor = container.querySelector('.recharts-brush-traveller');
     assertNotNull(leftCursor);
@@ -1068,7 +1068,7 @@ describe('<LineChart /> - Pure Rendering', () => {
     fireEvent.mouseUp(window);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(3);
+    expect(axisSpy).toHaveBeenCalledTimes(5);
   });
 });
 
@@ -1102,7 +1102,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(3);
+    expect(axisSpy).toHaveBeenCalledTimes(5);
 
     fireEvent.mouseEnter(container, { clientX: 30, clientY: 200, bubbles: true, cancelable: true });
 
@@ -1111,7 +1111,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     fireEvent.mouseLeave(container);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(3);
+    expect(axisSpy).toHaveBeenCalledTimes(5);
   });
 
   // protect against the future where someone might mess up our clean rendering
@@ -1119,7 +1119,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(3);
+    expect(axisSpy).toHaveBeenCalledTimes(5);
 
     const leftCursor = container.querySelector('.recharts-brush-traveller');
     assertNotNull(leftCursor);
@@ -1128,7 +1128,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     fireEvent.mouseUp(window);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(3);
+    expect(axisSpy).toHaveBeenCalledTimes(5);
   });
 });
 

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -6,6 +6,7 @@ import {
   mergeDomains,
   selectAllAppliedValues,
   selectAxisDomain,
+  selectAxisDomainIncludingNiceTicks,
   selectAxisScale,
   selectCalculatedXAxisPadding,
   selectCartesianGraphicalItemsData,
@@ -42,6 +43,7 @@ import { generateMockData } from '../../helper/generateMockData';
 import { AxisId } from '../../../src/state/axisMapSlice';
 import { pageData } from '../../../storybook/stories/data';
 import { AxisDomain } from '../../../src/util/types';
+import { ChartData } from '../../../src/state/chartDataSlice';
 
 const defaultAxisId: AxisId = 0;
 
@@ -59,7 +61,7 @@ describe('selectAxisScale', () => {
     render(<Comp />);
   });
 
-  it('should return empty object for initial state', () => {
+  it('should return empty for initial state', () => {
     const initialState: RechartsRootState = createRechartsStore().getState();
     const result = selectAxisScale(initialState, 'yAxis', 'foo');
     expect(result).toEqual({ scale: undefined, realScaleType: undefined });
@@ -740,10 +742,128 @@ describe('selectAxisDomain', () => {
     });
 
     it('with allowDuplicatedCategory=true, and the data has duplicates, it should return domain as array indexes', () => {
-      const spy = vi.fn();
+      const domainSpy = vi.fn();
       const Comp = (): null => {
         const result = useAppSelector(state => selectAxisDomain(state, 'xAxis', '0'));
-        spy(result);
+        domainSpy(result);
+        return null;
+      };
+      const monthsWithDuplicatesData: ChartData = [
+        { x: 'Jan' },
+        { x: 'Jan' },
+        { x: 'Feb' },
+        { x: 'Feb' },
+        { x: 'Mar' },
+        { x: 'Mar' },
+        { x: 'Apr' },
+        { x: 'Apr' },
+        { x: 'May' },
+        { x: 'May' },
+        { x: 'Jun' },
+        { x: 'Jun' },
+        { x: 'Jul' },
+        { x: 'Jul' },
+        { x: 'Aug' },
+        { x: 'Aug' },
+      ];
+      const { container } = render(
+        <BarChart data={monthsWithDuplicatesData} width={100} height={100}>
+          <XAxis dataKey="x" type={type} allowDuplicatedCategory />
+          <Customized component={Comp} />
+        </BarChart>,
+      );
+      expect(domainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+      expectXAxisTicks(container, [
+        {
+          textContent: 'Jan',
+          x: '7.8125',
+          y: '73',
+        },
+        {
+          textContent: 'Jan',
+          x: '13.4375',
+          y: '73',
+        },
+        {
+          textContent: 'Feb',
+          x: '19.0625',
+          y: '73',
+        },
+        {
+          textContent: 'Feb',
+          x: '24.6875',
+          y: '73',
+        },
+        {
+          textContent: 'Mar',
+          x: '30.3125',
+          y: '73',
+        },
+        {
+          textContent: 'Mar',
+          x: '35.9375',
+          y: '73',
+        },
+        {
+          textContent: 'Apr',
+          x: '41.5625',
+          y: '73',
+        },
+        {
+          textContent: 'Apr',
+          x: '47.1875',
+          y: '73',
+        },
+        {
+          textContent: 'May',
+          x: '52.8125',
+          y: '73',
+        },
+        {
+          textContent: 'May',
+          x: '58.4375',
+          y: '73',
+        },
+        {
+          textContent: 'Jun',
+          x: '64.0625',
+          y: '73',
+        },
+        {
+          textContent: 'Jun',
+          x: '69.6875',
+          y: '73',
+        },
+        {
+          textContent: 'Jul',
+          x: '75.3125',
+          y: '73',
+        },
+        {
+          textContent: 'Jul',
+          x: '80.9375',
+          y: '73',
+        },
+        {
+          textContent: 'Aug',
+          x: '86.5625',
+          y: '73',
+        },
+        {
+          textContent: 'Aug',
+          x: '92.1875',
+          y: '73',
+        },
+      ]);
+    });
+
+    it('with allowDuplicatedCategory=true, and the data has duplicates that are not strings, it should return domain of values', () => {
+      const domainSpy = vi.fn();
+      const scaleSpy = vi.fn();
+      const Comp = (): null => {
+        domainSpy(useAppSelector(state => selectAxisDomainIncludingNiceTicks(state, 'xAxis', 0)));
+        const scaleObj = useAppSelector(state => selectAxisScale(state, 'xAxis', 0));
+        scaleSpy(scaleObj?.scale?.domain());
         return null;
       };
       const { container } = render(
@@ -752,92 +872,53 @@ describe('selectAxisDomain', () => {
           <Customized component={Comp} />
         </BarChart>,
       );
-      expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+      expect(domainSpy).toHaveBeenLastCalledWith(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug']);
+      expect(scaleSpy).toHaveBeenLastCalledWith(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug']);
+      /*
+       * These are not great ticks.
+       * All of them are undefined because axisOptions.categoricalDomain is undefined
+       * - once we move categoricalDomain and getTicksOfAxis to be selectors,
+       * I expect that to improve.
+       */
       expectXAxisTicks(container, [
         {
-          textContent: '',
-          x: '7.647058823529411',
-          y: '73',
-        },
-        {
-          textContent: 'Jan',
-          x: '12.941176470588234',
-          y: '73',
-        },
-        {
-          textContent: '',
-          x: '18.235294117647058',
-          y: '73',
-        },
-        {
-          textContent: 'Feb',
-          x: '23.529411764705884',
-          y: '73',
-        },
-        {
-          textContent: 'Mar',
-          x: '28.823529411764707',
-          y: '73',
-        },
-        {
-          textContent: '',
-          x: '34.11764705882353',
-          y: '73',
-        },
-        {
-          textContent: 'Apr',
-          x: '39.411764705882355',
-          y: '73',
-        },
-        {
-          textContent: '',
-          x: '44.705882352941174',
-          y: '73',
-        },
-        {
-          textContent: 'May',
-          x: '50',
-          y: '73',
-        },
-        {
-          textContent: '',
-          x: '55.294117647058826',
-          y: '73',
-        },
-        {
-          textContent: 'Jun',
-          x: '60.588235294117645',
-          y: '73',
-        },
-        {
-          textContent: '',
-          x: '65.88235294117646',
-          y: '73',
-        },
-        {
-          textContent: 'Jul',
-          x: '71.17647058823529',
-          y: '73',
-        },
-        {
-          textContent: '',
-          x: '76.47058823529412',
-          y: '73',
-        },
-        {
-          textContent: 'Aug',
-          x: '81.76470588235293',
-          y: '73',
-        },
-        {
-          textContent: '',
-          x: '87.05882352941175',
-          y: '73',
-        },
-        {
-          // no idea where the string 'undefined' comes from - the new implementation doesn't have it, breaking or not.
           textContent: 'undefined',
-          x: '92.35294117647058',
+          x: '10.625',
+          y: '73',
+        },
+        {
+          textContent: 'undefined',
+          x: '21.875',
+          y: '73',
+        },
+        {
+          textContent: 'undefined',
+          x: '33.125',
+          y: '73',
+        },
+        {
+          textContent: 'undefined',
+          x: '44.375',
+          y: '73',
+        },
+        {
+          textContent: 'undefined',
+          x: '55.625',
+          y: '73',
+        },
+        {
+          textContent: 'undefined',
+          x: '66.875',
+          y: '73',
+        },
+        {
+          textContent: 'undefined',
+          x: '78.125',
+          y: '73',
+        },
+        {
+          textContent: 'undefined',
+          x: '89.375',
           y: '73',
         },
       ]);
@@ -905,51 +986,46 @@ describe('selectAxisDomain', () => {
           <Customized component={Comp} />
         </BarChart>,
       );
-      expect(spy).toHaveBeenLastCalledWith(['', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug']);
+      expect(spy).toHaveBeenLastCalledWith(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug']);
       expectXAxisTicks(container, [
         {
-          textContent: '',
-          x: '10',
-          y: '73',
-        },
-        {
           textContent: 'Jan',
-          x: '20',
+          x: '10.625',
           y: '73',
         },
         {
           textContent: 'Feb',
-          x: '30',
+          x: '21.875',
           y: '73',
         },
         {
           textContent: 'Mar',
-          x: '40',
+          x: '33.125',
           y: '73',
         },
         {
           textContent: 'Apr',
-          x: '50',
+          x: '44.375',
           y: '73',
         },
         {
           textContent: 'May',
-          x: '60',
+          x: '55.625',
           y: '73',
         },
         {
           textContent: 'Jun',
-          x: '70',
+          x: '66.875',
           y: '73',
         },
         {
           textContent: 'Jul',
-          x: '80',
+          x: '78.125',
           y: '73',
         },
         {
           textContent: 'Aug',
-          x: '90',
+          x: '89.375',
           y: '73',
         },
       ]);


### PR DESCRIPTION
## Description

Same as https://github.com/recharts/recharts/pull/4730 but for YAxis now.

There are some temporary pains, as we use half redux half generator to decide the ticks. I expect it will get better as we move all to redux.

## Related Issue

https://github.com/recharts/recharts/issues/4583

## Visual diff

This is the latest build: https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=1157
