### PR TITLE
Getting Scatter ready to use hooks

### DIFF
--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -22,7 +22,6 @@ import {
   LegendType,
   AnimationTiming,
   D3Scale,
-  ChartOffset,
   DataKey,
   TickItem,
   adaptEventsOfChild,
@@ -49,6 +48,7 @@ import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 import { SetCartesianGraphicalItem } from '../state/SetCartesianGraphicalItem';
 import { CartesianGraphicalItemContext } from '../context/CartesianGraphicalItemContext';
 import { AxisSettings, ZAxisSettings } from '../state/axisMapSlice';
+import { ClipPath } from '../container/ClipPath';
 
 interface ScatterPointNode {
   x?: number | string;
@@ -114,7 +114,7 @@ interface State {
   prevAnimationId?: number;
 }
 
-type ScatterComposedData = ChartOffset & {
+type ScatterComposedData = {
   points: ReadonlyArray<ScatterPointItem>;
 };
 
@@ -368,7 +368,6 @@ export class Scatter extends PureComponent<Props, State> {
     displayedData,
     xAxisTicks,
     yAxisTicks,
-    offset,
   }: {
     props: Props;
     xAxis: Props['xAxis'];
@@ -379,7 +378,6 @@ export class Scatter extends PureComponent<Props, State> {
     item: Scatter;
     bandSize: number;
     displayedData: any[];
-    offset: ChartOffset;
   }): ScatterComposedData => {
     const cells = findAllByType(item.props.children, Cell);
     const points: ReadonlyArray<ScatterPointItem> = computeScatterPoints({
@@ -399,7 +397,6 @@ export class Scatter extends PureComponent<Props, State> {
 
     return {
       points,
-      ...offset,
     };
   };
 
@@ -565,7 +562,7 @@ export class Scatter extends PureComponent<Props, State> {
   }
 
   render() {
-    const { hide, points, line, className, xAxis, yAxis, left, top, width, height, id, isAnimationActive } = this.props;
+    const { hide, points, line, className, xAxis, yAxis, id, isAnimationActive } = this.props;
     if (hide || !points || !points.length) {
       return (
         <>
@@ -604,18 +601,7 @@ export class Scatter extends PureComponent<Props, State> {
         <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
           <SetScatterLegend {...this.props} />
           <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
-          {needClipX || needClipY ? (
-            <defs>
-              <clipPath id={`clipPath-${clipPathId}`}>
-                <rect
-                  x={needClipX ? left : left - width / 2}
-                  y={needClipY ? top : top - height / 2}
-                  width={needClipX ? width : width * 2}
-                  height={needClipY ? height : height * 2}
-                />
-              </clipPath>
-            </defs>
-          ) : null}
+          {needClipX || needClipY ? <ClipPath clipPathId={`clipPath-${clipPathId}`} /> : null}
           {line && this.renderLine()}
           {this.renderErrorBar()}
           <Layer key="recharts-scatter-symbols">{this.renderSymbols()}</Layer>

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -103,6 +103,8 @@ const XAxisSettingsDispatcher = (props: Props) => {
         orientation={props.orientation}
         mirror={props.mirror}
         hide={props.hide}
+        unit={props.unit}
+        name={props.name}
       />
       <XAxisImpl {...props} />
     </>

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -97,6 +97,8 @@ const YAxisSettingsDispatcher = (props: Props) => {
         orientation={props.orientation}
         mirror={props.mirror}
         hide={props.hide}
+        unit={props.unit}
+        name={props.name}
       />
       <YAxisImpl {...props} />
     </>

--- a/src/cartesian/ZAxis.tsx
+++ b/src/cartesian/ZAxis.tsx
@@ -1,15 +1,25 @@
-/**
- * @fileOverview Z Axis
- */
-import type { FunctionComponent } from 'react';
+import React, { Component, useEffect } from 'react';
 import { ScaleType, DataKey, AxisDomain } from '../util/types';
+import { addZAxis, removeZAxis, ZAxisSettings } from '../state/axisMapSlice';
+import { useAppDispatch } from '../state/hooks';
+
+function SetZAxisSettings(settings: ZAxisSettings): null {
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    dispatch(addZAxis(settings));
+    return () => {
+      dispatch(removeZAxis(settings));
+    };
+  }, [settings, dispatch]);
+  return null;
+}
 
 export interface Props {
   type?: 'number' | 'category';
   /** The name of data displayed in the axis */
-  name?: string | number;
+  name?: string;
   /** The unit of data displayed in the axis */
-  unit?: string | number;
+  unit?: string;
   /** The unique id of z-axis */
   zAxisId?: string | number;
   /** The key of data displayed in the axis */
@@ -21,12 +31,26 @@ export interface Props {
   domain?: AxisDomain;
 }
 
-export const ZAxis: FunctionComponent<Props> = () => null;
+// eslint-disable-next-line react/prefer-stateless-function
+export class ZAxis extends Component<Props> {
+  static displayName = 'ZAxis';
 
-ZAxis.displayName = 'ZAxis';
-ZAxis.defaultProps = {
-  zAxisId: 0,
-  range: [64, 64],
-  scale: 'auto',
-  type: 'number',
-};
+  static defaultProps = {
+    zAxisId: 0,
+    range: [64, 64],
+    scale: 'auto',
+    type: 'number',
+  };
+
+  render() {
+    return (
+      <SetZAxisSettings
+        id={this.props.zAxisId}
+        dataKey={this.props.dataKey}
+        name={this.props.name}
+        unit={this.props.unit}
+        range={this.props.range}
+      />
+    );
+  }
+}

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1814,6 +1814,7 @@ export const generateCategoricalChart = ({
       ReferenceDot: { handler: renderAsIs },
       XAxis: { handler: renderAsIs },
       YAxis: { handler: renderAsIs },
+      ZAxis: { handler: renderAsIs },
       Brush: { handler: renderAsIs },
       Bar: { handler: this.renderGraphicChild },
       Line: { handler: this.renderGraphicChild },

--- a/src/state/axisMapSlice.ts
+++ b/src/state/axisMapSlice.ts
@@ -56,6 +56,7 @@ export type YAxisSettings = AxisSettings & {
 };
 
 export type ZAxisSettings = {
+  id: AxisId;
   dataKey: AxisSettings['dataKey'];
   name: AxisSettings['name'];
   unit: AxisSettings['unit'];
@@ -94,9 +95,15 @@ const axisMapSlice = createSlice({
     removeYAxis(state, action: PayloadAction<YAxisSettings>) {
       delete state.yAxis[action.payload.id];
     },
+    addZAxis(state, action: PayloadAction<ZAxisSettings>) {
+      state.zAxis[action.payload.id] = castDraft(action.payload);
+    },
+    removeZAxis(state, action: PayloadAction<ZAxisSettings>) {
+      delete state.zAxis[action.payload.id];
+    },
   },
 });
 
-export const { addXAxis, removeXAxis, addYAxis, removeYAxis } = axisMapSlice.actions;
+export const { addXAxis, removeXAxis, addYAxis, removeYAxis, addZAxis, removeZAxis } = axisMapSlice.actions;
 
 export const axisMapReducer = axisMapSlice.reducer;

--- a/src/state/axisMapSlice.ts
+++ b/src/state/axisMapSlice.ts
@@ -39,6 +39,8 @@ export type AxisSettings = {
    */
   ticks: ReadonlyArray<AxisTick> | undefined;
   hide: boolean;
+  unit: string | undefined;
+  name: string | undefined;
 };
 
 export type XAxisSettings = AxisSettings & {
@@ -53,7 +55,12 @@ export type YAxisSettings = AxisSettings & {
   orientation: YAxisOrientation;
 };
 
-export type ZAxisSettings = AxisSettings;
+export type ZAxisSettings = {
+  dataKey: AxisSettings['dataKey'];
+  name: AxisSettings['name'];
+  unit: AxisSettings['unit'];
+  range: number[];
+};
 
 type AxisMapState = {
   xAxis: Record<AxisId, XAxisSettings>;

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -33,6 +33,7 @@ import {
   XAxisSettings,
   YAxisOrientation,
   YAxisSettings,
+  ZAxisSettings,
 } from '../axisMapSlice';
 import { selectBarCategoryGap, selectChartName, selectStackOffsetType } from './selectors';
 import { RechartsRootState } from '../store';
@@ -124,6 +125,18 @@ export const selectYAxisSettings = (state: RechartsRootState, axisId: AxisId): Y
   return axis;
 };
 
+export const selectZAxisSettings = (state: RechartsRootState, axisId: AxisId): ZAxisSettings => {
+  // there is no implicit Z axis - so here we return null.
+  return state.axisMap.zAxis[axisId];
+};
+
+/**
+ * Selects either an X or Y axis. Doesn't work with Z axis - for that, instead use selectZAxisSettings
+ * @param state Root state
+ * @param axisType xAxis | yAxis
+ * @param axisId xAxisId | yAxisId
+ * @returns axis settings object
+ */
 export const selectAxisSettings = (state: RechartsRootState, axisType: AxisType, axisId: AxisId): AxisSettings => {
   switch (axisType) {
     case 'xAxis': {
@@ -133,7 +146,7 @@ export const selectAxisSettings = (state: RechartsRootState, axisType: AxisType,
       return selectYAxisSettings(state, axisId);
     }
     default:
-      throw new Error('Not implemented yet, TODO add!');
+      throw new Error(`Unexpected axis type: ${axisType}`);
   }
 };
 

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -70,6 +70,7 @@ export const implicitXAxis: XAxisSettings = {
   id: undefined,
   includeHidden: false,
   mirror: false,
+  name: undefined,
   orientation: 'bottom',
   padding: { left: 0, right: 0 },
   reversed: false,
@@ -77,6 +78,7 @@ export const implicitXAxis: XAxisSettings = {
   tickCount: 5,
   ticks: undefined,
   type: 'category',
+  unit: undefined,
 };
 
 export const selectXAxisSettings = (state: RechartsRootState, axisId: AxisId): XAxisSettings => {
@@ -102,6 +104,7 @@ export const implicitYAxis: YAxisSettings = {
   id: undefined,
   includeHidden: false,
   mirror: false,
+  name: undefined,
   orientation: 'left',
   padding: { top: 0, bottom: 0 },
   reversed: false,
@@ -109,6 +112,7 @@ export const implicitYAxis: YAxisSettings = {
   tickCount: 5,
   ticks: undefined,
   type: 'number',
+  unit: undefined,
   width: 60,
 };
 

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1158,7 +1158,7 @@ export interface BaseAxisProps {
   /** The name of data displayed in the axis */
   name?: string;
   /** The unit of data displayed in the axis */
-  unit?: string | number;
+  unit?: string;
   range?: Array<number>;
   /** axis react component */
   AxisComp?: any;

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -1286,6 +1286,8 @@ describe('<XAxis />', () => {
             height={31}
             orientation="top"
             mirror
+            name="axis name"
+            unit="axis unit"
           />
           <Customized component={Comp} />
         </BarChart>,
@@ -1293,6 +1295,8 @@ describe('<XAxis />', () => {
       expect(container.querySelector('.xAxis')).toBeVisible();
       expect(spy).toHaveBeenCalledTimes(3);
       const expectedSettings: XAxisSettings = {
+        name: 'axis name',
+        unit: 'axis unit',
         hide: false,
         mirror: true,
         orientation: 'top',
@@ -1332,6 +1336,8 @@ describe('<XAxis />', () => {
         </BarChart>,
       );
       const expectedSettings1: XAxisSettings = {
+        name: undefined,
+        unit: undefined,
         hide: false,
         mirror: false,
         height: 30,
@@ -1369,6 +1375,8 @@ describe('<XAxis />', () => {
         foo: XAxisSettings;
       } = {
         foo: {
+          name: undefined,
+          unit: undefined,
           hide: false,
           mirror: false,
           orientation: 'bottom',
@@ -1391,6 +1399,8 @@ describe('<XAxis />', () => {
           reversed: false,
         },
         bar: {
+          name: undefined,
+          unit: undefined,
           hide: false,
           mirror: false,
           orientation: 'bottom',
@@ -1422,6 +1432,8 @@ describe('<XAxis />', () => {
       );
 
       const expectedSettings3: XAxisSettings = {
+        name: undefined,
+        unit: undefined,
         hide: false,
         mirror: false,
         orientation: 'bottom',
@@ -3952,6 +3964,8 @@ describe('<XAxis />', () => {
         },
       ]);
       const expectedSettings: XAxisSettings = {
+        name: undefined,
+        unit: undefined,
         hide: false,
         mirror: false,
         orientation: 'bottom',

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -882,6 +882,8 @@ describe('<YAxis />', () => {
             width={32}
             orientation="right"
             mirror
+            name="axis name"
+            unit="axis unit"
           />
           <Customized component={Comp} />
         </BarChart>,
@@ -889,6 +891,8 @@ describe('<YAxis />', () => {
       expect(container.querySelector('.yAxis')).toBeVisible();
       expect(spy).toHaveBeenCalledTimes(3);
       const expectedSettings: YAxisSettings = {
+        name: 'axis name',
+        unit: 'axis unit',
         hide: false,
         orientation: 'right',
         mirror: true,
@@ -928,6 +932,8 @@ describe('<YAxis />', () => {
         </BarChart>,
       );
       const expectedSettings1: YAxisSettings = {
+        name: undefined,
+        unit: undefined,
         orientation: 'left',
         mirror: false,
         width: 60,
@@ -965,6 +971,8 @@ describe('<YAxis />', () => {
         foo: YAxisSettings;
       } = {
         foo: {
+          name: undefined,
+          unit: undefined,
           hide: false,
           orientation: 'left',
           mirror: false,
@@ -987,6 +995,8 @@ describe('<YAxis />', () => {
           ticks: undefined,
         },
         bar: {
+          name: undefined,
+          unit: undefined,
           hide: false,
           orientation: 'left',
           mirror: false,
@@ -1018,6 +1028,8 @@ describe('<YAxis />', () => {
       );
 
       const expectedSettings3: YAxisSettings = {
+        name: undefined,
+        unit: undefined,
         hide: false,
         mirror: false,
         orientation: 'left',

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -149,7 +149,7 @@ describe('ScatterChart of two dimension data', () => {
     expect(container.querySelectorAll('.recharts-symbols')).toHaveLength(6);
   });
 
-  test('renders 1 jointed line when line is setted to be true', () => {
+  test('renders line when line prop=true', () => {
     const { container } = render(
       <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
         <XAxis dataKey="x" name="stature" unit="cm" />
@@ -158,7 +158,15 @@ describe('ScatterChart of two dimension data', () => {
       </ScatterChart>,
     );
 
-    expect(container.querySelectorAll('.recharts-scatter-line')).toHaveLength(1);
+    const allLines = container.querySelectorAll('.recharts-scatter-line path');
+    expect(allLines).toHaveLength(1);
+    const line = allLines[0];
+    expect(line.getAttributeNames()).toEqual(['name', 'fill', 'stroke', 'class', 'd']);
+    expect(line.getAttribute('name')).toEqual('A school');
+    expect(line.getAttribute('fill')).toEqual('none');
+    expect(line.getAttribute('stroke')).toEqual('#ff7300');
+    expect(line.getAttribute('class')).toEqual('recharts-curve');
+    expect(line.getAttribute('d')).toEqual('M105,185L155,267.5L205,102.5L255,143.75L305,20L355,119');
   });
 
   test('Renders customized active shape when activeShape set to be an object', () => {

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -54,6 +54,27 @@ describe('ScatterChart of three dimension data', () => {
     expect(container.querySelectorAll('.recharts-scatter-symbol path')).toHaveLength(data01.length + data02.length);
   });
 
+  it('should render clipPath if one of axes has allowDataOverflow=true', () => {
+    const { container } = render(
+      <ScatterChart width={400} height={400} margin={{ top: 10, right: 20, bottom: 30, left: 40 }}>
+        <XAxis dataKey="x" name="stature" unit="cm" allowDataOverflow />
+        <YAxis dataKey="y" name="weight" unit="kg" allowDataOverflow />
+        <ZAxis dataKey="z" range={[4, 20]} name="score" unit="km" />
+        <CartesianGrid />
+        <Scatter name="A school" data={[]} fillOpacity={0.3} fill="#ff7300" />
+        <Tooltip />
+        <Legend layout="vertical" />
+      </ScatterChart>,
+    );
+
+    const clipPath = container.querySelector('clipPath rect');
+    expect(clipPath.getAttributeNames().sort()).toEqual(['height', 'width', 'x', 'y']);
+    expect(clipPath).toHaveAttribute('width', '280');
+    expect(clipPath).toHaveAttribute('height', '330');
+    expect(clipPath).toHaveAttribute('x', '100');
+    expect(clipPath).toHaveAttribute('y', '10');
+  });
+
   test("Don't render any symbols when data is empty", () => {
     const { container } = render(
       <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>


### PR DESCRIPTION
## Description

Scatter is now ready to use hooks instead of relying on props from getComposedData. The actual hooks will come in next PR.

## Related Issue

https://github.com/recharts/recharts/pull/4791
