### PR TITLE
ErrorBar context must be independent from GraphicalItemContext

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -512,8 +512,6 @@ function AreaImpl(props: Props) {
   return <AreaWithState {...everythingElse} needClip={needClip} />;
 }
 
-const noop = (): undefined => {};
-
 export class Area extends PureComponent<Props, State> {
   static displayName = 'Area';
 
@@ -687,6 +685,7 @@ export class Area extends PureComponent<Props, State> {
   };
 
   render() {
+    // Report all props to Redux store first, before calling any hooks, to avoid circular dependencies.
     return (
       <CartesianGraphicalItemContext
         data={this.props.data}
@@ -696,10 +695,6 @@ export class Area extends PureComponent<Props, State> {
         zAxisId={0}
         stackId={this.props.stackId}
         hide={this.props.hide}
-        // Area does not support ErrorBars
-        errorBarData={undefined}
-        dataPointFormatter={noop}
-        errorBarOffset={0}
       >
         <SetAreaLegend {...this.props} />
         <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -53,7 +53,7 @@ import {
 import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 import { ReportBar } from '../state/ReportBar';
-import { CartesianGraphicalItemContext } from '../context/CartesianGraphicalItemContext';
+import { CartesianGraphicalItemContext, SetErrorBarContext } from '../context/CartesianGraphicalItemContext';
 import { GraphicalItemClipPath, useNeedsClip } from './GraphicalItemClipPath';
 import type { XAxisProps, YAxisProps } from '../index';
 import { useChartLayout } from '../context/chartLayoutContext';
@@ -502,24 +502,15 @@ function BarImpl(props: Props) {
 
   const { ref, ...everythingElse } = props;
   return (
-    <CartesianGraphicalItemContext
-      // Bar does not allow setting data directly on the graphical item (why?)
-      data={null}
+    <SetErrorBarContext
       xAxisId={props.xAxisId}
       yAxisId={props.yAxisId}
-      zAxisId={0}
-      dataKey={props.dataKey}
-      stackId={props.stackId}
-      hide={props.hide}
-      errorBarData={props.data}
+      data={props.data}
       dataPointFormatter={errorBarDataPointFormatter}
       errorBarOffset={errorBarOffset}
     >
-      <ReportBar />
-      <SetBarLegend {...props} />
-      <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={props} />
       <BarWithState {...everythingElse} needClip={needClip} />
-    </CartesianGraphicalItemContext>
+    </SetErrorBarContext>
   );
 }
 
@@ -667,6 +658,23 @@ export class Bar extends PureComponent<Props> {
   };
 
   render() {
-    return <BarImpl {...this.props} />;
+    // Report all props to Redux store first, before calling any hooks, to avoid circular dependencies.
+    return (
+      <CartesianGraphicalItemContext
+        // Bar does not allow setting data directly on the graphical item (why?)
+        data={null}
+        xAxisId={this.props.xAxisId}
+        yAxisId={this.props.yAxisId}
+        zAxisId={0}
+        dataKey={this.props.dataKey}
+        stackId={this.props.stackId}
+        hide={this.props.hide}
+      >
+        <ReportBar />
+        <SetBarLegend {...this.props} />
+        <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
+        <BarImpl {...this.props} />
+      </CartesianGraphicalItemContext>
+    );
   }
 }

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -38,7 +38,7 @@ import { useLegendPayloadDispatch } from '../context/legendPayloadContext';
 import { ActivePoints } from '../component/ActivePoints';
 import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
-import { CartesianGraphicalItemContext } from '../context/CartesianGraphicalItemContext';
+import { CartesianGraphicalItemContext, SetErrorBarContext } from '../context/CartesianGraphicalItemContext';
 import { GraphicalItemClipPath, useNeedsClip } from './GraphicalItemClipPath';
 
 export interface LinePointItem extends CurvePoint {
@@ -478,7 +478,15 @@ class LineWithState extends Component<Props, State> {
           )}
           {!hasSinglePoint && this.renderCurve(needClip, clipPathId)}
           <SetErrorBarPreferredDirection direction={layout === 'horizontal' ? 'y' : 'x'}>
-            {this.props.children}
+            <SetErrorBarContext
+              xAxisId={xAxisId}
+              yAxisId={yAxisId}
+              data={points}
+              dataPointFormatter={errorBarDataPointFormatter}
+              errorBarOffset={0}
+            >
+              {this.props.children}
+            </SetErrorBarContext>
           </SetErrorBarPreferredDirection>
           {(hasSinglePoint || dot) && this.renderDots(needClip, clipDot, clipPathId)}
           {(!isAnimationActive || isAnimationFinished) && LabelList.renderCallByParent(this.props, points)}
@@ -581,6 +589,7 @@ export class Line extends PureComponent<Props> {
   };
 
   render() {
+    // Report all props to Redux store first, before calling any hooks, to avoid circular dependencies.
     return (
       <CartesianGraphicalItemContext
         data={this.props.data}
@@ -591,9 +600,6 @@ export class Line extends PureComponent<Props> {
         // line doesn't stack
         stackId={undefined}
         hide={this.props.hide}
-        dataPointFormatter={errorBarDataPointFormatter}
-        errorBarData={this.props.points}
-        errorBarOffset={0}
       >
         <SetLineLegend {...this.props} />
         <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />

--- a/src/context/CartesianGraphicalItemContext.tsx
+++ b/src/context/CartesianGraphicalItemContext.tsx
@@ -37,9 +37,14 @@ const initialContextState: ErrorBarContextType<any> = {
 
 const ErrorBarContext = createContext(initialContextState);
 
+export function SetErrorBarContext<T>(props: ErrorBarContextType<T> & { children: React.ReactNode }) {
+  const { children, ...rest } = props;
+  return <ErrorBarContext.Provider value={rest}>{children}</ErrorBarContext.Provider>;
+}
+
 export const useErrorBarContext = () => useContext(ErrorBarContext);
 
-type GraphicalItemContextProps<T> = {
+type GraphicalItemContextProps = {
   data: ChartData;
   xAxisId: AxisId;
   yAxisId: AxisId;
@@ -48,9 +53,6 @@ type GraphicalItemContextProps<T> = {
   children: React.ReactNode;
   stackId: StackId | undefined;
   hide: boolean;
-  errorBarData: ReadonlyArray<T>;
-  dataPointFormatter: ErrorBarDataPointFormatter;
-  errorBarOffset: number;
 };
 
 export const CartesianGraphicalItemContext = ({
@@ -62,10 +64,7 @@ export const CartesianGraphicalItemContext = ({
   data,
   stackId,
   hide,
-  errorBarData,
-  dataPointFormatter,
-  errorBarOffset,
-}: GraphicalItemContextProps<any>) => {
+}: GraphicalItemContextProps) => {
   const [errorBars, updateErrorBars] = React.useState<ReadonlyArray<ErrorBarsSettings>>([]);
   // useCallback is necessary in these two because without it, the new function reference causes an infinite render loop
   const addErrorBar = useCallback(
@@ -81,29 +80,19 @@ export const CartesianGraphicalItemContext = ({
     [updateErrorBars],
   );
   return (
-    <ErrorBarContext.Provider
-      value={{
-        data: errorBarData,
-        xAxisId,
-        yAxisId,
-        dataPointFormatter,
-        errorBarOffset,
-      }}
-    >
-      <ErrorBarDirectionDispatchContext.Provider value={{ addErrorBar, removeErrorBar }}>
-        <SetCartesianGraphicalItem
-          data={data}
-          xAxisId={xAxisId}
-          yAxisId={yAxisId}
-          zAxisId={zAxisId}
-          dataKey={dataKey}
-          errorBars={errorBars}
-          stackId={stackId}
-          hide={hide}
-        />
-        {children}
-      </ErrorBarDirectionDispatchContext.Provider>
-    </ErrorBarContext.Provider>
+    <ErrorBarDirectionDispatchContext.Provider value={{ addErrorBar, removeErrorBar }}>
+      <SetCartesianGraphicalItem
+        data={data}
+        xAxisId={xAxisId}
+        yAxisId={yAxisId}
+        zAxisId={zAxisId}
+        dataKey={dataKey}
+        errorBars={errorBars}
+        stackId={stackId}
+        hide={hide}
+      />
+      {children}
+    </ErrorBarDirectionDispatchContext.Provider>
   );
 };
 

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -346,7 +346,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3600]);
-      expect(axisDomainSpy).toHaveBeenCalledTimes(7);
+      expect(axisDomainSpy).toHaveBeenCalledTimes(6);
     });
 
     it('should extend YAxis domain when data is defined on the graphical item', () => {
@@ -519,7 +519,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(xAxisSpy).toHaveBeenLastCalledWith([0, 3600]);
-      expect(xAxisSpy).toHaveBeenCalledTimes(7);
+      expect(xAxisSpy).toHaveBeenCalledTimes(6);
     });
 
     it('should extend XAxis domain when data is defined on the graphical item', () => {

--- a/test/cartesian/ReferenceArea.spec.tsx
+++ b/test/cartesian/ReferenceArea.spec.tsx
@@ -600,7 +600,7 @@ describe('<ReferenceArea />', () => {
       );
 
       expect(areaSpy).toHaveBeenLastCalledWith([]);
-      expect(areaSpy).toHaveBeenCalledTimes(6);
+      expect(areaSpy).toHaveBeenCalledTimes(5);
     });
   });
 });


### PR DESCRIPTION
## Description

so that I can call hooks in the middle and prevent infinite renders. Yes yes I realize I only wrote and merged this thing like yesterday. But after I merged the stable selectors I continue discovering new blockers. Good news is, this one appears to be the last, then I can proceed with the scatter points selector.

## Related Issue

https://github.com/recharts/recharts/issues/4583