### PR TITLE
selectScatterPoints

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -74,6 +74,7 @@
   "es6/state/selectors/selectors.js",
   "es6/state/selectors/selectChartOffset.js",
   "es6/state/selectors/selectAllAxes.js",
+  "es6/state/selectors/scatterSelectors.js",
   "es6/state/selectors/legendSelectors.js",
   "es6/state/selectors/dataSelectors.js",
   "es6/state/selectors/containerSelectors.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -74,6 +74,7 @@
   "lib/state/selectors/selectors.js",
   "lib/state/selectors/selectChartOffset.js",
   "lib/state/selectors/selectAllAxes.js",
+  "lib/state/selectors/scatterSelectors.js",
   "lib/state/selectors/legendSelectors.js",
   "lib/state/selectors/dataSelectors.js",
   "lib/state/selectors/containerSelectors.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -74,6 +74,7 @@
   "types/state/selectors/selectors.d.ts",
   "types/state/selectors/selectChartOffset.d.ts",
   "types/state/selectors/selectAllAxes.d.ts",
+  "types/state/selectors/scatterSelectors.d.ts",
   "types/state/selectors/legendSelectors.d.ts",
   "types/state/selectors/dataSelectors.d.ts",
   "types/state/selectors/containerSelectors.d.ts",

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -594,7 +594,6 @@ export class Scatter extends Component<InternalProps> {
     displayedData: any[];
   }): ScatterComposedData => {
     const cells = findAllByType(item.props.children, Cell);
-    console.log('getComposedData', { xAxisTicks });
     const points: ReadonlyArray<ScatterPointItem> = computeScatterPoints({
       displayedData,
       xAxis,

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Render a group of scatters
  */
 // eslint-disable-next-line max-classes-per-file
-import React, { Component, PureComponent, ReactElement } from 'react';
+import React, { Component, PureComponent, ReactElement, useMemo } from 'react';
 import Animate from 'react-smooth';
 
 import isNil from 'lodash/isNil';
@@ -18,7 +18,7 @@ import { Curve, CurveType, Props as CurveProps } from '../shape/Curve';
 import type { ErrorBarDataItem, ErrorBarDirection } from './ErrorBar';
 import { Cell } from '../component/Cell';
 import { getLinearRegression, interpolateNumber, uniqueId } from '../util/DataUtils';
-import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey, RechartsScale } from '../util/ChartUtils';
+import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
 import {
   ActiveShape,
   adaptEventsOfChild,
@@ -44,8 +44,11 @@ import {
 import { TooltipPayload, TooltipPayloadConfiguration, TooltipPayloadEntry } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 import { CartesianGraphicalItemContext, SetErrorBarContext } from '../context/CartesianGraphicalItemContext';
-import { AxisId, AxisSettings, ZAxisSettings } from '../state/axisMapSlice';
+import { AxisId } from '../state/axisMapSlice';
 import { GraphicalItemClipPath, useNeedsClip } from './GraphicalItemClipPath';
+import { ResolvedScatterSettings, selectScatterPoints } from '../state/selectors/scatterSelectors';
+import { useAppSelector } from '../state/hooks';
+import { BaseAxisWithScale, ZAxisWithScale } from '../state/selectors/axisSelectors';
 
 interface ScatterPointNode {
   x?: number | string;
@@ -59,7 +62,7 @@ export interface ScatterPointItem {
   size?: number;
   node?: ScatterPointNode;
   payload?: any;
-  tooltipPayload?: ReadonlyArray<TooltipPayload>;
+  tooltipPayload?: TooltipPayload;
 }
 
 export type ScatterCustomizedShape = ActiveShape<ScatterPointItem, SVGPathElement & InnerSymbolsProp> | SymbolType;
@@ -82,7 +85,7 @@ interface ScatterInternalProps {
 
   activeShape?: ScatterCustomizedShape;
   shape?: ScatterCustomizedShape;
-  points?: ScatterPointItem[];
+  points?: ReadonlyArray<ScatterPointItem>;
   hide?: boolean;
   label?: ImplicitLabelListType<any>;
 
@@ -123,7 +126,7 @@ interface ScatterProps {
   animationEasing?: AnimationTiming;
 }
 
-type InternalProps = PresentationAttributesAdaptChildEvent<any, SVGElement> & ScatterInternalProps;
+type InternalProps = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>, 'points'> & ScatterInternalProps;
 
 export type Props = PresentationAttributesAdaptChildEvent<any, SVGElement> & ScatterProps;
 
@@ -158,7 +161,7 @@ function SetScatterLegend(props: InternalProps): null {
 }
 
 type ScatterSymbolsProps = {
-  points: ScatterPointItem[];
+  points: ReadonlyArray<ScatterPointItem>;
   allOtherScatterProps: InternalProps;
 };
 
@@ -237,9 +240,7 @@ function getTooltipEntrySettings(props: InternalProps): TooltipPayloadConfigurat
   };
 }
 
-type AxisWithScale = Omit<AxisSettings, 'scale'> & { scale: RechartsScale };
-
-function computeScatterPoints({
+export function computeScatterPoints({
   displayedData,
   xAxis,
   yAxis,
@@ -250,9 +251,9 @@ function computeScatterPoints({
   cells,
 }: {
   displayedData: ReadonlyArray<any>;
-  xAxis: AxisWithScale;
-  yAxis: AxisWithScale;
-  zAxis: ZAxisSettings;
+  xAxis: BaseAxisWithScale;
+  yAxis: BaseAxisWithScale;
+  zAxis: ZAxisWithScale;
   scatterSettings: {
     dataKey: DataKey<any> | undefined;
     tooltipType: TooltipType;
@@ -326,7 +327,6 @@ function computeScatterPoints({
       index,
       dataKey: yAxisDataKey,
     });
-    // @ts-expect-error getValueByDataKey does not validate the output type
     const size = z !== '-' ? zAxis.scale(z) : defaultZ;
     const radius = Math.sqrt(Math.max(size, 0) / Math.PI);
 
@@ -336,9 +336,6 @@ function computeScatterPoints({
       cy,
       x: cx - radius,
       y: cy - radius,
-      xAxis,
-      yAxis,
-      zAxis,
       width: 2 * radius,
       height: 2 * radius,
       size,
@@ -439,7 +436,7 @@ class ScatterWithState extends PureComponent<InternalProps, State> {
 
   id = uniqueId('recharts-scatter-');
 
-  renderSymbolsStatically(points: ScatterPointItem[]) {
+  renderSymbolsStatically(points: ReadonlyArray<ScatterPointItem>) {
     return <ScatterSymbols points={points} allOtherScatterProps={this.props} />;
   }
 
@@ -532,8 +529,22 @@ class ScatterWithState extends PureComponent<InternalProps, State> {
 
 function ScatterImpl(props: InternalProps) {
   const { needClip } = useNeedsClip(props.xAxisId, props.yAxisId);
-  const { ref, ...everythingElse } = props;
-  return <ScatterWithState {...everythingElse} needClip={needClip} />;
+  const cells = useMemo(() => findAllByType(props.children, Cell), [props.children]);
+  const scatterSettings: ResolvedScatterSettings = useMemo(
+    () => ({
+      name: props.name,
+      tooltipType: props.tooltipType,
+      data: props.data,
+      dataKey: props.dataKey,
+    }),
+    [props.data, props.dataKey, props.name, props.tooltipType],
+  );
+  const points = useAppSelector(state => {
+    return selectScatterPoints(state, props.xAxisId, props.yAxisId, props.zAxisId, scatterSettings, cells);
+  });
+  const { ref, points: _pointsFromClonedProps, ...everythingElse } = props;
+
+  return <ScatterWithState {...everythingElse} points={points} needClip={needClip} />;
 }
 
 export class Scatter extends Component<InternalProps> {
@@ -573,9 +584,9 @@ export class Scatter extends Component<InternalProps> {
     yAxisTicks,
   }: {
     props: InternalProps;
-    xAxis?: AxisWithScale;
-    yAxis?: AxisWithScale;
-    zAxis?: ZAxisSettings;
+    xAxis?: BaseAxisWithScale;
+    yAxis?: BaseAxisWithScale;
+    zAxis?: ZAxisWithScale;
     xAxisTicks: TickItem[];
     yAxisTicks: TickItem[];
     item: ScatterWithState;
@@ -583,6 +594,7 @@ export class Scatter extends Component<InternalProps> {
     displayedData: any[];
   }): ScatterComposedData => {
     const cells = findAllByType(item.props.children, Cell);
+    console.log('getComposedData', { xAxisTicks });
     const points: ReadonlyArray<ScatterPointItem> = computeScatterPoints({
       displayedData,
       xAxis,

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -18,7 +18,7 @@ interface Data {
 
 interface LabelListProps<T extends Data> {
   id?: string;
-  data?: Array<T>;
+  data?: ReadonlyArray<T>;
   valueAccessor?: Function;
   clockWise?: boolean;
   dataKey?: DataKey<T>;
@@ -73,7 +73,7 @@ export function LabelList<T extends Data>({ valueAccessor = defaultAccessor, ...
 
 LabelList.displayName = 'LabelList';
 
-function parseLabelList<T extends Data>(label: unknown, data: Array<T>) {
+function parseLabelList<T extends Data>(label: unknown, data: ReadonlyArray<T>) {
   if (!label) {
     return null;
   }
@@ -95,7 +95,7 @@ function parseLabelList<T extends Data>(label: unknown, data: Array<T>) {
 
 function renderCallByParent<T extends Data>(
   parentProps: { children?: ReactNode; label?: unknown },
-  data: Array<T>,
+  data: ReadonlyArray<T>,
   checkPropsLabel = true,
 ) {
   if (!parentProps || (!parentProps.children && checkPropsLabel && !parentProps.label)) {

--- a/src/state/selectors/scatterSelectors.ts
+++ b/src/state/selectors/scatterSelectors.ts
@@ -1,0 +1,97 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { ReactElement } from 'react';
+import { computeScatterPoints, ScatterPointItem } from '../../cartesian/Scatter';
+import { RechartsRootState } from '../store';
+import { AxisId } from '../axisMapSlice';
+import { selectChartDataWithIndexes } from './dataSelectors';
+import { ChartData, ChartDataState } from '../chartDataSlice';
+import { selectAxisWithScale, selectZAxisWithScale, selectTicksOfGraphicalItem, ZAxisWithScale } from './axisSelectors';
+import { DataKey } from '../../util/types';
+import { TooltipType } from '../../component/DefaultTooltipContent';
+
+export type ResolvedScatterSettings = {
+  data: ChartData | undefined;
+  dataKey: DataKey<any> | undefined;
+  tooltipType: TooltipType | undefined;
+  name: string | number;
+};
+
+const selectXAxisWithScale = (state: RechartsRootState, xAxisId: AxisId) =>
+  selectAxisWithScale(state, 'xAxis', xAxisId);
+const selectXAxisTicks = (state: RechartsRootState, xAxisId: AxisId) =>
+  selectTicksOfGraphicalItem(state, 'xAxis', xAxisId);
+const selectYAxisWithScale = (state: RechartsRootState, _xAxisId: AxisId, yAxisId: AxisId) =>
+  selectAxisWithScale(state, 'yAxis', yAxisId);
+const selectYAxisTicks = (state: RechartsRootState, _xAxisId: AxisId, yAxisId: AxisId) =>
+  selectTicksOfGraphicalItem(state, 'yAxis', yAxisId);
+const selectZAxis = (state: RechartsRootState, _xAxisId: AxisId, _yAxisId: AxisId, zAxisId: AxisId) =>
+  selectZAxisWithScale(state, 'zAxis', zAxisId);
+const pickScatterSettings = (
+  _state: RechartsRootState,
+  _xAxisId: AxisId,
+  _yAxisId: AxisId,
+  _zAxisId: AxisId,
+  scatterSettings: ResolvedScatterSettings,
+) => scatterSettings;
+const pickCells = (
+  _state: RechartsRootState,
+  _xAxisId: AxisId,
+  _yAxisId: AxisId,
+  _zAxisId: AxisId,
+  _scatterSettings: ResolvedScatterSettings,
+  cells: ReadonlyArray<ReactElement> | undefined,
+): ReadonlyArray<ReactElement> | undefined => cells;
+export const selectScatterPoints: (
+  state: RechartsRootState,
+  xAxisId: AxisId,
+  yAxisId: AxisId,
+  zAxisId: AxisId,
+  scatterSettings: ResolvedScatterSettings,
+  cells: ReadonlyArray<ReactElement> | undefined,
+) => ReadonlyArray<ScatterPointItem> = createSelector(
+  selectChartDataWithIndexes,
+  selectXAxisWithScale,
+  selectXAxisTicks,
+  selectYAxisWithScale,
+  selectYAxisTicks,
+  selectZAxis,
+  pickScatterSettings,
+  pickCells,
+  (
+    { chartData, dataStartIndex, dataEndIndex }: ChartDataState,
+    xAxis,
+    xAxisTicks,
+    yAxis,
+    yAxisTicks,
+    zAxis: ZAxisWithScale,
+    scatterSettings: ResolvedScatterSettings,
+    cells,
+  ): ReadonlyArray<ScatterPointItem> | undefined => {
+    let displayedData: ChartData | undefined;
+    if (scatterSettings?.data?.length > 0) {
+      displayedData = scatterSettings.data;
+    } else {
+      displayedData = chartData?.slice(dataStartIndex, dataEndIndex + 1);
+    }
+
+    if (
+      displayedData == null ||
+      xAxis == null ||
+      yAxis == null ||
+      xAxisTicks?.length === 0 ||
+      yAxisTicks?.length === 0
+    ) {
+      return undefined;
+    }
+    return computeScatterPoints({
+      displayedData,
+      xAxis,
+      yAxis,
+      zAxis,
+      scatterSettings,
+      xAxisTicks,
+      yAxisTicks,
+      cells,
+    });
+  },
+);

--- a/src/util/DataUtils.ts
+++ b/src/util/DataUtils.ts
@@ -123,7 +123,7 @@ export function findEntryInArray<T>(
  * @param {Array} data The array of points
  * @returns {Object} The domain of x, and the parameter of linear function
  */
-export const getLinearRegression = (data: Array<{ cx?: number; cy?: number }>) => {
+export const getLinearRegression = (data: ReadonlyArray<{ cx?: number; cy?: number }>) => {
   if (!data || !data.length) {
     return null;
   }

--- a/storybook/stories/Examples/ScatterChart.stories.tsx
+++ b/storybook/stories/Examples/ScatterChart.stories.tsx
@@ -131,7 +131,7 @@ export const JointLine = {
           <CartesianGrid />
           <XAxis type="number" dataKey="x" name="stature" unit="cm" />
           <YAxis type="number" dataKey="y" name="weight" unit="kg" />
-          <ZAxis type="number" range={[100]} />
+          <ZAxis type="number" dataKey="x" range={[100, 100]} />
           <Legend />
           <Scatter name="A school" data={data01} fill="#8884d8" line shape="cross" />
           <Scatter name="B school" data={data02} fill="#82ca9d" line shape="diamond" />

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -231,6 +231,7 @@ describe('<ErrorBar />', () => {
         <XAxis type="number" />
       </ScatterChart>,
     );
+    expect(container.querySelectorAll('.recharts-errorBars')).toHaveLength(2);
     assertErrorBars(container, 8);
   });
 
@@ -244,6 +245,16 @@ describe('<ErrorBar />', () => {
         <XAxis type="number" />
       </ScatterChart>,
     );
+
+    expect(container.querySelectorAll('.recharts-errorBars')).toHaveLength(2);
+
+    const errorBars = container.querySelectorAll('.recharts-errorBar');
+    errorBars.forEach(bar => {
+      expect(bar.tagName).toEqual('g');
+      expect(bar.getAttributeNames()).toEqual(['class', 'stroke', 'stroke-width', 'offset']);
+      expect(bar.childElementCount).toEqual(3);
+    });
+
     assertErrorBars(container, 8);
   });
 

--- a/test/cartesian/Scatter.spec.tsx
+++ b/test/cartesian/Scatter.spec.tsx
@@ -6,27 +6,7 @@ import { assertNotNull } from '../helper/assertNotNull';
 import { useAppSelector } from '../../src/state/hooks';
 import { selectUnfilteredCartesianItems } from '../../src/state/selectors/axisSelectors';
 import { CartesianGraphicalItemSettings } from '../../src/state/graphicalItemsSlice';
-
-type ExpectedPoint = {
-  cx: string;
-  cy: string;
-  transform: string;
-  d: string;
-};
-
-function expectScatterPoints(container: Element, expectedPoints: ReadonlyArray<ExpectedPoint>) {
-  assertNotNull(container);
-  const allPoints = container.querySelectorAll('.recharts-scatter-symbol .recharts-symbols');
-  const actualPoints = Array.from(allPoints).map(point => {
-    return {
-      cx: point.getAttribute('cx'),
-      cy: point.getAttribute('cy'),
-      transform: point.getAttribute('transform'),
-      d: point.getAttribute('d'),
-    };
-  });
-  expect(actualPoints).toEqual(expectedPoints);
-}
+import { expectScatterPoints } from '../helper/expectScatterPoints';
 
 describe('<Scatter />', () => {
   const data = [
@@ -49,31 +29,41 @@ describe('<Scatter />', () => {
         cx: '54',
         cy: '467.77777777777777',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(54, 467.77777777777777)',
+        width: '9.0270333367641',
       },
       {
         cx: '152',
         cy: '358.8888888888889',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(152, 358.8888888888889)',
+        width: '9.0270333367641',
       },
       {
         cx: '250',
         cy: '250',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(250, 250)',
+        width: '9.0270333367641',
       },
       {
         cx: '348',
         cy: '141.11111111111111',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(348, 141.11111111111111)',
+        width: '9.0270333367641',
       },
       {
         cx: '446',
         cy: '32.222222222222236',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(446, 32.222222222222236)',
+        width: '9.0270333367641',
       },
     ]);
   });
@@ -94,7 +84,7 @@ describe('<Scatter />', () => {
     );
     const { container } = render(
       <ScatterChart width={500} height={500}>
-        <Scatter isAnimationActive={false} shape={<CustomizedShape cx={0} cy={0} />} data={data} />
+        <Scatter isAnimationActive={false} shape={<CustomizedShape cx={0} cy={0} />} data={data} dataKey="size" />
       </ScatterChart>,
     );
 
@@ -107,7 +97,7 @@ describe('<Scatter />', () => {
     );
     const { container } = render(
       <ScatterChart width={500} height={500}>
-        <Scatter isAnimationActive={false} shape={renderCustomizedShape} data={data} />
+        <Scatter isAnimationActive={false} shape={renderCustomizedShape} data={data} dataKey="size" />
       </ScatterChart>,
     );
 
@@ -118,7 +108,7 @@ describe('<Scatter />', () => {
     const CustomizedLine = () => <path d="M0,0L200,200" className="customized-line" />;
     const { container } = render(
       <ScatterChart width={500} height={500}>
-        <Scatter isAnimationActive={false} line={<CustomizedLine />} data={data} />
+        <Scatter isAnimationActive={false} line={<CustomizedLine />} data={data} dataKey="size" />
       </ScatterChart>,
     );
 
@@ -129,7 +119,7 @@ describe('<Scatter />', () => {
     const renderCustomizedLine = () => <path d="M0,0L200,200" className="customized-line" />;
     const { container } = render(
       <ScatterChart width={500} height={500}>
-        <Scatter isAnimationActive={false} line={renderCustomizedLine} data={data} />
+        <Scatter isAnimationActive={false} line={renderCustomizedLine} data={data} dataKey="size" />
       </ScatterChart>,
     );
 

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -2427,6 +2427,93 @@ describe('<XAxis />', () => {
       });
     });
 
+    describe('when the axis dataKey and graphical item dataKey are different', () => {
+      it('should render ticks', () => {
+        const dataWithNegativeValues = [
+          {
+            x: -50,
+            y: -50,
+          },
+          {
+            x: 0,
+            y: 0,
+          },
+          {
+            x: 50,
+            y: 50,
+          },
+          {
+            x: 100,
+            y: 100,
+          },
+          {
+            x: 150,
+            y: 150,
+          },
+          {
+            x: 200,
+            y: 200,
+          },
+          {
+            x: 250,
+            y: 250,
+          },
+          {
+            x: 350,
+            y: 350,
+          },
+          {
+            x: 400,
+            y: 400,
+          },
+          {
+            x: 450,
+            y: 450,
+          },
+          {
+            x: 500,
+            y: 500,
+          },
+        ];
+
+        const { container } = render(
+          <LineChart width={500} height={300}>
+            <XAxis dataKey="x" domain={['auto', 'auto']} interval={0} type="number" allowDataOverflow />
+
+            <Line data={dataWithNegativeValues} dataKey="y" />
+          </LineChart>,
+        );
+
+        expectXAxisTicks(container, [
+          {
+            textContent: '-200',
+            x: '5',
+            y: '273',
+          },
+          {
+            textContent: '0',
+            x: '127.5',
+            y: '273',
+          },
+          {
+            textContent: '200',
+            x: '250',
+            y: '273',
+          },
+          {
+            textContent: '400',
+            x: '372.5',
+            y: '273',
+          },
+          {
+            textContent: '600',
+            x: '495',
+            y: '273',
+          },
+        ]);
+      });
+    });
+
     describe('when data is defined on multiple graphical elements', () => {
       const spy = vi.fn();
       const data1 = data.slice(0, 3);

--- a/test/chart/AccessibilityScans.spec.tsx
+++ b/test/chart/AccessibilityScans.spec.tsx
@@ -29,6 +29,7 @@ import {
   YAxis,
 } from '../../src';
 import { PageData as data, exampleSankeyData, exampleTreemapData, exampleSunburstData } from '../_data';
+import { expectScatterPoints } from '../helper/expectScatterPoints';
 
 const svgTagMustHaveLabelViolation = expect.objectContaining({
   description: 'Ensures <svg> elements with an img, graphics-document or graphics-symbol role have an accessible text',
@@ -166,12 +167,62 @@ describe('Static scanning for accessibility markup issues', () => {
   test('Scatter chart', async () => {
     const { container } = render(
       <ScatterChart width={400} height={400}>
-        <XAxis dataKey="x" name="stature" unit="cm" />
-        <YAxis dataKey="y" name="weight" unit="kg" />
+        <XAxis dataKey="uv" name="stature" unit="cm" />
+        <YAxis dataKey="pv" name="weight" unit="kg" />
         <Scatter line name="A school" data={data} fill="#ff7300" />
         <Tooltip />
       </ScatterChart>,
     );
+    expectScatterPoints(container, [
+      {
+        cx: '92.5',
+        cy: '278.59999999999997',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(92.5, 278.59999999999997)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '147.5',
+        cy: '200.588',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(147.5, 200.588)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '202.5',
+        cy: '314.672',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(202.5, 314.672)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '257.5',
+        cy: '12.200000000000006',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(257.5, 12.200000000000006)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '312.5',
+        cy: '224.31199999999998',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(312.5, 224.31199999999998)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '367.5',
+        cy: '192.20000000000002',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(367.5, 192.20000000000002)',
+        width: '9.0270333367641',
+      },
+    ]);
     expect((await axe(container)).violations).toEqual([svgTagMustHaveLabelViolation]);
     expect(document.querySelector('.recharts-wrapper')).toHaveAttribute('role', 'application');
   });

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { expect, vi } from 'vitest';
 import { fireEvent, render } from '@testing-library/react';
 import {
+  Bar,
+  Brush,
   CartesianGrid,
+  ComposedChart,
   Customized,
   Legend,
   Scatter,
@@ -17,28 +20,16 @@ import {
 import { testChartLayoutContext } from '../util/context';
 import { useClipPathId, useViewBox } from '../../src/context/chartLayoutContext';
 import { useAppSelector } from '../../src/state/hooks';
-import { assertNotNull } from '../helper/assertNotNull';
-
-type ExpectedPoint = {
-  cx: string;
-  cy: string;
-  transform: string;
-  d: string;
-};
-
-function expectScatterPoints(container: Element, expectedPoints: ReadonlyArray<ExpectedPoint>) {
-  assertNotNull(container);
-  const allPoints = container.querySelectorAll('.recharts-scatter-symbol .recharts-symbols');
-  const actualPoints = Array.from(allPoints).map(point => {
-    return {
-      cx: point.getAttribute('cx'),
-      cy: point.getAttribute('cy'),
-      transform: point.getAttribute('transform'),
-      d: point.getAttribute('d'),
-    };
-  });
-  expect(actualPoints).toEqual(expectedPoints);
-}
+import { expectScatterPoints } from '../helper/expectScatterPoints';
+import {
+  selectAllAppliedNumericalValuesIncludingErrorValues,
+  selectAxisDomain,
+  selectBaseAxis,
+  selectDisplayedData,
+  selectDomainOfStackGroups,
+  selectTicksOfGraphicalItem,
+  selectZAxisWithScale,
+} from '../../src/state/selectors/axisSelectors';
 
 describe('ScatterChart of three dimension data', () => {
   const data01 = [
@@ -83,73 +74,97 @@ describe('ScatterChart of three dimension data', () => {
         cx: '73.33333333333333',
         cy: '185',
         d: 'M0,0',
+        height: '3.638913473173784',
         transform: 'translate(73.33333333333333, 185)',
+        width: '3.638913473173784',
       },
       {
         cx: '100',
         cy: '267.5',
         d: 'M0,0',
+        height: '3.960594802695323',
         transform: 'translate(100, 267.5)',
+        width: '3.960594802695323',
       },
       {
         cx: '126.66666666666667',
         cy: '102.5',
         d: 'M0,0',
+        height: '4.624978308224887',
         transform: 'translate(126.66666666666667, 102.5)',
+        width: '4.624978308224887',
       },
       {
         cx: '153.33333333333334',
         cy: '143.75',
         d: 'M0,0',
+        height: '4.062165001543845',
         transform: 'translate(153.33333333333334, 143.75)',
+        width: '4.062165001543845',
       },
       {
         cx: '180.00000000000003',
         cy: '20',
         d: 'M0,0',
+        height: '5.046265044040321',
         transform: 'translate(180.00000000000003, 20)',
+        width: '5.046265044040321',
       },
       {
         cx: '206.66666666666669',
         cy: '119.00000000000001',
         d: 'M0,0',
+        height: '3.638913473173784',
         transform: 'translate(206.66666666666669, 119.00000000000001)',
+        width: '3.638913473173784',
       },
       {
         cx: '73.33333333333333',
         cy: '135.5',
         d: 'M0,0',
+        height: '3.8563503319209342',
         transform: 'translate(73.33333333333333, 135.5)',
+        width: '3.8563503319209342',
       },
       {
         cx: '100',
         cy: '110.75000000000001',
         d: 'M0,0',
+        height: '3.749208526326083',
         transform: 'translate(100, 110.75000000000001)',
+        width: '3.749208526326083',
       },
       {
         cx: '126.66666666666667',
         cy: '110.75000000000001',
         d: 'M0,0',
+        height: '3.9088200952233594',
         transform: 'translate(126.66666666666667, 110.75000000000001)',
+        width: '3.9088200952233594',
       },
       {
         cx: '153.33333333333334',
         cy: '143.75',
         d: 'M0,0',
+        height: '3.694472617243352',
         transform: 'translate(153.33333333333334, 143.75)',
+        width: '3.694472617243352',
       },
       {
         cx: '180.00000000000003',
         cy: '119.00000000000001',
         d: 'M0,0',
+        height: '3.960594802695323',
         transform: 'translate(180.00000000000003, 119.00000000000001)',
+        width: '3.960594802695323',
       },
       {
         cx: '206.66666666666669',
         cy: '168.49999999999997',
         d: 'M0,0',
+        height: '3.803156745151513',
         transform: 'translate(206.66666666666669, 168.49999999999997)',
+        width: '3.803156745151513',
       },
     ]);
   });
@@ -213,6 +228,242 @@ describe('ScatterChart of three dimension data', () => {
   });
 });
 
+describe('ScatterChart with joint line', () => {
+  it('should compute ZAxis from explicit dataKey', () => {
+    const data01 = [
+      { x: 10, y: 30, z: 120 },
+      { x: 30, y: 200, z: 190 },
+      { x: 45, y: 100, z: 32 },
+      { x: 50, y: 400, z: 67 },
+      { x: 70, y: 150, z: 109 },
+      { x: 100, y: 250, z: 120 },
+    ];
+    const data02 = [
+      { x: 30, y: 20, z: 190 },
+      { x: 50, y: 180, z: 32 },
+      { x: 75, y: 240, z: 67 },
+      { x: 100, y: 100, z: 109 },
+      { x: 120, y: 190, z: 120 },
+    ];
+
+    const zAxisScaleSpy = vi.fn();
+    const zAxisDataSpy = vi.fn();
+    const Comp = (): null => {
+      zAxisScaleSpy(useAppSelector(state => selectZAxisWithScale(state, 'zAxis', 0)));
+      zAxisDataSpy(useAppSelector(state => selectAllAppliedNumericalValuesIncludingErrorValues(state, 'zAxis', 0)));
+      return null;
+    };
+
+    const { container } = render(
+      <ScatterChart width={600} height={400}>
+        <CartesianGrid />
+        <XAxis type="number" dataKey="x" name="stature" unit="cm" />
+        <YAxis type="number" dataKey="y" name="weight" unit="kg" />
+        <ZAxis type="number" dataKey="z" range={[100, 200]} />
+        <Legend />
+        <Scatter name="A school" data={data01} fill="#8884d8" line shape="cross" />
+        <Scatter name="B school" data={data02} fill="#82ca9d" line shape="diamond" />
+        <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+        <Customized component={<Comp />} />
+      </ScatterChart>,
+    );
+
+    expect(zAxisDataSpy).toHaveBeenLastCalledWith([
+      {
+        errorDomain: [],
+        value: 120,
+      },
+      {
+        errorDomain: [],
+        value: 120,
+      },
+      {
+        errorDomain: [],
+        value: 190,
+      },
+      {
+        errorDomain: [],
+        value: 190,
+      },
+      {
+        errorDomain: [],
+        value: 32,
+      },
+      {
+        errorDomain: [],
+        value: 32,
+      },
+      {
+        errorDomain: [],
+        value: 67,
+      },
+      {
+        errorDomain: [],
+        value: 67,
+      },
+      {
+        errorDomain: [],
+        value: 109,
+      },
+      {
+        errorDomain: [],
+        value: 109,
+      },
+      {
+        errorDomain: [],
+        value: 120,
+      },
+      {
+        errorDomain: [],
+        value: 120,
+      },
+      {
+        errorDomain: [],
+        value: 190,
+      },
+      {
+        errorDomain: [],
+        value: 190,
+      },
+      {
+        errorDomain: [],
+        value: 32,
+      },
+      {
+        errorDomain: [],
+        value: 32,
+      },
+      {
+        errorDomain: [],
+        value: 67,
+      },
+      {
+        errorDomain: [],
+        value: 67,
+      },
+      {
+        errorDomain: [],
+        value: 109,
+      },
+      {
+        errorDomain: [],
+        value: 109,
+      },
+      {
+        errorDomain: [],
+        value: 120,
+      },
+      {
+        errorDomain: [],
+        value: 120,
+      },
+    ]);
+    expect(zAxisScaleSpy).toHaveBeenLastCalledWith({
+      allowDataOverflow: false,
+      allowDuplicatedCategory: false,
+      dataKey: 'z',
+      id: 0,
+      includeHidden: false,
+      name: undefined,
+      range: [100, 200],
+      reversed: false,
+      scale: expect.any(Function),
+      type: 'number',
+      unit: undefined,
+    });
+    expectScatterPoints(container, [
+      {
+        cx: '109.16666666666666',
+        cy: '338',
+        d: 'M0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0Z',
+        height: '14.413156615213909',
+        transform: 'translate(109.16666666666666, 338)',
+        width: '14.413156615213909',
+      },
+      {
+        cx: '197.5',
+        cy: '185',
+        d: 'M0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0Z',
+        height: '15.957691216057308',
+        transform: 'translate(197.5, 185)',
+        width: '15.957691216057308',
+      },
+      {
+        cx: '263.75',
+        cy: '275',
+        d: 'M0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0Z',
+        height: '12.197048368812888',
+        transform: 'translate(263.75, 275)',
+        width: '12.197048368812888',
+      },
+      {
+        cx: '285.83333333333337',
+        cy: '5',
+        d: 'M0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0Z',
+        height: '13.12335329012121',
+        transform: 'translate(285.83333333333337, 5)',
+        width: '13.12335329012121',
+      },
+      {
+        cx: '374.1666666666667',
+        cy: '230',
+        d: 'M0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0Z',
+        height: '14.155129698337069',
+        transform: 'translate(374.1666666666667, 230)',
+        width: '14.155129698337069',
+      },
+      {
+        cx: '506.6666666666667',
+        cy: '140',
+        d: 'M0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0L0,0Z',
+        height: '14.413156615213909',
+        transform: 'translate(506.6666666666667, 140)',
+        width: '14.413156615213909',
+      },
+      {
+        cx: '197.5',
+        cy: '347',
+        d: 'M0,0L0,0L0,0L0,0Z',
+        height: '15.957691216057308',
+        transform: 'translate(197.5, 347)',
+        width: '15.957691216057308',
+      },
+      {
+        cx: '285.83333333333337',
+        cy: '203.00000000000003',
+        d: 'M0,0L0,0L0,0L0,0Z',
+        height: '12.197048368812888',
+        transform: 'translate(285.83333333333337, 203.00000000000003)',
+        width: '12.197048368812888',
+      },
+      {
+        cx: '396.25',
+        cy: '149',
+        d: 'M0,0L0,0L0,0L0,0Z',
+        height: '13.12335329012121',
+        transform: 'translate(396.25, 149)',
+        width: '13.12335329012121',
+      },
+      {
+        cx: '506.6666666666667',
+        cy: '275',
+        d: 'M0,0L0,0L0,0L0,0Z',
+        height: '14.155129698337069',
+        transform: 'translate(506.6666666666667, 275)',
+        width: '14.155129698337069',
+      },
+      {
+        cx: '595',
+        cy: '194',
+        d: 'M0,0L0,0L0,0L0,0Z',
+        height: '14.413156615213909',
+        transform: 'translate(595, 194)',
+        width: '14.413156615213909',
+      },
+    ]);
+  });
+});
+
 function assertActiveShapeInteractions(container: HTMLElement) {
   const sectorNodes = container.querySelectorAll('.recharts-scatter-symbol');
   expect(sectorNodes.length).toBeGreaterThanOrEqual(2);
@@ -253,37 +504,169 @@ describe('ScatterChart of two dimension data', () => {
         cx: '105',
         cy: '185',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(105, 185)',
+        width: '9.0270333367641',
       },
       {
         cx: '155',
         cy: '267.5',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(155, 267.5)',
+        width: '9.0270333367641',
       },
       {
         cx: '205',
         cy: '102.5',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(205, 102.5)',
+        width: '9.0270333367641',
       },
       {
         cx: '255',
         cy: '143.75',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(255, 143.75)',
+        width: '9.0270333367641',
       },
       {
         cx: '305',
         cy: '20',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(305, 20)',
+        width: '9.0270333367641',
       },
       {
         cx: '355',
         cy: '119.00000000000001',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(355, 119.00000000000001)',
+        width: '9.0270333367641',
+      },
+    ]);
+  });
+
+  test('renders 6 circles in ScatterChart when data is defined on chart root', () => {
+    const { container } = render(
+      <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }} data={data}>
+        <XAxis dataKey="x" name="stature" unit="cm" />
+        <YAxis dataKey="y" name="weight" unit="kg" />
+        <Scatter line name="A school" fill="#ff7300" />
+      </ScatterChart>,
+    );
+
+    expectScatterPoints(container, [
+      {
+        cx: '105',
+        cy: '185',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(105, 185)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '155',
+        cy: '267.5',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(155, 267.5)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '205',
+        cy: '102.5',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(205, 102.5)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '255',
+        cy: '143.75',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(255, 143.75)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '305',
+        cy: '20',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(305, 20)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '355',
+        cy: '119.00000000000001',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(355, 119.00000000000001)',
+        width: '9.0270333367641',
+      },
+    ]);
+  });
+
+  test('renders 6 circles in ScatterChart when data is defined on chart root and there are no axes', () => {
+    const { container } = render(
+      <ScatterChart width={400} height={400} data={data}>
+        <Scatter dataKey="y" />
+      </ScatterChart>,
+    );
+
+    expectScatterPoints(container, [
+      {
+        cx: '37.5',
+        cy: '200',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(37.5, 200)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '102.5',
+        cy: '297.5',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(102.5, 297.5)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '167.5',
+        cy: '102.5',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(167.5, 102.5)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '232.5',
+        cy: '151.25',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(232.5, 151.25)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '297.5',
+        cy: '5',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(297.5, 5)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '362.5',
+        cy: '122.00000000000001',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(362.5, 122.00000000000001)',
+        width: '9.0270333367641',
       },
     ]);
   });
@@ -306,6 +689,525 @@ describe('ScatterChart of two dimension data', () => {
     expect(line.getAttribute('stroke')).toEqual('#ff7300');
     expect(line.getAttribute('class')).toEqual('recharts-curve');
     expect(line.getAttribute('d')).toEqual('M105,185L155,267.5L205,102.5L255,143.75L305,20L355,119');
+  });
+
+  test('ignores points when data have nulls in it', () => {
+    /*
+     * This is technically a breaking change too. In recharts 2.x, this renders at "null-value" Scatter point if X axis is categorical.
+     * Which in the axis is represented by an empty string.
+     * I don't think that's useful for anyone so in 3.x, nulls will no longer be transformed to empty strings.
+     */
+    const dataWithNulls: Array<{ x: number | null; y: number | null }> = [
+      { x: null, y: 2 },
+      { x: 3, y: 4 },
+    ];
+    const { container } = render(
+      <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+        <XAxis dataKey="x" />
+        <YAxis dataKey="y" />
+        <Scatter name="A school" data={dataWithNulls} fill="#ff7300" />
+      </ScatterChart>,
+    );
+
+    expectScatterPoints(container, [
+      {
+        cx: '230',
+        cy: '185',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(230, 185)',
+        width: '9.0270333367641',
+      },
+    ]);
+  });
+
+  test.fails('renders scatter points in Brush panorama. TODO fix brush panorama before releasing 3.0', () => {
+    const { container } = render(
+      <ScatterChart width={400} height={400} data={data}>
+        <Scatter dataKey="y" />
+        <Brush>
+          <ScatterChart data={data}>
+            <Scatter dataKey="y" />
+          </ScatterChart>
+        </Brush>
+      </ScatterChart>,
+    );
+
+    expectScatterPoints(container, [
+      {
+        cx: '37.5',
+        cy: '180',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(37.5, 180)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '102.5',
+        cy: '267.5',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(102.5, 267.5)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '167.5',
+        cy: '92.5',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(167.5, 92.5)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '232.5',
+        cy: '136.25',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(232.5, 136.25)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '297.5',
+        cy: '5',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(297.5, 5)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '362.5',
+        cy: '110.00000000000001',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(362.5, 110.00000000000001)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '33.333333333333336',
+        cy: '20',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(33.333333333333336, 20)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '98',
+        cy: '29.5',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(98, 29.5)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '162.66666666666669',
+        cy: '10.5',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(162.66666666666669, 10.5)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '227.33333333333334',
+        cy: '15.25',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(227.33333333333334, 15.25)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '292',
+        cy: '1',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(292, 1)',
+        width: '9.0270333367641',
+      },
+      {
+        cx: '356.6666666666667',
+        cy: '12.4',
+        d: 'M0,0',
+        height: '9.0270333367641',
+        transform: 'translate(356.6666666666667, 12.4)',
+        width: '9.0270333367641',
+      },
+    ]);
+  });
+
+  test('renders points in Composed chart when there are stacks but the stacks are smaller than the ZAxis dataKey', () => {
+    const boxPlotData = [
+      {
+        min: 100,
+        bottomWhisker: 100,
+        bottomBox: 50,
+        topBox: 200,
+        topWhisker: 200,
+        average: 150,
+        size: 150,
+      },
+      {
+        min: 200,
+        bottomWhisker: 200,
+        bottomBox: 200,
+        topBox: 100,
+        topWhisker: 100,
+        average: 550,
+        size: 250,
+      },
+      {
+        min: 0,
+        bottomWhisker: 200,
+        bottomBox: 200,
+        topBox: 200,
+        topWhisker: 200,
+        average: 400,
+        size: 350,
+      },
+    ];
+
+    const yAxisDomainSpy = vi.fn();
+    const yAxisDataSpy = vi.fn();
+    const yAxisTicksSpy = vi.fn();
+    const displayedDataSpy = vi.fn();
+    const stackGroupsDomainSpy = vi.fn();
+    const zAxisAppliedDataSpy = vi.fn();
+    const zAxisSettingsSpy = vi.fn();
+    const zAxisDomainSpy = vi.fn();
+    const Comp = (): null => {
+      displayedDataSpy(useAppSelector(state => selectDisplayedData(state, 'zAxis', 0)));
+      stackGroupsDomainSpy(useAppSelector(state => selectDomainOfStackGroups(state, 'zAxis', 0)));
+      zAxisAppliedDataSpy(
+        useAppSelector(state => selectAllAppliedNumericalValuesIncludingErrorValues(state, 'zAxis', 0)),
+      );
+      zAxisSettingsSpy(useAppSelector(state => selectBaseAxis(state, 'zAxis', 0)));
+      zAxisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'zAxis', 0)));
+      yAxisTicksSpy(useAppSelector(state => selectTicksOfGraphicalItem(state, 'yAxis', 0)));
+      yAxisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'yAxis', 0)));
+      yAxisDataSpy(useAppSelector(state => selectAllAppliedNumericalValuesIncludingErrorValues(state, 'yAxis', 0)));
+      return null;
+    };
+
+    const { container } = render(
+      <ComposedChart width={400} height={200} data={boxPlotData}>
+        <Bar stackId="a" dataKey="min" />
+        <ZAxis type="number" dataKey="size" range={[0, 250]} />
+
+        <Scatter dataKey="average" />
+        <XAxis />
+        <YAxis />
+
+        <Customized component={<Comp />} />
+      </ComposedChart>,
+    );
+
+    expect(yAxisDataSpy).toHaveBeenLastCalledWith([
+      {
+        errorDomain: [],
+        value: 150,
+      },
+      {
+        errorDomain: [],
+        value: 550,
+      },
+      {
+        errorDomain: [],
+        value: 400,
+      },
+    ]);
+    expect(yAxisDomainSpy).toHaveBeenLastCalledWith([0, 550]);
+    expect(yAxisTicksSpy).toHaveBeenLastCalledWith([
+      { coordinate: 165, value: 0, offset: 0 },
+      { coordinate: 138.33333333333334, value: 100, offset: 0 },
+      { coordinate: 111.66666666666669, value: 200, offset: 0 },
+      { coordinate: 85, value: 300, offset: 0 },
+      { coordinate: 58.33333333333334, value: 400, offset: 0 },
+      { coordinate: 31.66666666666666, value: 500, offset: 0 },
+      { coordinate: 5, value: 600, offset: 0 },
+    ]);
+    expect(displayedDataSpy).toHaveBeenLastCalledWith([
+      {
+        average: 150,
+        bottomBox: 50,
+        bottomWhisker: 100,
+        min: 100,
+        size: 150,
+        topBox: 200,
+        topWhisker: 200,
+      },
+      {
+        average: 550,
+        bottomBox: 200,
+        bottomWhisker: 200,
+        min: 200,
+        size: 250,
+        topBox: 100,
+        topWhisker: 100,
+      },
+      {
+        average: 400,
+        bottomBox: 200,
+        bottomWhisker: 200,
+        min: 0,
+        size: 350,
+        topBox: 200,
+        topWhisker: 200,
+      },
+    ]);
+    // expect(stackGroupsDomainSpy).toHaveBeenLastCalledWith([0, 200]);
+    expect(zAxisAppliedDataSpy).toHaveBeenLastCalledWith([
+      {
+        errorDomain: [],
+        value: 150,
+      },
+      {
+        errorDomain: [],
+        value: 250,
+      },
+      {
+        errorDomain: [],
+        value: 350,
+      },
+    ]);
+    expect(zAxisSettingsSpy).toHaveBeenLastCalledWith({
+      allowDataOverflow: false,
+      allowDuplicatedCategory: false,
+      dataKey: 'size',
+      id: 0,
+      includeHidden: false,
+      name: undefined,
+      range: [0, 250],
+      reversed: false,
+      scale: 'auto',
+      type: 'number',
+      unit: undefined,
+    });
+    expect(zAxisDomainSpy).toHaveBeenLastCalledWith([0, 350]);
+    expectScatterPoints(container, [
+      {
+        cx: '120',
+        cy: '125',
+        d: 'M0,0',
+        height: '11.67983401638037',
+        transform: 'translate(120, 125)',
+        width: '11.67983401638037',
+      },
+      {
+        cx: '230',
+        cy: '18.33333333333334',
+        d: 'M0,0',
+        height: '15.078600877302687',
+        transform: 'translate(230, 18.33333333333334)',
+        width: '15.078600877302687',
+      },
+      {
+        cx: '340',
+        cy: '58.33333333333334',
+        d: 'M0,0',
+        height: '17.841241161527712',
+        transform: 'translate(340, 58.33333333333334)',
+        width: '17.841241161527712',
+      },
+    ]);
+  });
+
+  test('renders points in Composed chart when stacks are bigger than ZAxis dataKey', () => {
+    const boxPlotData = [
+      {
+        min: 100,
+        bottomWhisker: 100,
+        bottomBox: 50,
+        topBox: 200,
+        topWhisker: 200,
+        average: 150,
+        size: 150,
+      },
+      {
+        min: 200,
+        bottomWhisker: 200,
+        bottomBox: 200,
+        topBox: 100,
+        topWhisker: 100,
+        average: 550,
+        size: 250,
+      },
+      {
+        min: 0,
+        bottomWhisker: 200,
+        bottomBox: 200,
+        topBox: 200,
+        topWhisker: 200,
+        average: 400,
+        size: 350,
+      },
+    ];
+
+    const yAxisDomainSpy = vi.fn();
+    const yAxisDataSpy = vi.fn();
+    const yAxisTicksSpy = vi.fn();
+    const displayedDataSpy = vi.fn();
+    const stackGroupsDomainSpy = vi.fn();
+    const zAxisAppliedDataSpy = vi.fn();
+    const zAxisSettingsSpy = vi.fn();
+    const zAxisDomainSpy = vi.fn();
+    const Comp = (): null => {
+      displayedDataSpy(useAppSelector(state => selectDisplayedData(state, 'zAxis', 0)));
+      stackGroupsDomainSpy(useAppSelector(state => selectDomainOfStackGroups(state, 'zAxis', 0)));
+      zAxisAppliedDataSpy(
+        useAppSelector(state => selectAllAppliedNumericalValuesIncludingErrorValues(state, 'zAxis', 0)),
+      );
+      zAxisSettingsSpy(useAppSelector(state => selectBaseAxis(state, 'zAxis', 0)));
+      zAxisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'zAxis', 0)));
+      yAxisTicksSpy(useAppSelector(state => selectTicksOfGraphicalItem(state, 'yAxis', 0)));
+      yAxisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'yAxis', 0)));
+      yAxisDataSpy(useAppSelector(state => selectAllAppliedNumericalValuesIncludingErrorValues(state, 'yAxis', 0)));
+      return null;
+    };
+
+    const { container } = render(
+      <ComposedChart width={400} height={200} data={boxPlotData}>
+        <Bar stackId="a" dataKey="min" />
+        <Bar stackId="a" dataKey="bar" />
+        <Bar stackId="a" dataKey="bottomWhisker" />
+        <Bar stackId="a" dataKey="bottomBox" />
+        <Bar stackId="a" dataKey="bar" />
+        <Bar stackId="a" dataKey="topBox" />
+        <Bar stackId="a" dataKey="topWhisker" />
+        <Bar stackId="a" dataKey="bar" />
+        <ZAxis type="number" dataKey="size" range={[0, 250]} />
+
+        <Scatter dataKey="average" />
+        <XAxis />
+        <YAxis />
+
+        <Customized component={<Comp />} />
+      </ComposedChart>,
+    );
+
+    expect(yAxisDataSpy).toHaveBeenLastCalledWith([
+      {
+        errorDomain: [],
+        value: 150,
+      },
+      {
+        errorDomain: [],
+        value: 550,
+      },
+      {
+        errorDomain: [],
+        value: 400,
+      },
+    ]);
+    expect(yAxisDomainSpy).toHaveBeenLastCalledWith([0, 800]);
+    expect(yAxisTicksSpy).toHaveBeenLastCalledWith([
+      {
+        coordinate: 165,
+        offset: 0,
+        value: 0,
+      },
+      {
+        coordinate: 125,
+        offset: 0,
+        value: 200,
+      },
+      {
+        coordinate: 85,
+        offset: 0,
+        value: 400,
+      },
+      {
+        coordinate: 45,
+        offset: 0,
+        value: 600,
+      },
+      {
+        coordinate: 5,
+        offset: 0,
+        value: 800,
+      },
+    ]);
+    expect(displayedDataSpy).toHaveBeenLastCalledWith([
+      {
+        average: 150,
+        bottomBox: 50,
+        bottomWhisker: 100,
+        min: 100,
+        size: 150,
+        topBox: 200,
+        topWhisker: 200,
+      },
+      {
+        average: 550,
+        bottomBox: 200,
+        bottomWhisker: 200,
+        min: 200,
+        size: 250,
+        topBox: 100,
+        topWhisker: 100,
+      },
+      {
+        average: 400,
+        bottomBox: 200,
+        bottomWhisker: 200,
+        min: 0,
+        size: 350,
+        topBox: 200,
+        topWhisker: 200,
+      },
+    ]);
+    // expect(stackGroupsDomainSpy).toHaveBeenLastCalledWith([0, 800]);
+    expect(zAxisAppliedDataSpy).toHaveBeenLastCalledWith([
+      {
+        errorDomain: [],
+        value: 150,
+      },
+      {
+        errorDomain: [],
+        value: 250,
+      },
+      {
+        errorDomain: [],
+        value: 350,
+      },
+    ]);
+    expect(zAxisSettingsSpy).toHaveBeenLastCalledWith({
+      allowDataOverflow: false,
+      allowDuplicatedCategory: false,
+      dataKey: 'size',
+      id: 0,
+      includeHidden: false,
+      name: undefined,
+      range: [0, 250],
+      reversed: false,
+      scale: 'auto',
+      type: 'number',
+      unit: undefined,
+    });
+    expect(zAxisDomainSpy).toHaveBeenLastCalledWith([0, 350]);
+    expectScatterPoints(container, [
+      {
+        cx: '120',
+        cy: '135',
+        d: 'M0,0',
+        height: '11.67983401638037',
+        transform: 'translate(120, 135)',
+        width: '11.67983401638037',
+      },
+      {
+        cx: '230',
+        cy: '55',
+        d: 'M0,0',
+        height: '15.078600877302687',
+        transform: 'translate(230, 55)',
+        width: '15.078600877302687',
+      },
+      {
+        cx: '340',
+        cy: '85',
+        d: 'M0,0',
+        height: '17.841241161527712',
+        transform: 'translate(340, 85)',
+        width: '17.841241161527712',
+      },
+    ]);
   });
 
   describe('customized active shape', () => {
@@ -582,109 +1484,145 @@ describe('ScatterChart with multiple Y axes', () => {
         cx: '186.66666666666669',
         cy: '185',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(186.66666666666669, 185)',
+        width: '9.0270333367641',
       },
       {
         cx: '208',
         cy: '267.5',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(208, 267.5)',
+        width: '9.0270333367641',
       },
       {
         cx: '261.3333333333333',
         cy: '102.5',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(261.3333333333333, 102.5)',
+        width: '9.0270333367641',
       },
       {
         cx: '229.33333333333331',
         cy: '143.75',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(229.33333333333331, 143.75)',
+        width: '9.0270333367641',
       },
       {
         cx: '240',
         cy: '20',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(240, 20)',
+        width: '9.0270333367641',
       },
       {
         cx: '197.33333333333331',
         cy: '119.00000000000001',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(197.33333333333331, 119.00000000000001)',
+        width: '9.0270333367641',
       },
       {
         cx: '400',
         cy: '226.25',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(400, 226.25)',
+        width: '9.0270333367641',
       },
       {
         cx: '506.6666666666667',
         cy: '143.75',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(506.6666666666667, 143.75)',
+        width: '9.0270333367641',
       },
       {
         cx: '293.33333333333337',
         cy: '61.25',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(293.33333333333337, 61.25)',
+        width: '9.0270333367641',
       },
       {
         cx: '442.6666666666667',
         cy: '205.625',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(442.6666666666667, 205.625)',
+        width: '9.0270333367641',
       },
       {
         cx: '677.3333333333334',
         cy: '143.75',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(677.3333333333334, 143.75)',
+        width: '9.0270333367641',
       },
       {
         cx: '325.3333333333333',
         cy: '28.250000000000007',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(325.3333333333333, 28.250000000000007)',
+        width: '9.0270333367641',
       },
       {
         cx: '613.3333333333334',
         cy: '185',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(613.3333333333334, 185)',
+        width: '9.0270333367641',
       },
       {
         cx: '400',
         cy: '143.75',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(400, 143.75)',
+        width: '9.0270333367641',
       },
       {
         cx: '336',
         cy: '226.25',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(336, 226.25)',
+        width: '9.0270333367641',
       },
       {
         cx: '421.3333333333333',
         cy: '123.125',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(421.3333333333333, 123.125)',
+        width: '9.0270333367641',
       },
       {
         cx: '613.3333333333334',
         cy: '185',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(613.3333333333334, 185)',
+        width: '9.0270333367641',
       },
       {
         cx: '528',
         cy: '234.5',
         d: 'M0,0',
+        height: '9.0270333367641',
         transform: 'translate(528, 234.5)',
+        width: '9.0270333367641',
       },
     ]);
   });

--- a/test/component/LabelList.spec.tsx
+++ b/test/component/LabelList.spec.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 
 import { Bar, BarChart, LabelList, Scatter, ScatterChart, XAxis, YAxis, ZAxis } from '../../src';
+import { expectScatterPoints } from '../helper/expectScatterPoints';
 
 describe('<LabelList />', () => {
   it('Render labels in ScatterChart', () => {
@@ -26,6 +27,56 @@ describe('<LabelList />', () => {
 
     const label = container.querySelectorAll('.recharts-label');
 
+    expectScatterPoints(container, [
+      {
+        cx: '86.66666666666667',
+        cy: '185',
+        d: 'M1.819,0A1.819,1.819,0,1,1,-1.819,0A1.819,1.819,0,1,1,1.819,0',
+        height: '3.638913473173784',
+        transform: 'translate(86.66666666666667, 185)',
+        width: '3.638913473173784',
+      },
+      {
+        cx: '140',
+        cy: '267.5',
+        d: 'M1.98,0A1.98,1.98,0,1,1,-1.98,0A1.98,1.98,0,1,1,1.98,0',
+        height: '3.960594802695323',
+        transform: 'translate(140, 267.5)',
+        width: '3.960594802695323',
+      },
+      {
+        cx: '193.33333333333334',
+        cy: '102.5',
+        d: 'M2.312,0A2.312,2.312,0,1,1,-2.312,0A2.312,2.312,0,1,1,2.312,0',
+        height: '4.624978308224887',
+        transform: 'translate(193.33333333333334, 102.5)',
+        width: '4.624978308224887',
+      },
+      {
+        cx: '246.66666666666666',
+        cy: '143.75',
+        d: 'M2.031,0A2.031,2.031,0,1,1,-2.031,0A2.031,2.031,0,1,1,2.031,0',
+        height: '4.062165001543845',
+        transform: 'translate(246.66666666666666, 143.75)',
+        width: '4.062165001543845',
+      },
+      {
+        cx: '300.00000000000006',
+        cy: '20',
+        d: 'M2.523,0A2.523,2.523,0,1,1,-2.523,0A2.523,2.523,0,1,1,2.523,0',
+        height: '5.046265044040321',
+        transform: 'translate(300.00000000000006, 20)',
+        width: '5.046265044040321',
+      },
+      {
+        cx: '353.33333333333337',
+        cy: '119.00000000000001',
+        d: 'M1.819,0A1.819,1.819,0,1,1,-1.819,0A1.819,1.819,0,1,1,1.819,0',
+        height: '3.638913473173784',
+        transform: 'translate(353.33333333333337, 119.00000000000001)',
+        width: '3.638913473173784',
+      },
+    ]);
     expect(label?.length).toEqual(data.length);
   });
 

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -406,7 +406,11 @@ describe('Tooltip payload', () => {
     },
   );
 
-  describe('filterNull prop', () => {
+  /*
+   * Scatter no longer renders values with nulls in them so the Tooltip never displays in the first place.
+   * What should we do here? I would be in favour of removing the `filterNull` prop completely.
+   */
+  describe.skip('filterNull prop', () => {
     const dataWithNulls: Array<{ x: number | null; y: number | null }> = [{ x: null, y: 2 }];
     test.each([undefined, true])('should filter away nulls when filterNull = %s', filterNull => {
       const { container, debug } = render(

--- a/test/helper/expectScatterPoints.ts
+++ b/test/helper/expectScatterPoints.ts
@@ -1,0 +1,27 @@
+import { expect } from 'vitest';
+import { assertNotNull } from './assertNotNull';
+
+type ExpectedPoint = {
+  cx: string;
+  cy: string;
+  transform: string;
+  d: string;
+  width: string;
+  height: string;
+};
+
+export function expectScatterPoints(container: Element, expectedPoints: ReadonlyArray<ExpectedPoint>) {
+  assertNotNull(container);
+  const allPoints = container.querySelectorAll('.recharts-scatter-symbol .recharts-symbols');
+  const actualPoints = Array.from(allPoints).map(point => {
+    return {
+      cx: point.getAttribute('cx'),
+      cy: point.getAttribute('cy'),
+      transform: point.getAttribute('transform'),
+      d: point.getAttribute('d'),
+      width: point.getAttribute('width'),
+      height: point.getAttribute('height'),
+    };
+  });
+  expect(actualPoints).toEqual(expectedPoints);
+}

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -11,6 +11,7 @@ import {
   selectAxisDomainIncludingNiceTicks,
   selectAxisRangeWithReverse,
   selectAxisScale,
+  selectAxisSettings,
   selectBaseAxis,
   selectCalculatedXAxisPadding,
   selectCartesianGraphicalItemsData,
@@ -2612,16 +2613,18 @@ describe('selectErrorBarsSettings', () => {
   });
 
   it('should return bars settings if present in ScatterChart', () => {
-    const xAxisSpy = vi.fn();
+    const xAxisErrorBarSpy = vi.fn();
+    const yAxisErrorBarSpy = vi.fn();
     const yAxisSpy = vi.fn();
     const Comp = (): null => {
-      xAxisSpy(useAppSelector(state => selectErrorBarsSettings(state, 'xAxis', defaultAxisId)));
-      yAxisSpy(useAppSelector(state => selectErrorBarsSettings(state, 'yAxis', defaultAxisId)));
+      xAxisErrorBarSpy(useAppSelector(state => selectErrorBarsSettings(state, 'xAxis', defaultAxisId)));
+      yAxisErrorBarSpy(useAppSelector(state => selectErrorBarsSettings(state, 'yAxis', defaultAxisId)));
+      yAxisSpy(useAppSelector(state => selectAxisSettings(state, 'yAxis', defaultAxisId)));
       return null;
     };
     render(
       <ScatterChart width={100} height={100}>
-        <Scatter data={[{ x: 1 }, { x: 2 }, { x: 3 }]} isAnimationActive={false}>
+        <Scatter data={[{ x: 1 }, { x: 2 }, { x: 3 }]} dataKey="x" isAnimationActive={false}>
           <ErrorBar dataKey="data-x" direction="x" />
           <ErrorBar dataKey="data-y" direction="y" />
         </Scatter>
@@ -2629,20 +2632,49 @@ describe('selectErrorBarsSettings', () => {
         <XAxis type="number" />
       </ScatterChart>,
     );
-    expect(xAxisSpy).toHaveBeenLastCalledWith([
+    expect(yAxisSpy).toHaveBeenLastCalledWith({
+      allowDataOverflow: false,
+      allowDecimals: true,
+      allowDuplicatedCategory: true,
+      angle: 0,
+      dataKey: undefined,
+      domain: [0, 'auto'],
+      hide: true,
+      id: undefined,
+      includeHidden: false,
+      interval: 'preserveEnd',
+      minTickGap: 5,
+      mirror: false,
+      name: undefined,
+      orientation: 'left',
+      padding: {
+        bottom: 0,
+        top: 0,
+      },
+      reversed: false,
+      scale: 'auto',
+      tick: true,
+      tickCount: 5,
+      tickFormatter: undefined,
+      ticks: undefined,
+      type: 'number',
+      unit: undefined,
+      width: 60,
+    });
+    expect(xAxisErrorBarSpy).toHaveBeenLastCalledWith([
       {
         dataKey: 'data-x',
         direction: 'x',
       },
     ]);
-    expect(yAxisSpy).toHaveBeenLastCalledWith([
+    expect(yAxisErrorBarSpy).toHaveBeenLastCalledWith([
       {
         dataKey: 'data-y',
         direction: 'y',
       },
     ]);
-    expect(xAxisSpy).toHaveBeenCalledTimes(4);
-    expect(yAxisSpy).toHaveBeenCalledTimes(4);
+    expect(xAxisErrorBarSpy).toHaveBeenCalledTimes(4);
+    expect(yAxisErrorBarSpy).toHaveBeenCalledTimes(4);
   });
 
   it('should report all relevant error bars on Bar, Line, and Scatter', () => {
@@ -2669,6 +2701,7 @@ describe('selectErrorBarsSettings', () => {
         </Scatter>
         <Customized component={Comp} />
         <XAxis type="number" />
+        <YAxis dataKey="x" />
       </ComposedChart>,
     );
     expect(xAxisSpy).toHaveBeenLastCalledWith([
@@ -2829,5 +2862,10 @@ describe('mergeDomains', () => {
   it('should find min, max when called with multiple domains', () => {
     expect(mergeDomains([100, 200], [150, 250])).toEqual([100, 250]);
     expect(mergeDomains([100, 200], [150, 250], [0, 50])).toEqual([0, 250]);
+  });
+
+  it('should ignore domains that are undefined', () => {
+    expect(mergeDomains([100, 200], [150, 250])).toEqual([100, 250]);
+    expect(mergeDomains([100, 200], [150, 250], undefined, [0, 50])).toEqual([0, 250]);
   });
 });

--- a/test/state/selectors/scatterSelectors.spec.tsx
+++ b/test/state/selectors/scatterSelectors.spec.tsx
@@ -1,0 +1,452 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useAppSelector } from '../../../src/state/hooks';
+import { ResolvedScatterSettings, selectScatterPoints } from '../../../src/state/selectors/scatterSelectors';
+import { createRechartsStore } from '../../../src/state/store';
+import { Customized, Pie, PieChart, Scatter, ScatterChart } from '../../../src';
+import { pageData } from '../../../storybook/stories/data';
+
+describe('selectScatterPoints', () => {
+  const scatterSettings: ResolvedScatterSettings = {
+    name: undefined,
+    tooltipType: undefined,
+    data: pageData,
+    dataKey: 'uv',
+  };
+  it('should return undefined when called out of Recharts context', () => {
+    const scatterPointsSpy = vi.fn();
+    const Comp = (): null => {
+      scatterPointsSpy(
+        useAppSelector(state => selectScatterPoints(state, 'xAxis', 'yAxis', 'zAxis', scatterSettings, [])),
+      );
+      return null;
+    };
+    render(<Comp />);
+    expect(scatterPointsSpy).toHaveBeenCalledWith(undefined);
+    expect(scatterPointsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return undefined when called with initial state', () => {
+    const store = createRechartsStore();
+    const result = selectScatterPoints(store.getState(), 'xAxis', 'yAxis', 'zAxis', scatterSettings, []);
+    expect(result).toEqual(undefined);
+  });
+
+  it('should return undefined in a chart that does not support Scatter', () => {
+    const scatterPointsSpy = vi.fn();
+    const Comp = (): null => {
+      scatterPointsSpy(
+        useAppSelector(state => selectScatterPoints(state, 'xAxis', 'yAxis', 'zAxis', scatterSettings, [])),
+      );
+      return null;
+    };
+    render(
+      <PieChart width={100} height={200}>
+        <Pie data={pageData} dataKey="uv" />
+        <Customized component={<Comp />} />
+      </PieChart>,
+    );
+    expect(scatterPointsSpy).toHaveBeenCalledWith(undefined);
+    expect(scatterPointsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return computed scatter points when data is defined on Scatter child', () => {
+    const scatterPointsSpy = vi.fn();
+    // this really should be ReadonlyArray<ScatterPointItem> but because Scatter expands all properties of everything, the type does not really match the object.
+    const expectedPoints: ReadonlyArray<any> = [
+      {
+        name: 'Page A',
+        uv: 590,
+        pv: 800,
+        amt: 1400,
+        cx: 11.428571428571429,
+        cy: 124.9375,
+        x: 6.915054760189379,
+        y: 120.42398333161795,
+        width: 9.0270333367641,
+        height: 9.0270333367641,
+        size: 64,
+        node: {
+          x: 590,
+          y: 590,
+          z: '-',
+        },
+        tooltipPayload: [
+          {
+            unit: '',
+            value: 590,
+            payload: {
+              name: 'Page A',
+              uv: 590,
+              pv: 800,
+              amt: 1400,
+            },
+            dataKey: 'uv',
+          },
+          {
+            unit: '',
+            value: 590,
+            payload: {
+              name: 'Page A',
+              uv: 590,
+              pv: 800,
+              amt: 1400,
+            },
+            dataKey: 'uv',
+          },
+        ],
+        tooltipPosition: {
+          x: 11.428571428571429,
+          y: 124.9375,
+        },
+        payload: {
+          name: 'Page A',
+          uv: 590,
+          pv: 800,
+          amt: 1400,
+        },
+      },
+      {
+        name: 'Page B',
+        uv: 590,
+        pv: 800,
+        amt: 1400,
+        cx: 24.285714285714285,
+        cy: 124.9375,
+        x: 19.772197617332235,
+        y: 120.42398333161795,
+        width: 9.0270333367641,
+        height: 9.0270333367641,
+        size: 64,
+        node: {
+          x: 590,
+          y: 590,
+          z: '-',
+        },
+        tooltipPayload: [
+          {
+            unit: '',
+            value: 590,
+            payload: {
+              name: 'Page B',
+              uv: 590,
+              pv: 800,
+              amt: 1400,
+            },
+            dataKey: 'uv',
+          },
+          {
+            unit: '',
+            value: 590,
+            payload: {
+              name: 'Page B',
+              uv: 590,
+              pv: 800,
+              amt: 1400,
+            },
+            dataKey: 'uv',
+          },
+        ],
+        tooltipPosition: {
+          x: 24.285714285714285,
+          y: 124.9375,
+        },
+        payload: {
+          name: 'Page B',
+          uv: 590,
+          pv: 800,
+          amt: 1400,
+        },
+      },
+      {
+        name: 'Page C',
+        uv: 868,
+        pv: 967,
+        amt: 1506,
+        cx: 37.142857142857146,
+        cy: 91.92500000000001,
+        x: 32.62934047447509,
+        y: 87.41148333161796,
+        width: 9.0270333367641,
+        height: 9.0270333367641,
+        size: 64,
+        node: {
+          x: 868,
+          y: 868,
+          z: '-',
+        },
+        tooltipPayload: [
+          {
+            unit: '',
+            value: 868,
+            payload: {
+              name: 'Page C',
+              uv: 868,
+              pv: 967,
+              amt: 1506,
+            },
+            dataKey: 'uv',
+          },
+          {
+            unit: '',
+            value: 868,
+            payload: {
+              name: 'Page C',
+              uv: 868,
+              pv: 967,
+              amt: 1506,
+            },
+            dataKey: 'uv',
+          },
+        ],
+        tooltipPosition: {
+          x: 37.142857142857146,
+          y: 91.92500000000001,
+        },
+        payload: {
+          name: 'Page C',
+          uv: 868,
+          pv: 967,
+          amt: 1506,
+        },
+      },
+      {
+        name: 'Page D',
+        uv: 1397,
+        pv: 1098,
+        amt: 989,
+        cx: 50,
+        cy: 29.106249999999992,
+        x: 45.48648333161795,
+        y: 24.592733331617943,
+        width: 9.0270333367641,
+        height: 9.0270333367641,
+        size: 64,
+        node: {
+          x: 1397,
+          y: 1397,
+          z: '-',
+        },
+        tooltipPayload: [
+          {
+            unit: '',
+            value: 1397,
+            payload: {
+              name: 'Page D',
+              uv: 1397,
+              pv: 1098,
+              amt: 989,
+            },
+            dataKey: 'uv',
+          },
+          {
+            unit: '',
+            value: 1397,
+            payload: {
+              name: 'Page D',
+              uv: 1397,
+              pv: 1098,
+              amt: 989,
+            },
+            dataKey: 'uv',
+          },
+        ],
+        tooltipPosition: {
+          x: 50,
+          y: 29.106249999999992,
+        },
+        payload: {
+          name: 'Page D',
+          uv: 1397,
+          pv: 1098,
+          amt: 989,
+        },
+      },
+      {
+        name: 'Page E',
+        uv: 1480,
+        pv: 1200,
+        amt: 1228,
+        cx: 62.85714285714286,
+        cy: 19.249999999999993,
+        x: 58.34362618876081,
+        y: 14.736483331617944,
+        width: 9.0270333367641,
+        height: 9.0270333367641,
+        size: 64,
+        node: {
+          x: 1480,
+          y: 1480,
+          z: '-',
+        },
+        tooltipPayload: [
+          {
+            unit: '',
+            value: 1480,
+            payload: {
+              name: 'Page E',
+              uv: 1480,
+              pv: 1200,
+              amt: 1228,
+            },
+            dataKey: 'uv',
+          },
+          {
+            unit: '',
+            value: 1480,
+            payload: {
+              name: 'Page E',
+              uv: 1480,
+              pv: 1200,
+              amt: 1228,
+            },
+            dataKey: 'uv',
+          },
+        ],
+        tooltipPosition: {
+          x: 62.85714285714286,
+          y: 19.249999999999993,
+        },
+        payload: {
+          name: 'Page E',
+          uv: 1480,
+          pv: 1200,
+          amt: 1228,
+        },
+      },
+      {
+        name: 'Page F',
+        uv: 1520,
+        pv: 1108,
+        amt: 1100,
+        cx: 75.71428571428572,
+        cy: 14.500000000000009,
+        x: 71.20076904590367,
+        y: 9.986483331617958,
+        width: 9.0270333367641,
+        height: 9.0270333367641,
+        size: 64,
+        node: {
+          x: 1520,
+          y: 1520,
+          z: '-',
+        },
+        tooltipPayload: [
+          {
+            unit: '',
+            value: 1520,
+            payload: {
+              name: 'Page F',
+              uv: 1520,
+              pv: 1108,
+              amt: 1100,
+            },
+            dataKey: 'uv',
+          },
+          {
+            unit: '',
+            value: 1520,
+            payload: {
+              name: 'Page F',
+              uv: 1520,
+              pv: 1108,
+              amt: 1100,
+            },
+            dataKey: 'uv',
+          },
+        ],
+        tooltipPosition: {
+          x: 75.71428571428572,
+          y: 14.500000000000009,
+        },
+        payload: {
+          name: 'Page F',
+          uv: 1520,
+          pv: 1108,
+          amt: 1100,
+        },
+      },
+      {
+        name: 'Page G',
+        uv: 1400,
+        pv: 680,
+        amt: 1700,
+        cx: 88.57142857142857,
+        cy: 28.75,
+        x: 84.05791190304652,
+        y: 24.23648333161795,
+        width: 9.0270333367641,
+        height: 9.0270333367641,
+        size: 64,
+        node: {
+          x: 1400,
+          y: 1400,
+          z: '-',
+        },
+        tooltipPayload: [
+          {
+            unit: '',
+            value: 1400,
+            payload: {
+              name: 'Page G',
+              uv: 1400,
+              pv: 680,
+              amt: 1700,
+            },
+            dataKey: 'uv',
+          },
+          {
+            unit: '',
+            value: 1400,
+            payload: {
+              name: 'Page G',
+              uv: 1400,
+              pv: 680,
+              amt: 1700,
+            },
+            dataKey: 'uv',
+          },
+        ],
+        tooltipPosition: {
+          x: 88.57142857142857,
+          y: 28.75,
+        },
+        payload: {
+          name: 'Page G',
+          uv: 1400,
+          pv: 680,
+          amt: 1700,
+        },
+      },
+    ];
+    const Comp = (props: any): null => {
+      expect(props.formattedGraphicalItems[0].props.points).toEqual(expectedPoints);
+      scatterPointsSpy(useAppSelector(state => selectScatterPoints(state, 0, 0, 0, scatterSettings, undefined)));
+      return null;
+    };
+    render(
+      <ScatterChart width={100} height={200}>
+        <Scatter data={scatterSettings.data} dataKey={scatterSettings.dataKey} />
+        <Customized component={<Comp />} />
+      </ScatterChart>,
+    );
+    expect(scatterPointsSpy).toHaveBeenLastCalledWith(expectedPoints);
+  });
+
+  it('should be stable', () => {
+    expect.assertions(3);
+    const Comp = (): null => {
+      const result1 = useAppSelector(state => selectScatterPoints(state, 0, 0, 0, scatterSettings, undefined));
+      const result2 = useAppSelector(state => selectScatterPoints(state, 0, 0, 0, scatterSettings, undefined));
+      expect(result1).toBe(result2);
+      return null;
+    };
+    render(
+      <ScatterChart width={100} height={200}>
+        <Scatter data={scatterSettings.data} dataKey={scatterSettings.dataKey} />
+        <Customized component={<Comp />} />
+      </ScatterChart>,
+    );
+  });
+});


### PR DESCRIPTION
## Description

Adds new selector, and uses the selector in Scatter. The old `getComposedData` function is still around and used in Tooltip, but Scatter itself does not use it anymore.

There are some breaking changes:

- Scatter doesn't work in Brush panorama anymore - I will need to fix that before we can release 3.0
- ZAxis range had this behaviour where it used to get the first digit of the range and used that as a default size in an absence of a dataKey. That is gone, if you want to change the size then give it a dataKey. In my opinion this can stay.
- Scatter used to display `null` values _somehow, somewhere_ and then Tooltip had a `filterNull` prop that further defined what happens with the nulls. Now it doesn't display nulls at all and the `filterNull` accordingly does not do anything. In my opinion, this too can stay and we should remove the `filterNull` completely. If anyone wants to display empty strings in a chart then they can pass empty strings instead of relying on Recharts to convert nulls to empty strings.

## Related Issue

https://github.com/recharts/recharts/issues/4583

This is the latest visual diff report: https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=1265