### PR TITLE
Area, Bar, Line and Scatter report their settings before rendering

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -38,7 +38,6 @@ import { useLegendPayloadDispatch } from '../context/legendPayloadContext';
 import { ActivePoints } from '../component/ActivePoints';
 import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
-import { SetCartesianGraphicalItem } from '../state/SetCartesianGraphicalItem';
 import { CartesianGraphicalItemContext } from '../context/CartesianGraphicalItemContext';
 import { GraphicalItemClipPath, useNeedsClip } from './GraphicalItemClipPath';
 
@@ -153,8 +152,6 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
     },
   };
 }
-
-const noErrorBars: never[] = [];
 
 class AreaWithState extends PureComponent<Props, State> {
   state: State = {
@@ -457,22 +454,7 @@ class AreaWithState extends PureComponent<Props, State> {
     } = this.props;
 
     if (hide || !points || !points.length) {
-      return (
-        <>
-          <SetCartesianGraphicalItem
-            data={this.props.data}
-            xAxisId={xAxisId}
-            yAxisId={yAxisId}
-            zAxisId={0}
-            dataKey={this.props.dataKey}
-            errorBars={noErrorBars}
-            stackId={this.props.stackId}
-            hide={this.props.hide}
-          />
-          <SetAreaLegend {...this.props} />
-          <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
-        </>
-      );
+      return null;
     }
 
     const { isAnimationFinished } = this.state;
@@ -484,18 +466,8 @@ class AreaWithState extends PureComponent<Props, State> {
     const dotSize = r * 2 + strokeWidth;
 
     return (
-      <CartesianGraphicalItemContext
-        data={this.props.data}
-        dataKey={this.props.dataKey}
-        xAxisId={xAxisId}
-        yAxisId={yAxisId}
-        zAxisId={0}
-        stackId={this.props.stackId}
-        hide={this.props.hide}
-      >
+      <>
         <Layer className={layerClass}>
-          <SetAreaLegend {...this.props} />
-          <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
           {needClip && (
             <defs>
               <GraphicalItemClipPath clipPathId={clipPathId} xAxisId={xAxisId} yAxisId={yAxisId} />
@@ -529,7 +501,7 @@ class AreaWithState extends PureComponent<Props, State> {
             activeDot={this.props.activeDot}
           />
         )}
-      </CartesianGraphicalItemContext>
+      </>
     );
   }
 }
@@ -713,6 +685,20 @@ export class Area extends PureComponent<Props, State> {
   };
 
   render() {
-    return <AreaImpl {...this.props} />;
+    return (
+      <CartesianGraphicalItemContext
+        data={this.props.data}
+        dataKey={this.props.dataKey}
+        xAxisId={this.props.xAxisId}
+        yAxisId={this.props.yAxisId}
+        zAxisId={0}
+        stackId={this.props.stackId}
+        hide={this.props.hide}
+      >
+        <SetAreaLegend {...this.props} />
+        <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
+        <AreaImpl {...this.props} />
+      </CartesianGraphicalItemContext>
+    );
   }
 }

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -60,7 +60,6 @@ import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 import { ReportBar } from '../state/ReportBar';
 import { CartesianGraphicalItemContext } from '../context/CartesianGraphicalItemContext';
-import { SetCartesianGraphicalItem } from '../state/SetCartesianGraphicalItem';
 import { GraphicalItemClipPath, useNeedsClip } from './GraphicalItemClipPath';
 import type { XAxisProps, YAxisProps } from '../index';
 
@@ -317,8 +316,6 @@ function BarRectangles(props: BarRectanglesProps) {
 
 const defaultMinPointSize: number = 0;
 
-const emptyArray: Array<never> = [];
-
 const errorBarDataPointFormatter: ErrorBarDataPointFormatter = (
   dataPoint: BarRectangleItem,
   dataKey,
@@ -496,24 +493,7 @@ class BarWithState extends PureComponent<Props, State> {
     const { hide, data, dataKey, className, xAxisId, yAxisId, needClip, isAnimationActive, background, id, layout } =
       this.props;
     if (hide || !data || !data.length) {
-      return (
-        <>
-          <SetCartesianGraphicalItem
-            // Bar does not allow setting data directly on the graphical item (why?)
-            data={null}
-            xAxisId={xAxisId}
-            yAxisId={yAxisId}
-            zAxisId={0}
-            dataKey={this.props.dataKey}
-            errorBars={emptyArray}
-            stackId={this.props.stackId}
-            hide={this.props.hide}
-          />
-          <ReportBar />
-          <SetBarLegend {...this.props} />
-          <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
-        </>
-      );
+      return null;
     }
 
     const { isAnimationFinished } = this.state;
@@ -521,42 +501,28 @@ class BarWithState extends PureComponent<Props, State> {
     const clipPathId = isNil(id) ? this.id : id;
 
     return (
-      <CartesianGraphicalItemContext
-        // Bar does not allow setting data directly on the graphical item (why?)
-        data={null}
-        xAxisId={xAxisId}
-        yAxisId={yAxisId}
-        zAxisId={0}
-        dataKey={this.props.dataKey}
-        stackId={this.props.stackId}
-        hide={this.props.hide}
-      >
-        <Layer className={layerClass}>
-          <ReportBar />
-          <SetBarLegend {...this.props} />
-          <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
-          {needClip && (
-            <defs>
-              <GraphicalItemClipPath clipPathId={clipPathId} xAxisId={xAxisId} yAxisId={yAxisId} />
-            </defs>
-          )}
-          <Layer className="recharts-bar-rectangles" clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
-            <BarBackground
-              data={data}
-              dataKey={dataKey}
-              background={background}
-              onAnimationStart={this.handleAnimationStart}
-              onAnimationEnd={this.handleAnimationEnd}
-              allOtherBarProps={this.props}
-            />
-            {this.renderRectangles()}
-          </Layer>
-          <SetErrorBarPreferredDirection direction={layout === 'horizontal' ? 'y' : 'x'}>
-            {this.renderErrorBar(needClip, clipPathId)}
-          </SetErrorBarPreferredDirection>
-          {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, data)}
+      <Layer className={layerClass}>
+        {needClip && (
+          <defs>
+            <GraphicalItemClipPath clipPathId={clipPathId} xAxisId={xAxisId} yAxisId={yAxisId} />
+          </defs>
+        )}
+        <Layer className="recharts-bar-rectangles" clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
+          <BarBackground
+            data={data}
+            dataKey={dataKey}
+            background={background}
+            onAnimationStart={this.handleAnimationStart}
+            onAnimationEnd={this.handleAnimationEnd}
+            allOtherBarProps={this.props}
+          />
+          {this.renderRectangles()}
         </Layer>
-      </CartesianGraphicalItemContext>
+        <SetErrorBarPreferredDirection direction={layout === 'horizontal' ? 'y' : 'x'}>
+          {this.renderErrorBar(needClip, clipPathId)}
+        </SetErrorBarPreferredDirection>
+        {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, data)}
+      </Layer>
     );
   }
 }
@@ -711,6 +677,22 @@ export class Bar extends PureComponent<Props> {
   };
 
   render() {
-    return <BarImpl {...this.props} />;
+    return (
+      <CartesianGraphicalItemContext
+        // Bar does not allow setting data directly on the graphical item (why?)
+        data={null}
+        xAxisId={this.props.xAxisId}
+        yAxisId={this.props.yAxisId}
+        zAxisId={0}
+        dataKey={this.props.dataKey}
+        stackId={this.props.stackId}
+        hide={this.props.hide}
+      >
+        <ReportBar />
+        <SetBarLegend {...this.props} />
+        <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
+        <BarImpl {...this.props} />
+      </CartesianGraphicalItemContext>
+    );
   }
 }

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -44,7 +44,6 @@ import { useLegendPayloadDispatch } from '../context/legendPayloadContext';
 import { ActivePoints } from '../component/ActivePoints';
 import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
-import { SetCartesianGraphicalItem } from '../state/SetCartesianGraphicalItem';
 import { CartesianGraphicalItemContext } from '../context/CartesianGraphicalItemContext';
 import { GraphicalItemClipPath, useNeedsClip } from './GraphicalItemClipPath';
 
@@ -201,8 +200,6 @@ function renderDotItem(option: ActiveDotType, props: any) {
 
   return dotItem;
 }
-
-const noErrorBars: never[] = [];
 
 const errorBarDataPointFormatter: ErrorBarDataPointFormatter = (
   dataPoint: LinePointItem,
@@ -487,23 +484,7 @@ class LineWithState extends Component<Props, State> {
     } = this.props;
 
     if (hide || !points || !points.length) {
-      return (
-        <>
-          <SetCartesianGraphicalItem
-            data={this.props.data}
-            xAxisId={xAxisId}
-            yAxisId={yAxisId}
-            zAxisId={0}
-            dataKey={this.props.dataKey}
-            errorBars={noErrorBars}
-            // line doesn't stack
-            stackId={undefined}
-            hide={this.props.hide}
-          />
-          <SetLineLegend {...this.props} />
-          <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
-        </>
-      );
+      return null;
     }
 
     const { isAnimationFinished } = this.state;
@@ -515,19 +496,8 @@ class LineWithState extends Component<Props, State> {
     const dotSize = r * 2 + strokeWidth;
 
     return (
-      <CartesianGraphicalItemContext
-        data={this.props.data}
-        xAxisId={xAxisId}
-        yAxisId={yAxisId}
-        zAxisId={0}
-        dataKey={this.props.dataKey}
-        // line doesn't stack
-        stackId={undefined}
-        hide={this.props.hide}
-      >
+      <>
         <Layer className={layerClass}>
-          <SetLineLegend {...this.props} />
-          <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
           {needClip && (
             <defs>
               <GraphicalItemClipPath clipPathId={clipPathId} xAxisId={xAxisId} yAxisId={yAxisId} />
@@ -556,7 +526,7 @@ class LineWithState extends Component<Props, State> {
           mainColor={this.props.stroke}
           itemDataKey={this.props.dataKey}
         />
-      </CartesianGraphicalItemContext>
+      </>
     );
   }
 }
@@ -648,6 +618,21 @@ export class Line extends PureComponent<Props> {
   };
 
   render() {
-    return <LineImpl {...this.props} />;
+    return (
+      <CartesianGraphicalItemContext
+        data={this.props.data}
+        xAxisId={this.props.xAxisId}
+        yAxisId={this.props.yAxisId}
+        zAxisId={0}
+        dataKey={this.props.dataKey}
+        // line doesn't stack
+        stackId={undefined}
+        hide={this.props.hide}
+      >
+        <SetLineLegend {...this.props} />
+        <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
+        <LineImpl {...this.props} />
+      </CartesianGraphicalItemContext>
+    );
   }
 }

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -43,7 +43,6 @@ import {
 } from '../context/tooltipContext';
 import { TooltipPayload, TooltipPayloadConfiguration, TooltipPayloadEntry } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
-import { SetCartesianGraphicalItem } from '../state/SetCartesianGraphicalItem';
 import { CartesianGraphicalItemContext } from '../context/CartesianGraphicalItemContext';
 import { AxisId, AxisSettings, ZAxisSettings } from '../state/axisMapSlice';
 import { GraphicalItemClipPath, useNeedsClip } from './GraphicalItemClipPath';
@@ -237,8 +236,6 @@ function getTooltipEntrySettings(props: InternalProps): TooltipPayloadConfigurat
     },
   };
 }
-
-const noErrorBars: never[] = [];
 
 type AxisWithScale = Omit<AxisSettings, 'scale'> & { scale: RechartsScale };
 
@@ -528,52 +525,23 @@ class ScatterWithState extends PureComponent<InternalProps, State> {
   render() {
     const { hide, points, className, needClip, xAxisId, yAxisId, id, isAnimationActive } = this.props;
     if (hide || !points || !points.length) {
-      return (
-        <>
-          <SetCartesianGraphicalItem
-            data={this.props.data}
-            xAxisId={this.props.xAxisId}
-            yAxisId={this.props.yAxisId}
-            zAxisId={this.props.zAxisId}
-            dataKey={this.props.dataKey}
-            errorBars={noErrorBars}
-            // scatter doesn't stack
-            stackId={undefined}
-            hide={this.props.hide}
-          />
-          <SetScatterLegend {...this.props} />
-          <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
-        </>
-      );
+      return null;
     }
     const { isAnimationFinished } = this.state;
     const layerClass = clsx('recharts-scatter', className);
     const clipPathId = isNil(id) ? this.id : id;
     return (
-      <CartesianGraphicalItemContext
-        data={this.props.data}
-        xAxisId={this.props.xAxisId}
-        yAxisId={this.props.yAxisId}
-        zAxisId={this.props.zAxisId}
-        dataKey={this.props.dataKey}
-        // scatter doesn't stack
-        stackId={undefined}
-        hide={this.props.hide}
-      >
-        <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
-          <SetScatterLegend {...this.props} />
-          <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
-          {needClip && (
-            <defs>
-              <GraphicalItemClipPath clipPathId={clipPathId} xAxisId={xAxisId} yAxisId={yAxisId} />
-            </defs>
-          )}
-          <ScatterLine {...this.props} />
-          <ScatterErrorBars {...this.props} isAnimationFinished={this.state.isAnimationFinished} />
-          <Layer key="recharts-scatter-symbols">{this.renderSymbols()}</Layer>
-          {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
-        </Layer>
-      </CartesianGraphicalItemContext>
+      <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
+        {needClip && (
+          <defs>
+            <GraphicalItemClipPath clipPathId={clipPathId} xAxisId={xAxisId} yAxisId={yAxisId} />
+          </defs>
+        )}
+        <ScatterLine {...this.props} />
+        <ScatterErrorBars {...this.props} isAnimationFinished={this.state.isAnimationFinished} />
+        <Layer key="recharts-scatter-symbols">{this.renderSymbols()}</Layer>
+        {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
+      </Layer>
     );
   }
 }
@@ -649,6 +617,21 @@ export class Scatter extends Component<InternalProps> {
   };
 
   render() {
-    return <ScatterImpl {...this.props} />;
+    return (
+      <CartesianGraphicalItemContext
+        data={this.props.data}
+        xAxisId={this.props.xAxisId}
+        yAxisId={this.props.yAxisId}
+        zAxisId={this.props.zAxisId}
+        dataKey={this.props.dataKey}
+        // scatter doesn't stack
+        stackId={undefined}
+        hide={this.props.hide}
+      >
+        <SetScatterLegend {...this.props} />
+        <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
+        <ScatterImpl {...this.props} />
+      </CartesianGraphicalItemContext>
+    );
   }
 }

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -433,7 +433,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3600]);
-      expect(axisDomainSpy).toHaveBeenCalledTimes(7);
+      expect(axisDomainSpy).toHaveBeenCalledTimes(6);
     });
 
     it('should extend XAxis domain', () => {

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -4028,7 +4028,7 @@ describe('<XAxis />', () => {
       expect(itemDataSpy).toHaveBeenCalledTimes(3);
       expect(displayedDataSpy).toHaveBeenLastCalledWith(pageData);
       // oof
-      expect(axisDomainSpy).toHaveBeenCalledTimes(23);
+      expect(axisDomainSpy).toHaveBeenCalledTimes(15);
       expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 2520]);
     });
   });

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -632,7 +632,7 @@ describe('Tooltip visibility', () => {
       assertNotNull(chart);
       fireEvent.mouseOver(chart, { clientX: 200, clientY: 200 });
 
-      expect(tooltipPayload.map(({ name }) => name).join('')).toBe('12statureweight35');
+      expect(tooltipPayload.map(({ name }) => name).join('')).toBe('1235statureweight');
     });
 
     test('false - Should hide tooltip for hidden items', () => {

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -308,54 +308,54 @@ describe('selectAxisDomain', () => {
     );
     expectXAxisTicks(container, [
       {
-        textContent: '70',
+        textContent: '10',
         x: '5',
         y: '73',
       },
       {
-        textContent: '80',
+        textContent: '20',
         x: '16.25',
         y: '73',
       },
       {
-        textContent: '90',
+        textContent: '30',
         x: '27.5',
         y: '73',
       },
       {
-        textContent: '10',
+        textContent: '40',
         x: '38.75',
         y: '73',
       },
       {
-        textContent: '20',
+        textContent: '50',
         x: '50',
         y: '73',
       },
       {
-        textContent: '30',
+        textContent: '60',
         x: '61.25',
         y: '73',
       },
       {
-        textContent: '40',
+        textContent: '70',
         x: '72.5',
         y: '73',
       },
       {
-        textContent: '50',
+        textContent: '80',
         x: '83.75',
         y: '73',
       },
       {
-        textContent: '60',
+        textContent: '90',
         x: '95',
         y: '73',
       },
     ]);
-    expect(domainSpy).toHaveBeenLastCalledWith([70, 80, 90, 10, 20, 30, 40, 50, 60]);
+    expect(domainSpy).toHaveBeenLastCalledWith([10, 20, 30, 40, 50, 60, 70, 80, 90]);
     // big oof
-    expect(domainSpy).toHaveBeenCalledTimes(29);
+    expect(domainSpy).toHaveBeenCalledTimes(21);
   });
 
   it('should return array indexes if there are multiple graphical items, and no explicit dataKey on the matching XAxis', () => {
@@ -421,7 +421,7 @@ describe('selectAxisDomain', () => {
     ]);
     expect(domainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8]);
     // big oof
-    expect(domainSpy).toHaveBeenCalledTimes(29);
+    expect(domainSpy).toHaveBeenCalledTimes(21);
   });
 
   describe('XAxis with type = number', () => {


### PR DESCRIPTION
## Description

This has two benefits, one: fewer renders, two: helps to avoid the errorbar - scatter circular dependency.

## Related Issue

https://github.com/recharts/recharts/issues/4583