### PR TITLE
Fix Tooltip storybook default value

### DIFF
--- a/storybook/StorybookArgs.ts
+++ b/storybook/StorybookArgs.ts
@@ -18,7 +18,7 @@ export type StorybookArg = {
    */
   defaultValue?: unknown;
   control?: ControlType | { type: ControlType };
-  options?: string[];
+  options?: unknown[];
   /**
    * Specifies the semantic type of the argType.
    * When an argType is inferred, the information from the various tools is summarized in this property,

--- a/storybook/stories/API/component/Tooltip.stories.tsx
+++ b/storybook/stories/API/component/Tooltip.stories.tsx
@@ -8,7 +8,11 @@ const TooltipProps: StorybookArgs = {
   active: {
     description: `When set to true, the tooltip will remain visible, even after the user has moved off of the chart.
       Set \`defaultIndex\` if you want the tooltip to be visible by default, before first mouse enter.`,
-    defaultValue: false,
+    defaultValue: undefined,
+    options: [true, false, undefined],
+    control: {
+      type: 'inline-radio',
+    },
   },
   defaultIndex: {
     description: 'The index where the Tooltip should appear *before* the user has interacted with the chart.',


### PR DESCRIPTION
For a minute I was scared when I found that Tooltip storybook doesn't render tooltip. And then I realized that it has a defaultValue: false so I fixed that.