### PR TITLE
Error bars read axis config from redux

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -18,6 +18,7 @@
   "es6/util/isWellBehavedNumber.js",
   "es6/util/isDomainSpecifiedByUser.js",
   "es6/util/getEveryNthWithCondition.js",
+  "es6/util/getDomainOfErrorBars.js",
   "es6/util/cursor",
   "es6/util/calculateViewBox.js",
   "es6/util/TickUtils.js",

--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -5,6 +5,7 @@
   "es6/polar",
   "es6/numberAxis",
   "es6/index.js",
+  "es6/hooks.js",
   "es6/context",
   "es6/container",
   "es6/component",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -5,6 +5,7 @@
   "lib/polar",
   "lib/numberAxis",
   "lib/index.js",
+  "lib/hooks.js",
   "lib/context",
   "lib/container",
   "lib/component",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -18,6 +18,7 @@
   "lib/util/isWellBehavedNumber.js",
   "lib/util/isDomainSpecifiedByUser.js",
   "lib/util/getEveryNthWithCondition.js",
+  "lib/util/getDomainOfErrorBars.js",
   "lib/util/cursor",
   "lib/util/calculateViewBox.js",
   "lib/util/TickUtils.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -5,6 +5,7 @@
   "types/polar",
   "types/numberAxis",
   "types/index.d.ts",
+  "types/hooks.d.ts",
   "types/context",
   "types/container",
   "types/component",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -18,6 +18,7 @@
   "types/util/isWellBehavedNumber.d.ts",
   "types/util/isDomainSpecifiedByUser.d.ts",
   "types/util/getEveryNthWithCondition.d.ts",
+  "types/util/getDomainOfErrorBars.d.ts",
   "types/util/cursor",
   "types/util/calculateViewBox.d.ts",
   "types/util/TickUtils.d.ts",

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -583,7 +583,7 @@ export class Bar extends PureComponent<Props, State> {
       return null;
     }
 
-    const { data, xAxis, yAxis, layout, children } = this.props;
+    const { data, xAxisId, yAxisId, layout, children } = this.props;
     const errorBarItems = findAllByType(children, ErrorBar);
 
     if (!errorBarItems) {
@@ -617,8 +617,8 @@ export class Bar extends PureComponent<Props, State> {
           React.cloneElement(item, {
             key: `error-bar-${clipPathId}-${item.props.dataKey}`,
             data,
-            xAxis,
-            yAxis,
+            xAxisId,
+            yAxisId,
             layout,
             offset,
             dataPointFormatter,

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -342,7 +342,7 @@ export class Line extends PureComponent<Props, State> {
       return null;
     }
 
-    const { points, xAxis, yAxis, layout, children } = this.props;
+    const { points, xAxisId, yAxisId, layout, children } = this.props;
     const errorBarItems = findAllByType(children, ErrorBar);
 
     if (!errorBarItems) {
@@ -369,8 +369,8 @@ export class Line extends PureComponent<Props, State> {
           React.cloneElement(item, {
             key: `bar-${item.props.dataKey}`,
             data: points,
-            xAxis,
-            yAxis,
+            xAxisId,
+            yAxisId,
             layout,
             dataPointFormatter,
           }),

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -11,29 +11,26 @@ import isFunction from 'lodash/isFunction';
 import clsx from 'clsx';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelListType, LabelList } from '../component/LabelList';
-import { findAllByType, filterProps } from '../util/ReactUtils';
+import { filterProps, findAllByType } from '../util/ReactUtils';
 import { Global } from '../util/Global';
-import { ZAxis, Props as ZAxisProps } from './ZAxis';
-import { Curve, Props as CurveProps, CurveType } from '../shape/Curve';
+import { ZAxis } from './ZAxis';
+import { Curve, CurveType, Props as CurveProps } from '../shape/Curve';
 import { ErrorBar, Props as ErrorBarProps } from './ErrorBar';
 import { Cell } from '../component/Cell';
-import { uniqueId, interpolateNumber, getLinearRegression } from '../util/DataUtils';
-import { getValueByDataKey, getCateCoordinateOfLine, getTooltipNameProp, RechartsScale } from '../util/ChartUtils';
+import { getLinearRegression, interpolateNumber, uniqueId } from '../util/DataUtils';
+import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey, RechartsScale } from '../util/ChartUtils';
 import {
-  LegendType,
-  AnimationTiming,
-  D3Scale,
-  DataKey,
-  TickItem,
-  adaptEventsOfChild,
-  PresentationAttributesAdaptChildEvent,
-  AnimationDuration,
   ActiveShape,
+  adaptEventsOfChild,
+  AnimationDuration,
+  AnimationTiming,
+  DataKey,
+  LegendType,
+  PresentationAttributesAdaptChildEvent,
   SymbolType,
+  TickItem,
 } from '../util/types';
 import { TooltipType } from '../component/DefaultTooltipContent';
-import { Props as XAxisProps } from './XAxis';
-import { Props as YAxisProps } from './YAxis';
 import { ScatterSymbol } from '../util/ScatterUtils';
 import { InnerSymbolsProp } from '../shape/Symbols';
 import type { Payload as LegendPayload } from '../component/DefaultLegendContent';
@@ -74,9 +71,9 @@ interface ScatterInternalProps {
   yAxisId?: string | number;
   zAxisId?: string | number;
 
-  xAxis?: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> };
-  yAxis?: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> };
-  zAxis?: Omit<ZAxisProps, 'scale'> & { scale: D3Scale<string | number> };
+  xAxis?: AxisWithScale;
+  yAxis?: AxisWithScale;
+  zAxis?: ZAxisSettings;
 
   dataKey?: DataKey<any>;
 
@@ -404,7 +401,7 @@ function ScatterLine(props: InternalProps) {
 }
 
 function ScatterErrorBars(props: InternalProps & { isAnimationFinished: boolean }) {
-  const { points, xAxis, yAxis, children, isAnimationActive, isAnimationFinished } = props;
+  const { points, xAxisId, yAxisId, children, isAnimationActive, isAnimationFinished } = props;
   if (isAnimationActive && !isAnimationFinished) {
     return null;
   }
@@ -419,8 +416,8 @@ function ScatterErrorBars(props: InternalProps & { isAnimationFinished: boolean 
     return React.cloneElement(item, {
       key: `${direction}-${errorDataKey}-${points[i]}`,
       data: points,
-      xAxis,
-      yAxis,
+      xAxisId,
+      yAxisId,
       layout: direction === 'x' ? 'vertical' : 'horizontal',
       // @ts-expect-error getValueByDataKey does not validate the output type
       dataPointFormatter: (dataPoint: ScatterPointItem, dataKey: Props['dataKey']) => {
@@ -630,11 +627,8 @@ export class Scatter extends Component<InternalProps> {
     const cells = findAllByType(item.props.children, Cell);
     const points: ReadonlyArray<ScatterPointItem> = computeScatterPoints({
       displayedData,
-      // @ts-expect-error getComposedData types are not matching, TODO switch this to redux
       xAxis,
-      // @ts-expect-error getComposedData types are not matching, TODO switch this to redux
       yAxis,
-      // @ts-expect-error getComposedData types are not matching, TODO switch this to redux
       zAxis,
       // @ts-expect-error getComposedData types are not matching, TODO switch this to redux
       scatterSettings: item.props,

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -39,7 +39,6 @@ import {
   getBandSizeOfAxis,
   getBarPositions,
   getDomainOfDataByKey,
-  getDomainOfItemsWithSameAxis,
   getDomainOfStackGroups,
   getStackedDataOfItem,
   getStackGroupsByAxisId,
@@ -49,7 +48,6 @@ import {
   isAxisLTR,
   isCategoricalAxis,
   parseDomainOfCategoryAxis,
-  parseErrorBarsOfAxis,
   parseSpecifiedDomain,
 } from '../util/ChartUtils';
 import { detectReferenceElementsDomain } from '../util/DetectReferenceElementsDomain';
@@ -105,6 +103,7 @@ import {
 } from '../context/tooltipContext';
 import { RechartsWrapper } from './RechartsWrapper';
 import { getDefaultDomainByAxisType } from '../state/selectors/axisSelectors';
+import { getDomainOfItemsWithSameAxis, parseErrorBarsOfAxis } from '../util/getDomainOfErrorBars';
 
 export interface MousePointer {
   pageX: number;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,9 @@
+import type { AxisId } from './state/axisMapSlice';
+import { AxisWithScale, selectAxisWithScale } from './state/selectors/axisSelectors';
+import { useAppSelector } from './state/hooks';
+
+export const useXAxis = (xAxisId: AxisId): AxisWithScale | undefined =>
+  useAppSelector(state => selectAxisWithScale(state, 'xAxis', xAxisId));
+
+export const useYAxis = (yAxisId: AxisId): AxisWithScale | undefined =>
+  useAppSelector(state => selectAxisWithScale(state, 'yAxis', yAxisId));

--- a/src/state/legendSlice.ts
+++ b/src/state/legendSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { LayoutType, Size } from '../util/types';
-import { HorizontalAlignmentType, VerticalAlignmentType } from '../component/DefaultLegendContent';
+import type { HorizontalAlignmentType, VerticalAlignmentType } from '../component/DefaultLegendContent';
 
 export type LegendSettings = {
   layout: LayoutType;

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -1337,3 +1337,20 @@ export const selectTicksOfAxis = createSelector(
     );
   },
 );
+
+export type AxisWithScale = AxisSettings & ParsedScaleReturn;
+
+export const selectAxisWithScale = createSelector(
+  selectAxisSettings,
+  selectAxisScale,
+  (axis, parsedScaleReturn): AxisWithScale | undefined => {
+    if (axis == null || parsedScaleReturn == null || parsedScaleReturn.scale == null) {
+      return undefined;
+    }
+    return {
+      ...axis,
+      scale: parsedScaleReturn.scale,
+      realScaleType: parsedScaleReturn.realScaleType,
+    };
+  },
+);

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, current, PayloadAction } from '@reduxjs/toolkit';
 import { TooltipTrigger } from '../chart/types';
-import { NameType, Payload, ValueType } from '../component/DefaultTooltipContent';
+import type { NameType, Payload, ValueType } from '../component/DefaultTooltipContent';
 import { ChartCoordinate, DataKey } from '../util/types';
 
 /**

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -21,8 +21,6 @@ import {
 } from 'victory-vendor/d3-shape';
 
 import { ReactElement, ReactNode } from 'react';
-
-import { ErrorBar } from '../cartesian/ErrorBar';
 import {
   findEntryInArray,
   getAnyElementOfObject,
@@ -32,7 +30,7 @@ import {
   mathSign,
   uniqueId,
 } from './DataUtils';
-import { filterProps, findAllByType, getDisplayName } from './ReactUtils';
+import { filterProps, getDisplayName } from './ReactUtils';
 // TODO: Cause of circular dependency. Needs refactor.
 // import { RadiusAxisProps, AngleAxisProps } from '../polar/types';
 import { TooltipEntrySettings, TooltipPayloadEntry } from '../state/tooltipSlice';
@@ -463,140 +461,6 @@ export const isErrorBarRelevantForAxis = (layout?: LayoutType, axisType?: AxisTy
   }
 
   return true;
-};
-
-/**
- * @deprecated - this is using direct DOM access. Use different approach.
- * @param data do not use
- * @param item do not use
- * @param dataKey do not use
- * @param layout do not use
- * @param axisType do not use
- * @returns do not use
- */
-export const getDomainOfErrorBars = (
-  data: Array<object>,
-  item: ReactElement,
-  dataKey: DataKey<any>,
-  layout?: LayoutType,
-  axisType?: AxisType,
-): NumberDomain | null => {
-  const { children } = item.props;
-  const errorBars = findAllByType(children, ErrorBar).filter(errorBarChild =>
-    isErrorBarRelevantForAxis(layout, axisType, errorBarChild.props.direction),
-  );
-
-  if (errorBars && errorBars.length) {
-    const keys: ReadonlyArray<DataKey<any>> = errorBars.map(errorBarChild => errorBarChild.props.dataKey);
-
-    return data.reduce<NumberDomain>(
-      (result: NumberDomain, entry: object): NumberDomain => {
-        const entryValue = getValueByDataKey(entry, dataKey);
-        if (isNil(entryValue)) return result;
-
-        const mainValue = Array.isArray(entryValue) ? [min(entryValue), max(entryValue)] : [entryValue, entryValue];
-        const errorDomain = keys.reduce(
-          (prevErrorArr: [number, number], k: DataKey<any>): NumberDomain => {
-            const errorValue = getValueByDataKey(entry, k, 0);
-            const lowerValue = mainValue[0] - Math.abs(Array.isArray(errorValue) ? errorValue[0] : errorValue);
-            const upperValue = mainValue[1] + Math.abs(Array.isArray(errorValue) ? errorValue[1] : errorValue);
-
-            return [Math.min(lowerValue, prevErrorArr[0]), Math.max(upperValue, prevErrorArr[1])];
-          },
-          [Infinity, -Infinity],
-        );
-
-        return [Math.min(errorDomain[0], result[0]), Math.max(errorDomain[1], result[1])];
-      },
-      [Infinity, -Infinity],
-    );
-  }
-
-  return null;
-};
-
-/**
- * @deprecated this is relying on direct DOM access, do not use
- * @param data do not use
- * @param items do not use
- * @param dataKey do not use
- * @param axisType do not use
- * @param layout do not use
- * @returns do not use
- */
-export const parseErrorBarsOfAxis = (
-  data: any[],
-  items: any[],
-  dataKey: any,
-  axisType: AxisType,
-  layout?: LayoutType,
-): NumberDomain | null => {
-  const domains = items
-    .map(item => getDomainOfErrorBars(data, item, dataKey, layout, axisType))
-    .filter(entry => !isNil(entry));
-
-  if (domains && domains.length) {
-    return domains.reduce(
-      (result, entry) => [Math.min(result[0], entry[0]), Math.max(result[1], entry[1])],
-      [Infinity, -Infinity],
-    );
-  }
-
-  return null;
-};
-
-/**
- * @deprecated this is relying on direct DOM access, do not use.
- *
- * Get domain of data by the configuration of item element
- * @param  {Array}   data      The data displayed in the chart
- * @param  {Array}   items     The instances of item
- * @param  {String}  type      The type of axis, number - Number Axis, category - Category Axis
- * @param  {LayoutType} layout The type of layout
- * @param  {Boolean} filterNil Whether or not filter nil values
- * @return {Array}        Domain
- */
-export const getDomainOfItemsWithSameAxis = (
-  data: any[],
-  items: ReactElement[],
-  type: BaseAxisProps['type'],
-  layout?: LayoutType,
-  filterNil?: boolean,
-) => {
-  const domains: (NumberDomain | CategoricalDomain | null)[] = items.map(item => {
-    const { dataKey } = item.props;
-
-    if (type === 'number' && dataKey) {
-      return getDomainOfErrorBars(data, item, dataKey, layout) || getDomainOfDataByKey(data, dataKey, type, filterNil);
-    }
-    return getDomainOfDataByKey(data, dataKey, type, filterNil);
-  });
-
-  if (type === 'number') {
-    // Calculate the domain of number axis
-    return domains.reduce(
-      // @ts-expect-error if (type === number) means that the domain is numerical type
-      // - but this link is missing in the type definition
-      (result, entry) => [Math.min(result[0], entry[0]), Math.max(result[1], entry[1])],
-      [Infinity, -Infinity],
-    );
-  }
-
-  const tag: Record<string, any> = {};
-  // Get the union set of category axis
-  return domains.reduce((result, entry) => {
-    for (let i = 0, len = entry.length; i < len; i++) {
-      // @ts-expect-error Date cannot index an object
-      if (!tag[entry[i]]) {
-        // @ts-expect-error Date cannot index an object
-        tag[entry[i]] = true;
-
-        // @ts-expect-error Date cannot index an object
-        result.push(entry[i]);
-      }
-    }
-    return result;
-  }, []);
 };
 
 export const isCategoricalAxis = (layout: LayoutType, axisType: AxisType) =>

--- a/src/util/getDomainOfErrorBars.ts
+++ b/src/util/getDomainOfErrorBars.ts
@@ -1,0 +1,142 @@
+import { ReactElement } from 'react';
+import isNil from 'lodash/isNil';
+import min from 'lodash/min';
+import max from 'lodash/max';
+import { AxisType, BaseAxisProps, CategoricalDomain, DataKey, LayoutType, NumberDomain } from './types';
+import { findAllByType } from './ReactUtils';
+import { ErrorBar } from '../cartesian/ErrorBar';
+import { getDomainOfDataByKey, getValueByDataKey, isErrorBarRelevantForAxis } from './ChartUtils';
+
+/**
+ * @deprecated - this is using direct DOM access. Use different approach.
+ * @param data do not use
+ * @param item do not use
+ * @param dataKey do not use
+ * @param layout do not use
+ * @param axisType do not use
+ * @returns do not use
+ */
+export const getDomainOfErrorBars = (
+  data: Array<object>,
+  item: ReactElement,
+  dataKey: DataKey<any>,
+  layout?: LayoutType,
+  axisType?: AxisType,
+): NumberDomain | null => {
+  const { children } = item.props;
+  const errorBars = findAllByType(children, ErrorBar).filter(errorBarChild =>
+    isErrorBarRelevantForAxis(layout, axisType, errorBarChild.props.direction),
+  );
+
+  if (errorBars && errorBars.length) {
+    const keys: ReadonlyArray<DataKey<any>> = errorBars.map(errorBarChild => errorBarChild.props.dataKey);
+
+    return data.reduce<NumberDomain>(
+      (result: NumberDomain, entry: object): NumberDomain => {
+        const entryValue = getValueByDataKey(entry, dataKey);
+        if (isNil(entryValue)) return result;
+
+        const mainValue = Array.isArray(entryValue) ? [min(entryValue), max(entryValue)] : [entryValue, entryValue];
+        const errorDomain = keys.reduce(
+          (prevErrorArr: [number, number], k: DataKey<any>): NumberDomain => {
+            const errorValue = getValueByDataKey(entry, k, 0);
+            const lowerValue = mainValue[0] - Math.abs(Array.isArray(errorValue) ? errorValue[0] : errorValue);
+            const upperValue = mainValue[1] + Math.abs(Array.isArray(errorValue) ? errorValue[1] : errorValue);
+
+            return [Math.min(lowerValue, prevErrorArr[0]), Math.max(upperValue, prevErrorArr[1])];
+          },
+          [Infinity, -Infinity],
+        );
+
+        return [Math.min(errorDomain[0], result[0]), Math.max(errorDomain[1], result[1])];
+      },
+      [Infinity, -Infinity],
+    );
+  }
+
+  return null;
+};
+
+/**
+ * @deprecated this is relying on direct DOM access, do not use
+ * @param data do not use
+ * @param items do not use
+ * @param dataKey do not use
+ * @param axisType do not use
+ * @param layout do not use
+ * @returns do not use
+ */
+export const parseErrorBarsOfAxis = (
+  data: any[],
+  items: any[],
+  dataKey: any,
+  axisType: AxisType,
+  layout?: LayoutType,
+): NumberDomain | null => {
+  const domains = items
+    .map(item => getDomainOfErrorBars(data, item, dataKey, layout, axisType))
+    .filter(entry => !isNil(entry));
+
+  if (domains && domains.length) {
+    return domains.reduce(
+      (result, entry) => [Math.min(result[0], entry[0]), Math.max(result[1], entry[1])],
+      [Infinity, -Infinity],
+    );
+  }
+
+  return null;
+};
+
+/**
+ * @deprecated this is relying on direct DOM access, do not use.
+ *
+ * Get domain of data by the configuration of item element
+ * @param  {Array}   data      The data displayed in the chart
+ * @param  {Array}   items     The instances of item
+ * @param  {String}  type      The type of axis, number - Number Axis, category - Category Axis
+ * @param  {LayoutType} layout The type of layout
+ * @param  {Boolean} filterNil Whether or not filter nil values
+ * @return {Array}        Domain
+ */
+export const getDomainOfItemsWithSameAxis = (
+  data: any[],
+  items: ReactElement[],
+  type: BaseAxisProps['type'],
+  layout?: LayoutType,
+  filterNil?: boolean,
+) => {
+  const domains: (NumberDomain | CategoricalDomain | null)[] = items.map(item => {
+    const { dataKey } = item.props;
+
+    if (type === 'number' && dataKey) {
+      return getDomainOfErrorBars(data, item, dataKey, layout) || getDomainOfDataByKey(data, dataKey, type, filterNil);
+    }
+    return getDomainOfDataByKey(data, dataKey, type, filterNil);
+  });
+
+  if (type === 'number') {
+    // Calculate the domain of number axis
+    return domains.reduce(
+      // @ts-expect-error if (type === number) means that the domain is numerical type
+      // - but this link is missing in the type definition
+      (result, entry) => [Math.min(result[0], entry[0]), Math.max(result[1], entry[1])],
+      [Infinity, -Infinity],
+    );
+  }
+
+  const tag: Record<string, any> = {};
+  // Get the union set of category axis
+  return domains.reduce((result, entry) => {
+    for (let i = 0, len = entry.length; i < len; i++) {
+      // @ts-expect-error Date cannot index an object
+      if (!tag[entry[i]]) {
+        // @ts-expect-error Date cannot index an object
+        tag[entry[i]] = true;
+
+        // @ts-expect-error Date cannot index an object
+        result.push(entry[i]);
+      }
+    }
+    return result;
+  }, []);
+};

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -265,9 +265,10 @@ describe('<ErrorBar />', () => {
     assertErrorBars(container, 8);
   });
 
-  test.each(['category', undefined])('throws when direction=x and XAxis id type=%s', (domainType: AxisDomainType) => {
-    expect(() => {
-      render(
+  test.each(['category', undefined])(
+    'does not render anything when direction=x and XAxis id type=%s',
+    (domainType: AxisDomainType) => {
+      const { container } = render(
         <BarChart data={dataWithError} width={500} height={500}>
           <XAxis dataKey="name" type={domainType} />
           <Bar isAnimationActive={false} dataKey="uv">
@@ -275,8 +276,9 @@ describe('<ErrorBar />', () => {
           </Bar>
         </BarChart>,
       );
-    }).toThrow('Invariant failed: ErrorBar requires Axis type property to be "number".');
-  });
+      assertErrorBars(container, 0);
+    },
+  );
 
   describe('ErrorBar and axis domain interaction', () => {
     it('should extend YAxis domain', () => {

--- a/test/util/ChartUtils.spec.tsx
+++ b/test/util/ChartUtils.spec.tsx
@@ -6,7 +6,6 @@ import {
   calculateActiveTickIndex,
   getBandSizeOfAxis,
   getDomainOfDataByKey,
-  getDomainOfErrorBars,
   getDomainOfStackGroups,
   getTicksOfScale,
   getValueByDataKey,
@@ -19,6 +18,7 @@ import {
   isCategoricalAxis,
 } from '../../src/util/ChartUtils';
 import { AxisType, BaseAxisProps, DataKey, LayoutType } from '../../src/util/types';
+import { getDomainOfErrorBars } from '../../src/util/getDomainOfErrorBars';
 
 describe('getTicksForAxis', () => {
   const Y_AXIS_EXAMPLE: AxisPropsNeededForTicksGenerator = {

--- a/test/util/ChartUtils/getDomainOfErrorBars.spec.tsx
+++ b/test/util/ChartUtils/getDomainOfErrorBars.spec.tsx
@@ -1,9 +1,9 @@
 import React, { ReactElement, ReactNode } from 'react';
 import { vi } from 'vitest';
 import { findAllByType } from '../../../src/util/ReactUtils';
-import { getDomainOfErrorBars } from '../../../src/util/ChartUtils';
 import { ErrorBar } from '../../../src/cartesian/ErrorBar';
 import { AxisType, LayoutType } from '../../../src/util/types';
+import { getDomainOfErrorBars } from '../../../src/util/getDomainOfErrorBars';
 
 vi.mock('../../../src/util/ReactUtils');
 


### PR DESCRIPTION
## Description

This means that the parent elements also do not need to have a reference to the axes. One less dependency makes it easier to get rid of the `getComposedData` loop.

I had to move some functions around to break circular dependency. Redux selectors are sensitive to those.

## Related Issue

https://github.com/recharts/recharts/issues/4583
