### PR TITLE
ErrorBarPreferredDirection context instead of injecting layout prop

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -9,7 +9,13 @@ import isEqual from 'lodash/isEqual';
 import isNil from 'lodash/isNil';
 import { Props as RectangleProps } from '../shape/Rectangle';
 import { Layer } from '../container/Layer';
-import { ErrorBar, ErrorBarDataItem, ErrorBarDataPointFormatter, Props as ErrorBarProps } from './ErrorBar';
+import {
+  ErrorBar,
+  ErrorBarDataItem,
+  ErrorBarDataPointFormatter,
+  Props as ErrorBarProps,
+  SetErrorBarPreferredDirection,
+} from './ErrorBar';
 import { Cell } from '../component/Cell';
 import { LabelList } from '../component/LabelList';
 import { interpolateNumber, mathSign, uniqueId } from '../util/DataUtils';
@@ -478,7 +484,6 @@ class BarWithState extends PureComponent<Props, State> {
             data,
             xAxisId,
             yAxisId,
-            layout,
             offset,
             dataPointFormatter: errorBarDataPointFormatter,
           }),
@@ -488,7 +493,7 @@ class BarWithState extends PureComponent<Props, State> {
   }
 
   render() {
-    const { hide, data, dataKey, className, xAxisId, yAxisId, needClip, isAnimationActive, background, id } =
+    const { hide, data, dataKey, className, xAxisId, yAxisId, needClip, isAnimationActive, background, id, layout } =
       this.props;
     if (hide || !data || !data.length) {
       return (
@@ -546,7 +551,9 @@ class BarWithState extends PureComponent<Props, State> {
             />
             {this.renderRectangles()}
           </Layer>
-          {this.renderErrorBar(needClip, clipPathId)}
+          <SetErrorBarPreferredDirection direction={layout === 'horizontal' ? 'y' : 'x'}>
+            {this.renderErrorBar(needClip, clipPathId)}
+          </SetErrorBarPreferredDirection>
           {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, data)}
         </Layer>
       </CartesianGraphicalItemContext>

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -14,7 +14,13 @@ import { Dot } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelType } from '../component/Label';
 import { LabelList } from '../component/LabelList';
-import { ErrorBar, ErrorBarDataItem, ErrorBarDataPointFormatter, Props as ErrorBarProps } from './ErrorBar';
+import {
+  ErrorBar,
+  ErrorBarDataItem,
+  ErrorBarDataPointFormatter,
+  Props as ErrorBarProps,
+  SetErrorBarPreferredDirection,
+} from './ErrorBar';
 import { interpolateNumber, uniqueId } from '../util/DataUtils';
 import { filterProps, findAllByType, hasClipDot } from '../util/ReactUtils';
 import { Global } from '../util/Global';
@@ -293,7 +299,7 @@ class LineWithState extends Component<Props, State> {
       return null;
     }
 
-    const { points, xAxisId, yAxisId, layout, children } = this.props;
+    const { points, xAxisId, yAxisId, children } = this.props;
     const errorBarItems = findAllByType(children, ErrorBar);
 
     if (!errorBarItems) {
@@ -312,7 +318,6 @@ class LineWithState extends Component<Props, State> {
             data: points,
             xAxisId,
             yAxisId,
-            layout,
             dataPointFormatter: errorBarDataPointFormatter,
           }),
         )}
@@ -478,6 +483,7 @@ class LineWithState extends Component<Props, State> {
       isAnimationActive,
       id,
       needClip,
+      layout,
     } = this.props;
 
     if (hide || !points || !points.length) {
@@ -538,7 +544,9 @@ class LineWithState extends Component<Props, State> {
             </defs>
           )}
           {!hasSinglePoint && this.renderCurve(needClip, clipPathId)}
-          {this.renderErrorBar(needClip, clipPathId)}
+          <SetErrorBarPreferredDirection direction={layout === 'horizontal' ? 'y' : 'x'}>
+            {this.renderErrorBar(needClip, clipPathId)}
+          </SetErrorBarPreferredDirection>
           {(hasSinglePoint || dot) && this.renderDots(needClip, clipDot, clipPathId)}
           {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
         </Layer>

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -431,7 +431,6 @@ function ScatterErrorBars(props: InternalProps & { isAnimationFinished: boolean 
       data: points,
       xAxisId,
       yAxisId,
-      layout: direction === 'x' ? 'vertical' : 'horizontal',
       dataPointFormatter: errorBarDataPointFormatter,
     });
   });

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -7,7 +7,6 @@ import { expectXAxisTicks, expectYAxisTicks } from '../helper/expectAxisTicks';
 import { AxisDomainType } from '../../src/util/types';
 import { useAppSelector } from '../../src/state/hooks';
 import { selectAxisDomainIncludingNiceTicks } from '../../src/state/selectors/axisSelectors';
-import { getRealDirection } from '../../src/cartesian/ErrorBar';
 
 // asserts an error bar has both a start and end position
 const assertErrorBars = (container: HTMLElement, barsExpected: number) => {
@@ -47,23 +46,6 @@ function assertAnimationStyles(
     });
   });
 }
-
-describe('getRealDirection', () => {
-  it('should return direction from props if it is provided', () => {
-    expect(getRealDirection('x', 'horizontal')).toBe('x');
-    expect(getRealDirection('y', 'horizontal')).toBe('y');
-    expect(getRealDirection('x', 'vertical')).toBe('x');
-    expect(getRealDirection('y', 'vertical')).toBe('y');
-  });
-
-  it('should return "y" for horizontal layout', () => {
-    expect(getRealDirection(undefined, 'horizontal')).toBe('y');
-  });
-
-  it('should return "x" for vertical layout', () => {
-    expect(getRealDirection(undefined, 'vertical')).toBe('x');
-  });
-});
 
 describe('<ErrorBar />', () => {
   const dataWithError = [


### PR DESCRIPTION
## Description

Removing injected cloned props and replacing with context. This is needed to break the circular dependency between Scatter and ErrorBars.

## Related Issue

https://github.com/recharts/recharts/issues/4583
