### PR TITLE
Refresh axis stories

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -16,8 +16,6 @@ import { selectAxisScale, selectNiceTicks } from '../state/selectors/axisSelecto
 interface XAxisProps extends BaseAxisProps {
   /** The unique id of x-axis */
   xAxisId?: string | number;
-  /** The width of axis which is usually calculated internally */
-  width?: number;
   /** The height of axis, which need to be set by user */
   height?: number;
   mirror?: boolean;
@@ -125,7 +123,6 @@ export class XAxis extends Component<Props> {
     allowDecimals: true,
     hide: false,
     orientation: 'bottom',
-    width: 0,
     height: 30,
     mirror: false,
     xAxisId: 0,

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -17,8 +17,6 @@ interface YAxisProps extends BaseAxisProps {
   ticks?: ReadonlyArray<AxisTick>;
   /** The width of axis, which need to be set by user */
   width?: number;
-  /** The height of axis which is usually calculated in Chart */
-  height?: number;
   mirror?: boolean;
   /** The orientation of axis */
   orientation?: 'left' | 'right';
@@ -120,7 +118,6 @@ export class YAxis extends Component<Props> {
     hide: false,
     orientation: 'left',
     width: 60,
-    height: 0,
     mirror: false,
     yAxisId: 0,
     tickCount: 5,

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -678,7 +678,7 @@ export type AxisPropsNeededForTicksGenerator = {
   /**
    * The range appears to be only used in Angle Axis - needs further investigation
    */
-  range?: Array<number>;
+  range?: ReadonlyArray<number>;
   tickCount?: number;
 };
 

--- a/storybook/stories/API/cartesian/XAxis.stories.tsx
+++ b/storybook/stories/API/cartesian/XAxis.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from '../../../../src';
 import { coordinateWithValueData } from '../../data';
 import { XAxisProps } from '../props/XAxisProps';
+import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 
 export default {
   component: XAxis,
@@ -24,12 +25,14 @@ export const API = {
     );
   },
   args: {
+    ...getStoryArgsFromArgsTypesObject(XAxisProps),
     dataKey: 'x',
     domain: [100, 500],
     type: 'number',
     allowDataOverflow: true,
     tickMargin: 20,
     angle: 45,
-    label: { value: 'The Axis Label', position: 'insideBottomRight', offset: 0 },
+    height: 70,
+    label: { value: 'The Axis Label', position: 'insideBottomRight' },
   },
 };

--- a/storybook/stories/API/cartesian/YAxis.stories.tsx
+++ b/storybook/stories/API/cartesian/YAxis.stories.tsx
@@ -1,30 +1,12 @@
 import React from 'react';
-import { Args } from '@storybook/react';
 import { YAxis, XAxis, Line, ResponsiveContainer, LineChart, CartesianGrid, Tooltip, Legend } from '../../../../src';
 import { coordinateWithValueData } from '../../data';
+import { YAxisProps } from '../props/YAxisProps';
+import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 
-const GeneralProps: Args = {
-  yAxisId: {
-    description: 'The id of y-axis which is corresponding to the data.',
-    table: { type: { summary: 'string | number' }, category: 'General' },
-  },
-  unit: {
-    description: 'The unit of data displayed in the axis.',
-    table: { type: { summary: 'string | number' }, category: 'General' },
-  },
-  scale: {
-    table: { type: { summary: 'ScaleType | Function' }, category: 'General' },
-  },
-  domain: {
-    description: 'The domain of scale in this axis.',
-    table: { type: { summary: 'AxisDomain' }, category: 'General' },
-  },
-};
 export default {
   component: YAxis,
-  argTypes: {
-    ...GeneralProps,
-  },
+  argTypes: YAxisProps,
 };
 
 export const API = {
@@ -43,12 +25,14 @@ export const API = {
     );
   },
   args: {
+    ...getStoryArgsFromArgsTypesObject(YAxisProps),
     dataKey: 'pv',
     domain: [0, 300],
     type: 'number',
     allowDataOverflow: true,
     tickMargin: 20,
     angle: 45,
-    label: { value: 'The Axis Label', position: 'insideBottomRight', offset: 0 },
+    width: 120,
+    label: { value: 'The Axis Label', position: 'center', angle: 90 },
   },
 };

--- a/storybook/stories/API/props/SharedAxisProps.ts
+++ b/storybook/stories/API/props/SharedAxisProps.ts
@@ -1,14 +1,24 @@
-import { Args } from '@storybook/react';
+import { StorybookArgs } from '../../../StorybookArgs';
 
-export const XAxisProps: Args = {
+export const sharedAxisProps: StorybookArgs = {
   hide: {
     description: 'If set true, the axis do not display in the chart.',
     table: {
       type: {
-        summary: 'Boolean',
-        defaultValue: false,
+        summary: 'boolean',
       },
+      defaultValue: false,
       category: 'General',
+    },
+  },
+  includeHidden: {
+    description: 'Consider hidden graphical elements when computing domain.',
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: false,
+      category: 'Domain',
     },
   },
   dataKey: {
@@ -20,64 +30,14 @@ export const XAxisProps: Args = {
       category: 'General',
     },
   },
-  xAxisId: {
-    description: 'The unique id of x-axis.',
-    table: {
-      type: {
-        summary: 'String | Number',
-        defaultValue: 0,
-      },
-      category: 'General',
-    },
-  },
-  width: {
-    description: 'The width of axis which is usually calculated internally.',
-    table: {
-      type: {
-        summary: 'Number',
-        defaultValue: 0,
-      },
-      category: 'General',
-    },
-  },
-  height: {
-    description: 'The height of axis, which can be setted by user.',
-    table: {
-      type: {
-        summary: 'Number',
-        defaultValue: 30,
-      },
-      category: 'General',
-    },
-  },
-  orientation: {
-    description: 'The orientation of axis',
-    table: {
-      type: {
-        summary: "'bottom' , 'top'",
-        defaultValue: 'bottom',
-      },
-      category: 'General',
-    },
-  },
-  type: {
-    description: 'The type of axis.',
-    table: {
-      type: {
-        summary: "'number' | 'category'",
-        defaultValue: 'category',
-      },
-      category: 'General',
-    },
-  },
   allowDecimals: {
-    description: 'Allow the ticks of XAxis to be decimals or not.',
+    description: 'Allow the ticks to be decimals or not.',
     table: {
       type: {
         summary: 'Boolean',
-        defaultValue: true,
       },
-      category: 'General',
+      defaultValue: true,
+      category: 'Ticks',
     },
   },
   allowDataOverflow: {
@@ -91,7 +51,7 @@ export const XAxisProps: Args = {
         summary: 'boolean',
       },
       defaultValue: false,
-      category: 'General',
+      category: 'Domain',
     },
   },
   allowDuplicatedCategory: {
@@ -101,7 +61,7 @@ export const XAxisProps: Args = {
         summary: 'boolean',
       },
       defaultValue: true,
-      category: 'General',
+      category: 'Domain',
     },
   },
   angle: {
@@ -109,9 +69,9 @@ export const XAxisProps: Args = {
     table: {
       type: {
         summary: 'Number',
-        defaultValue: 0,
       },
-      category: 'General',
+      defaultValue: 0,
+      category: 'Ticks',
     },
   },
   tickCount: {
@@ -119,9 +79,9 @@ export const XAxisProps: Args = {
     table: {
       type: {
         summary: 'Number',
-        defaultValue: 5,
       },
-      category: 'General',
+      defaultValue: 5,
+      category: 'Ticks',
     },
   },
   domain: {
@@ -135,9 +95,9 @@ export const XAxisProps: Args = {
     table: {
       type: {
         summary: 'Array | Function',
-        defaultValue: [0, 'auto'],
       },
-      category: 'General',
+      defaultValue: [0, 'auto'],
+      category: 'Domain',
     },
   },
   interval: {
@@ -146,19 +106,9 @@ export const XAxisProps: Args = {
     table: {
       type: {
         summary: '"preserveStart" | "preserveEnd" | "preserveStartEnd" | Number',
-        defaultValue: 'preserveEnd',
       },
-      category: 'General',
-    },
-  },
-  padding: {
-    description: 'Specify the padding of x-axis.',
-    table: {
-      type: {
-        summary: 'Object | "gap" | "no-gap"',
-        defaultValue: { left: 0, right: 0 },
-      },
-      category: 'General',
+      defaultValue: 'preserveEnd',
+      category: 'Ticks',
     },
   },
   minTickGap: {
@@ -166,9 +116,9 @@ export const XAxisProps: Args = {
     table: {
       type: {
         summary: 'Number',
-        defaultValue: 5,
       },
-      category: 'General',
+      defaultValue: 5,
+      category: 'Ticks',
     },
   },
   axisLine: {
@@ -177,8 +127,8 @@ export const XAxisProps: Args = {
     table: {
       type: {
         summary: 'Boolean | Object',
-        defaultValue: true,
       },
+      defaultValue: true,
       category: 'General',
     },
   },
@@ -188,9 +138,9 @@ export const XAxisProps: Args = {
     table: {
       type: {
         summary: 'Boolean | Object',
-        defaultValue: true,
       },
-      category: 'General',
+      defaultValue: true,
+      category: 'Ticks',
     },
   },
   tickSize: {
@@ -198,9 +148,9 @@ export const XAxisProps: Args = {
     table: {
       type: {
         summary: 'Number',
-        defaultValue: 6,
       },
-      category: 'General',
+      defaultValue: 6,
+      category: 'Ticks',
     },
   },
   tickFormatter: {
@@ -209,7 +159,7 @@ export const XAxisProps: Args = {
       type: {
         summary: 'Function',
       },
-      category: 'General',
+      category: 'Ticks',
     },
   },
   ticks: {
@@ -218,7 +168,7 @@ export const XAxisProps: Args = {
       type: {
         summary: 'Array',
       },
-      category: 'General',
+      category: 'Ticks',
     },
   },
   tick: {
@@ -228,27 +178,27 @@ export const XAxisProps: Args = {
       type: {
         summary: 'Boolean | Object | ReactElement',
       },
-      category: 'General',
+      category: 'Ticks',
     },
   },
   mirror: {
     description:
-      'If set true, flips ticks around the axis line, displaying the labels inside the chart instead of outside.',
+      'If set true, flips ticks around the horizontal axis line, displaying the labels inside the chart instead of outside.',
     table: {
       type: {
         summary: 'Boolean',
-        defaultValue: false,
       },
+      defaultValue: false,
       category: 'General',
     },
   },
   reversed: {
-    description: 'Reverse the ticks or not.',
+    description: 'Reverses ticks left-to-right.',
     table: {
       type: {
         summary: 'Boolean',
-        defaultValue: false,
       },
+      defaultValue: false,
       category: 'General',
     },
   },
@@ -270,8 +220,8 @@ export const XAxisProps: Args = {
       type: {
         summary: `'auto' | 'linear' | 'pow' | 'sqrt' | 'log' | 'identity' | 'time' |
           'band' | 'point' | 'ordinal' | 'quantile' | 'quantize' | 'utc' | 'sequential' | 'threshold' | Function`,
-        defaultValue: 'auto',
       },
+      defaultValue: 'auto',
       category: 'General',
     },
   },

--- a/storybook/stories/API/props/XAxisProps.ts
+++ b/storybook/stories/API/props/XAxisProps.ts
@@ -1,0 +1,85 @@
+import { StorybookArgs } from '../../../StorybookArgs';
+import { sharedAxisProps } from './SharedAxisProps';
+
+export const XAxisProps: StorybookArgs = {
+  ...sharedAxisProps,
+  hide: {
+    description: 'If set true, the axis do not display in the chart.',
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: false,
+      category: 'General',
+    },
+  },
+  includeHidden: {
+    description: 'Consider hidden graphical elements when computing domain.',
+    table: {
+      type: {
+        summary: 'boolean',
+      },
+      defaultValue: false,
+      category: 'Domain',
+    },
+  },
+  dataKey: {
+    description: 'The key of data displayed in the axis.',
+    table: {
+      type: {
+        summary: 'String | Number | Function',
+      },
+      category: 'General',
+    },
+  },
+  xAxisId: {
+    description: 'The unique id of x-axis.',
+    table: {
+      type: {
+        summary: 'String | Number',
+      },
+      defaultValue: 0,
+      category: 'General',
+    },
+  },
+  height: {
+    description: 'The height of axis element in pixels.',
+    table: {
+      type: {
+        summary: 'Number',
+      },
+      defaultValue: 30,
+      category: 'Layout',
+    },
+  },
+  orientation: {
+    description: 'The orientation of axis',
+    table: {
+      type: {
+        summary: "'bottom' , 'top'",
+      },
+      defaultValue: 'bottom',
+      category: 'Layout',
+    },
+  },
+  type: {
+    description: 'The type of axis.',
+    table: {
+      type: {
+        summary: "'number' | 'category'",
+      },
+      defaultValue: 'category',
+      category: 'General',
+    },
+  },
+  padding: {
+    description: 'Specify the padding of x-axis.',
+    table: {
+      type: {
+        summary: 'Object | "gap" | "no-gap"',
+      },
+      defaultValue: { left: 0, right: 0 },
+      category: 'Ticks',
+    },
+  },
+};

--- a/storybook/stories/API/props/YAxisProps.ts
+++ b/storybook/stories/API/props/YAxisProps.ts
@@ -1,0 +1,56 @@
+import { StorybookArgs } from '../../../StorybookArgs';
+import { sharedAxisProps } from './SharedAxisProps';
+
+export const YAxisProps: StorybookArgs = {
+  ...sharedAxisProps,
+  xAxisId: {
+    description: 'The unique id of x-axis.',
+    table: {
+      type: {
+        summary: 'String | Number',
+      },
+      defaultValue: 0,
+      category: 'General',
+    },
+  },
+  width: {
+    description: 'The width of axis element in pixels.',
+    table: {
+      type: {
+        summary: 'Number',
+      },
+      defaultValue: 60,
+      category: 'Layout',
+    },
+  },
+  orientation: {
+    description: 'The orientation of axis',
+    table: {
+      type: {
+        summary: "'left' , 'right'",
+      },
+      defaultValue: 'left',
+      category: 'Layout',
+    },
+  },
+  type: {
+    description: 'The type of axis.',
+    table: {
+      type: {
+        summary: "'number' | 'category'",
+      },
+      defaultValue: 'number',
+      category: 'General',
+    },
+  },
+  padding: {
+    description: 'Specify the padding of x-axis.',
+    table: {
+      type: {
+        summary: '{ top: number, bottom: number }',
+      },
+      defaultValue: { top: 0, bottom: 0 },
+      category: 'Ticks',
+    },
+  },
+};


### PR DESCRIPTION
## Description

- Remove props that do nothing
- Update positions so that label no longer covers ticks
- Fix default values and storybook controls

## Related Issue

https://github.com/recharts/recharts/issues/4583

## Motivation and Context

There will be some visual diff, I want it to be in its own PR so we can tell it wasn't caused by the other changes.

## Screenshots (if appropriate):

<img width="673" alt="image" src="https://github.com/user-attachments/assets/1938a928-037a-4584-b6a2-abfbc11c9588">

<img width="404" alt="image" src="https://github.com/user-attachments/assets/bf16a0e9-4fe8-4fa6-910b-8b39782976ac">
