### PR TITLE
Send all internal props to ErrorBar through context instead of cloning

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -512,6 +512,8 @@ function AreaImpl(props: Props) {
   return <AreaWithState {...everythingElse} needClip={needClip} />;
 }
 
+const noop = (): undefined => {};
+
 export class Area extends PureComponent<Props, State> {
   static displayName = 'Area';
 
@@ -694,6 +696,10 @@ export class Area extends PureComponent<Props, State> {
         zAxisId={0}
         stackId={this.props.stackId}
         hide={this.props.hide}
+        // Area does not support ErrorBars
+        errorBarData={undefined}
+        dataPointFormatter={noop}
+        errorBarOffset={0}
       >
         <SetAreaLegend {...this.props} />
         <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />

--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -9,8 +9,7 @@ import { filterProps } from '../util/ReactUtils';
 import { BarRectangleItem } from './Bar';
 import { LinePointItem } from './Line';
 import { ScatterPointItem } from './Scatter';
-import { ReportErrorBarSettings } from '../context/CartesianGraphicalItemContext';
-import { AxisId } from '../state/axisMapSlice';
+import { ReportErrorBarSettings, useErrorBarContext } from '../context/CartesianGraphicalItemContext';
 import { useXAxis, useYAxis } from '../hooks';
 
 export interface ErrorBarDataItem {
@@ -37,16 +36,7 @@ export type ErrorBarDataPointFormatter = (
   direction: ErrorBarDirection,
 ) => ErrorBarDataItem;
 
-interface InternalErrorBarProps {
-  xAxisId?: AxisId;
-  yAxisId?: AxisId;
-  data?: any[];
-  dataPointFormatter?: ErrorBarDataPointFormatter;
-  /** The offset between central and the given coordinate, often set by <Bar/> */
-  offset?: number;
-}
-
-interface ErrorBarProps extends InternalErrorBarProps {
+interface ErrorBarProps {
   dataKey: DataKey<any>;
   /** the width of the error bar ends */
   width?: number;
@@ -65,14 +55,9 @@ export type Props = SVGProps<SVGLineElement> & ErrorBarProps;
 
 function ErrorBarImpl(props: Props) {
   const {
-    offset,
     direction,
     width,
     dataKey,
-    data,
-    dataPointFormatter,
-    xAxisId,
-    yAxisId,
     isAnimationActive,
     animationBegin,
     animationDuration,
@@ -81,10 +66,12 @@ function ErrorBarImpl(props: Props) {
   } = props;
   const svgProps = filterProps(others, false);
 
-  const xAxis = useXAxis(props.xAxisId);
-  const yAxis = useYAxis(props.yAxisId);
+  const { data, dataPointFormatter, xAxisId, yAxisId, errorBarOffset: offset } = useErrorBarContext();
 
-  if (xAxis?.scale == null || yAxis?.scale == null) {
+  const xAxis = useXAxis(xAxisId);
+  const yAxis = useYAxis(yAxisId);
+
+  if (xAxis?.scale == null || yAxis?.scale == null || data == null) {
     return null;
   }
 

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Line
  */
 // eslint-disable-next-line max-classes-per-file
-import React, { Component, PureComponent, ReactElement } from 'react';
+import React, { Component, PureComponent } from 'react';
 import Animate from 'react-smooth';
 import isFunction from 'lodash/isFunction';
 import isNil from 'lodash/isNil';
@@ -14,15 +14,9 @@ import { Dot } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelType } from '../component/Label';
 import { LabelList } from '../component/LabelList';
-import {
-  ErrorBar,
-  ErrorBarDataItem,
-  ErrorBarDataPointFormatter,
-  Props as ErrorBarProps,
-  SetErrorBarPreferredDirection,
-} from './ErrorBar';
+import { ErrorBarDataItem, ErrorBarDataPointFormatter, SetErrorBarPreferredDirection } from './ErrorBar';
 import { interpolateNumber, uniqueId } from '../util/DataUtils';
-import { filterProps, findAllByType, hasClipDot } from '../util/ReactUtils';
+import { filterProps, hasClipDot } from '../util/ReactUtils';
 import { Global } from '../util/Global';
 import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
 import { Props as XAxisProps } from './XAxis';
@@ -291,37 +285,6 @@ class LineWithState extends Component<Props, State> {
     }
   };
 
-  renderErrorBar(needClip: boolean, clipPathId: string) {
-    if (this.props.isAnimationActive && !this.state.isAnimationFinished) {
-      return null;
-    }
-
-    const { points, xAxisId, yAxisId, children } = this.props;
-    const errorBarItems = findAllByType(children, ErrorBar);
-
-    if (!errorBarItems) {
-      return null;
-    }
-
-    const errorBarProps = {
-      clipPath: needClip ? `url(#clipPath-${clipPathId})` : null,
-    };
-
-    return (
-      <Layer {...errorBarProps}>
-        {errorBarItems.map((item: ReactElement<ErrorBarProps>) =>
-          React.cloneElement(item, {
-            key: `bar-${item.props.dataKey}`,
-            data: points,
-            xAxisId,
-            yAxisId,
-            dataPointFormatter: errorBarDataPointFormatter,
-          }),
-        )}
-      </Layer>
-    );
-  }
-
   renderDots(needClip: boolean, clipDot: boolean, clipPathId: string) {
     const { isAnimationActive } = this.props;
 
@@ -515,7 +478,7 @@ class LineWithState extends Component<Props, State> {
           )}
           {!hasSinglePoint && this.renderCurve(needClip, clipPathId)}
           <SetErrorBarPreferredDirection direction={layout === 'horizontal' ? 'y' : 'x'}>
-            {this.renderErrorBar(needClip, clipPathId)}
+            {this.props.children}
           </SetErrorBarPreferredDirection>
           {(hasSinglePoint || dot) && this.renderDots(needClip, clipDot, clipPathId)}
           {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
@@ -628,6 +591,9 @@ export class Line extends PureComponent<Props> {
         // line doesn't stack
         stackId={undefined}
         hide={this.props.hide}
+        dataPointFormatter={errorBarDataPointFormatter}
+        errorBarData={this.props.points}
+        errorBarOffset={0}
       >
         <SetLineLegend {...this.props} />
         <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -346,7 +346,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3600]);
-      expect(axisDomainSpy).toHaveBeenCalledTimes(6);
+      expect(axisDomainSpy).toHaveBeenCalledTimes(7);
     });
 
     it('should extend YAxis domain when data is defined on the graphical item', () => {
@@ -519,7 +519,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(xAxisSpy).toHaveBeenLastCalledWith([0, 3600]);
-      expect(xAxisSpy).toHaveBeenCalledTimes(6);
+      expect(xAxisSpy).toHaveBeenCalledTimes(7);
     });
 
     it('should extend XAxis domain when data is defined on the graphical item', () => {

--- a/test/cartesian/ReferenceArea.spec.tsx
+++ b/test/cartesian/ReferenceArea.spec.tsx
@@ -600,7 +600,7 @@ describe('<ReferenceArea />', () => {
       );
 
       expect(areaSpy).toHaveBeenLastCalledWith([]);
-      expect(areaSpy).toHaveBeenCalledTimes(5);
+      expect(areaSpy).toHaveBeenCalledTimes(6);
     });
   });
 });


### PR DESCRIPTION
## Description

No more "internal props" on ErrorBar, no more element cloning. And hopefully no more circular dependency problem.

## Related Issue

https://github.com/recharts/recharts/issues/4583