### PR TITLE
Scatter no longer depends on generateCategoricalChart

### DIFF
--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -49,6 +49,7 @@ import { GraphicalItemClipPath, useNeedsClip } from './GraphicalItemClipPath';
 import { ResolvedScatterSettings, selectScatterPoints } from '../state/selectors/scatterSelectors';
 import { useAppSelector } from '../state/hooks';
 import { BaseAxisWithScale, ZAxisWithScale } from '../state/selectors/axisSelectors';
+import { useUpdateId } from '../context/chartLayoutContext';
 
 interface ScatterPointNode {
   x?: number | string;
@@ -67,37 +68,43 @@ export interface ScatterPointItem {
 
 export type ScatterCustomizedShape = ActiveShape<ScatterPointItem, SVGPathElement & InnerSymbolsProp> | SymbolType;
 
+/**
+ * Internal props, combination of external props + defaultProps + private Recharts state
+ */
 interface ScatterInternalProps {
   data?: any[];
-  xAxisId?: string | number;
-  yAxisId?: string | number;
-  zAxisId?: string | number;
+  xAxisId: string | number;
+  yAxisId: string | number;
+  zAxisId: string | number;
 
   dataKey?: DataKey<any>;
 
   line?: ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | CurveProps | boolean;
-  lineType?: 'fitting' | 'joint';
-  lineJointType?: CurveType;
-  legendType?: LegendType;
+  lineType: 'fitting' | 'joint';
+  lineJointType: CurveType;
+  legendType: LegendType;
   tooltipType?: TooltipType;
   className?: string;
   name?: string;
 
   activeShape?: ScatterCustomizedShape;
-  shape?: ScatterCustomizedShape;
-  points?: ReadonlyArray<ScatterPointItem>;
-  hide?: boolean;
+  shape: ScatterCustomizedShape;
+  points: ReadonlyArray<ScatterPointItem>;
+  hide: boolean;
   label?: ImplicitLabelListType<any>;
 
-  isAnimationActive?: boolean;
-  animationId?: number;
-  animationBegin?: number;
-  animationDuration?: AnimationDuration;
-  animationEasing?: AnimationTiming;
+  isAnimationActive: boolean;
+  animationId: string;
+  animationBegin: number;
+  animationDuration: AnimationDuration;
+  animationEasing: AnimationTiming;
 
-  needClip?: boolean;
+  needClip: boolean;
 }
 
+/**
+ * External props, intended for end users to fill in
+ */
 interface ScatterProps {
   data?: any[];
   xAxisId?: AxisId;
@@ -120,28 +127,32 @@ interface ScatterProps {
   label?: ImplicitLabelListType<any>;
 
   isAnimationActive?: boolean;
-  animationId?: number;
   animationBegin?: number;
   animationDuration?: AnimationDuration;
   animationEasing?: AnimationTiming;
 }
 
-type InternalProps = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>, 'points'> & ScatterInternalProps;
+/**
+ * Because of naming conflict, we are forced to ignore certain (valid) SVG attributes.
+ */
+type BaseScatterSvgProps = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>, 'points'>;
 
-export type Props = PresentationAttributesAdaptChildEvent<any, SVGElement> & ScatterProps;
+type InternalProps = BaseScatterSvgProps & ScatterInternalProps;
+
+export type Props = BaseScatterSvgProps & ScatterProps;
 
 interface State {
   isAnimationFinished?: boolean;
   prevPoints?: ReadonlyArray<ScatterPointItem>;
   curPoints?: ReadonlyArray<ScatterPointItem>;
-  prevAnimationId?: number;
+  prevAnimationId?: string;
 }
 
 type ScatterComposedData = {
   points: ReadonlyArray<ScatterPointItem>;
 };
 
-const computeLegendPayloadFromScatterProps = (props: InternalProps): Array<LegendPayload> => {
+const computeLegendPayloadFromScatterProps = (props: Props): Array<LegendPayload> => {
   const { dataKey, name, fill, legendType, hide } = props;
   return [
     {
@@ -155,7 +166,7 @@ const computeLegendPayloadFromScatterProps = (props: InternalProps): Array<Legen
   ];
 };
 
-function SetScatterLegend(props: InternalProps): null {
+function SetScatterLegend(props: Props): null {
   useLegendPayloadDispatch(computeLegendPayloadFromScatterProps, props);
   return null;
 }
@@ -221,7 +232,18 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
   );
 }
 
-function getTooltipEntrySettings(props: InternalProps): TooltipPayloadConfiguration {
+type InputRequiredToComputeTooltipEntrySettings = {
+  dataKey?: DataKey<any> | undefined;
+  points?: ReadonlyArray<ScatterPointItem>;
+  stroke?: string;
+  strokeWidth?: number | string;
+  fill?: string;
+  name?: string;
+  hide?: boolean;
+  tooltipType?: TooltipType;
+};
+
+function getTooltipEntrySettings(props: InputRequiredToComputeTooltipEntrySettings): TooltipPayloadConfiguration {
   const { dataKey, points, stroke, strokeWidth, fill, name, hide, tooltipType } = props;
   return {
     dataDefinedOnItem: points?.map((p: ScatterPointItem) => p.tooltipPayload),
@@ -527,9 +549,27 @@ class ScatterWithState extends PureComponent<InternalProps, State> {
   }
 }
 
-function ScatterImpl(props: InternalProps) {
+const defaultScatterProps: Partial<Props> = {
+  xAxisId: 0,
+  yAxisId: 0,
+  zAxisId: 0,
+  legendType: 'circle',
+  lineType: 'joint',
+  lineJointType: 'linear',
+  data: [] as any[],
+  shape: 'circle',
+  hide: false,
+
+  isAnimationActive: !Global.isSsr,
+  animationBegin: 0,
+  animationDuration: 400,
+  animationEasing: 'linear',
+};
+
+function ScatterImpl(props: Props) {
   const { needClip } = useNeedsClip(props.xAxisId, props.yAxisId);
   const cells = useMemo(() => findAllByType(props.children, Cell), [props.children]);
+  const updateId = useUpdateId();
   const scatterSettings: ResolvedScatterSettings = useMemo(
     () => ({
       name: props.name,
@@ -542,35 +582,37 @@ function ScatterImpl(props: InternalProps) {
   const points = useAppSelector(state => {
     return selectScatterPoints(state, props.xAxisId, props.yAxisId, props.zAxisId, scatterSettings, cells);
   });
-  const { ref, points: _pointsFromClonedProps, ...everythingElse } = props;
+  const { ref, xAxisId, ...everythingElse } = props;
 
   return (
     <>
       <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={{ ...props, points }} />
-      <ScatterWithState {...everythingElse} points={points} needClip={needClip} />
+      <ScatterWithState
+        {...everythingElse}
+        xAxisId={props.xAxisId ?? defaultScatterProps.xAxisId}
+        yAxisId={props.yAxisId ?? defaultScatterProps.yAxisId}
+        zAxisId={props.zAxisId ?? defaultScatterProps.zAxisId}
+        lineType={props.lineType ?? defaultScatterProps.lineType}
+        lineJointType={props.lineJointType ?? defaultScatterProps.lineJointType}
+        legendType={props.legendType ?? defaultScatterProps.legendType}
+        shape={props.shape ?? defaultScatterProps.shape}
+        hide={props.hide ?? defaultScatterProps.hide}
+        isAnimationActive={props.isAnimationActive ?? defaultScatterProps.isAnimationActive}
+        animationBegin={props.animationBegin ?? defaultScatterProps.animationBegin}
+        animationDuration={props.animationDuration ?? defaultScatterProps.animationDuration}
+        animationEasing={props.animationEasing ?? defaultScatterProps.animationEasing}
+        points={points}
+        needClip={needClip}
+        animationId={updateId}
+      />
     </>
   );
 }
 
-export class Scatter extends Component<InternalProps> {
+export class Scatter extends Component<Props> {
   static displayName = 'Scatter';
 
-  static defaultProps = {
-    xAxisId: 0,
-    yAxisId: 0,
-    zAxisId: 0,
-    legendType: 'circle',
-    lineType: 'joint',
-    lineJointType: 'linear',
-    data: [] as any[],
-    shape: 'circle',
-    hide: false,
-
-    isAnimationActive: !Global.isSsr,
-    animationBegin: 0,
-    animationDuration: 400,
-    animationEasing: 'linear',
-  };
+  static defaultProps = defaultScatterProps;
 
   /**
    * Compose the data of each group

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -224,7 +224,7 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
 function getTooltipEntrySettings(props: InternalProps): TooltipPayloadConfiguration {
   const { dataKey, points, stroke, strokeWidth, fill, name, hide, tooltipType } = props;
   return {
-    dataDefinedOnItem: points.map((p: ScatterPointItem) => p.tooltipPayload),
+    dataDefinedOnItem: points?.map((p: ScatterPointItem) => p.tooltipPayload),
     settings: {
       stroke,
       strokeWidth,
@@ -544,7 +544,12 @@ function ScatterImpl(props: InternalProps) {
   });
   const { ref, points: _pointsFromClonedProps, ...everythingElse } = props;
 
-  return <ScatterWithState {...everythingElse} points={points} needClip={needClip} />;
+  return (
+    <>
+      <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={{ ...props, points }} />
+      <ScatterWithState {...everythingElse} points={points} needClip={needClip} />
+    </>
+  );
 }
 
 export class Scatter extends Component<InternalProps> {
@@ -594,7 +599,6 @@ export class Scatter extends Component<InternalProps> {
     displayedData: any[];
   }): ScatterComposedData => {
     const cells = findAllByType(item.props.children, Cell);
-    console.log('getComposedData', { xAxisTicks });
     const points: ReadonlyArray<ScatterPointItem> = computeScatterPoints({
       displayedData,
       xAxis,
@@ -626,7 +630,6 @@ export class Scatter extends Component<InternalProps> {
         hide={this.props.hide}
       >
         <SetScatterLegend {...this.props} />
-        <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
         <ScatterImpl {...this.props} />
       </CartesianGraphicalItemContext>
     );

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -594,6 +594,7 @@ export class Scatter extends Component<InternalProps> {
     displayedData: any[];
   }): ScatterComposedData => {
     const cells = findAllByType(item.props.children, Cell);
+    console.log('getComposedData', { xAxisTicks });
     const points: ReadonlyArray<ScatterPointItem> = computeScatterPoints({
       displayedData,
       xAxis,

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1820,7 +1820,7 @@ export const generateCategoricalChart = ({
       Area: { handler: this.renderGraphicChild },
       Radar: { handler: this.renderGraphicChild },
       RadialBar: { handler: this.renderGraphicChild },
-      Scatter: { handler: this.renderGraphicChild },
+      Scatter: { handler: renderAsIs },
       Pie: { handler: this.renderGraphicChild },
       Funnel: { handler: this.renderGraphicChild },
       Tooltip: { handler: renderAsIs },

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -468,7 +468,7 @@ describe('selectAxisDomain', () => {
     ]);
     expect(domainSpy).toHaveBeenLastCalledWith([10, 20, 30, 40, 50, 60, 70, 80, 90]);
     // big oof
-    expect(domainSpy).toHaveBeenCalledTimes(21);
+    expect(domainSpy).toHaveBeenCalledTimes(17);
   });
 
   it('should return array indexes if there are multiple graphical items, and no explicit dataKey on the matching XAxis', () => {
@@ -534,7 +534,7 @@ describe('selectAxisDomain', () => {
     ]);
     expect(domainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8]);
     // big oof
-    expect(domainSpy).toHaveBeenCalledTimes(21);
+    expect(domainSpy).toHaveBeenCalledTimes(17);
   });
 
   describe('XAxis with type = number', () => {
@@ -2673,8 +2673,8 @@ describe('selectErrorBarsSettings', () => {
         direction: 'y',
       },
     ]);
-    expect(xAxisErrorBarSpy).toHaveBeenCalledTimes(4);
-    expect(yAxisErrorBarSpy).toHaveBeenCalledTimes(4);
+    expect(xAxisErrorBarSpy).toHaveBeenCalledTimes(5);
+    expect(yAxisErrorBarSpy).toHaveBeenCalledTimes(5);
   });
 
   it('should report all relevant error bars on Bar, Line, and Scatter', () => {
@@ -2732,8 +2732,8 @@ describe('selectErrorBarsSettings', () => {
         direction: 'y',
       },
     ]);
-    expect(xAxisSpy).toHaveBeenCalledTimes(4);
-    expect(yAxisSpy).toHaveBeenCalledTimes(4);
+    expect(xAxisSpy).toHaveBeenCalledTimes(5);
+    expect(yAxisSpy).toHaveBeenCalledTimes(5);
   });
 
   it('should be stable when empty', () => {

--- a/test/state/selectors/selectors.spec.tsx
+++ b/test/state/selectors/selectors.spec.tsx
@@ -856,8 +856,8 @@ describe('selectTooltipState.tooltipItemPayloads', () => {
         <Area dataKey="" data={[10, 20, 30]} />
         <Line data={[4, 5, 6]} />
         <Line data={[40, 50, 60]} />
-        <Scatter data={[7, 8, 9]} />
-        <Scatter data={[70, 80, 90]} />
+        <Scatter data={[{ x: 7 }, { x: 8 }, { x: 9 }]} dataKey="x" />
+        <Scatter data={[{ y: 70 }, { y: 80 }, { y: 90 }]} dataKey="y" />
         <Customized component={Comp} />
       </ComposedChart>,
     );
@@ -872,112 +872,136 @@ describe('selectTooltipState.tooltipItemPayloads', () => {
         [
           [
             {
-              dataKey: undefined,
+              dataKey: 'x',
               name: undefined,
-              payload: 7,
+              payload: {
+                x: 7,
+              },
               type: undefined,
               unit: '',
-              value: undefined,
+              value: 7,
             },
             {
-              dataKey: undefined,
+              dataKey: 'x',
               name: undefined,
-              payload: 7,
+              payload: {
+                x: 7,
+              },
               type: undefined,
               unit: '',
-              value: undefined,
-            },
-          ],
-          [
-            {
-              dataKey: undefined,
-              name: undefined,
-              payload: 8,
-              type: undefined,
-              unit: '',
-              value: undefined,
-            },
-            {
-              dataKey: undefined,
-              name: undefined,
-              payload: 8,
-              type: undefined,
-              unit: '',
-              value: undefined,
+              value: 7,
             },
           ],
           [
             {
-              dataKey: undefined,
+              dataKey: 'x',
               name: undefined,
-              payload: 9,
+              payload: {
+                x: 8,
+              },
               type: undefined,
               unit: '',
-              value: undefined,
+              value: 8,
             },
             {
-              dataKey: undefined,
+              dataKey: 'x',
               name: undefined,
-              payload: 9,
+              payload: {
+                x: 8,
+              },
               type: undefined,
               unit: '',
-              value: undefined,
+              value: 8,
+            },
+          ],
+          [
+            {
+              dataKey: 'x',
+              name: undefined,
+              payload: {
+                x: 9,
+              },
+              type: undefined,
+              unit: '',
+              value: 9,
+            },
+            {
+              dataKey: 'x',
+              name: undefined,
+              payload: {
+                x: 9,
+              },
+              type: undefined,
+              unit: '',
+              value: 9,
             },
           ],
         ],
         [
           [
             {
-              dataKey: undefined,
+              dataKey: 'y',
               name: undefined,
-              payload: 70,
+              payload: {
+                y: 70,
+              },
               type: undefined,
               unit: '',
-              value: undefined,
+              value: 70,
             },
             {
-              dataKey: undefined,
+              dataKey: 'y',
               name: undefined,
-              payload: 70,
+              payload: {
+                y: 70,
+              },
               type: undefined,
               unit: '',
-              value: undefined,
-            },
-          ],
-          [
-            {
-              dataKey: undefined,
-              name: undefined,
-              payload: 80,
-              type: undefined,
-              unit: '',
-              value: undefined,
-            },
-            {
-              dataKey: undefined,
-              name: undefined,
-              payload: 80,
-              type: undefined,
-              unit: '',
-              value: undefined,
+              value: 70,
             },
           ],
           [
             {
-              dataKey: undefined,
+              dataKey: 'y',
               name: undefined,
-              payload: 90,
+              payload: {
+                y: 80,
+              },
               type: undefined,
               unit: '',
-              value: undefined,
+              value: 80,
             },
             {
-              dataKey: undefined,
+              dataKey: 'y',
               name: undefined,
-              payload: 90,
+              payload: {
+                y: 80,
+              },
               type: undefined,
               unit: '',
-              value: undefined,
+              value: 80,
+            },
+          ],
+          [
+            {
+              dataKey: 'y',
+              name: undefined,
+              payload: {
+                y: 90,
+              },
+              type: undefined,
+              unit: '',
+              value: 90,
+            },
+            {
+              dataKey: 'y',
+              name: undefined,
+              payload: {
+                y: 90,
+              },
+              type: undefined,
+              unit: '',
+              value: 90,
             },
           ],
         ],


### PR DESCRIPTION
## Description

Following up from https://github.com/recharts/recharts/pull/4863, we can now stop cloning Scatter and rely on hooks only.

## Related Issue

https://github.com/recharts/recharts/issues/4583

No new visual diff: https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=1271