### PR TITLE
Axes, Reference elements, and Scatter compute their position using panorama dimensions

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -105,6 +105,7 @@
   "es6/context/chartDataContext.js",
   "es6/context/brushUpdateContext.js",
   "es6/context/accessibilityContext.js",
+  "es6/context/PanoramaContext.js",
   "es6/context/CartesianGraphicalItemContext.js",
   "es6/container/Surface.js",
   "es6/container/Layer.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -105,6 +105,7 @@
   "lib/context/chartDataContext.js",
   "lib/context/brushUpdateContext.js",
   "lib/context/accessibilityContext.js",
+  "lib/context/PanoramaContext.js",
   "lib/context/CartesianGraphicalItemContext.js",
   "lib/container/Surface.js",
   "lib/container/Layer.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -105,6 +105,7 @@
   "types/context/chartDataContext.d.ts",
   "types/context/brushUpdateContext.d.ts",
   "types/context/accessibilityContext.d.ts",
+  "types/context/PanoramaContext.d.ts",
   "types/context/CartesianGraphicalItemContext.d.ts",
   "types/container/Surface.d.ts",
   "types/container/Layer.d.ts",

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -16,6 +16,7 @@ import { useChartHeight, useChartWidth, useOffset } from '../context/chartLayout
 import { AxisId } from '../state/axisMapSlice';
 import { selectAxisPropsNeededForCartesianGridTicksGenerator } from '../state/selectors/axisSelectors';
 import { useAppSelector } from '../state/hooks';
+import { useIsPanorama } from '../context/PanoramaContext';
 
 /**
  * The <CartesianGrid horizontal
@@ -391,11 +392,12 @@ export function CartesianGrid(props: Props) {
   const { xAxisId, yAxisId, x, y, width, height, syncWithTicks, horizontalValues, verticalValues } =
     propsIncludingDefaults;
 
+  const isPanorama = useIsPanorama();
   const xAxis: AxisPropsForCartesianGridTicksGeneration = useAppSelector(state =>
-    selectAxisPropsNeededForCartesianGridTicksGenerator(state, 'xAxis', xAxisId),
+    selectAxisPropsNeededForCartesianGridTicksGenerator(state, 'xAxis', xAxisId, isPanorama),
   );
   const yAxis: AxisPropsForCartesianGridTicksGeneration = useAppSelector(state =>
-    selectAxisPropsNeededForCartesianGridTicksGenerator(state, 'yAxis', yAxisId),
+    selectAxisPropsNeededForCartesianGridTicksGenerator(state, 'yAxis', yAxisId, isPanorama),
   );
 
   if (

--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -14,6 +14,7 @@ import { addArea, ReferenceAreaSettings, removeArea } from '../state/referenceEl
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { selectAxisScale } from '../state/selectors/axisSelectors';
 import { RechartsScale } from '../util/ChartUtils';
+import { useIsPanorama } from '../context/PanoramaContext';
 
 interface ReferenceAreaProps {
   ifOverflow?: IfOverflow;
@@ -93,8 +94,9 @@ function ReportReferenceArea(props: ReferenceAreaSettings): null {
 function ReferenceAreaImpl(props: Props) {
   const { x1, x2, y1, y2, className, shape, xAxisId, yAxisId } = props;
   const clipPathId = useClipPathId();
-  const xAxisScale = useAppSelector(state => selectAxisScale(state, 'xAxis', xAxisId));
-  const yAxisScale = useAppSelector(state => selectAxisScale(state, 'yAxis', yAxisId));
+  const isPanorama = useIsPanorama();
+  const xAxisScale = useAppSelector(state => selectAxisScale(state, 'xAxis', xAxisId, isPanorama));
+  const yAxisScale = useAppSelector(state => selectAxisScale(state, 'yAxis', yAxisId, isPanorama));
 
   if (xAxisScale == null || !yAxisScale == null) {
     return null;

--- a/src/cartesian/ReferenceDot.tsx
+++ b/src/cartesian/ReferenceDot.tsx
@@ -12,6 +12,7 @@ import { useClipPathId } from '../context/chartLayoutContext';
 import { addDot, ReferenceDotSettings, removeDot } from '../state/referenceElementsSlice';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { selectAxisScale } from '../state/selectors/axisSelectors';
+import { useIsPanorama } from '../context/PanoramaContext';
 
 interface ReferenceDotProps {
   r?: number;
@@ -43,8 +44,9 @@ const useCoordinate = (
 ) => {
   const isX = isNumOrStr(x);
   const isY = isNumOrStr(y);
-  const xAxisScale = useAppSelector(state => selectAxisScale(state, 'xAxis', xAxisId));
-  const yAxisScale = useAppSelector(state => selectAxisScale(state, 'yAxis', yAxisId));
+  const isPanorama = useIsPanorama();
+  const xAxisScale = useAppSelector(state => selectAxisScale(state, 'xAxis', xAxisId, isPanorama));
+  const yAxisScale = useAppSelector(state => selectAxisScale(state, 'yAxis', yAxisId, isPanorama));
 
   if (!isX || !isY || xAxisScale == null || yAxisScale == null) {
     return null;

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -18,6 +18,7 @@ import { useClipPathId, useViewBox } from '../context/chartLayoutContext';
 import { addLine, ReferenceLineSettings, removeLine } from '../state/referenceElementsSlice';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { selectAxisScale, selectXAxisSettings, selectYAxisSettings } from '../state/selectors/axisSelectors';
+import { useIsPanorama } from '../context/PanoramaContext';
 
 interface InternalReferenceLineProps {
   viewBox?: CartesianViewBox;
@@ -153,11 +154,12 @@ function ReportReferenceLine(props: ReferenceLineSettings): null {
 function ReferenceLineImpl(props: Props) {
   const { x: fixedX, y: fixedY, segment, xAxisId, yAxisId, shape, className, ifOverflow } = props;
 
+  const isPanorama = useIsPanorama();
   const clipPathId = useClipPathId();
   const xAxis = useAppSelector(state => selectXAxisSettings(state, xAxisId));
   const yAxis = useAppSelector(state => selectYAxisSettings(state, yAxisId));
-  const xAxisScale = useAppSelector(state => selectAxisScale(state, 'xAxis', xAxisId));
-  const yAxisScale = useAppSelector(state => selectAxisScale(state, 'yAxis', yAxisId));
+  const xAxisScale = useAppSelector(state => selectAxisScale(state, 'xAxis', xAxisId, isPanorama));
+  const yAxisScale = useAppSelector(state => selectAxisScale(state, 'yAxis', yAxisId, isPanorama));
 
   const viewBox = useViewBox();
   const isFixedX = isNumOrStr(fixedX);

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -50,6 +50,7 @@ import { ResolvedScatterSettings, selectScatterPoints } from '../state/selectors
 import { useAppSelector } from '../state/hooks';
 import { BaseAxisWithScale, ZAxisWithScale } from '../state/selectors/axisSelectors';
 import { useUpdateId } from '../context/chartLayoutContext';
+import { useIsPanorama } from '../context/PanoramaContext';
 
 interface ScatterPointNode {
   x?: number | string;
@@ -579,8 +580,10 @@ function ScatterImpl(props: Props) {
     }),
     [props.data, props.dataKey, props.name, props.tooltipType],
   );
+
+  const isPanorama = useIsPanorama();
   const points = useAppSelector(state => {
-    return selectScatterPoints(state, props.xAxisId, props.yAxisId, props.zAxisId, scatterSettings, cells);
+    return selectScatterPoints(state, props.xAxisId, props.yAxisId, props.zAxisId, scatterSettings, cells, isPanorama);
   });
   const { ref, xAxisId, ...everythingElse } = props;
 

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -16,6 +16,7 @@ import {
   selectXAxisSize,
 } from '../state/selectors/axisSelectors';
 import { selectAxisViewBox } from '../state/selectors/selectChartOffset';
+import { useIsPanorama } from '../context/PanoramaContext';
 
 interface XAxisProps extends BaseAxisProps {
   /** The unique id of x-axis */
@@ -54,9 +55,10 @@ function SetXAxisSettings(settings: XAxisSettings): null {
 const XAxisImpl = (props: Props) => {
   const { xAxisId, className } = props;
   const viewBox = useAppSelector(selectAxisViewBox);
+  const isPanorama = useIsPanorama();
   const axisType = 'xAxis';
-  const scale = useAppSelector(state => selectAxisScale(state, axisType, xAxisId));
-  const cartesianTickItems = useAppSelector(state => selectTicksOfAxis(state, axisType, xAxisId));
+  const scale = useAppSelector(state => selectAxisScale(state, axisType, xAxisId, isPanorama));
+  const cartesianTickItems = useAppSelector(state => selectTicksOfAxis(state, axisType, xAxisId, isPanorama));
   const axisSize = useAppSelector(state => selectXAxisSize(state, xAxisId));
   const position = useAppSelector(state => selectXAxisPosition(state, xAxisId));
 

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -12,6 +12,7 @@ import {
   selectYAxisSize,
 } from '../state/selectors/axisSelectors';
 import { selectAxisViewBox } from '../state/selectors/selectChartOffset';
+import { useIsPanorama } from '../context/PanoramaContext';
 
 interface YAxisProps extends BaseAxisProps {
   /** The unique id of y-axis */
@@ -50,11 +51,12 @@ function SetYAxisSettings(settings: YAxisSettings): null {
 const YAxisImpl: FunctionComponent<Props> = (props: Props) => {
   const { yAxisId, className } = props;
   const viewBox = useAppSelector(selectAxisViewBox);
+  const isPanorama = useIsPanorama();
   const axisType = 'yAxis';
-  const scale = useAppSelector(state => selectAxisScale(state, axisType, yAxisId));
+  const scale = useAppSelector(state => selectAxisScale(state, axisType, yAxisId, isPanorama));
   const axisSize = useAppSelector(state => selectYAxisSize(state, yAxisId));
   const position = useAppSelector(state => selectYAxisPosition(state, yAxisId));
-  const cartesianTickItems = useAppSelector(state => selectTicksOfAxis(state, axisType, yAxisId));
+  const cartesianTickItems = useAppSelector(state => selectTicksOfAxis(state, axisType, yAxisId, isPanorama));
 
   if (axisSize == null || position == null) {
     return null;

--- a/src/cartesian/ZAxis.tsx
+++ b/src/cartesian/ZAxis.tsx
@@ -3,7 +3,7 @@ import { ScaleType, DataKey, AxisDomain } from '../util/types';
 import { addZAxis, removeZAxis, ZAxisSettings } from '../state/axisMapSlice';
 import { useAppDispatch } from '../state/hooks';
 import { RechartsScale } from '../util/ChartUtils';
-import { implicitZAxis } from '../state/selectors/axisSelectors';
+import { AxisRange, implicitZAxis } from '../state/selectors/axisSelectors';
 
 function SetZAxisSettings(settings: ZAxisSettings): null {
   const dispatch = useAppDispatch();
@@ -27,7 +27,7 @@ export interface Props {
   /** The key of data displayed in the axis */
   dataKey?: DataKey<any>;
   /** The range of axis */
-  range?: number[];
+  range?: AxisRange;
   scale?: ScaleType | RechartsScale | undefined;
   /** The domain of scale in this axis */
   domain?: AxisDomain;

--- a/src/context/PanoramaContext.tsx
+++ b/src/context/PanoramaContext.tsx
@@ -1,0 +1,9 @@
+import React, { createContext, ReactNode, useContext } from 'react';
+
+const PanoramaContext = createContext<boolean | null>(null);
+
+export const useIsPanorama = (): boolean => useContext(PanoramaContext) != null;
+
+export const PanoramaContextProvider = ({ children }: { children: ReactNode }) => (
+  <PanoramaContext.Provider value>{children}</PanoramaContext.Provider>
+);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,9 +1,14 @@
 import type { AxisId } from './state/axisMapSlice';
 import { BaseAxisWithScale, selectAxisWithScale } from './state/selectors/axisSelectors';
 import { useAppSelector } from './state/hooks';
+import { useIsPanorama } from './context/PanoramaContext';
 
-export const useXAxis = (xAxisId: AxisId): BaseAxisWithScale | undefined =>
-  useAppSelector(state => selectAxisWithScale(state, 'xAxis', xAxisId));
+export const useXAxis = (xAxisId: AxisId): BaseAxisWithScale | undefined => {
+  const isPanorama = useIsPanorama();
+  return useAppSelector(state => selectAxisWithScale(state, 'xAxis', xAxisId, isPanorama));
+};
 
-export const useYAxis = (yAxisId: AxisId): BaseAxisWithScale | undefined =>
-  useAppSelector(state => selectAxisWithScale(state, 'yAxis', yAxisId));
+export const useYAxis = (yAxisId: AxisId): BaseAxisWithScale | undefined => {
+  const isPanorama = useIsPanorama();
+  return useAppSelector(state => selectAxisWithScale(state, 'yAxis', yAxisId, isPanorama));
+};

--- a/src/state/RechartsStoreProvider.tsx
+++ b/src/state/RechartsStoreProvider.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useRef } from 'react';
 import { Provider } from 'react-redux';
 import { createRechartsStore, RechartsRootState } from './store';
+import { useIsPanorama } from '../context/PanoramaContext';
 
 type RechartsStoreProviderProps = {
   children: ReactNode;
@@ -9,6 +10,7 @@ type RechartsStoreProviderProps = {
 };
 
 export function RechartsStoreProvider({ preloadedState, children, reduxStoreName }: RechartsStoreProviderProps) {
+  const isPanorama = useIsPanorama();
   /*
    * Why the ref? Redux official documentation recommends to use store as a singleton,
    * and reuse that everywhere: https://redux-toolkit.js.org/api/configureStore#basic-example
@@ -21,6 +23,18 @@ export function RechartsStoreProvider({ preloadedState, children, reduxStoreName
    * Which would make working with everything a little bit more painful because we need the chart id everywhere.
    */
   const storeRef = useRef(null);
+
+  /*
+   * Panorama means that this chart is not its own chart, it's only a "preview"
+   * being rendered as a child of Brush.
+   * In such case, it should not have a store on its own - it should implicitly inherit
+   * whatever data is in the "parent" or "root" chart.
+   * Which here is represented by not having a Provider at all. All selectors will use the root store by default.
+   */
+  if (isPanorama) {
+    return children;
+  }
+
   if (storeRef.current == null) {
     storeRef.current = createRechartsStore(preloadedState, reduxStoreName);
   }

--- a/src/state/axisMapSlice.ts
+++ b/src/state/axisMapSlice.ts
@@ -4,6 +4,7 @@ import { ReactElement, SVGProps } from 'react';
 import { AxisDomain, AxisDomainType, AxisInterval, AxisTick, DataKey, ScaleType } from '../util/types';
 import { RechartsScale } from '../util/ChartUtils';
 import { TickFormatter } from '../cartesian/CartesianAxis';
+import type { AxisRange } from './selectors/axisSelectors';
 
 export type AxisId = string | number;
 export type XAxisPadding = { left?: number; right?: number } | 'gap' | 'no-gap';
@@ -75,7 +76,7 @@ export type YAxisSettings = AxisSettings & {
  * but it never displays ticks anywhere.
  */
 export type ZAxisSettings = BaseAxis & {
-  range: number[];
+  range: AxisRange;
 };
 
 type AxisMapState = {

--- a/src/state/brushSlice.ts
+++ b/src/state/brushSlice.ts
@@ -1,22 +1,38 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Padding } from '../util/types';
 
+/**
+ * From all Brush properties, only height has a default value and will be always defined.
+ * Other properties are nullable and will be computed from offsets and margins if they are not set.
+ */
 export type BrushSettings = {
+  x: number | undefined;
+  y: number | undefined;
+  width: number | undefined;
   height: number;
+  padding: Padding;
 };
 
 const initialState: BrushSettings = {
+  x: 0,
+  y: 0,
+  width: 0,
   height: 0,
+  padding: { top: 0, right: 0, bottom: 0, left: 0 },
 };
 export const brushSlice = createSlice({
   name: 'brush',
   initialState,
   reducers: {
-    setBrushHeight(state, action: PayloadAction<number>) {
-      state.height = action.payload;
+    setBrushSettings(_state, action: PayloadAction<BrushSettings | null>) {
+      if (action.payload == null) {
+        return initialState;
+      }
+      return action.payload;
     },
   },
 });
 
-export const { setBrushHeight } = brushSlice.actions;
+export const { setBrushSettings } = brushSlice.actions;
 
 export const brushReducer = brushSlice.reducer;

--- a/src/state/selectors/brushSelectors.ts
+++ b/src/state/selectors/brushSelectors.ts
@@ -1,3 +1,26 @@
+import { createSelector } from '@reduxjs/toolkit';
 import { RechartsRootState } from '../store';
+import { selectChartOffset } from './selectChartOffset';
+import { selectMargin } from './containerSelectors';
+import { isNumber } from '../../util/DataUtils';
 
-export const selectBrushHeight = (state: RechartsRootState) => state.brush.height;
+export const selectBrushSettings = (state: RechartsRootState) => state.brush;
+
+export type BrushDimensions = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export const selectBrushDimensions = createSelector(
+  [selectBrushSettings, selectChartOffset, selectMargin],
+  (brushSettings, offset, margin) => ({
+    height: brushSettings.height,
+    x: isNumber(brushSettings.x) ? brushSettings.x : offset.left,
+    y: isNumber(brushSettings.y)
+      ? brushSettings.y
+      : offset.top + offset.height + offset.brushBottom - (margin.bottom || 0),
+    width: isNumber(brushSettings.width) ? brushSettings.width : offset.width,
+  }),
+);

--- a/src/state/selectors/scatterSelectors.ts
+++ b/src/state/selectors/scatterSelectors.ts
@@ -16,16 +16,49 @@ export type ResolvedScatterSettings = {
   name: string | number;
 };
 
-const selectXAxisWithScale = (state: RechartsRootState, xAxisId: AxisId) =>
-  selectAxisWithScale(state, 'xAxis', xAxisId);
-const selectXAxisTicks = (state: RechartsRootState, xAxisId: AxisId) =>
-  selectTicksOfGraphicalItem(state, 'xAxis', xAxisId);
-const selectYAxisWithScale = (state: RechartsRootState, _xAxisId: AxisId, yAxisId: AxisId) =>
-  selectAxisWithScale(state, 'yAxis', yAxisId);
-const selectYAxisTicks = (state: RechartsRootState, _xAxisId: AxisId, yAxisId: AxisId) =>
-  selectTicksOfGraphicalItem(state, 'yAxis', yAxisId);
+const selectXAxisWithScale = (
+  state: RechartsRootState,
+  xAxisId: AxisId,
+  _yAxisId: AxisId,
+  _zAxisId: AxisId,
+  _scatterSettings: ResolvedScatterSettings,
+  _cells: ReadonlyArray<ReactElement> | undefined,
+  isPanorama: boolean,
+) => selectAxisWithScale(state, 'xAxis', xAxisId, isPanorama);
+
+const selectXAxisTicks = (
+  state: RechartsRootState,
+  xAxisId: AxisId,
+  _yAxisId: AxisId,
+  _zAxisId: AxisId,
+  _scatterSettings: ResolvedScatterSettings,
+  _cells: ReadonlyArray<ReactElement> | undefined,
+  isPanorama: boolean,
+) => selectTicksOfGraphicalItem(state, 'xAxis', xAxisId, isPanorama);
+
+const selectYAxisWithScale = (
+  state: RechartsRootState,
+  _xAxisId: AxisId,
+  yAxisId: AxisId,
+  _zAxisId: AxisId,
+  _scatterSettings: ResolvedScatterSettings,
+  _cells: ReadonlyArray<ReactElement> | undefined,
+  isPanorama: boolean,
+) => selectAxisWithScale(state, 'yAxis', yAxisId, isPanorama);
+
+const selectYAxisTicks = (
+  state: RechartsRootState,
+  _xAxisId: AxisId,
+  yAxisId: AxisId,
+  _zAxisId: AxisId,
+  _scatterSettings: ResolvedScatterSettings,
+  _cells: ReadonlyArray<ReactElement> | undefined,
+  isPanorama: boolean,
+) => selectTicksOfGraphicalItem(state, 'yAxis', yAxisId, isPanorama);
+
 const selectZAxis = (state: RechartsRootState, _xAxisId: AxisId, _yAxisId: AxisId, zAxisId: AxisId) =>
-  selectZAxisWithScale(state, 'zAxis', zAxisId);
+  selectZAxisWithScale(state, 'zAxis', zAxisId, false);
+
 const pickScatterSettings = (
   _state: RechartsRootState,
   _xAxisId: AxisId,
@@ -41,6 +74,7 @@ const pickCells = (
   _scatterSettings: ResolvedScatterSettings,
   cells: ReadonlyArray<ReactElement> | undefined,
 ): ReadonlyArray<ReactElement> | undefined => cells;
+
 export const selectScatterPoints: (
   state: RechartsRootState,
   xAxisId: AxisId,
@@ -48,15 +82,18 @@ export const selectScatterPoints: (
   zAxisId: AxisId,
   scatterSettings: ResolvedScatterSettings,
   cells: ReadonlyArray<ReactElement> | undefined,
+  isPanorama: boolean,
 ) => ReadonlyArray<ScatterPointItem> = createSelector(
-  selectChartDataWithIndexes,
-  selectXAxisWithScale,
-  selectXAxisTicks,
-  selectYAxisWithScale,
-  selectYAxisTicks,
-  selectZAxis,
-  pickScatterSettings,
-  pickCells,
+  [
+    selectChartDataWithIndexes,
+    selectXAxisWithScale,
+    selectXAxisTicks,
+    selectYAxisWithScale,
+    selectYAxisTicks,
+    selectZAxis,
+    pickScatterSettings,
+    pickCells,
+  ],
   (
     { chartData, dataStartIndex, dataEndIndex }: ChartDataState,
     xAxis,

--- a/src/state/selectors/selectChartOffset.ts
+++ b/src/state/selectors/selectChartOffset.ts
@@ -1,6 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit';
 import get from 'lodash/get';
-import { selectBrushHeight } from './brushSelectors';
 import { selectLegendState } from './legendSelectors';
 import { CartesianViewBox, ChartOffset, Margin } from '../../util/types';
 import { XAxisSettings, YAxisSettings } from '../axisMapSlice';
@@ -8,6 +7,9 @@ import { LegendState } from '../legendSlice';
 import { appendOffsetOfLegend } from '../../util/ChartUtils';
 import { selectChartHeight, selectChartWidth, selectMargin } from './containerSelectors';
 import { selectAllXAxes, selectAllYAxes } from './selectAllAxes';
+import { RechartsRootState } from '../store';
+
+export const selectBrushHeight = (state: RechartsRootState) => state.brush.height;
 
 export const selectChartOffset = createSelector(
   selectChartWidth,

--- a/storybook/stories/Examples/ScatterChart.stories.tsx
+++ b/storybook/stories/Examples/ScatterChart.stories.tsx
@@ -222,7 +222,7 @@ export const BubbleChart = {
     ];
 
     const domain = parseDomain();
-    const range = [16, 225];
+    const range = [16, 225] as const;
 
     const renderTooltip = (props: any) => {
       const { active, payload } = props;

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -231,7 +231,7 @@ describe('CartesianGrid', () => {
   it('should render all ticks from LineChart Biaxial storybook', () => {
     const scaleSpy = vi.fn();
     const Comp = (): null => {
-      const scale = useAppSelector(state => selectAxisScale(state, 'yAxis', 'left'));
+      const scale = useAppSelector(state => selectAxisScale(state, 'yAxis', 'left', false));
       scaleSpy(scale?.domain());
       return null;
     };

--- a/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
+++ b/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
@@ -1,10 +1,44 @@
 import React from 'react';
-import { MockInstance, vi, beforeEach, it } from 'vitest';
+import { MockInstance, vi, beforeEach, describe, it, test, expect } from 'vitest';
 import { screen, render } from '@testing-library/react';
-import { BarChart, ReferenceLine, Bar, XAxis, YAxis, LineChart, Line, Customized } from '../../../src';
+import {
+  BarChart,
+  ReferenceLine,
+  Bar,
+  XAxis,
+  YAxis,
+  LineChart,
+  Line,
+  Customized,
+  Brush,
+  ComposedChart,
+} from '../../../src';
 import { CartesianViewBox } from '../../../src/util/types';
 import { useAppSelector } from '../../../src/state/hooks';
-import { selectReferenceLinesByAxis } from '../../../src/state/selectors/axisSelectors';
+import { selectAxisRangeWithReverse, selectReferenceLinesByAxis } from '../../../src/state/selectors/axisSelectors';
+import { pageData } from '../../../storybook/stories/data';
+import { assertNotNull } from '../../helper/assertNotNull';
+import { selectBrushDimensions, selectBrushSettings } from '../../../src/state/selectors/brushSelectors';
+
+type ExpectedReferenceLine = {
+  x1: string;
+  x2: string;
+  y1: string;
+  y2: string;
+};
+
+function expectReferenceLines(container: Element, expectedLines: ReadonlyArray<ExpectedReferenceLine>) {
+  assertNotNull(container);
+  const referenceLines = container.querySelectorAll('.recharts-reference-line-line');
+  assertNotNull(referenceLines);
+  const referenceLinesContexts = Array.from(referenceLines).map(line => ({
+    x1: line.getAttribute('x1'),
+    x2: line.getAttribute('x2'),
+    y1: line.getAttribute('y1'),
+    y2: line.getAttribute('y2'),
+  }));
+  expect(referenceLinesContexts).toEqual(expectedLines);
+}
 
 describe('<ReferenceLine />', () => {
   let consoleSpy: MockInstance<(...args: any[]) => void>;
@@ -26,7 +60,7 @@ describe('<ReferenceLine />', () => {
     { name: '201112', uv: 4.3, pv: 0 },
   ];
 
-  test('Renders 1 line in ReferenceLine', () => {
+  test('Renders 1 line in each ReferenceLine', () => {
     const { container } = render(
       <BarChart
         width={1100}
@@ -43,7 +77,20 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine y={0} stroke="#666" label="0" />
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(2);
+    expectReferenceLines(container, [
+      {
+        x1: '412.72727272727275',
+        x2: '412.72727272727275',
+        y1: '50',
+        y2: '250',
+      },
+      {
+        x1: '980',
+        x2: '20',
+        y1: '150',
+        y2: '150',
+      },
+    ]);
     expect(container.querySelectorAll('.recharts-label')).toHaveLength(2);
   });
 
@@ -65,7 +112,20 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine x={0} stroke="#666" label="0" />
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(2);
+    expectReferenceLines(container, [
+      {
+        x1: '980',
+        x2: '20',
+        y1: '131.8181818181818',
+        y2: '131.8181818181818',
+      },
+      {
+        x1: '500',
+        x2: '500',
+        y1: '50',
+        y2: '250',
+      },
+    ]);
     expect(container.querySelectorAll('.recharts-label')).toHaveLength(2);
   });
 
@@ -86,7 +146,20 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine y={0} stroke="#666" label="0" />
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(2);
+    expectReferenceLines(container, [
+      {
+        x1: '412.72727272727275',
+        x2: '412.72727272727275',
+        y1: '50',
+        y2: '250',
+      },
+      {
+        x1: '980',
+        x2: '20',
+        y1: '150',
+        y2: '150',
+      },
+    ]);
     expect(container.querySelectorAll('.recharts-label')).toHaveLength(2);
   });
 
@@ -106,7 +179,7 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine stroke="#666" label="0" />
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);
+    expectReferenceLines(container, []);
     expect(container.querySelectorAll('.recharts-label')).toHaveLength(0);
   });
 
@@ -127,7 +200,7 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine x="20150201" stroke="#666" />
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);
+    expectReferenceLines(container, []);
     expect(container.querySelectorAll('.recharts-label')).toHaveLength(0);
   });
 
@@ -148,7 +221,20 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine y={20} stroke="#666" label="20" ifOverflow="extendDomain" />
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(2);
+    expectReferenceLines(container, [
+      {
+        x1: '123.63636363636368',
+        x2: '123.63636363636368',
+        y1: '220',
+        y2: '20',
+      },
+      {
+        x1: '80',
+        x2: '1040',
+        y1: '20',
+        y2: '20',
+      },
+    ]);
     expect(container.querySelectorAll('.recharts-label')).toHaveLength(2);
   });
 
@@ -169,7 +255,20 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine y={20} stroke="#666" label="20" ifOverflow="extendDomain" />
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(2);
+    expectReferenceLines(container, [
+      {
+        x1: '123.63636363636368',
+        x2: '123.63636363636368',
+        y1: '220',
+        y2: '20',
+      },
+      {
+        x1: '80',
+        x2: '1040',
+        y1: '20',
+        y2: '20',
+      },
+    ]);
     expect(container.querySelectorAll('.recharts-label')).toHaveLength(2);
     expect(consoleSpy).not.toHaveBeenCalled();
   });
@@ -199,11 +298,19 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine y={20} stroke="#666" label={renderLabel} ifOverflow="visible" />
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(1);
+
+    expectReferenceLines(container, [
+      {
+        x1: '80',
+        x2: '1040',
+        y1: '-102.22222222222223',
+        y2: '-102.22222222222223',
+      },
+    ]);
     expect(container.querySelectorAll('.customized-reference-line-label')).toHaveLength(1);
   });
 
-  test("Don't Render 1 label when label is set to be a object", () => {
+  test("Don't Render 1 label when label=true", () => {
     const { container } = render(
       <BarChart
         width={1100}
@@ -274,7 +381,7 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine />
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);
+    expectReferenceLines(container, []);
   });
 
   it('should not render anything when rendered without YAxis', () => {
@@ -284,7 +391,7 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine x={20} />
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);
+    expectReferenceLines(container, []);
   });
 
   it('should not render anything when rendered without XAxis', () => {
@@ -294,7 +401,7 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine y={20} />
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);
+    expectReferenceLines(container, []);
   });
 
   it('should not render anything when passed in invalid xAxisId', () => {
@@ -305,7 +412,7 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine xAxisId="this ID definitely does not exist anywhere" />
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);
+    expectReferenceLines(container, []);
   });
 
   it('should not render anything when passed in invalid yAxisId', () => {
@@ -324,12 +431,12 @@ describe('<ReferenceLine />', () => {
       </BarChart>,
     );
 
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);
+    expectReferenceLines(container, []);
   });
 
   it('should not render anything when rendered alone, outside of context', () => {
     const { container } = render(<ReferenceLine x={20} />);
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);
+    expectReferenceLines(container, []);
   });
 
   it('should not return anything when rendered as a nested child', () => {
@@ -342,7 +449,7 @@ describe('<ReferenceLine />', () => {
         </p>
       </BarChart>,
     );
-    expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(0);
+    expectReferenceLines(container, []);
   });
 
   it('should render one line when there is a duplicated category', () => {
@@ -360,6 +467,15 @@ describe('<ReferenceLine />', () => {
     // Is this correct? That looks like a category, not pixel coordinate.
     expect(allLines[0]).toHaveAttribute('y', '201102');
     expect(allLines[0]).not.toHaveAttribute('x');
+
+    expectReferenceLines(container, [
+      {
+        x1: '65',
+        x2: '1095',
+        y1: '23.038999999999994',
+        y2: '23.038999999999994',
+      },
+    ]);
   });
 
   /**
@@ -424,6 +540,98 @@ describe('<ReferenceLine />', () => {
 
       expect(lineSpy).toHaveBeenLastCalledWith([]);
       expect(lineSpy).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe('panorama', () => {
+    it('should render two ReferenceLines in a Brush panorama', () => {
+      const brushDimensionsSpy = vi.fn();
+      const brushPaddingSpy = vi.fn();
+      const rootYAxisRangeSpy = vi.fn();
+      const panoramaYAxisRangeSpy = vi.fn();
+      const rootXAxisRangeSpy = vi.fn();
+      const panoramaXAxisRangeSpy = vi.fn();
+      const RootComp = (): null => {
+        brushDimensionsSpy(useAppSelector(selectBrushDimensions));
+        brushPaddingSpy(useAppSelector(selectBrushSettings)?.padding);
+        rootYAxisRangeSpy(useAppSelector(state => selectAxisRangeWithReverse(state, 'yAxis', 0, false)));
+        rootXAxisRangeSpy(useAppSelector(state => selectAxisRangeWithReverse(state, 'xAxis', 0, false)));
+        return null;
+      };
+
+      const PanoramaComp = (): null => {
+        panoramaYAxisRangeSpy(useAppSelector(state => selectAxisRangeWithReverse(state, 'yAxis', 0, true)));
+        panoramaXAxisRangeSpy(useAppSelector(state => selectAxisRangeWithReverse(state, 'xAxis', 0, true)));
+        return null;
+      };
+
+      const { container } = render(
+        <ComposedChart width={600} height={300} data={pageData} margin={{ top: 11, right: 13, left: 17, bottom: 19 }}>
+          <XAxis dataKey="name" />
+          <YAxis />
+          <ReferenceLine y={1000} />
+          <ReferenceLine x="Page C" />
+          <Line dataKey="pv" />
+          <Line dataKey="uv" />
+          <Brush dataKey="name" padding={{ bottom: 1, left: 3, right: 5, top: 9 }}>
+            <LineChart>
+              <ReferenceLine y={1000} />
+              <ReferenceLine x="Page C" />
+              <Line dataKey="pv" />
+              <Line dataKey="uv" />
+              <Customized component={<PanoramaComp />} />
+            </LineChart>
+          </Brush>
+          <Customized component={<RootComp />} />
+        </ComposedChart>,
+      );
+
+      expect(rootYAxisRangeSpy).toHaveBeenLastCalledWith([211, 11]);
+      expect(panoramaYAxisRangeSpy).toHaveBeenLastCalledWith([39, 9]);
+
+      expect(rootXAxisRangeSpy).toHaveBeenLastCalledWith([77, 587]);
+      expect(panoramaXAxisRangeSpy).toHaveBeenLastCalledWith([3, 505]);
+
+      expect(brushDimensionsSpy).toHaveBeenLastCalledWith({
+        height: 40,
+        width: 510,
+        x: 77,
+        y: 241,
+      });
+
+      expect(brushPaddingSpy).toHaveBeenLastCalledWith({
+        bottom: 1,
+        left: 3,
+        right: 5,
+        top: 9,
+      });
+
+      expectReferenceLines(container, [
+        {
+          x1: '77',
+          x2: '587',
+          y1: '86',
+          y2: '86',
+        },
+        {
+          x1: '247',
+          x2: '247',
+          y1: '211',
+          y2: '11',
+        },
+        {
+          x1: '3',
+          x2: '505',
+          y1: '20.25',
+          y2: '20.25',
+        },
+        {
+          x1: '170.33333333333334',
+          x2: '170.33333333333334',
+          y1: '39',
+          y2: '9',
+        },
+      ]);
     });
   });
 });

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -3790,7 +3790,7 @@ describe('<XAxis />', () => {
       const axisDomainSpy = vi.fn();
       const ticksSpy = vi.fn();
       const Comp = (): null => {
-        ticksSpy(useAppSelector(state => selectTicksOfAxis(state, 'xAxis', 0)));
+        ticksSpy(useAppSelector(state => selectTicksOfAxis(state, 'xAxis', 0, false)));
         return null;
       };
       const { container } = render(
@@ -3856,7 +3856,7 @@ describe('<XAxis />', () => {
       const axisDomainSpy = vi.fn();
       const ticksSpy = vi.fn();
       const Comp = (): null => {
-        ticksSpy(useAppSelector(state => selectTicksOfAxis(state, 'xAxis', 0)));
+        ticksSpy(useAppSelector(state => selectTicksOfAxis(state, 'xAxis', 0, false)));
         return null;
       };
       const { container, rerender } = render(

--- a/test/cartesian/ZAxis.spec.tsx
+++ b/test/cartesian/ZAxis.spec.tsx
@@ -94,7 +94,7 @@ describe('<ZAxis />', () => {
       const Comp = (): null => {
         axisSettingsSpy(useAppSelector(state => selectZAxisSettings(state, 'zaxis id')));
         axisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'zAxis', 'zaxis id')));
-        const axis = useAppSelector(state => selectZAxisWithScale(state, 'zAxis', 'zaxis id'));
+        const axis = useAppSelector(state => selectZAxisWithScale(state, 'zAxis', 'zaxis id', false));
         const realScaleType = useAppSelector(state => selectRealScaleType(state, 'zAxis', 'zaxis id'));
         axisScaleSpy({
           domain: axis?.scale?.domain(),

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -249,7 +249,7 @@ describe('ScatterChart with joint line', () => {
     const zAxisScaleSpy = vi.fn();
     const zAxisDataSpy = vi.fn();
     const Comp = (): null => {
-      zAxisScaleSpy(useAppSelector(state => selectZAxisWithScale(state, 'zAxis', 0)));
+      zAxisScaleSpy(useAppSelector(state => selectZAxisWithScale(state, 'zAxis', 0, false)));
       zAxisDataSpy(useAppSelector(state => selectAllAppliedNumericalValuesIncludingErrorValues(state, 'zAxis', 0)));
       return null;
     };
@@ -721,7 +721,7 @@ describe('ScatterChart of two dimension data', () => {
     ]);
   });
 
-  test.fails('renders scatter points in Brush panorama. TODO fix brush panorama before releasing 3.0', () => {
+  test('renders scatter points in Brush panorama', () => {
     const { container } = render(
       <ScatterChart width={400} height={400} data={data}>
         <Scatter dataKey="y" />
@@ -880,7 +880,7 @@ describe('ScatterChart of two dimension data', () => {
       );
       zAxisSettingsSpy(useAppSelector(state => selectBaseAxis(state, 'zAxis', 0)));
       zAxisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'zAxis', 0)));
-      yAxisTicksSpy(useAppSelector(state => selectTicksOfGraphicalItem(state, 'yAxis', 0)));
+      yAxisTicksSpy(useAppSelector(state => selectTicksOfGraphicalItem(state, 'yAxis', 0, false)));
       yAxisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'yAxis', 0)));
       yAxisDataSpy(useAppSelector(state => selectAllAppliedNumericalValuesIncludingErrorValues(state, 'yAxis', 0)));
       return null;
@@ -1056,7 +1056,7 @@ describe('ScatterChart of two dimension data', () => {
       );
       zAxisSettingsSpy(useAppSelector(state => selectBaseAxis(state, 'zAxis', 0)));
       zAxisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'zAxis', 0)));
-      yAxisTicksSpy(useAppSelector(state => selectTicksOfGraphicalItem(state, 'yAxis', 0)));
+      yAxisTicksSpy(useAppSelector(state => selectTicksOfGraphicalItem(state, 'yAxis', 0, false)));
       yAxisDomainSpy(useAppSelector(state => selectAxisDomain(state, 'yAxis', 0)));
       yAxisDataSpy(useAppSelector(state => selectAllAppliedNumericalValuesIncludingErrorValues(state, 'yAxis', 0)));
       return null;

--- a/test/helper/expectAxisTicks.ts
+++ b/test/helper/expectAxisTicks.ts
@@ -41,7 +41,7 @@ export function ExpectAxisDomain({
   assert: (domainFromRedux: ReadonlyArray<unknown>) => void;
 }): null {
   useAppSelector(state => {
-    const scale = selectAxisScale(state, axisType, axisId);
+    const scale = selectAxisScale(state, axisType, axisId, false);
     assert(scale?.domain());
   });
   return null;

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -64,7 +64,7 @@ const data2 = mockData.slice(5);
 describe('selectAxisScale', () => {
   it('should return undefined when called outside of Redux context', () => {
     const Comp = (): null => {
-      const result = useAppSelector(state => selectAxisScale(state, 'xAxis', 'foo'));
+      const result = useAppSelector(state => selectAxisScale(state, 'xAxis', 'foo', false));
       expect(result).toBeUndefined();
       return null;
     };
@@ -73,14 +73,16 @@ describe('selectAxisScale', () => {
 
   it('should return undefined for initial state', () => {
     const initialState: RechartsRootState = createRechartsStore().getState();
-    const result = selectAxisScale(initialState, 'yAxis', 'foo');
+    const result = selectAxisScale(initialState, 'yAxis', 'foo', false);
     expect(result).toEqual(undefined);
   });
 
   it('should return implicit scale if there is no XAxis with this ID', () => {
     const spy = vi.fn();
     const Comp = (): null => {
-      const result = useAppSelector(state => selectAxisScale(state, 'xAxis', 'this id is not present in the chart'));
+      const result = useAppSelector(state =>
+        selectAxisScale(state, 'xAxis', 'this id is not present in the chart', false),
+      );
       spy(result);
       return null;
     };
@@ -99,7 +101,7 @@ describe('selectAxisScale', () => {
   it('should return scale if there is an Axis in the chart', () => {
     const spy = vi.fn();
     const Comp = (): null => {
-      const result = useAppSelector(state => selectAxisScale(state, 'xAxis', '0'));
+      const result = useAppSelector(state => selectAxisScale(state, 'xAxis', '0', false));
       spy(result);
       return null;
     };
@@ -117,8 +119,8 @@ describe('selectAxisScale', () => {
 
   it('should be stable', () => {
     const Comp = (): null => {
-      const result1 = useAppSelector(state => selectAxisScale(state, 'xAxis', '0'));
-      const result2 = useAppSelector(state => selectAxisScale(state, 'xAxis', '0'));
+      const result1 = useAppSelector(state => selectAxisScale(state, 'xAxis', '0', false));
+      const result2 = useAppSelector(state => selectAxisScale(state, 'xAxis', '0', false));
       expect(result1).toBe(result2);
       return null;
     };
@@ -133,11 +135,11 @@ describe('selectAxisScale', () => {
 
   it('should not recompute when an irrelevant property in the state changes', () => {
     const store = createRechartsStore();
-    const result1 = selectAxisScale(store.getState(), 'xAxis', '0');
+    const result1 = selectAxisScale(store.getState(), 'xAxis', '0', false);
     store.dispatch(
       setActiveMouseOverItemIndex({ activeMouseOverCoordinate: undefined, activeDataKey: 'x', activeIndex: '7' }),
     );
-    const result2 = selectAxisScale(store.getState(), 'xAxis', '0');
+    const result2 = selectAxisScale(store.getState(), 'xAxis', '0', false);
     expect(result1).toBe(result2);
   });
 
@@ -145,7 +147,7 @@ describe('selectAxisScale', () => {
     const scaleDomainSpy = vi.fn();
     const scaleRangeSpy = vi.fn();
     const Comp = (): null => {
-      const scale = useAppSelector(state => selectAxisScale(state, 'xAxis', '0'));
+      const scale = useAppSelector(state => selectAxisScale(state, 'xAxis', '0', false));
       scaleDomainSpy(scale?.domain());
       scaleRangeSpy(scale?.range());
       return null;
@@ -232,7 +234,7 @@ describe('selectAxisRangeWithReverse', () => {
   it('should return undefined when called outside of Redux context', () => {
     expect.assertions(1);
     const Comp = (): null => {
-      const result = useAppSelector(state => selectAxisRangeWithReverse(state, 'xAxis', '0'));
+      const result = useAppSelector(state => selectAxisRangeWithReverse(state, 'xAxis', '0', false));
       expect(result).toBeUndefined();
       return null;
     };
@@ -241,14 +243,14 @@ describe('selectAxisRangeWithReverse', () => {
 
   it('should return default array when called with initial state', () => {
     const initialState: RechartsRootState = createRechartsStore().getState();
-    const result = selectAxisRangeWithReverse(initialState, 'xAxis', '0');
+    const result = selectAxisRangeWithReverse(initialState, 'xAxis', '0', false);
     expect(result).toEqual([5, 5]);
   });
 
   it('should be stable', () => {
     const Comp = (): null => {
-      const result1 = useAppSelector(state => selectAxisRangeWithReverse(state, 'xAxis', '0'));
-      const result2 = useAppSelector(state => selectAxisRangeWithReverse(state, 'xAxis', '0'));
+      const result1 = useAppSelector(state => selectAxisRangeWithReverse(state, 'xAxis', '0', false));
+      const result2 = useAppSelector(state => selectAxisRangeWithReverse(state, 'xAxis', '0', false));
       expect(result1).toBe(result2);
       return null;
     };
@@ -263,13 +265,13 @@ describe('selectAxisRangeWithReverse', () => {
 
   it('should not recompute when an irrelevant property in the state changes', () => {
     const store = createRechartsStore();
-    const result1 = selectAxisRangeWithReverse(store.getState(), 'xAxis', '0');
-    const xAxisRange1 = combineXAxisRange(store.getState(), '0');
+    const result1 = selectAxisRangeWithReverse(store.getState(), 'xAxis', '0', false);
+    const xAxisRange1 = combineXAxisRange(store.getState(), '0', false);
     store.dispatch(
       setActiveMouseOverItemIndex({ activeMouseOverCoordinate: undefined, activeDataKey: 'x', activeIndex: '7' }),
     );
-    const result2 = selectAxisRangeWithReverse(store.getState(), 'xAxis', '0');
-    const xAxisRange2 = combineXAxisRange(store.getState(), '0');
+    const result2 = selectAxisRangeWithReverse(store.getState(), 'xAxis', '0', false);
+    const xAxisRange2 = combineXAxisRange(store.getState(), '0', false);
     expect(xAxisRange1).toBe(xAxisRange2);
     expect(result1).toBe(result2);
   });
@@ -362,9 +364,9 @@ describe('selectAxisDomain', () => {
       domainRightIncludingNiceTicksSpy(
         useAppSelector(state => selectAxisDomainIncludingNiceTicks(state, 'yAxis', 'right')),
       );
-      const scaleLeft = useAppSelector(state => selectAxisScale(state, 'yAxis', 'left'));
+      const scaleLeft = useAppSelector(state => selectAxisScale(state, 'yAxis', 'left', false));
       scaleLeftSpy(scaleLeft?.domain());
-      const scaleRight = useAppSelector(state => selectAxisScale(state, 'yAxis', 'right'));
+      const scaleRight = useAppSelector(state => selectAxisScale(state, 'yAxis', 'right', false));
       scaleRightSpy(scaleRight?.domain());
       return null;
     };
@@ -1037,7 +1039,7 @@ describe('selectAxisDomain', () => {
       const scaleSpy = vi.fn();
       const Comp = (): null => {
         domainSpy(useAppSelector(state => selectAxisDomainIncludingNiceTicks(state, 'xAxis', 0)));
-        const scale = useAppSelector(state => selectAxisScale(state, 'xAxis', 0));
+        const scale = useAppSelector(state => selectAxisScale(state, 'xAxis', 0, false));
         scaleSpy(scale?.domain());
         return null;
       };

--- a/test/state/selectors/brushSelectors.spec.tsx
+++ b/test/state/selectors/brushSelectors.spec.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { useAppSelector } from '../../../src/state/hooks';
-import { selectBrushHeight } from '../../../src/state/selectors/brushSelectors';
 import { BarChart, Brush, Customized } from '../../../src';
 import { createRechartsStore } from '../../../src/state/store';
+import { selectBrushHeight } from '../../../src/state/selectors/selectChartOffset';
 
 describe('selectBrushHeight', () => {
   it('should return undefined when called outside of Redux context', () => {

--- a/test/state/selectors/scatterSelectors.spec.tsx
+++ b/test/state/selectors/scatterSelectors.spec.tsx
@@ -18,7 +18,7 @@ describe('selectScatterPoints', () => {
     const scatterPointsSpy = vi.fn();
     const Comp = (): null => {
       scatterPointsSpy(
-        useAppSelector(state => selectScatterPoints(state, 'xAxis', 'yAxis', 'zAxis', scatterSettings, [])),
+        useAppSelector(state => selectScatterPoints(state, 'xAxis', 'yAxis', 'zAxis', scatterSettings, [], false)),
       );
       return null;
     };
@@ -29,7 +29,7 @@ describe('selectScatterPoints', () => {
 
   it('should return undefined when called with initial state', () => {
     const store = createRechartsStore();
-    const result = selectScatterPoints(store.getState(), 'xAxis', 'yAxis', 'zAxis', scatterSettings, []);
+    const result = selectScatterPoints(store.getState(), 'xAxis', 'yAxis', 'zAxis', scatterSettings, [], false);
     expect(result).toEqual(undefined);
   });
 
@@ -37,7 +37,7 @@ describe('selectScatterPoints', () => {
     const scatterPointsSpy = vi.fn();
     const Comp = (): null => {
       scatterPointsSpy(
-        useAppSelector(state => selectScatterPoints(state, 'xAxis', 'yAxis', 'zAxis', scatterSettings, [])),
+        useAppSelector(state => selectScatterPoints(state, 'xAxis', 'yAxis', 'zAxis', scatterSettings, [], false)),
       );
       return null;
     };
@@ -422,7 +422,7 @@ describe('selectScatterPoints', () => {
     ];
     const Comp = (props: any): null => {
       expect(props.formattedGraphicalItems[0].props.points).toEqual(expectedPoints);
-      scatterPointsSpy(useAppSelector(state => selectScatterPoints(state, 0, 0, 0, scatterSettings, undefined)));
+      scatterPointsSpy(useAppSelector(state => selectScatterPoints(state, 0, 0, 0, scatterSettings, undefined, false)));
       return null;
     };
     render(
@@ -437,8 +437,8 @@ describe('selectScatterPoints', () => {
   it('should be stable', () => {
     expect.assertions(3);
     const Comp = (): null => {
-      const result1 = useAppSelector(state => selectScatterPoints(state, 0, 0, 0, scatterSettings, undefined));
-      const result2 = useAppSelector(state => selectScatterPoints(state, 0, 0, 0, scatterSettings, undefined));
+      const result1 = useAppSelector(state => selectScatterPoints(state, 0, 0, 0, scatterSettings, undefined, false));
+      const result2 = useAppSelector(state => selectScatterPoints(state, 0, 0, 0, scatterSettings, undefined, false));
       expect(result1).toBe(result2);
       return null;
     };


### PR DESCRIPTION
## Description

This adds Brush Panorama support to Redux and fixes two visual diffs.

Latest VR: https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=1277

## Related Issue

https://github.com/recharts/recharts/issues/4583
