### PR TITLE
fix: do not clear coordinate on item or chart leave

### DIFF
--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -210,17 +210,16 @@ const tooltipSlice = createSlice({
       state.itemInteraction.activeMouseOverCoordinate = action.payload.activeMouseOverCoordinate;
     },
     mouseLeaveChart(state) {
+      // clear everything except for coordinate - we don't always want to animate from 0,0
       state.itemInteraction.activeHover = false;
-      state.itemInteraction.activeMouseOverCoordinate = null;
       state.itemInteraction.activeMouseOverIndex = null;
       state.axisInteraction.activeHover = false;
-      state.axisInteraction.activeMouseOverCoordinate = null;
       state.axisInteraction.activeMouseOverAxisDataKey = undefined;
       state.axisInteraction.activeMouseOverAxisIndex = null;
     },
     mouseLeaveItem(state) {
+      // clear everything except for coordinate - we don't always want to animate from 0,0
       state.itemInteraction.activeHover = false;
-      state.itemInteraction.activeMouseOverCoordinate = null;
       state.itemInteraction.activeMouseOverIndex = null;
       state.itemInteraction.activeMouseOverDataKey = undefined;
     },

--- a/test/state/selectors/selectors.spec.tsx
+++ b/test/state/selectors/selectors.spec.tsx
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react';
 import { Store } from '@reduxjs/toolkit';
 import {
   combineTooltipPayload,
+  selectActiveCoordinate,
   selectActiveIndex,
   selectActivePropsFromMousePointer,
   selectIsTooltipActive,
@@ -14,10 +15,11 @@ import {
 } from '../../../src/state/selectors/selectors';
 import { createRechartsStore, RechartsRootState } from '../../../src/state/store';
 import { RechartsStoreProvider } from '../../../src/state/RechartsStoreProvider';
-import { BaseAxisProps, TooltipEventType } from '../../../src/util/types';
+import { BaseAxisProps, ChartCoordinate, TooltipEventType } from '../../../src/util/types';
 import { useAppSelector } from '../../../src/state/hooks';
 import {
   addTooltipEntrySettings,
+  mouseLeaveChart,
   mouseLeaveItem,
   setActiveClickItemIndex,
   setActiveMouseOverItemIndex,
@@ -482,6 +484,109 @@ describe('selectActiveIndex', () => {
     });
     const expected: TooltipIndex = '7';
     expect(selectActiveIndex(state, 'axis', 'click', 17)).toBe(expected);
+  });
+});
+
+describe('selectActiveCoordinate', () => {
+  it('should return undefined for initial state', () => {
+    const initialState = createRechartsStore().getState();
+    const expected: ChartCoordinate = undefined;
+    expect(selectActiveCoordinate(initialState, 'axis', 'hover')).toBe(expected);
+    expect(selectActiveCoordinate(initialState, 'axis', 'click')).toBe(expected);
+    expect(selectActiveCoordinate(initialState, 'item', 'hover')).toBe(expected);
+    expect(selectActiveCoordinate(initialState, 'item', 'click')).toBe(expected);
+  });
+
+  it('should return coordinates when mouseOverAxisIndex is fired and keep them after mouseLeaveChart', () => {
+    const store = createRechartsStore(preloadedState);
+
+    const initialState = createRechartsStore().getState();
+    const expected: ChartCoordinate = { x: 100, y: 150 };
+    expect(selectActiveCoordinate(initialState, 'axis', 'hover')).toBe(undefined);
+
+    store.dispatch(
+      setMouseOverAxisIndex({
+        activeIndex: '1',
+        activeMouseOverCoordinate: expected,
+        activeDataKey: undefined,
+      }),
+    );
+
+    expect(selectActiveCoordinate(store.getState(), 'axis', 'hover')).toBe(expected);
+
+    store.dispatch(mouseLeaveChart());
+
+    expect(selectActiveCoordinate(store.getState(), 'axis', 'hover')).toBe(expected);
+  });
+
+  it('should return coordinates when mouseClickAxisIndex is fired and keep them after mouseLeaveChart', () => {
+    const store = createRechartsStore(preloadedState);
+
+    const initialState = createRechartsStore().getState();
+    const expected: ChartCoordinate = { x: 100, y: 150 };
+    expect(selectActiveCoordinate(initialState, 'axis', 'click')).toBe(undefined);
+
+    store.dispatch(
+      setMouseClickAxisIndex({
+        activeIndex: '1',
+        activeClickCoordinate: expected,
+        activeDataKey: undefined,
+      }),
+    );
+
+    expect(selectActiveCoordinate(store.getState(), 'axis', 'click')).toBe(expected);
+
+    store.dispatch(mouseLeaveChart());
+
+    expect(selectActiveCoordinate(store.getState(), 'axis', 'click')).toBe(expected);
+  });
+
+  it('should return coordinates when mouseOverItemIndex is fired and keep them after mouseLeaveItem', () => {
+    const store = createRechartsStore(preloadedState);
+
+    const initialState = createRechartsStore().getState();
+    const expected: ChartCoordinate = { x: 100, y: 150 };
+    expect(selectActiveCoordinate(initialState, 'item', 'hover')).toBe(undefined);
+
+    store.dispatch(
+      setActiveMouseOverItemIndex({
+        activeIndex: '1',
+        activeMouseOverCoordinate: expected,
+        activeDataKey: undefined,
+      }),
+    );
+
+    expect(selectActiveCoordinate(store.getState(), 'item', 'hover')).toBe(expected);
+
+    // neither of these should reset coordinate
+    store.dispatch(mouseLeaveItem());
+    store.dispatch(mouseLeaveChart());
+
+    expect(selectActiveCoordinate(store.getState(), 'item', 'hover')).toBe(expected);
+  });
+
+  it('should return coordinates when mouseClickItemIndex is fired and keep them after mouseLeaveItem', () => {
+    const store = createRechartsStore(preloadedState);
+
+    const initialState = createRechartsStore().getState();
+    const expected: ChartCoordinate = { x: 100, y: 150 };
+    expect(selectActiveCoordinate(initialState, 'item', 'click')).toBe(undefined);
+
+    store.dispatch(
+      setActiveClickItemIndex({
+        activeIndex: '1',
+        activeClickCoordinate: expected,
+        activeDataKey: undefined,
+      }),
+    );
+
+    expect(selectActiveCoordinate(store.getState(), 'item', 'click')).toBe(expected);
+
+    // neither of these should reset coordinate
+    store.dispatch(mouseLeaveItem());
+    store.dispatch(mouseLeaveChart());
+
+    expect(selectActiveCoordinate(store.getState(), 'item', 'click')).toBe(expected);
   });
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
small fix for Redux tooltip animations

If we reset coordinate on every item and mouse out dispatch then we jarr the user when they hover again as the Tooltip always animates from the corner 0,0. This change keeps Tooltip animation the same as 2.x

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4549

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Animations be the same that they are in 2.x. Also less stuttering/flying in from 0,0

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- storybook

## Screenshots (if appropriate):
<img width="338" alt="image" src="https://github.com/user-attachments/assets/a9ec63e9-b8f9-4c91-8f5e-a82341c60226">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
