### PR TITLE
Make scale selector stable

### DIFF
--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -1,6 +1,3 @@
-/**
- * @fileOverview Reference Line
- */
 import React, { Component, ReactElement, useEffect } from 'react';
 import isFunction from 'lodash/isFunction';
 import clsx from 'clsx';
@@ -10,13 +7,13 @@ import { createLabeledScales, rectWithPoints } from '../util/CartesianUtils';
 import { IfOverflow } from '../util/IfOverflow';
 import { isNumOrStr } from '../util/DataUtils';
 import { Props as RectangleProps, Rectangle } from '../shape/Rectangle';
-import { D3Scale } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 
 import { useClipPathId } from '../context/chartLayoutContext';
 import { addArea, ReferenceAreaSettings, removeArea } from '../state/referenceElementsSlice';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { selectAxisScale } from '../state/selectors/axisSelectors';
+import { RechartsScale } from '../util/ChartUtils';
 
 interface ReferenceAreaProps {
   ifOverflow?: IfOverflow;
@@ -39,8 +36,8 @@ const getRect = (
   hasX2: boolean,
   hasY1: boolean,
   hasY2: boolean,
-  xAxisScale: D3Scale<string | number>,
-  yAxisScale: D3Scale<string | number>,
+  xAxisScale: RechartsScale | undefined,
+  yAxisScale: RechartsScale | undefined,
   props: Props,
 ) => {
   const { x1: xValue1, x2: xValue2, y1: yValue1, y2: yValue2 } = props;
@@ -99,7 +96,7 @@ function ReferenceAreaImpl(props: Props) {
   const xAxisScale = useAppSelector(state => selectAxisScale(state, 'xAxis', xAxisId));
   const yAxisScale = useAppSelector(state => selectAxisScale(state, 'yAxis', yAxisId));
 
-  if (xAxisScale?.scale == null || !yAxisScale?.scale == null) {
+  if (xAxisScale == null || !yAxisScale == null) {
     return null;
   }
 
@@ -112,8 +109,7 @@ function ReferenceAreaImpl(props: Props) {
     return null;
   }
 
-  // @ts-expect-error the xAxis and yAxis in context do not match what this function is expecting - the whole axis type situation needs improvement
-  const rect = getRect(hasX1, hasX2, hasY1, hasY2, xAxisScale.scale, yAxisScale.scale, props);
+  const rect = getRect(hasX1, hasX2, hasY1, hasY2, xAxisScale, yAxisScale, props);
 
   if (!rect && !shape) {
     return null;

--- a/src/cartesian/ReferenceDot.tsx
+++ b/src/cartesian/ReferenceDot.tsx
@@ -46,11 +46,11 @@ const useCoordinate = (
   const xAxisScale = useAppSelector(state => selectAxisScale(state, 'xAxis', xAxisId));
   const yAxisScale = useAppSelector(state => selectAxisScale(state, 'yAxis', yAxisId));
 
-  if (!isX || !isY || xAxisScale?.scale == null || yAxisScale?.scale == null) {
+  if (!isX || !isY || xAxisScale == null || yAxisScale == null) {
     return null;
   }
 
-  const scales = createLabeledScales({ x: xAxisScale.scale, y: yAxisScale.scale });
+  const scales = createLabeledScales({ x: xAxisScale, y: yAxisScale });
 
   const result = scales.apply({ x, y }, { bandAware: true });
 

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -163,18 +163,11 @@ function ReferenceLineImpl(props: Props) {
   const isFixedX = isNumOrStr(fixedX);
   const isFixedY = isNumOrStr(fixedY);
 
-  if (
-    !clipPathId ||
-    !viewBox ||
-    xAxis == null ||
-    yAxis == null ||
-    xAxisScale?.scale == null ||
-    yAxisScale?.scale == null
-  ) {
+  if (!clipPathId || !viewBox || xAxis == null || yAxis == null || xAxisScale == null || yAxisScale == null) {
     return null;
   }
 
-  const scales = createLabeledScales({ x: xAxisScale.scale, y: yAxisScale.scale });
+  const scales = createLabeledScales({ x: xAxisScale, y: yAxisScale });
 
   const isSegment = segment && segment.length === 2;
 

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -55,12 +55,12 @@ const XAxisImpl = (props: Props) => {
   const { xAxisId, className } = props;
   const viewBox = useAppSelector(selectAxisViewBox);
   const axisType = 'xAxis';
-  const scaleObj = useAppSelector(state => selectAxisScale(state, axisType, xAxisId));
+  const scale = useAppSelector(state => selectAxisScale(state, axisType, xAxisId));
   const cartesianTickItems = useAppSelector(state => selectTicksOfAxis(state, axisType, xAxisId));
   const axisSize = useAppSelector(state => selectXAxisSize(state, xAxisId));
   const position = useAppSelector(state => selectXAxisPosition(state, xAxisId));
 
-  if (axisSize == null || position == null || scaleObj == null) {
+  if (axisSize == null || position == null) {
     return null;
   }
 
@@ -69,7 +69,7 @@ const XAxisImpl = (props: Props) => {
   return (
     <CartesianAxis
       {...allOtherProps}
-      scale={scaleObj.scale}
+      scale={scale}
       x={position.x}
       y={position.y}
       width={axisSize.width}

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -51,12 +51,12 @@ const YAxisImpl: FunctionComponent<Props> = (props: Props) => {
   const { yAxisId, className } = props;
   const viewBox = useAppSelector(selectAxisViewBox);
   const axisType = 'yAxis';
-  const scaleObj = useAppSelector(state => selectAxisScale(state, axisType, yAxisId));
+  const scale = useAppSelector(state => selectAxisScale(state, axisType, yAxisId));
   const axisSize = useAppSelector(state => selectYAxisSize(state, yAxisId));
   const position = useAppSelector(state => selectYAxisPosition(state, yAxisId));
   const cartesianTickItems = useAppSelector(state => selectTicksOfAxis(state, axisType, yAxisId));
 
-  if (axisSize == null || position == null || scaleObj == null) {
+  if (axisSize == null || position == null) {
     return null;
   }
 
@@ -65,7 +65,7 @@ const YAxisImpl: FunctionComponent<Props> = (props: Props) => {
   return (
     <CartesianAxis
       {...allOtherProps}
-      scale={scaleObj.scale}
+      scale={scale}
       x={position.x}
       y={position.y}
       width={axisSize.width}

--- a/src/state/selectors/selectAllAxes.ts
+++ b/src/state/selectors/selectAllAxes.ts
@@ -1,14 +1,17 @@
+import { createSelector } from '@reduxjs/toolkit';
 import { RechartsRootState } from '../store';
 import { XAxisSettings, YAxisSettings } from '../axisMapSlice';
 
-export const selectAllXAxes: (state: RechartsRootState) => ReadonlyArray<XAxisSettings> = (
-  state: RechartsRootState,
-): ReadonlyArray<XAxisSettings> => {
-  return Object.values(state.axisMap.xAxis);
-};
+export const selectAllXAxes: (state: RechartsRootState) => ReadonlyArray<XAxisSettings> = createSelector(
+  (state: RechartsRootState) => state.axisMap.xAxis,
+  (xAxisMap): ReadonlyArray<XAxisSettings> => {
+    return Object.values(xAxisMap);
+  },
+);
 
-export const selectAllYAxes: (state: RechartsRootState) => ReadonlyArray<YAxisSettings> = (
-  state: RechartsRootState,
-): ReadonlyArray<YAxisSettings> => {
-  return Object.values(state.axisMap.yAxis);
-};
+export const selectAllYAxes: (state: RechartsRootState) => ReadonlyArray<YAxisSettings> = createSelector(
+  (state: RechartsRootState) => state.axisMap.yAxis,
+  (yAxisMap): ReadonlyArray<YAxisSettings> => {
+    return Object.values(yAxisMap);
+  },
+);

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -636,7 +636,7 @@ export type ParseScaleAxisInput = {
   axisType: 'radiusAxis' | 'angleAxis' | unknown;
 };
 
-export type ParsedScaleReturn = {
+type ParsedScaleReturn = {
   scale: RechartsScale | undefined;
   realScaleType: string | undefined;
 };

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -232,7 +232,7 @@ describe('CartesianGrid', () => {
     const scaleSpy = vi.fn();
     const Comp = (): null => {
       const scale = useAppSelector(state => selectAxisScale(state, 'yAxis', 'left'));
-      scaleSpy(scale?.scale?.domain());
+      scaleSpy(scale?.domain());
       return null;
     };
     const { container } = render(
@@ -732,7 +732,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
 
           const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
           expect(allLines).toHaveLength(2);
@@ -780,7 +780,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
           const expectedYAxis: AxisPropsForCartesianGridTicksGeneration = {
             angle: 0,
             interval: 'preserveEnd',
@@ -795,7 +795,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             isCategorical: false,
             niceTicks: undefined,
             range: [189, 14],
-            realScaleType: undefined,
+            realScaleType: 'linear',
             scale: undefined,
             tickCount: 5,
             ticks: undefined,
@@ -826,7 +826,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
           const expectedYAxis: AxisPropsForCartesianGridTicksGeneration = {
             angle: 0,
             interval: 'preserveEnd',
@@ -841,7 +841,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             isCategorical: false,
             niceTicks: undefined,
             range: [189, 14],
-            realScaleType: undefined,
+            realScaleType: 'linear',
             scale: undefined,
             tickCount: 5,
             ticks: ['a', 'b'],
@@ -873,7 +873,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               </ChartElement>,
             );
 
-            expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+            expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
             const expectedYAxis: AxisPropsForCartesianGridTicksGeneration = {
               angle: 0,
               interval: 'preserveEnd',
@@ -888,7 +888,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               isCategorical: false,
               niceTicks: undefined,
               range: [189, 14],
-              realScaleType: undefined,
+              realScaleType: 'linear',
               scale: undefined,
               tickCount: 5,
               ticks: undefined,
@@ -920,7 +920,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               </ChartElement>,
             );
 
-            expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+            expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
             const expectedYAxis: AxisPropsForCartesianGridTicksGeneration = {
               angle: 0,
               interval: 'preserveEnd',
@@ -935,7 +935,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               isCategorical: false,
               niceTicks: undefined,
               range: [189, 14],
-              realScaleType: undefined,
+              realScaleType: 'linear',
               scale: undefined,
               tickCount: 5,
               ticks: undefined,
@@ -966,7 +966,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               </ChartElement>,
             );
 
-            expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+            expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
 
             const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
             expect(allLines).toHaveLength(0);
@@ -1009,7 +1009,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
 
           const allLines = container.querySelectorAll('.recharts-cartesian-grid-vertical line');
           expect(allLines).toHaveLength(2);
@@ -1057,7 +1057,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
           const expectedXAxis: AxisPropsForCartesianGridTicksGeneration = {
             angle: 0,
             interval: 'preserveEnd',
@@ -1103,7 +1103,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
           const expectedXAxis: AxisPropsForCartesianGridTicksGeneration = {
             angle: 0,
             interval: 'preserveEnd',
@@ -1150,7 +1150,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               </ChartElement>,
             );
 
-            expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+            expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
             const expectedXAxis: AxisPropsForCartesianGridTicksGeneration = {
               angle: 0,
               interval: 'preserveEnd',
@@ -1197,7 +1197,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               </ChartElement>,
             );
 
-            expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+            expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
             const expectedXAxis: AxisPropsForCartesianGridTicksGeneration = {
               angle: 0,
               interval: 'preserveEnd',
@@ -1243,7 +1243,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               </ChartElement>,
             );
 
-            expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+            expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
 
             const allLines = container.querySelectorAll('.recharts-cartesian-grid-vertical line');
             expect(allLines).toHaveLength(0);
@@ -1287,7 +1287,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               />
             </ChartElement>,
           );
-          expect(horizontal).toHaveBeenCalledTimes(3 * horizontalPoints.length);
+          expect(horizontal).toHaveBeenCalledTimes(horizontalPoints.length);
 
           const expectedProps: GridLineTypeFunctionProps = {
             stroke: '#ccc',
@@ -1351,7 +1351,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               isCategorical: false,
               niceTicks: undefined,
               range: [495, 5],
-              realScaleType: undefined,
+              realScaleType: 'linear',
               scale: undefined,
               tickCount: 5,
               ticks: undefined,
@@ -1381,7 +1381,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               />
             </ChartElement>,
           );
-          expect(spy).toHaveBeenCalledTimes(3 * horizontalPoints.length);
+          expect(spy).toHaveBeenCalledTimes(horizontalPoints.length);
 
           const expectedProps: GridLineTypeFunctionProps = {
             stroke: '#ccc',
@@ -1445,7 +1445,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               isCategorical: false,
               niceTicks: undefined,
               range: [495, 5],
-              realScaleType: undefined,
+              realScaleType: 'linear',
               scale: undefined,
               tickCount: 5,
               ticks: undefined,
@@ -1471,7 +1471,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               />
             </ChartElement>,
           );
-          expect(vertical).toHaveBeenCalledTimes(3 * verticalPoints.length);
+          expect(vertical).toHaveBeenCalledTimes(verticalPoints.length);
 
           const expectedProps: GridLineTypeFunctionProps = {
             stroke: '#ccc',
@@ -1535,7 +1535,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               isCategorical: false,
               niceTicks: undefined,
               range: [495, 5],
-              realScaleType: undefined,
+              realScaleType: 'linear',
               scale: undefined,
               tickCount: 5,
               ticks: undefined,
@@ -1565,7 +1565,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               />
             </ChartElement>,
           );
-          expect(spy).toHaveBeenCalledTimes(3 * verticalPoints.length);
+          expect(spy).toHaveBeenCalledTimes(verticalPoints.length);
 
           const expectedProps: GridLineTypeFunctionProps = {
             stroke: '#ccc',
@@ -1621,7 +1621,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               isCategorical: false,
               niceTicks: undefined,
               range: [495, 5],
-              realScaleType: undefined,
+              realScaleType: 'linear',
               scale: undefined,
               tickCount: 5,
               ticks: undefined,
@@ -1711,7 +1711,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
 
           const allLines = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
           expect(allLines).toHaveLength(3);
@@ -1928,7 +1928,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(3);
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
 
           const allLines = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
           expect(allLines).toHaveLength(3);

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -22,6 +22,7 @@ import {
   selectAxisSettings,
   selectCartesianGraphicalItemsData,
   selectDisplayedData,
+  selectRealScaleType,
   selectTicksOfAxis,
   selectXAxisPosition,
 } from '../../src/state/selectors/axisSelectors';
@@ -266,7 +267,12 @@ describe('<XAxis />', () => {
   it('Render ticks of when the scale of XAxis is time', () => {
     // This test assumes UTC timezone because it renders strings that include timezone
     expect(new Date().getTimezoneOffset()).toEqual(0);
-    const spy = vi.fn();
+    const axisDomainSpy = vi.fn();
+    const scaleTypeSpy = vi.fn();
+    const Comp = (): null => {
+      scaleTypeSpy(useAppSelector(state => selectRealScaleType(state, 'xAxis', 0)));
+      return null;
+    };
     const timeData = [
       {
         x: new Date('2019-07-04T00:00:00.000Z'),
@@ -308,10 +314,12 @@ describe('<XAxis />', () => {
         />
         <YAxis />
         <Line type="monotone" dataKey="y" stroke="#8884d8" activeDot={{ r: 8 }} />
-        <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
+        <Customized component={<ExpectAxisDomain assert={axisDomainSpy} axisType="xAxis" />} />
+        <Customized component={<Comp />} />
       </LineChart>,
     );
 
+    expect(scaleTypeSpy).toHaveBeenLastCalledWith('scaleTime');
     expect(container.querySelectorAll('.recharts-xAxis .recharts-cartesian-axis-tick')).toHaveLength(timeData.length);
     expectXAxisTicks(container, [
       {
@@ -350,7 +358,10 @@ describe('<XAxis />', () => {
         y: '273',
       },
     ]);
-    expect(spy).toHaveBeenLastCalledWith([new Date('2019-07-04T00:00:00.000Z'), new Date('2019-07-10T00:00:00.000Z')]);
+    expect(axisDomainSpy).toHaveBeenLastCalledWith([
+      new Date('2019-07-04T00:00:00.000Z'),
+      new Date('2019-07-10T00:00:00.000Z'),
+    ]);
   });
 
   it('Render Bars with gap', () => {

--- a/test/cartesian/ZAxis.spec.tsx
+++ b/test/cartesian/ZAxis.spec.tsx
@@ -5,7 +5,12 @@ import { describe, it, expect, vi } from 'vitest';
 import { CartesianGrid, Customized, Scatter, ScatterChart, Surface, Tooltip, XAxis, YAxis, ZAxis } from '../../src';
 import { assertNotNull } from '../helper/assertNotNull';
 import { useAppSelector } from '../../src/state/hooks';
-import { selectAxisDomain, selectZAxisSettings, selectZAxisWithScale } from '../../src/state/selectors/axisSelectors';
+import {
+  selectAxisDomain,
+  selectRealScaleType,
+  selectZAxisSettings,
+  selectZAxisWithScale,
+} from '../../src/state/selectors/axisSelectors';
 import { ZAxisSettings } from '../../src/state/axisMapSlice';
 
 describe('<ZAxis />', () => {
@@ -89,11 +94,12 @@ describe('<ZAxis />', () => {
       const Comp = (): null => {
         axisSettingsSpy(useAppSelector(state => selectZAxisSettings(state, 'zaxis id')));
         axisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'zAxis', 'zaxis id')));
-        const scaleReturn = useAppSelector(state => selectZAxisWithScale(state, 'zAxis', 'zaxis id'));
+        const axis = useAppSelector(state => selectZAxisWithScale(state, 'zAxis', 'zaxis id'));
+        const realScaleType = useAppSelector(state => selectRealScaleType(state, 'zAxis', 'zaxis id'));
         axisScaleSpy({
-          domain: scaleReturn?.scale?.domain(),
-          range: scaleReturn?.scale?.range(),
-          realScaleType: scaleReturn?.realScaleType,
+          domain: axis?.scale?.domain(),
+          range: axis?.scale?.range(),
+          realScaleType,
         });
         return null;
       };

--- a/test/chart/AreaChart.spec.tsx
+++ b/test/chart/AreaChart.spec.tsx
@@ -180,14 +180,14 @@ describe('AreaChart', () => {
       const { container } = render(chart);
 
       spies.forEach(el => expect(el.mock.calls.length).toBe(1));
-      expect(axisSpy).toHaveBeenCalledTimes(6);
+      expect(axisSpy).toHaveBeenCalledTimes(4);
 
       fireEvent.mouseEnter(container, { clientX: 30, clientY: 200 });
       fireEvent.mouseMove(container, { clientX: 200, clientY: 200 });
       fireEvent.mouseLeave(container);
 
       spies.forEach(el => expect(el.mock.calls.length).toBe(1));
-      expect(axisSpy).toHaveBeenCalledTimes(6);
+      expect(axisSpy).toHaveBeenCalledTimes(4);
     });
 
     // protect against the future where someone might mess up our clean rendering
@@ -195,7 +195,7 @@ describe('AreaChart', () => {
       const { container } = render(chart);
 
       spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-      expect(axisSpy).toHaveBeenCalledTimes(6);
+      expect(axisSpy).toHaveBeenCalledTimes(4);
 
       const brushSlide = container.querySelector('.recharts-brush-slide');
       assertNotNull(brushSlide);
@@ -204,7 +204,7 @@ describe('AreaChart', () => {
       fireEvent.mouseUp(window);
 
       spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-      expect(axisSpy).toHaveBeenCalledTimes(10);
+      expect(axisSpy).toHaveBeenCalledTimes(4);
     });
 
     test('should only show the last data when the brush travelers all moved to the right', () => {

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -1044,14 +1044,14 @@ describe('<LineChart /> - Pure Rendering', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(6);
+    expect(axisSpy).toHaveBeenCalledTimes(4);
 
     fireEvent.mouseEnter(container, { clientX: 30, clientY: 200, bubbles: true, cancelable: true });
     fireEvent.mouseMove(container, { clientX: 200, clientY: 200, bubbles: true, cancelable: true });
     fireEvent.mouseLeave(container);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(6);
+    expect(axisSpy).toHaveBeenCalledTimes(4);
   });
 
   // protect against the future where someone might mess up our clean rendering
@@ -1059,7 +1059,7 @@ describe('<LineChart /> - Pure Rendering', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(6);
+    expect(axisSpy).toHaveBeenCalledTimes(4);
 
     const leftCursor = container.querySelector('.recharts-brush-traveller');
     assertNotNull(leftCursor);
@@ -1070,7 +1070,7 @@ describe('<LineChart /> - Pure Rendering', () => {
     fireEvent.mouseUp(window);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(6);
+    expect(axisSpy).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -1104,7 +1104,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(6);
+    expect(axisSpy).toHaveBeenCalledTimes(4);
 
     fireEvent.mouseEnter(container, { clientX: 30, clientY: 200, bubbles: true, cancelable: true });
 
@@ -1113,7 +1113,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     fireEvent.mouseLeave(container);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(6);
+    expect(axisSpy).toHaveBeenCalledTimes(4);
   });
 
   // protect against the future where someone might mess up our clean rendering
@@ -1121,7 +1121,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(6);
+    expect(axisSpy).toHaveBeenCalledTimes(4);
 
     const leftCursor = container.querySelector('.recharts-brush-traveller');
     assertNotNull(leftCursor);
@@ -1130,7 +1130,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     fireEvent.mouseUp(window);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(6);
+    expect(axisSpy).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/test/context/chartLayoutContext.spec.tsx
+++ b/test/context/chartLayoutContext.spec.tsx
@@ -564,7 +564,7 @@ describe('useOffset', () => {
   });
 
   it('should return default offset in an empty chart', () => {
-    expect.assertions(3);
+    expect.assertions(2);
     const Comp = (): null => {
       const offset = useOffset();
       expect(offset).toEqual({ top: 5, right: 5, bottom: 5, left: 5, brushBottom: 5, height: 190, width: 90 });
@@ -578,7 +578,7 @@ describe('useOffset', () => {
   });
 
   it('should add chart margin', () => {
-    expect.assertions(3);
+    expect.assertions(2);
     const Comp = (): null => {
       const offset = useOffset();
       expect(offset).toEqual({ top: 10, right: 20, bottom: 30, left: 40, brushBottom: 30, height: 160, width: 40 });

--- a/test/helper/createDebugSelector.ts
+++ b/test/helper/createDebugSelector.ts
@@ -1,0 +1,20 @@
+import { createSelectorCreator, lruMemoize } from '@reduxjs/toolkit';
+
+// noinspection JSUnusedGlobalSymbols
+/**
+ * From https://stackoverflow.com/questions/59376392/reselect-how-to-figure-out-which-argument-changed
+ *
+ * Useful for debugging why a selector is changing its output reference when you expect that it should not.
+ * How to use:
+ * 1. Replace `createSelector` with `createDebugSelector`
+ * 2. observe console output
+ *
+ * @deprecated - do not actually use it in any production selectors! It's for debugging only.
+ */
+export const createDebugSelector = createSelectorCreator(lruMemoize, {
+  equalityCheck: (previous, current) => {
+    const rv = current === previous;
+    if (!rv) console.warn('Selector param value changed', { current, previous });
+    return rv;
+  },
+});

--- a/test/helper/expectAxisTicks.ts
+++ b/test/helper/expectAxisTicks.ts
@@ -42,7 +42,7 @@ export function ExpectAxisDomain({
 }): null {
   useAppSelector(state => {
     const scale = selectAxisScale(state, axisType, axisId);
-    assert(scale.scale?.domain());
+    assert(scale?.domain());
   });
   return null;
 }

--- a/test/state/selectors/selectAllAxes.spec.tsx
+++ b/test/state/selectors/selectAllAxes.spec.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useAppSelector } from '../../../src/state/hooks';
+import { selectAllXAxes, selectAllYAxes } from '../../../src/state/selectors/selectAllAxes';
+import { createRechartsStore } from '../../../src/state/store';
+
+describe('selectAllXAxes', () => {
+  it('should return undefined when called outside of Redux context', () => {
+    expect.assertions(1);
+    const Comp = (): null => {
+      const allAxes = useAppSelector(selectAllXAxes);
+      expect(allAxes).toEqual(undefined);
+      return null;
+    };
+    render(<Comp />);
+  });
+
+  it('should return default object for initial state, and should be stable', () => {
+    const store = createRechartsStore();
+    const allAxes1 = selectAllXAxes(store.getState());
+    expect(allAxes1).toEqual([]);
+
+    const allAxes2 = selectAllXAxes(store.getState());
+    expect(allAxes1).toBe(allAxes2);
+  });
+});
+
+describe('selectAllYAxes', () => {
+  it('should return undefined when called outside of Redux context', () => {
+    expect.assertions(1);
+    const Comp = (): null => {
+      const allAxes = useAppSelector(selectAllYAxes);
+      expect(allAxes).toEqual(undefined);
+      return null;
+    };
+    render(<Comp />);
+  });
+
+  it('should return default object for initial state, and should be stable', () => {
+    const store = createRechartsStore();
+    const allAxes1 = selectAllYAxes(store.getState());
+    expect(allAxes1).toEqual([]);
+
+    const allAxes2 = selectAllYAxes(store.getState());
+    expect(allAxes1).toBe(allAxes2);
+  });
+});

--- a/test/state/selectors/selectChartOffset.spec.tsx
+++ b/test/state/selectors/selectChartOffset.spec.tsx
@@ -3,6 +3,8 @@ import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { selectChartOffset } from '../../../src/state/selectors/selectChartOffset';
 import { useAppSelector } from '../../../src/state/hooks';
+import { createRechartsStore } from '../../../src/state/store';
+import { LineChart, Customized } from '../../../src';
 
 describe('selectChartOffset', () => {
   it('should return undefined when called outside of Redux context', () => {
@@ -14,5 +16,39 @@ describe('selectChartOffset', () => {
     };
 
     render(<Comp />);
+  });
+
+  it('should return default object for initial state, and should be stable', () => {
+    const store = createRechartsStore();
+    const offset1 = selectChartOffset(store.getState());
+    expect(offset1).toEqual({
+      bottom: 5,
+      brushBottom: 5,
+      height: 0,
+      left: 5,
+      right: 5,
+      top: 5,
+      width: 0,
+    });
+
+    const offset2 = selectChartOffset(store.getState());
+    expect(offset1).toBe(offset2);
+  });
+
+  it('should be stable', () => {
+    expect.assertions(4);
+    const Comp = (): null => {
+      const offset1 = useAppSelector(selectChartOffset);
+      const offset2 = useAppSelector(selectChartOffset);
+      expect(offset1).not.toBe(undefined);
+      expect(offset1).toBe(offset2);
+      return null;
+    };
+
+    render(
+      <LineChart width={100} height={200}>
+        <Customized component={<Comp />} />
+      </LineChart>,
+    );
   });
 });


### PR DESCRIPTION
## Description

This is necessary to prevent infinite re-rendering loop in Scatter.

## Related Issue

https://github.com/recharts/recharts/issues/4583