### PR TITLE
refactor: move funnel tooltip coordinate and index to redux

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -127,8 +127,8 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    dispatch(setTooltipSettingsState({ shared }));
-  }, [dispatch, shared]);
+    dispatch(setTooltipSettingsState({ shared, trigger }));
+  }, [dispatch, shared, trigger]);
 
   const viewBox = useViewBox();
   const accessibilityLayer = useAccessibilityLayer();

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -53,7 +53,13 @@ export const useMouseEnterItemDispatch = <T extends TooltipPayloadType>(
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseEnterFromProps?.(data, index, event);
     onMouseEnterFromContext?.(data, index, event);
-    dispatch(setActiveMouseOverItemIndex({ activeIndex: String(index), activeDataKey: dataKey }));
+    dispatch(
+      setActiveMouseOverItemIndex({
+        activeIndex: String(index),
+        activeDataKey: dataKey,
+        activeMouseOverCoordinate: data.tooltipPosition,
+      }),
+    );
   };
 };
 
@@ -78,6 +84,12 @@ export const useMouseClickItemDispatch = <T extends TooltipPayloadType>(
   return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
     onMouseClickFromProps?.(data, index, event);
     onMouseClickFromContext?.(data, index, event);
-    dispatch(setActiveClickItemIndex({ activeIndex: String(index), activeDataKey: dataKey }));
+    dispatch(
+      setActiveClickItemIndex({
+        activeIndex: String(index),
+        activeDataKey: dataKey,
+        activeClickCoordinate: data.tooltipPosition,
+      }),
+    );
   };
 };

--- a/src/numberAxis/Funnel.tsx
+++ b/src/numberAxis/Funnel.tsx
@@ -10,6 +10,8 @@ import omit from 'lodash/omit';
 import isEqual from 'lodash/isEqual';
 
 import clsx from 'clsx';
+import { selectActiveIndex } from '../state/selectors/selectors';
+import { useAppSelector } from '../state/hooks';
 import { Layer } from '../container/Layer';
 import { Props as TrapezoidProps } from '../shape/Trapezoid';
 import { LabelList } from '../component/LabelList';
@@ -34,7 +36,6 @@ import {
   useMouseClickItemDispatch,
   useMouseEnterItemDispatch,
   useMouseLeaveItemDispatch,
-  useTooltipContext,
 } from '../context/tooltipContext';
 import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
@@ -115,7 +116,9 @@ function getTooltipEntrySettings(props: FunnelProps): TooltipPayloadConfiguratio
 
 function FunnelTrapezoids(props: FunnelTrapezoidsProps) {
   const { trapezoids, shape, activeShape, allOtherFunnelProps } = props;
-  const { index: activeIndex } = useTooltipContext();
+  const activeItemIndex = useAppSelector(state =>
+    selectActiveIndex(state, 'item', state.tooltip.settings.trigger, undefined),
+  );
   const {
     onMouseEnter: onMouseEnterFromProps,
     onClick: onItemClickFromProps,
@@ -128,7 +131,7 @@ function FunnelTrapezoids(props: FunnelTrapezoidsProps) {
   const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps, allOtherFunnelProps.dataKey);
 
   return trapezoids.map((entry, i) => {
-    const isActiveIndex = activeShape && activeIndex === i;
+    const isActiveIndex = activeShape && activeItemIndex === String(i);
     const trapezoidOptions = isActiveIndex ? activeShape : shape;
     const trapezoidProps: FunnelTrapezoidProps = {
       ...entry,

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, current, PayloadAction } from '@reduxjs/toolkit';
+import { TooltipTrigger } from '../chart/types';
 import { NameType, Payload, ValueType } from '../component/DefaultTooltipContent';
 import { ChartCoordinate, DataKey } from '../util/types';
 
@@ -57,7 +58,7 @@ export type ActiveTooltipProps = {
   activeCoordinate: ChartCoordinate | undefined;
 };
 
-type TooltipSettingsState = { shared?: boolean };
+type TooltipSettingsState = { shared?: boolean; trigger?: TooltipTrigger };
 
 /**
  * The tooltip interaction state stores:
@@ -176,7 +177,7 @@ export const initialState: TooltipState = {
     activeClickAxisDataKey: undefined,
   },
   tooltipItemPayloads: [],
-  settings: {},
+  settings: { shared: false, trigger: 'hover' },
 };
 
 const tooltipSlice = createSlice({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Small one moving the rest of Funnel state to redux (coordinate)

Wheras previously the tooltip did not "fly in" every time we go out of the chart, now it does. Might want to address that but I think its just because we clear state after mouse out. Can address later if needed.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4549

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
https://github.com/recharts/recharts/issues/4549

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- tests pass
- no storybook diff
- if I remove context fallback I can both click and hover to make tooltip work as normal



## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/0cc4cdc9-3374-41e0-a5af-57036878a75b)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
