### PR TITLE
Errorbar axis negative extension

### DIFF
--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -428,12 +428,17 @@ export function getErrorDomainByDataKey(
   return onlyAllowNumbers(
     relevantErrorBars.flatMap(eb => {
       const errorValue = getValueByDataKey(entry, eb.dataKey);
-      const minError: unknown = Array.isArray(errorValue) ? Math.min(...errorValue) : errorValue;
-      const maxError: unknown = Array.isArray(errorValue) ? Math.max(...errorValue) : errorValue;
-      if (!isWellBehavedNumber(minError) || !isWellBehavedNumber(maxError)) {
+      let lowBound, highBound: unknown;
+
+      if (Array.isArray(errorValue)) {
+        [lowBound, highBound] = errorValue;
+      } else {
+        lowBound = highBound = errorValue;
+      }
+      if (!isWellBehavedNumber(lowBound) || !isWellBehavedNumber(highBound)) {
         return undefined;
       }
-      return [appliedValue - minError, appliedValue + maxError];
+      return [appliedValue - lowBound, appliedValue + highBound];
     }),
   );
 }


### PR DESCRIPTION
## Description

I found inconsistency between how Redux and how ErrorBar compute the error value if it's passed as an array so I fixed it.

- ErrorBar was treating `[a, b]` as `[min, max]`
- Redux was computing `min(a,b)` and `max(a,b)`

I changed the Redux selector to use what ErrorBar is doing.

Visual diff: https://www.chromatic.com/test?appId=63da8268a0da9970db6992aa&id=66b4a97840495bb078d96e22 notice how the XAxis is now correctly extended.

## Related Issue

https://github.com/recharts/recharts/issues/4583