### PR TITLE
Scatter storybook docs update: remove internal props, add comment

### DIFF
--- a/storybook/stories/API/cartesian/Scatter.stories.tsx
+++ b/storybook/stories/API/cartesian/Scatter.stories.tsx
@@ -465,49 +465,6 @@ const ReactiveProps = {
   },
 };
 
-const OtherProps = {
-  xAxis: {
-    table: {
-      category: 'Other',
-    },
-  },
-  yAxis: {
-    table: {
-      category: 'Other',
-    },
-  },
-  zAxis: {
-    table: {
-      category: 'Other',
-    },
-  },
-  top: {
-    table: {
-      category: 'Other',
-    },
-  },
-  left: {
-    table: {
-      category: 'Other',
-    },
-  },
-};
-
-const InternalProps = {
-  points: {
-    description: 'The coordinates of all the scatters.',
-    table: {
-      category: 'Internal',
-    },
-  },
-  activeIndex: {
-    description: "The active scatter's index in all the scatters. Active here refers to activeShape and the Tooltip.",
-    table: {
-      category: 'Internal',
-    },
-  },
-};
-
 const [surfaceWidth, surfaceHeight] = [600, 300];
 
 const GeneralPropsForScatter = {
@@ -526,10 +483,6 @@ export default {
     ...EventHandlers,
     ...AnimationProps,
     ...ReactiveProps,
-    ...OtherProps,
-    ...InternalProps,
-    // Deprecated
-    dangerouslySetInnerHTML: { table: { category: 'Deprecated' }, hide: true, disable: true },
   },
 };
 

--- a/storybook/stories/API/props/CartesianComponentShared.ts
+++ b/storybook/stories/API/props/CartesianComponentShared.ts
@@ -76,7 +76,7 @@ export const General: StorybookArgs = {
   yAxisId,
 };
 
-export const points: StorybookArg = {
+const points: StorybookArg = {
   description:
     'The coordinates of points in the line, usually calculated internally. In most cases this should not be used.',
   table: {
@@ -88,7 +88,18 @@ export const points: StorybookArg = {
   },
 };
 
-export const data: StorybookArg = { table: { category: 'Internal' } };
+export const data: StorybookArg = {
+  description: `The source data, in which each element is an object.
+    This can be defined either on the chart element (ScatterChart, LineChart, etc) or on the graphical item (Scatter, Line).
+    The object shape is flexible, with no pre-defined properties;
+    The dataKey props then define which properties from this object render where.`,
+  table: {
+    category: 'General',
+    type: {
+      summary: 'array of objects',
+    },
+  },
+};
 export const layout: StorybookArg = {
   description: 'The layout of line, usually inherited from parent.',
   table: {


### PR DESCRIPTION
These props no longer do anything in 3.x branch so let's remove them from storybook too.