### PR TITLE
selectLinePoints

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -75,6 +75,7 @@
   "es6/state/selectors/selectChartOffset.js",
   "es6/state/selectors/selectAllAxes.js",
   "es6/state/selectors/scatterSelectors.js",
+  "es6/state/selectors/lineSelectors.js",
   "es6/state/selectors/legendSelectors.js",
   "es6/state/selectors/dataSelectors.js",
   "es6/state/selectors/containerSelectors.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -75,6 +75,7 @@
   "lib/state/selectors/selectChartOffset.js",
   "lib/state/selectors/selectAllAxes.js",
   "lib/state/selectors/scatterSelectors.js",
+  "lib/state/selectors/lineSelectors.js",
   "lib/state/selectors/legendSelectors.js",
   "lib/state/selectors/dataSelectors.js",
   "lib/state/selectors/containerSelectors.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -75,6 +75,7 @@
   "types/state/selectors/selectChartOffset.d.ts",
   "types/state/selectors/selectAllAxes.d.ts",
   "types/state/selectors/scatterSelectors.d.ts",
+  "types/state/selectors/lineSelectors.d.ts",
   "types/state/selectors/legendSelectors.d.ts",
   "types/state/selectors/dataSelectors.d.ts",
   "types/state/selectors/containerSelectors.d.ts",

--- a/src/shape/Curve.tsx
+++ b/src/shape/Curve.tsx
@@ -67,8 +67,8 @@ export type CurveType =
   | CurveFactory;
 
 export interface Point {
-  x: number;
-  y: number;
+  readonly x: number;
+  readonly y: number;
 }
 
 const defined = (p: Point) => p.x === +p.x && p.y === +p.y;
@@ -92,8 +92,8 @@ interface CurveProps {
   className?: string;
   type?: CurveType;
   layout?: LayoutType;
-  baseLine?: number | Array<Point>;
-  points?: Array<Point>;
+  baseLine?: number | ReadonlyArray<Point>;
+  points?: ReadonlyArray<Point>;
   connectNulls?: boolean;
   path?: string;
   pathRef?: (ref: SVGPathElement) => void;

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -1558,7 +1558,7 @@ export const selectTicksOfGraphicalItem = createSelector(
     pickAxisType,
   ],
   (layout, axis, realScaleType, scale, niceTicks, axisRange, duplicateDomain, categoricalDomain, axisType) => {
-    if (axis == null || scale == null) {
+    if (axis == null || scale == null || axisRange == null || axisRange[0] === axisRange[1]) {
       return null;
     }
     const isCategorical = isCategoricalAxis(layout, axisType);

--- a/src/state/selectors/lineSelectors.ts
+++ b/src/state/selectors/lineSelectors.ts
@@ -1,0 +1,95 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { computeLinePoints, LinePointItem } from '../../cartesian/Line';
+import { RechartsRootState } from '../store';
+import { AxisId } from '../axisMapSlice';
+import { selectChartDataWithIndexes } from './dataSelectors';
+import { selectChartLayout } from '../../context/chartLayoutContext';
+import { selectAxisWithScale, selectTicksOfGraphicalItem } from './axisSelectors';
+import { DataKey } from '../../util/types';
+import { getBandSizeOfAxis, isCategoricalAxis } from '../../util/ChartUtils';
+import { ChartData } from '../chartDataSlice';
+
+export type ResolvedLineSettings = {
+  data: ChartData | undefined;
+  dataKey: DataKey<any> | undefined;
+};
+
+const selectXAxisWithScale = (state: RechartsRootState, xAxisId: AxisId, _yAxisId: AxisId, isPanorama: boolean) =>
+  selectAxisWithScale(state, 'xAxis', xAxisId, isPanorama);
+
+const selectXAxisTicks = (state: RechartsRootState, xAxisId: AxisId, _yAxisId: AxisId, isPanorama: boolean) =>
+  selectTicksOfGraphicalItem(state, 'xAxis', xAxisId, isPanorama);
+
+const selectYAxisWithScale = (state: RechartsRootState, _xAxisId: AxisId, yAxisId: AxisId, isPanorama: boolean) =>
+  selectAxisWithScale(state, 'yAxis', yAxisId, isPanorama);
+
+const selectYAxisTicks = (state: RechartsRootState, _xAxisId: AxisId, yAxisId: AxisId, isPanorama: boolean) =>
+  selectTicksOfGraphicalItem(state, 'yAxis', yAxisId, isPanorama);
+
+const selectBandSize = createSelector(
+  [selectChartLayout, selectXAxisWithScale, selectYAxisWithScale, selectXAxisTicks, selectYAxisTicks],
+  (layout, xAxis, yAxis, xAxisTicks, yAxisTicks) => {
+    if (isCategoricalAxis(layout, 'xAxis')) {
+      return getBandSizeOfAxis(xAxis, xAxisTicks, false);
+    }
+    return getBandSizeOfAxis(yAxis, yAxisTicks, false);
+  },
+);
+
+const pickLineSettings = (
+  _state: RechartsRootState,
+  _xAxisId: AxisId,
+  _yAxisId: AxisId,
+  _isPanorama: boolean,
+  lineSettings: ResolvedLineSettings,
+) => lineSettings;
+
+export const selectLinePoints: (
+  state: RechartsRootState,
+  xAxisId: AxisId,
+  yAxisId: AxisId,
+  isPanorama: boolean,
+  { dataKey, data }: ResolvedLineSettings,
+) => ReadonlyArray<LinePointItem> = createSelector(
+  [
+    selectChartLayout,
+    selectXAxisWithScale,
+    selectYAxisWithScale,
+    selectXAxisTicks,
+    selectYAxisTicks,
+    pickLineSettings,
+    selectBandSize,
+    selectChartDataWithIndexes,
+  ],
+  (
+    layout,
+    xAxis,
+    yAxis,
+    xAxisTicks,
+    yAxisTicks,
+    { dataKey, data },
+    bandSize,
+    { chartData, dataStartIndex, dataEndIndex },
+  ) => {
+    let displayedData: ChartData | undefined;
+    if (data?.length > 0) {
+      displayedData = data;
+    } else {
+      displayedData = chartData?.slice(dataStartIndex, dataEndIndex + 1);
+    }
+
+    if (
+      displayedData == null ||
+      xAxis == null ||
+      yAxis == null ||
+      xAxisTicks == null ||
+      yAxisTicks == null ||
+      xAxisTicks.length === 0 ||
+      yAxisTicks.length === 0
+    ) {
+      return undefined;
+    }
+
+    return computeLinePoints({ layout, xAxis, yAxis, xAxisTicks, yAxisTicks, dataKey, bandSize, displayedData });
+  },
+);

--- a/test/cartesian/Brush.spec.tsx
+++ b/test/cartesian/Brush.spec.tsx
@@ -181,7 +181,7 @@ describe('<Brush />', () => {
       <BarChart width={400} height={100} data={data}>
         <Brush x={90} y={40} width={300} height={50}>
           <LineChart>
-            <Line />
+            <Line dataKey="value" />
           </LineChart>
         </Brush>
       </BarChart>,

--- a/test/cartesian/Line.spec.tsx
+++ b/test/cartesian/Line.spec.tsx
@@ -16,9 +16,9 @@ describe('<Line />', () => {
 
   it('Renders a path in a simple Line', () => {
     const { container } = render(
-      <Surface width={500} height={500}>
-        <Line isAnimationActive={false} points={data} />
-      </Surface>,
+      <LineChart width={500} height={500}>
+        <Line isAnimationActive={false} data={data} dataKey="y" />
+      </LineChart>,
     );
 
     expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
@@ -26,9 +26,9 @@ describe('<Line />', () => {
 
   it('Does not fall into infinite loop if strokeDasharray is 0', () => {
     const { container } = render(
-      <Surface width={500} height={500}>
-        <Line points={data} strokeDasharray="0" />
-      </Surface>,
+      <LineChart width={500} height={500}>
+        <Line data={data} dataKey="y" strokeDasharray="0" />
+      </LineChart>,
     );
 
     const line = container.querySelectorAll('.recharts-line-curve');
@@ -39,12 +39,10 @@ describe('<Line />', () => {
 
   it('Does not throw when dot is null', () => {
     const { container } = render(
-      <Surface width={500} height={500}>
+      <LineChart width={500} height={500}>
         {/* Test that the error Cannot read properties of null (reading 'clipDot') does not appear in JS projects */}
-        {/* eslint-disable-next-line */}
-        {/* @ts-ignore */}
-        <Line isAnimationActive={false} points={data} dot={null} />
-      </Surface>,
+        <Line isAnimationActive={false} data={data} dataKey="value" dot={null} />
+      </LineChart>,
     );
 
     expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -2,7 +2,18 @@ import React, { FC } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { describe, MockInstance, test, vi } from 'vitest';
-import { Brush, CartesianAxis, Customized, Legend, Line, LineChart, Tooltip, XAxis, YAxis } from '../../src';
+import {
+  Brush,
+  CartesianAxis,
+  CartesianGrid,
+  Customized,
+  Legend,
+  Line,
+  LineChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from '../../src';
 import { assertNotNull } from '../helper/assertNotNull';
 import { testChartLayoutContext } from '../util/context';
 import { CurveType } from '../../src/shape/Curve';
@@ -12,6 +23,8 @@ import { expectXAxisTicks } from '../helper/expectAxisTicks';
 import { generateMockData } from '../helper/generateMockData';
 import { useClipPathId, useViewBox } from '../../src/context/chartLayoutContext';
 import { useAppSelector } from '../../src/state/hooks';
+import { pageData } from '../../storybook/stories/data';
+import { selectAxisRangeWithReverse, selectTicksOfGraphicalItem } from '../../src/state/selectors/axisSelectors';
 
 describe('<LineChart />', () => {
   test('Render 1 line in simple LineChart', () => {
@@ -81,6 +94,129 @@ describe('<LineChart />', () => {
       'd',
       'M80,350C100,308.75,120,267.5,140,267.5C160,267.5,180,267.5,200,267.5C220,267.5,240,212.5,260,185C280,157.5,300,130,320,102.5C340,75,360,47.5,380,20',
     );
+  });
+
+  test('renders two lines with two axes', () => {
+    const xAxisRangeSpy = vi.fn();
+    const xAxisLineTicks = vi.fn();
+
+    const Comp = (): null => {
+      xAxisRangeSpy(useAppSelector(state => selectAxisRangeWithReverse(state, 'xAxis', 0, false)));
+      xAxisLineTicks(useAppSelector(state => selectTicksOfGraphicalItem(state, 'xAxis', 0, false)));
+      return null;
+    };
+    const { container } = render(
+      <LineChart
+        width={500}
+        height={300}
+        data={pageData}
+        margin={{
+          top: 5,
+          right: 30,
+          left: 20,
+          bottom: 5,
+        }}
+      >
+        <CartesianGrid yAxisId="left" />
+        <XAxis dataKey="name" />
+        <YAxis yAxisId="left" />
+        <YAxis yAxisId="right" orientation="right" />
+        <Legend />
+        <Line yAxisId="left" dataKey="pv" />
+        <Line yAxisId="right" dataKey="uv" />
+        <Customized component={<Comp />} />
+      </LineChart>,
+    );
+
+    expect(xAxisRangeSpy).toHaveBeenLastCalledWith([80, 410]);
+    expect(xAxisLineTicks).toHaveBeenLastCalledWith([
+      {
+        coordinate: 80,
+        index: 0,
+        offset: 0,
+        value: 'Page A',
+      },
+      {
+        coordinate: 135,
+        index: 1,
+        offset: 0,
+        value: 'Page B',
+      },
+      {
+        coordinate: 190,
+        index: 2,
+        offset: 0,
+        value: 'Page C',
+      },
+      {
+        coordinate: 245,
+        index: 3,
+        offset: 0,
+        value: 'Page D',
+      },
+      {
+        coordinate: 300,
+        index: 4,
+        offset: 0,
+        value: 'Page E',
+      },
+      {
+        coordinate: 355,
+        index: 5,
+        offset: 0,
+        value: 'Page F',
+      },
+      {
+        coordinate: 410,
+        index: 6,
+        offset: 0,
+        value: 'Page G',
+      },
+    ]);
+
+    const allLines = container.querySelectorAll('.recharts-line .recharts-line-curve');
+    expect(allLines).toHaveLength(2);
+    const line1 = allLines[0];
+    assertNotNull(line1);
+    expect(line1.getAttributeNames()).toEqual([
+      'stroke',
+      'stroke-width',
+      'fill',
+      'width',
+      'height',
+      'class',
+      'stroke-dasharray',
+      'd',
+    ]);
+    expect(line1).toHaveAttribute('stroke', '#3182bd');
+    expect(line1).toHaveAttribute('stroke-width', '1');
+    expect(line1).toHaveAttribute('fill', 'none');
+    expect(line1).toHaveAttribute('width', '330');
+    expect(line1).toHaveAttribute('height', '260');
+    expect(line1).toHaveAttribute('class', 'recharts-curve recharts-line-curve');
+    expect(line1).toHaveAttribute('stroke-dasharray', '0px 0px');
+    expect(line1).toHaveAttribute('d', 'M80,91.667L135,91.667L190,55.483L245,27.1L300,5L355,24.933L410,117.667');
+
+    const line2 = allLines[1];
+    assertNotNull(line2);
+    expect(line2.getAttributeNames()).toEqual([
+      'stroke',
+      'stroke-width',
+      'fill',
+      'width',
+      'height',
+      'class',
+      'stroke-dasharray',
+      'd',
+    ]);
+    expect(line2).toHaveAttribute('stroke', '#3182bd');
+    expect(line2).toHaveAttribute('stroke-width', '1');
+    expect(line2).toHaveAttribute('fill', 'none');
+    expect(line2).toHaveAttribute('width', '330');
+    expect(line2).toHaveAttribute('height', '260');
+    expect(line2).toHaveAttribute('class', 'recharts-curve recharts-line-curve');
+    expect(line2).toHaveAttribute('stroke-dasharray', '0px 0px');
+    expect(line2).toHaveAttribute('d', 'M80,169.125L135,169.125L190,123.95L245,37.987L300,24.5L355,18L410,37.5');
   });
 
   test('Sets title and description correctly', () => {

--- a/test/component/Tooltip/ActiveDot.spec.tsx
+++ b/test/component/Tooltip/ActiveDot.spec.tsx
@@ -225,7 +225,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, lineChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 161,
@@ -341,7 +341,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, composedChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 161,

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -2506,8 +2506,8 @@ describe('selectErrorBarsSettings', () => {
     // There are ErrorBars but they are specified for another XAxis
     expect(xAxisSpy).toHaveBeenLastCalledWith([]);
     expect(yAxisSpy).toHaveBeenLastCalledWith([]);
-    expect(xAxisSpy).toHaveBeenCalledTimes(4);
-    expect(yAxisSpy).toHaveBeenCalledTimes(4);
+    expect(xAxisSpy).toHaveBeenCalledTimes(3);
+    expect(yAxisSpy).toHaveBeenCalledTimes(3);
   });
 
   it('should return bars settings if present in BarChart', () => {
@@ -2555,7 +2555,7 @@ describe('selectErrorBarsSettings', () => {
     render(
       <LineChart width={100} height={100}>
         <Line data={[{ x: 1 }, { x: 2 }, { x: 3 }]} />
-        <Line data={[{ x: 10 }, { x: 20 }, { x: 30 }]} isAnimationActive={false}>
+        <Line data={[{ x: 10 }, { x: 20 }, { x: 30 }]} isAnimationActive={false} dataKey="x">
           <ErrorBar dataKey="data-x" direction="x" />
           <ErrorBar dataKey="data-y" direction="y" />
         </Line>
@@ -2590,7 +2590,7 @@ describe('selectErrorBarsSettings', () => {
     render(
       <LineChart width={100} height={100} layout="vertical">
         <Line data={[{ x: 1 }, { x: 2 }, { x: 3 }]} />
-        <Line data={[{ x: 10 }, { x: 20 }, { x: 30 }]} isAnimationActive={false}>
+        <Line data={[{ x: 10 }, { x: 20 }, { x: 30 }]} isAnimationActive={false} dataKey="x">
           <ErrorBar dataKey="data-x" direction="x" />
           <ErrorBar dataKey="data-y" direction="y" />
         </Line>


### PR DESCRIPTION
## Description

Line reads its points from Redux only, and ignores what came through the generator.

There are some other things that fail when I actually use `renderAsIs`, I will look into that next.

Visual diff: https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=1281

## Related Issue

https://github.com/recharts/recharts/issues/4583