### PR TITLE
Error bars use direction instead of layout

### DIFF
--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -4,9 +4,7 @@
 import React, { Component, SVGProps } from 'react';
 import Animate from 'react-smooth';
 import { Layer } from '../container/Layer';
-import { Props as XAxisProps } from './XAxis';
-import { Props as YAxisProps } from './YAxis';
-import { AnimationTiming, D3Scale, DataKey, LayoutType } from '../util/types';
+import { AnimationTiming, DataKey, LayoutType } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { BarRectangleItem } from './Bar';
 import { LinePointItem } from './Line';
@@ -40,8 +38,6 @@ export type ErrorBarDataPointFormatter = (
 ) => ErrorBarDataItem;
 
 interface InternalErrorBarProps {
-  xAxis?: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> };
-  yAxis?: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> };
   xAxisId?: AxisId;
   yAxisId?: AxisId;
   data?: any[];
@@ -83,8 +79,6 @@ function ErrorBarImpl(props: Props) {
     dataKey,
     data,
     dataPointFormatter,
-    xAxis: xAxisFromClonedProps,
-    yAxis: yAxisFromClonedProps,
     xAxisId,
     yAxisId,
     isAnimationActive,

--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -77,7 +77,7 @@ export function getRealDirection(
 function ErrorBarImpl(props: Props) {
   const {
     offset,
-    layout,
+    direction,
     width,
     dataKey,
     data,
@@ -102,7 +102,7 @@ function ErrorBarImpl(props: Props) {
   }
 
   // ErrorBar requires type number XAxis, why?
-  if (props.direction === 'x' && xAxis.type !== 'number') {
+  if (direction === 'x' && xAxis.type !== 'number') {
     return null;
   }
 
@@ -122,7 +122,7 @@ function ErrorBarImpl(props: Props) {
       lowBound = highBound = errorVal;
     }
 
-    if (layout === 'vertical') {
+    if (direction === 'x') {
       // error bar for horizontal charts, the y is fixed, x is a range value
       const { scale } = xAxis;
 
@@ -139,7 +139,7 @@ function ErrorBarImpl(props: Props) {
       lineCoordinates.push({ x1: xMin, y1: yMid, x2: xMax, y2: yMid });
       // the left line of |--|
       lineCoordinates.push({ x1: xMin, y1: yMin, x2: xMin, y2: yMax });
-    } else if (layout === 'horizontal') {
+    } else if (direction === 'y') {
       // error bar for horizontal charts, the x is fixed, y is a range value
       const { scale } = yAxis;
 

--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -22,11 +22,6 @@ export interface ErrorBarDataItem {
   errorVal?: number[] | number;
 }
 
-export type ErrorBarDataPointFormatter = (
-  entry: BarRectangleItem | LinePointItem | ScatterPointItem,
-  dataKey: DataKey<any>,
-) => ErrorBarDataItem;
-
 /**
  * So usually the direction is decided by the chart layout.
  * Horizontal layout means error bars are vertical means direction=y
@@ -37,6 +32,12 @@ export type ErrorBarDataPointFormatter = (
  * So this property is only ever used in Scatter chart, and ignored elsewhere.
  */
 export type ErrorBarDirection = 'x' | 'y';
+
+export type ErrorBarDataPointFormatter = (
+  entry: BarRectangleItem | LinePointItem | ScatterPointItem,
+  dataKey: DataKey<any>,
+  direction: ErrorBarDirection,
+) => ErrorBarDataItem;
 
 interface InternalErrorBarProps {
   xAxis?: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> };
@@ -107,7 +108,7 @@ function ErrorBarImpl(props: Props) {
   }
 
   const errorBars = data.map((entry: any) => {
-    const { x, y, value, errorVal } = dataPointFormatter(entry, dataKey);
+    const { x, y, value, errorVal } = dataPointFormatter(entry, dataKey, direction);
 
     if (!errorVal) {
       return null;

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -14,7 +14,7 @@ import { Dot } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelType } from '../component/Label';
 import { LabelList } from '../component/LabelList';
-import { ErrorBar, ErrorBarDataPointFormatter, Props as ErrorBarProps } from './ErrorBar';
+import { ErrorBar, ErrorBarDataItem, ErrorBarDataPointFormatter, Props as ErrorBarProps } from './ErrorBar';
 import { interpolateNumber, uniqueId } from '../util/DataUtils';
 import { filterProps, findAllByType, hasClipDot } from '../util/ReactUtils';
 import { Global } from '../util/Global';
@@ -198,6 +198,19 @@ function renderDotItem(option: ActiveDotType, props: any) {
 
 const noErrorBars: never[] = [];
 
+const errorBarDataPointFormatter: ErrorBarDataPointFormatter = (
+  dataPoint: LinePointItem,
+  dataKey,
+): ErrorBarDataItem => {
+  return {
+    x: dataPoint.x,
+    y: dataPoint.y,
+    value: dataPoint.value,
+    // @ts-expect-error getValueByDataKey does not validate the output type
+    errorVal: getValueByDataKey(dataPoint.payload, dataKey),
+  };
+};
+
 class LineWithState extends Component<Props, State> {
   mainCurve?: SVGPathElement;
 
@@ -287,16 +300,6 @@ class LineWithState extends Component<Props, State> {
       return null;
     }
 
-    // @ts-expect-error getValueByDataKey does not validate the output type
-    const dataPointFormatter: ErrorBarDataPointFormatter = (dataPoint: LinePointItem, dataKey) => {
-      return {
-        x: dataPoint.x,
-        y: dataPoint.y,
-        value: dataPoint.value,
-        errorVal: getValueByDataKey(dataPoint.payload, dataKey),
-      };
-    };
-
     const errorBarProps = {
       clipPath: needClip ? `url(#clipPath-${clipPathId})` : null,
     };
@@ -310,7 +313,7 @@ class LineWithState extends Component<Props, State> {
             xAxisId,
             yAxisId,
             layout,
-            dataPointFormatter,
+            dataPointFormatter: errorBarDataPointFormatter,
           }),
         )}
       </Layer>


### PR DESCRIPTION
## Description

Small refactor to make it easier to break the Error bar - axis domain - scatter points - error bar cyclic dependency.

## Related Issue

https://github.com/recharts/recharts/issues/4583
