### PR TITLE
GraphicalItemClipPath component and usage

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -148,6 +148,7 @@
   "es6/cartesian/ReferenceDot.js",
   "es6/cartesian/ReferenceArea.js",
   "es6/cartesian/Line.js",
+  "es6/cartesian/GraphicalItemClipPath.js",
   "es6/cartesian/ErrorBar.js",
   "es6/cartesian/CartesianGrid.js",
   "es6/cartesian/CartesianAxis.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -148,6 +148,7 @@
   "lib/cartesian/ReferenceDot.js",
   "lib/cartesian/ReferenceArea.js",
   "lib/cartesian/Line.js",
+  "lib/cartesian/GraphicalItemClipPath.js",
   "lib/cartesian/ErrorBar.js",
   "lib/cartesian/CartesianGrid.js",
   "lib/cartesian/CartesianAxis.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -148,6 +148,7 @@
   "types/cartesian/ReferenceDot.d.ts",
   "types/cartesian/ReferenceArea.d.ts",
   "types/cartesian/Line.d.ts",
+  "types/cartesian/GraphicalItemClipPath.d.ts",
   "types/cartesian/ErrorBar.d.ts",
   "types/cartesian/CartesianGrid.d.ts",
   "types/cartesian/CartesianAxis.d.ts",

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -555,7 +555,7 @@ function BarImpl(props: Props) {
   return <BarWithState {...everythingElse} needClip={needClip} />;
 }
 
-export class Bar extends PureComponent<Props, State> {
+export class Bar extends PureComponent<Props> {
   static displayName = 'Bar';
 
   static defaultProps: Partial<Props> = {

--- a/src/cartesian/GraphicalItemClipPath.tsx
+++ b/src/cartesian/GraphicalItemClipPath.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { AxisId } from '../state/axisMapSlice';
+import { useOffset } from '../context/chartLayoutContext';
+import { useAppSelector } from '../state/hooks';
+import { selectXAxisSettings, selectYAxisSettings } from '../state/selectors/axisSelectors';
+
+type GraphicalItemClipPathProps = {
+  xAxisId: AxisId;
+  yAxisId: AxisId;
+  clipPathId: string;
+};
+
+export function useNeedsClip(xAxisId: AxisId, yAxisId: AxisId) {
+  const xAxis = useAppSelector(state => selectXAxisSettings(state, xAxisId));
+  const yAxis = useAppSelector(state => selectYAxisSettings(state, yAxisId));
+
+  const needClipX = xAxis && xAxis.allowDataOverflow;
+  const needClipY = yAxis && yAxis.allowDataOverflow;
+  const needClip = needClipX || needClipY;
+
+  return { needClip, needClipX, needClipY };
+}
+
+export function GraphicalItemClipPath({ xAxisId, yAxisId, clipPathId }: GraphicalItemClipPathProps) {
+  const offset = useOffset();
+
+  const { needClipX, needClipY, needClip } = useNeedsClip(xAxisId, yAxisId);
+
+  if (!needClip) {
+    return null;
+  }
+
+  const { left, top, width, height } = offset;
+
+  return (
+    <clipPath id={`clipPath-${clipPathId}`}>
+      <rect
+        x={needClipX ? left : left - width / 2}
+        y={needClipY ? top : top - height / 2}
+        width={needClipX ? width : width * 2}
+        height={needClipY ? height : height * 2}
+      />
+    </clipPath>
+  );
+}

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -3,7 +3,7 @@ import { describe, test, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Area, Customized, XAxis, YAxis } from '../../src';
 import type { Props } from '../../src/cartesian/Area';
-import { LayoutType } from '../../src/util/types';
+import { D3Scale, LayoutType } from '../../src/util/types';
 import {
   AreaChartCase,
   ComposedChartCase,
@@ -12,6 +12,8 @@ import {
 } from '../helper/parameterizedTestCases';
 import { useAppSelector } from '../../src/state/hooks';
 import { CartesianGraphicalItemSettings } from '../../src/state/graphicalItemsSlice';
+import { Props as YAxisProps } from '../../src/cartesian/YAxis';
+import { Props as XAxisProps } from '../../src/cartesian/XAxis';
 
 type TestCase = {
   ChartElement: ComponentType<{
@@ -551,9 +553,9 @@ describe('getBaseValue', () => {
         props: { baseValue: 8 },
       };
       // @ts-expect-error incomplete mock
-      const xAxis: Props['xAxis'] = {};
+      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
       // @ts-expect-error incomplete mock
-      const yAxis: Props['yAxis'] = {};
+      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
       const actual = Area.getBaseValue(props, item, xAxis, yAxis);
       expect(actual).toBe(8);
     });
@@ -568,9 +570,9 @@ describe('getBaseValue', () => {
         props: { baseValue: undefined },
       };
       // @ts-expect-error incomplete mock
-      const xAxis: Props['xAxis'] = {};
+      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
       // @ts-expect-error incomplete mock
-      const yAxis: Props['yAxis'] = {};
+      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
       const actual = Area.getBaseValue(props, item, xAxis, yAxis);
       expect(actual).toBe(9);
     });
@@ -585,9 +587,9 @@ describe('getBaseValue', () => {
         props: { baseValue: 10 },
       };
       // @ts-expect-error incomplete mock
-      const xAxis: Props['xAxis'] = {};
+      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
       // @ts-expect-error incomplete mock
-      const yAxis: Props['yAxis'] = {};
+      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
       const actual = Area.getBaseValue(props, item, xAxis, yAxis);
       expect(actual).toBe(10);
     });
@@ -602,8 +604,8 @@ describe('getBaseValue', () => {
         props: { baseValue: NaN },
       };
       // @ts-expect-error incomplete mock
-      const xAxis: Props['xAxis'] = {};
-      const yAxis: Props['yAxis'] = {
+      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
+      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
         scale: {
           // @ts-expect-error incomplete mock
           domain: () => [30, 40],
@@ -665,8 +667,8 @@ describe('getBaseValue', () => {
             props: { baseValue },
           };
           // @ts-expect-error incomplete mock
-          const xAxis: Props['xAxis'] = {};
-          const yAxis: Props['yAxis'] = {
+          const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
+          const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
             scale: {
               // @ts-expect-error incomplete mock
               domain: () => domain,
@@ -691,7 +693,7 @@ describe('getBaseValue', () => {
             // @ts-expect-error incomplete mock
             props: { baseValue },
           };
-          const xAxis: Props['xAxis'] = {
+          const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
             scale: {
               // @ts-expect-error incomplete mock
               domain: () => domain,
@@ -699,7 +701,7 @@ describe('getBaseValue', () => {
             type: axisType,
           };
           // @ts-expect-error incomplete mock
-          const yAxis: Props['yAxis'] = {};
+          const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
           const actual = Area.getBaseValue(props, item, xAxis, yAxis);
           expect(actual).toBe(expected);
         },
@@ -759,8 +761,8 @@ describe('getBaseValue', () => {
             props: { baseValue },
           };
           // @ts-expect-error incomplete mock
-          const xAxis: Props['xAxis'] = {};
-          const yAxis: Props['yAxis'] = {
+          const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
+          const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
             scale: {
               // @ts-expect-error incomplete mock
               domain: () => domain,
@@ -785,7 +787,7 @@ describe('getBaseValue', () => {
             // @ts-expect-error incomplete mock
             props: { baseValue },
           };
-          const xAxis: Props['xAxis'] = {
+          const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
             scale: {
               // @ts-expect-error incomplete mock
               domain: () => domain,
@@ -793,7 +795,7 @@ describe('getBaseValue', () => {
             type: axisType,
           };
           // @ts-expect-error incomplete mock
-          const yAxis: Props['yAxis'] = {};
+          const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
           const actual = Area.getBaseValue(props, item, xAxis, yAxis);
           expect(actual).toBe(expected);
         },
@@ -856,8 +858,8 @@ describe('getBaseValue', () => {
             props: { baseValue },
           };
           // @ts-expect-error incomplete mock
-          const xAxis: Props['xAxis'] = {};
-          const yAxis: Props['yAxis'] = {
+          const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
+          const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
             scale: {
               // @ts-expect-error incomplete mock
               domain: () => domain,
@@ -882,7 +884,7 @@ describe('getBaseValue', () => {
             // @ts-expect-error incomplete mock
             props: { baseValue },
           };
-          const xAxis: Props['xAxis'] = {
+          const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
             scale: {
               // @ts-expect-error incomplete mock
               domain: () => domain,
@@ -890,7 +892,7 @@ describe('getBaseValue', () => {
             type: axisType,
           };
           // @ts-expect-error incomplete mock
-          const yAxis: Props['yAxis'] = {};
+          const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
           const actual = Area.getBaseValue(props, item, xAxis, yAxis);
           expect(actual).toBe(expected);
         },

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -451,7 +451,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3600]);
-      expect(axisDomainSpy).toHaveBeenCalledTimes(6);
+      expect(axisDomainSpy).toHaveBeenCalledTimes(7);
     });
 
     it('should extend XAxis domain', () => {

--- a/test/cartesian/Line.spec.tsx
+++ b/test/cartesian/Line.spec.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import { scaleLinear } from 'victory-vendor/d3-scale';
-import { Surface, Line, ErrorBar, LineChart, Customized } from '../../src';
+import { Surface, Line, ErrorBar, LineChart, Customized, XAxis } from '../../src';
 import { useAppSelector } from '../../src/state/hooks';
 import { selectErrorBarsSettings } from '../../src/state/selectors/axisSelectors';
 
@@ -54,14 +53,11 @@ describe('<Line />', () => {
 
   it('Does not render clip dot when clipDot is false', () => {
     const { container } = render(
-      <Surface width={500} height={500}>
-        <Line
-          isAnimationActive={false}
-          points={data}
-          dot={{ clipDot: false }} // Line must have an XAxis or YAxis in order for clips to render
-          xAxis={{ allowDataOverflow: true, scale: scaleLinear() }}
-        />
-      </Surface>,
+      <LineChart width={500} height={500} data={data}>
+        <Line isAnimationActive={false} dataKey="x" dot={{ clipDot: false }} />
+        {/* Line must have an XAxis or YAxis in order for clips to render */}
+        <XAxis allowDataOverflow />
+      </LineChart>,
     );
 
     expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
@@ -75,15 +71,11 @@ describe('<Line />', () => {
 
   it('Does render clip dot when clipDot is true', () => {
     const { container } = render(
-      <Surface width={500} height={500}>
-        <Line
-          isAnimationActive={false}
-          points={data}
-          dot={{ clipDot: true }}
-          // Line must have an XAxis or YAxis in order for clips to render
-          xAxis={{ allowDataOverflow: true, scale: scaleLinear() }}
-        />
-      </Surface>,
+      <LineChart width={500} height={500} data={data}>
+        <Line isAnimationActive={false} dataKey="x" dot={{ clipDot: true }} />
+        {/* Line must have an XAxis or YAxis in order for clips to render */}
+        <XAxis allowDataOverflow />
+      </LineChart>,
     );
 
     expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
@@ -92,6 +84,7 @@ describe('<Line />', () => {
     expect(dots).toHaveLength(5);
 
     const dotsWrapper = container.querySelector('.recharts-line-dots');
+    expect(dotsWrapper.hasAttribute('clip-path')).toBe(true);
     expect(dotsWrapper.getAttribute('clip-path')).toContain('url(#clipPath-recharts-line');
   });
 

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -156,7 +156,7 @@ const ComposedChartTestCase: TooltipPayloadTestCase = {
   ),
   mouseHoverSelector: composedChartMouseHoverTooltipSelector,
   expectedTooltipTitle: '2',
-  expectedTooltipContent: ['My custom name : 1398$$$', 'uv : 300kg', 'amt : 2400'],
+  expectedTooltipContent: ['uv : 300kg', 'My custom name : 1398$$$', 'amt : 2400'],
 };
 
 const PieChartTestCase: TooltipPayloadTestCase = {

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -632,7 +632,7 @@ describe('Tooltip visibility', () => {
       assertNotNull(chart);
       fireEvent.mouseOver(chart, { clientX: 200, clientY: 200 });
 
-      expect(tooltipPayload.map(({ name }) => name).join('')).toBe('123statureweight5');
+      expect(tooltipPayload.map(({ name }) => name).join('')).toBe('12statureweight35');
     });
 
     test('false - Should hide tooltip for hidden items', () => {

--- a/test/container/ClipPath.spec.tsx
+++ b/test/container/ClipPath.spec.tsx
@@ -1,0 +1,424 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { Area, AreaChart, Bar, BarChart, Line, LineChart, Scatter, ScatterChart, XAxis, YAxis } from '../../src';
+import { assertNotNull } from '../helper/assertNotNull';
+import { pageData } from '../../storybook/stories/data';
+
+function selectAllClipPaths(container: Element | null) {
+  assertNotNull(container);
+  return container.querySelectorAll('clipPath rect');
+}
+
+function expectClipPathDimensions(
+  clipPathElement: Element,
+  expectedDimensions: { x: string; y: string; width: string; height: string },
+) {
+  const actualDimensions = {
+    x: clipPathElement.getAttribute('x'),
+    y: clipPathElement.getAttribute('y'),
+    width: clipPathElement.getAttribute('width'),
+    height: clipPathElement.getAttribute('height'),
+  };
+  expect(actualDimensions).toEqual(expectedDimensions);
+}
+
+function expectClipPath(
+  container: Element,
+  expectedDimensions: { x: string; y: string; width: string; height: string },
+) {
+  const allClipPaths = selectAllClipPaths(container);
+  expect(allClipPaths).toHaveLength(1);
+  const clipPath = allClipPaths[0];
+  assertNotNull(clipPath);
+  expectClipPathDimensions(clipPath, expectedDimensions);
+}
+
+describe('clip paths', () => {
+  describe('in chart root', () => {
+    it('should render clipPath with rect based on margin', () => {
+      const { container } = render(
+        <BarChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} />,
+      );
+      expectClipPath(container, {
+        height: '445',
+        width: '379',
+        x: '99',
+        y: '11',
+      });
+    });
+  });
+
+  describe('in Line', () => {
+    it('should render no clipPaths by default', () => {
+      const { container } = render(
+        <LineChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Line dataKey="pv" />
+        </LineChart>,
+      );
+      const line = container.querySelector('.recharts-line');
+      expect(selectAllClipPaths(line)).toHaveLength(0);
+    });
+
+    it('should clip in X dimension if xAxis has allowDataOverflow = true', () => {
+      const { container } = render(
+        <LineChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Line dataKey="pv" />
+          <XAxis allowDataOverflow />
+        </LineChart>,
+      );
+      const line = container.querySelector('.recharts-line');
+      expectClipPath(line, {
+        height: '830',
+        width: '379',
+        x: '99',
+        y: '-196.5',
+      });
+    });
+
+    it('should clip in Y dimension if yAxis has allowDataOverflow = true', () => {
+      const { container } = render(
+        <LineChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Line dataKey="pv" />
+          <YAxis allowDataOverflow />
+        </LineChart>,
+      );
+      const line = container.querySelector('.recharts-line');
+      expectClipPath(line, {
+        height: '445',
+        width: '638',
+        x: '-0.5',
+        y: '11',
+      });
+    });
+
+    it('should clip in both dimensions if both axes have allowDataOverflow = true', () => {
+      const { container } = render(
+        <LineChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Line dataKey="pv" />
+          <XAxis allowDataOverflow />
+          <YAxis allowDataOverflow />
+        </LineChart>,
+      );
+      const line = container.querySelector('.recharts-line');
+      expectClipPath(line, {
+        height: '415',
+        width: '319',
+        x: '159',
+        y: '11',
+      });
+    });
+
+    it('should render another clipPath when dot has clipDot = false', () => {
+      const { container } = render(
+        <LineChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Line dataKey="uv" dot={{ clipDot: false }} />
+          <YAxis allowDataOverflow />
+        </LineChart>,
+      );
+      const line = container.querySelector('.recharts-line');
+      const allClipPaths = selectAllClipPaths(line);
+      expect(allClipPaths).toHaveLength(2);
+      expectClipPathDimensions(allClipPaths[1], {
+        height: '453',
+        width: '327',
+        x: '155',
+        y: '7',
+      });
+    });
+
+    it('should change the dimensions of the second clipPath based on strokeWidth', () => {
+      const { container } = render(
+        <LineChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Line dataKey="uv" dot={{ strokeWidth: 13, clipDot: false }} />
+          <YAxis allowDataOverflow />
+        </LineChart>,
+      );
+      const line = container.querySelector('.recharts-line');
+      const allClipPaths = selectAllClipPaths(line);
+      expect(allClipPaths).toHaveLength(2);
+      expectClipPathDimensions(allClipPaths[1], {
+        height: '464',
+        width: '338',
+        x: '149.5',
+        y: '1.5',
+      });
+    });
+
+    it('should change the dimensions of the second clipPath based on r', () => {
+      const { container } = render(
+        <LineChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Line dataKey="uv" dot={{ r: 5, clipDot: false }} />
+          <YAxis allowDataOverflow />
+        </LineChart>,
+      );
+      const line = container.querySelector('.recharts-line');
+      const allClipPaths = selectAllClipPaths(line);
+      expect(allClipPaths).toHaveLength(2);
+      expectClipPathDimensions(allClipPaths[1], {
+        height: '457',
+        width: '331',
+        x: '153',
+        y: '5',
+      });
+    });
+  });
+
+  describe('in Bar', () => {
+    it('should render no clipPaths by default', () => {
+      const { container } = render(
+        <BarChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Bar dataKey="pv" />
+        </BarChart>,
+      );
+      const bar = container.querySelector('.recharts-bar');
+      expect(selectAllClipPaths(bar)).toHaveLength(0);
+    });
+
+    it('should clip in X dimension if xAxis has allowDataOverflow = true', () => {
+      const { container } = render(
+        <BarChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Bar dataKey="pv" />
+          <XAxis allowDataOverflow />
+        </BarChart>,
+      );
+      const bar = container.querySelector('.recharts-bar');
+      expectClipPath(bar, {
+        height: '830',
+        width: '379',
+        x: '99',
+        y: '-196.5',
+      });
+    });
+
+    it('should clip in Y dimension if yAxis has allowDataOverflow = true', () => {
+      const { container } = render(
+        <BarChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Bar dataKey="pv" />
+          <YAxis allowDataOverflow />
+        </BarChart>,
+      );
+      const bar = container.querySelector('.recharts-bar');
+      expectClipPath(bar, {
+        height: '445',
+        width: '638',
+        x: '-0.5',
+        y: '11',
+      });
+    });
+
+    it('should clip in both dimensions if both axes have allowDataOverflow = true', () => {
+      const { container } = render(
+        <BarChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Bar dataKey="pv" />
+          <XAxis allowDataOverflow />
+          <YAxis allowDataOverflow />
+        </BarChart>,
+      );
+      const bar = container.querySelector('.recharts-bar');
+      expectClipPath(bar, {
+        height: '415',
+        width: '319',
+        x: '159',
+        y: '11',
+      });
+    });
+  });
+
+  describe('in Scatter', () => {
+    it('should render no clipPaths by default', () => {
+      const { container } = render(
+        <ScatterChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Scatter dataKey="pv" />
+        </ScatterChart>,
+      );
+      const scatter = container.querySelector('.recharts-scatter');
+      expect(selectAllClipPaths(scatter)).toHaveLength(0);
+    });
+
+    it('should clip in X dimension if xAxis has allowDataOverflow = true', () => {
+      const { container } = render(
+        <ScatterChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Scatter dataKey="pv" />
+          <XAxis allowDataOverflow />
+        </ScatterChart>,
+      );
+      const scatter = container.querySelector('.recharts-scatter');
+      expectClipPath(scatter, {
+        height: '830',
+        width: '379',
+        x: '99',
+        y: '-196.5',
+      });
+    });
+
+    it('should clip in Y dimension if yAxis has allowDataOverflow = true', () => {
+      const { container } = render(
+        <ScatterChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Scatter dataKey="pv" />
+          <YAxis allowDataOverflow />
+        </ScatterChart>,
+      );
+      const scatter = container.querySelector('.recharts-scatter');
+      expectClipPath(scatter, {
+        height: '445',
+        width: '638',
+        x: '-0.5',
+        y: '11',
+      });
+    });
+
+    it('should clip in both dimensions if both axes have allowDataOverflow = true', () => {
+      const { container } = render(
+        <ScatterChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Scatter dataKey="pv" />
+          <XAxis allowDataOverflow />
+          <YAxis allowDataOverflow />
+        </ScatterChart>,
+      );
+      const scatter = container.querySelector('.recharts-scatter');
+      expectClipPath(scatter, {
+        height: '415',
+        width: '319',
+        x: '159',
+        y: '11',
+      });
+    });
+  });
+
+  describe('in Area', () => {
+    it('should render one animation clipPaths by default', () => {
+      const { container } = render(
+        <AreaChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Area dataKey="pv" />
+        </AreaChart>,
+      );
+      const area = container.querySelector('.recharts-area');
+      expectClipPath(area, {
+        height: '457',
+        width: '0',
+        x: '99',
+        y: '0',
+      });
+    });
+
+    it('should not render any clipPaths if isAnimationActive=false', () => {
+      const { container } = render(
+        <AreaChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Area dataKey="pv" isAnimationActive={false} />
+        </AreaChart>,
+      );
+      const area = container.querySelector('.recharts-area');
+      expect(selectAllClipPaths(area)).toHaveLength(0);
+    });
+
+    it('should clip in X dimension if xAxis has allowDataOverflow = true', () => {
+      const { container } = render(
+        <AreaChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Area dataKey="pv" />
+          <XAxis allowDataOverflow />
+        </AreaChart>,
+      );
+      const area = container.querySelector('.recharts-area');
+      const allClipPaths = selectAllClipPaths(area);
+      expect(allClipPaths).toHaveLength(2);
+      expectClipPathDimensions(allClipPaths[0], {
+        height: '830',
+        width: '379',
+        x: '99',
+        y: '-196.5',
+      });
+    });
+
+    it('should clip in Y dimension if yAxis has allowDataOverflow = true', () => {
+      const { container } = render(
+        <AreaChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Area dataKey="pv" />
+          <YAxis allowDataOverflow />
+        </AreaChart>,
+      );
+      const area = container.querySelector('.recharts-area');
+      const allClipPaths = selectAllClipPaths(area);
+      expect(allClipPaths).toHaveLength(2);
+      expectClipPathDimensions(allClipPaths[0], {
+        height: '445',
+        width: '638',
+        x: '-0.5',
+        y: '11',
+      });
+    });
+
+    it('should clip in both dimensions if both axes have allowDataOverflow = true', () => {
+      const { container } = render(
+        <AreaChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Area dataKey="pv" />
+          <XAxis allowDataOverflow />
+          <YAxis allowDataOverflow />
+        </AreaChart>,
+      );
+      const area = container.querySelector('.recharts-area');
+      const allClipPaths = selectAllClipPaths(area);
+      expect(allClipPaths).toHaveLength(2);
+      expectClipPathDimensions(allClipPaths[0], {
+        height: '415',
+        width: '319',
+        x: '159',
+        y: '11',
+      });
+    });
+
+    it('should render another clipPath when dot has clipDot = false', () => {
+      const { container } = render(
+        <AreaChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Area dataKey="uv" dot={{ clipDot: false }} />
+          <YAxis allowDataOverflow />
+        </AreaChart>,
+      );
+      const area = container.querySelector('.recharts-area');
+      const allClipPaths = selectAllClipPaths(area);
+      expect(allClipPaths).toHaveLength(3);
+      expectClipPathDimensions(allClipPaths[1], {
+        height: '453',
+        width: '327',
+        x: '155',
+        y: '7',
+      });
+    });
+
+    it('should change the dimensions of the second clipPath based on strokeWidth', () => {
+      const { container } = render(
+        <AreaChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Area dataKey="uv" dot={{ strokeWidth: 13, clipDot: false }} />
+          <YAxis allowDataOverflow />
+        </AreaChart>,
+      );
+      const area = container.querySelector('.recharts-area');
+      const allClipPaths = selectAllClipPaths(area);
+      expect(allClipPaths).toHaveLength(3);
+      expectClipPathDimensions(allClipPaths[1], {
+        height: '464',
+        width: '338',
+        x: '149.5',
+        y: '1.5',
+      });
+    });
+
+    it('should change the dimensions of the second clipPath based on r', () => {
+      const { container } = render(
+        <AreaChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
+          <Area dataKey="uv" dot={{ r: 5, clipDot: false }} />
+          <YAxis allowDataOverflow />
+        </AreaChart>,
+      );
+      const area = container.querySelector('.recharts-area');
+      const allClipPaths = selectAllClipPaths(area);
+      expect(allClipPaths).toHaveLength(3);
+      expectClipPathDimensions(allClipPaths[1], {
+        height: '457',
+        width: '331',
+        x: '153',
+        y: '5',
+      });
+    });
+  });
+});

--- a/test/container/ClipPath.spec.tsx
+++ b/test/container/ClipPath.spec.tsx
@@ -50,7 +50,7 @@ describe('clip paths', () => {
   });
 
   describe('in Line', () => {
-    it('should render no clipPaths by default', () => {
+    it('should render no clipPaths by default, and not clip the curve', () => {
       const { container } = render(
         <LineChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
           <Line dataKey="pv" />
@@ -58,9 +58,11 @@ describe('clip paths', () => {
       );
       const line = container.querySelector('.recharts-line');
       expect(selectAllClipPaths(line)).toHaveLength(0);
+      const curve = container.querySelector('.recharts-line-curve');
+      expect(curve.getAttribute('clip-path')).toEqual(null);
     });
 
-    it('should clip in X dimension if xAxis has allowDataOverflow = true', () => {
+    it('should clip in X dimension if xAxis has allowDataOverflow = true, and should clip the curve', () => {
       const { container } = render(
         <LineChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
           <Line dataKey="pv" />
@@ -74,6 +76,11 @@ describe('clip paths', () => {
         x: '99',
         y: '-196.5',
       });
+      const clipPath = line.querySelector('clipPath');
+      const clipPathId = clipPath.getAttribute('id');
+      expect(clipPathId).toEqual(expect.stringMatching(/clipPath-recharts-line-\d+/));
+      const curve = container.querySelector('.recharts-line-curve');
+      expect(curve.getAttribute('clip-path')).toEqual(`url(#${clipPathId})`);
     });
 
     it('should clip in Y dimension if yAxis has allowDataOverflow = true', () => {
@@ -165,7 +172,7 @@ describe('clip paths', () => {
   });
 
   describe('in Bar', () => {
-    it('should render no clipPaths by default', () => {
+    it('should render no clipPaths by default, and not clip its layer', () => {
       const { container } = render(
         <BarChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
           <Bar dataKey="pv" />
@@ -173,9 +180,11 @@ describe('clip paths', () => {
       );
       const bar = container.querySelector('.recharts-bar');
       expect(selectAllClipPaths(bar)).toHaveLength(0);
+      const layer = bar.querySelector('.recharts-bar-rectangles');
+      expect(layer.getAttribute('clip-path')).toBe(null);
     });
 
-    it('should clip in X dimension if xAxis has allowDataOverflow = true', () => {
+    it('should clip in X dimension if xAxis has allowDataOverflow = true, and clip its layer', () => {
       const { container } = render(
         <BarChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
           <Bar dataKey="pv" />
@@ -189,6 +198,11 @@ describe('clip paths', () => {
         x: '99',
         y: '-196.5',
       });
+      const clipPath = bar.querySelector('clipPath');
+      const clipPathId = clipPath.getAttribute('id');
+      expect(clipPathId).toEqual(expect.stringMatching(/clipPath-recharts-bar-\d+/));
+      const layer = bar.querySelector('.recharts-bar-rectangles');
+      expect(layer.getAttribute('clip-path')).toEqual(`url(#${clipPathId})`);
     });
 
     it('should clip in Y dimension if yAxis has allowDataOverflow = true', () => {
@@ -226,7 +240,7 @@ describe('clip paths', () => {
   });
 
   describe('in Scatter', () => {
-    it('should render no clipPaths by default', () => {
+    it('should render no clipPaths by default, and not clip its layer', () => {
       const { container } = render(
         <ScatterChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
           <Scatter dataKey="pv" />
@@ -234,9 +248,10 @@ describe('clip paths', () => {
       );
       const scatter = container.querySelector('.recharts-scatter');
       expect(selectAllClipPaths(scatter)).toHaveLength(0);
+      expect(scatter.getAttribute('clip-path')).toBe(null);
     });
 
-    it('should clip in X dimension if xAxis has allowDataOverflow = true', () => {
+    it('should clip in X dimension if xAxis has allowDataOverflow = true, and clip its layer', () => {
       const { container } = render(
         <ScatterChart width={500} height={500} margin={{ top: 11, right: 22, bottom: 44, left: 99 }} data={pageData}>
           <Scatter dataKey="pv" />
@@ -250,6 +265,10 @@ describe('clip paths', () => {
         x: '99',
         y: '-196.5',
       });
+      const clipPath = scatter.querySelector('clipPath');
+      const clipPathId = clipPath.getAttribute('id');
+      expect(clipPathId).toEqual(expect.stringMatching(/clipPath-recharts-scatter-\d+/));
+      expect(scatter.getAttribute('clip-path')).toEqual(`url(#${clipPathId})`);
     });
 
     it('should clip in Y dimension if yAxis has allowDataOverflow = true', () => {

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -293,7 +293,7 @@ describe('selectAxisDomain', () => {
     ]);
     expect(domainSpy).toHaveBeenLastCalledWith([70, 80, 90, 10, 20, 30, 40, 50, 60]);
     // big oof
-    expect(domainSpy).toHaveBeenCalledTimes(25);
+    expect(domainSpy).toHaveBeenCalledTimes(29);
   });
 
   it('should return array indexes if there are multiple graphical items, and no explicit dataKey on the matching XAxis', () => {
@@ -359,7 +359,7 @@ describe('selectAxisDomain', () => {
     ]);
     expect(domainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8]);
     // big oof
-    expect(domainSpy).toHaveBeenCalledTimes(25);
+    expect(domainSpy).toHaveBeenCalledTimes(29);
   });
 
   describe('XAxis with type = number', () => {

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -293,7 +293,7 @@ describe('selectAxisDomain', () => {
     ]);
     expect(domainSpy).toHaveBeenLastCalledWith([70, 80, 90, 10, 20, 30, 40, 50, 60]);
     // big oof
-    expect(domainSpy).toHaveBeenCalledTimes(29);
+    expect(domainSpy).toHaveBeenCalledTimes(25);
   });
 
   it('should return array indexes if there are multiple graphical items, and no explicit dataKey on the matching XAxis', () => {
@@ -359,7 +359,7 @@ describe('selectAxisDomain', () => {
     ]);
     expect(domainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8]);
     // big oof
-    expect(domainSpy).toHaveBeenCalledTimes(29);
+    expect(domainSpy).toHaveBeenCalledTimes(25);
   });
 
   describe('XAxis with type = number', () => {


### PR DESCRIPTION
## Description

GraphicalItemClipPath allows us to remove another dependency on the generator state - with this, it's no longer necessary to read `xAxis` and `yAxis` from cloned props.

Also back in https://github.com/recharts/recharts/pull/4793 I introduced a regression - so I wrote the tests here first, on a commit before that change, and then fixed it.

## Related Issue

https://github.com/recharts/recharts/issues/4583
