### PR TITLE
selectArea selector

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -81,6 +81,7 @@
   "es6/state/selectors/containerSelectors.js",
   "es6/state/selectors/brushSelectors.js",
   "es6/state/selectors/axisSelectors.js",
+  "es6/state/selectors/areaSelectors.js",
   "es6/shape/Trapezoid.js",
   "es6/shape/Symbols.js",
   "es6/shape/Sector.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -81,6 +81,7 @@
   "lib/state/selectors/containerSelectors.js",
   "lib/state/selectors/brushSelectors.js",
   "lib/state/selectors/axisSelectors.js",
+  "lib/state/selectors/areaSelectors.js",
   "lib/shape/Trapezoid.js",
   "lib/shape/Symbols.js",
   "lib/shape/Sector.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -81,6 +81,7 @@
   "types/state/selectors/containerSelectors.d.ts",
   "types/state/selectors/brushSelectors.d.ts",
   "types/state/selectors/axisSelectors.d.ts",
+  "types/state/selectors/areaSelectors.d.ts",
   "types/shape/Trapezoid.d.ts",
   "types/shape/Symbols.d.ts",
   "types/shape/Sector.d.ts",

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -10,20 +10,25 @@ import { ImplicitLabelType, Label } from '../component/Label';
 import { IfOverflow } from '../util/IfOverflow';
 import { isNumOrStr } from '../util/DataUtils';
 import { createLabeledScales, rectWithCoords } from '../util/CartesianUtils';
-import { CartesianViewBox, D3Scale } from '../util/types';
+import { CartesianViewBox } from '../util/types';
 import { Props as XAxisProps } from './XAxis';
 import { Props as YAxisProps } from './YAxis';
 import { filterProps } from '../util/ReactUtils';
 import { useClipPathId, useViewBox } from '../context/chartLayoutContext';
 import { addLine, ReferenceLineSettings, removeLine } from '../state/referenceElementsSlice';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
-import { selectAxisScale, selectXAxisSettings, selectYAxisSettings } from '../state/selectors/axisSelectors';
+import {
+  BaseAxisWithScale,
+  selectAxisScale,
+  selectXAxisSettings,
+  selectYAxisSettings,
+} from '../state/selectors/axisSelectors';
 import { useIsPanorama } from '../context/PanoramaContext';
 
 interface InternalReferenceLineProps {
   viewBox?: CartesianViewBox;
-  xAxis?: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> };
-  yAxis?: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> };
+  xAxis?: BaseAxisWithScale;
+  yAxis?: BaseAxisWithScale;
   clipPathId?: number | string;
 }
 

--- a/src/state/selectors/areaSelectors.ts
+++ b/src/state/selectors/areaSelectors.ts
@@ -1,0 +1,153 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { Series } from 'victory-vendor/d3-shape';
+import { Coordinate, DataKey } from '../../util/types';
+import { BaseValue, computeArea } from '../../cartesian/Area';
+import { selectAxisWithScale, selectStackGroups, selectTicksOfGraphicalItem, StackGroup } from './axisSelectors';
+import { RechartsRootState } from '../store';
+import { AxisId } from '../axisMapSlice';
+import { selectChartLayout } from '../../context/chartLayoutContext';
+import { selectChartDataWithIndexes } from './dataSelectors';
+import { getBandSizeOfAxis, isCategoricalAxis, StackId } from '../../util/ChartUtils';
+import { ChartData } from '../chartDataSlice';
+import { Point as CurvePoint } from '../../shape/Curve';
+
+export interface AreaPointItem extends CurvePoint {
+  value?: number | number[];
+  payload?: any;
+}
+export type AreaSettings = {
+  connectNulls: boolean;
+  baseValue: BaseValue | undefined;
+  dataKey: DataKey<any>;
+  stackId: StackId | undefined;
+  data: ChartData | undefined;
+};
+
+export type ComputedArea = {
+  points: ReadonlyArray<AreaPointItem>;
+  baseLine: number | Coordinate[];
+  isRange: boolean;
+};
+
+const selectXAxisWithScale = (state: RechartsRootState, xAxisId: AxisId, _yAxisId: AxisId, isPanorama: boolean) =>
+  selectAxisWithScale(state, 'xAxis', xAxisId, isPanorama);
+
+const selectXAxisTicks = (state: RechartsRootState, xAxisId: AxisId, _yAxisId: AxisId, isPanorama: boolean) =>
+  selectTicksOfGraphicalItem(state, 'xAxis', xAxisId, isPanorama);
+
+const selectYAxisWithScale = (state: RechartsRootState, _xAxisId: AxisId, yAxisId: AxisId, isPanorama: boolean) =>
+  selectAxisWithScale(state, 'yAxis', yAxisId, isPanorama);
+
+const selectYAxisTicks = (state: RechartsRootState, _xAxisId: AxisId, yAxisId: AxisId, isPanorama: boolean) =>
+  selectTicksOfGraphicalItem(state, 'yAxis', yAxisId, isPanorama);
+
+const selectBandSize = createSelector(
+  [selectChartLayout, selectXAxisWithScale, selectYAxisWithScale, selectXAxisTicks, selectYAxisTicks],
+  (layout, xAxis, yAxis, xAxisTicks, yAxisTicks) => {
+    if (isCategoricalAxis(layout, 'xAxis')) {
+      return getBandSizeOfAxis(xAxis, xAxisTicks, false);
+    }
+    return getBandSizeOfAxis(yAxis, yAxisTicks, false);
+  },
+);
+
+const selectGraphicalItemStackedData = (
+  state: RechartsRootState,
+  xAxisId: AxisId,
+  yAxisId: AxisId,
+  _isPanorama: boolean,
+  areaSettings: AreaSettings,
+) => {
+  const layout = selectChartLayout(state);
+  const isXAxisCategorical = isCategoricalAxis(layout, 'xAxis');
+  let stackGroups: Record<StackId, StackGroup> | undefined;
+  if (isXAxisCategorical) {
+    stackGroups = selectStackGroups(state, 'yAxis', yAxisId);
+  } else {
+    stackGroups = selectStackGroups(state, 'xAxis', xAxisId);
+  }
+  if (stackGroups == null) {
+    return undefined;
+  }
+  const { dataKey, stackId } = areaSettings;
+  const groups: ReadonlyArray<Series<Record<string, unknown>, DataKey<any>>> = stackGroups[stackId]?.stackedData;
+  return groups?.find(v => v.key === dataKey);
+};
+
+const pickAreaSettings = (
+  _state: RechartsRootState,
+  _xAxisId: AxisId,
+  _yAxisId: AxisId,
+  _isPanorama: boolean,
+  areaSettings: AreaSettings,
+) => areaSettings;
+
+export const selectArea: (
+  state: RechartsRootState,
+  xAxisId: AxisId,
+  yAxisId: AxisId,
+  isPanorama: boolean,
+  areaSettings: AreaSettings,
+) => ComputedArea | undefined = createSelector(
+  [
+    selectChartLayout,
+    selectXAxisWithScale,
+    selectYAxisWithScale,
+    selectXAxisTicks,
+    selectYAxisTicks,
+    selectGraphicalItemStackedData,
+    selectChartDataWithIndexes,
+    selectBandSize,
+    pickAreaSettings,
+  ],
+  (
+    layout,
+    xAxis,
+    yAxis,
+    xAxisTicks,
+    yAxisTicks,
+    stackedData,
+    { chartData, dataStartIndex, dataEndIndex },
+    bandSize,
+    areaSettings,
+  ) => {
+    if (
+      (layout !== 'horizontal' && layout !== 'vertical') ||
+      xAxis == null ||
+      yAxis == null ||
+      xAxisTicks == null ||
+      yAxisTicks == null
+    ) {
+      return undefined;
+    }
+    const { data } = areaSettings;
+
+    let displayedData: ChartData | undefined;
+    if (data?.length > 0) {
+      displayedData = data;
+    } else {
+      displayedData = chartData?.slice(dataStartIndex, dataEndIndex + 1);
+    }
+
+    if (displayedData == null) {
+      return undefined;
+    }
+
+    // Where is this supposed to come from? No charts have that as a prop.
+    const chartBaseValue: undefined = undefined;
+
+    return computeArea({
+      layout,
+      xAxis,
+      yAxis,
+      xAxisTicks,
+      yAxisTicks,
+      dataStartIndex,
+      areaSettings,
+      stackedData,
+      displayedData,
+      chartBaseValue,
+      bandSize,
+    });
+  },
+);

--- a/src/state/selectors/areaSelectors.ts
+++ b/src/state/selectors/areaSelectors.ts
@@ -116,7 +116,9 @@ export const selectArea: (
       xAxis == null ||
       yAxis == null ||
       xAxisTicks == null ||
-      yAxisTicks == null
+      yAxisTicks == null ||
+      xAxisTicks.length === 0 ||
+      yAxisTicks.length === 0
     ) {
       return undefined;
     }

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -1454,7 +1454,12 @@ export const selectAxisPropsNeededForCartesianGridTicksGenerator = createSelecto
   },
 );
 
-export const selectTicksOfAxis = createSelector(
+export const selectTicksOfAxis: (
+  state: RechartsRootState,
+  axisType: XorYType,
+  axisId: AxisId,
+  isPanorama: boolean,
+) => ReadonlyArray<CartesianTickItem> | undefined = createSelector(
   [
     selectChartLayout,
     selectAxisSettings,
@@ -1478,7 +1483,7 @@ export const selectTicksOfAxis = createSelector(
     axisType,
   ): ReadonlyArray<CartesianTickItem> | null => {
     if (axis == null || scale == null) {
-      return null;
+      return undefined;
     }
 
     const isCategorical = isCategoricalAxis(layout, axisType);

--- a/storybook/stories/Examples/AreaChart.stories.tsx
+++ b/storybook/stories/Examples/AreaChart.stories.tsx
@@ -130,7 +130,7 @@ export const PercentAreaChart = {
           }}
         >
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="month" />
+          <XAxis dataKey="name" />
           <YAxis tickFormatter={toPercent} />
           <Area type="monotone" dataKey="uv" stackId="1" stroke="#8884d8" fill="#8884d8" />
           <Area type="monotone" dataKey="pv" stackId="1" stroke="#82ca9d" fill="#82ca9d" />

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -26,7 +26,7 @@ type TestCase = {
   testName: string;
 };
 
-const chartsThatSupportArea: ReadonlyArray<TestCase> = includingCompact([ComposedChartCase, AreaChartCase]);
+const chartsThatSupportArea: ReadonlyArray<TestCase> = [ComposedChartCase, AreaChartCase];
 
 const chartsThatDoNotSupportArea: ReadonlyArray<TestCase> = includingCompact(
   allCategoricalsChartsExcept(chartsThatSupportArea),

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -1,19 +1,19 @@
 import React, { ComponentType, FC, ReactNode } from 'react';
-import { describe, test, it, expect, vi } from 'vitest';
+import { describe, expect, it, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Area, Customized, XAxis, YAxis } from '../../src';
 import { getBaseValue, Props } from '../../src/cartesian/Area';
-import { D3Scale, LayoutType } from '../../src/util/types';
+import { LayoutType } from '../../src/util/types';
 import {
+  allCategoricalsChartsExcept,
   AreaChartCase,
   ComposedChartCase,
-  allCategoricalsChartsExcept,
   includingCompact,
 } from '../helper/parameterizedTestCases';
 import { useAppSelector } from '../../src/state/hooks';
 import { CartesianGraphicalItemSettings } from '../../src/state/graphicalItemsSlice';
-import { Props as YAxisProps } from '../../src/cartesian/YAxis';
-import { Props as XAxisProps } from '../../src/cartesian/XAxis';
+import { BaseAxisWithScale, implicitYAxis } from '../../src/state/selectors/axisSelectors';
+import { mockXAxisWithScale, mockYAxisWithScale } from '../helper/mockAxes';
 
 type TestCase = {
   ChartElement: ComponentType<{
@@ -548,42 +548,29 @@ describe.each(chartsThatDoNotSupportArea)('<Area /> as a child of $testName', ({
 describe('getBaseValue', () => {
   describe('when defined explicitly in props', () => {
     it('should return number if baseValue is a number', () => {
-      // @ts-expect-error incomplete mock
-      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-      // @ts-expect-error incomplete mock
-      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-      const actual = getBaseValue('horizontal', undefined, 8, xAxis, yAxis);
+      const actual = getBaseValue('horizontal', undefined, 8, mockXAxisWithScale, mockYAxisWithScale);
       expect(actual).toBe(8);
     });
 
     it('should read baseValue from chart props, if item.props.baseValue is undefined', () => {
-      // @ts-expect-error incomplete mock
-      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-      // @ts-expect-error incomplete mock
-      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-      const actual = getBaseValue('horizontal', 9, undefined, xAxis, yAxis);
+      const actual = getBaseValue('horizontal', 9, undefined, mockXAxisWithScale, mockYAxisWithScale);
       expect(actual).toBe(9);
     });
 
     it('should prefer baseValue from Area props, if both are provided', () => {
-      // @ts-expect-error incomplete mock
-      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-      // @ts-expect-error incomplete mock
-      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-      const actual = getBaseValue('horizontal', 9, 10, xAxis, yAxis);
+      const actual = getBaseValue('horizontal', 9, 10, mockXAxisWithScale, mockYAxisWithScale);
       expect(actual).toBe(10);
     });
 
     it('should return number from domain when baseValue is NaN', () => {
-      // @ts-expect-error incomplete mock
-      const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-      const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+      const yAxis: BaseAxisWithScale = {
+        ...implicitYAxis,
         scale: {
           // @ts-expect-error incomplete mock
           domain: () => [30, 40],
         },
       };
-      const actual = getBaseValue('horizontal', undefined, NaN, xAxis, yAxis);
+      const actual = getBaseValue('horizontal', undefined, NaN, mockXAxisWithScale, yAxis);
       expect(actual).toBe(30);
     });
   });
@@ -625,38 +612,36 @@ describe('getBaseValue', () => {
         axisType: undefined,
       },
     ];
+
     describe('in horizontal layout uses Y axis', () => {
       test.each(testCases)(
         'should return $expected when $axisType axis domain is $domain',
         ({ domain, axisType, expected }) => {
-          // @ts-expect-error incomplete mock
-          const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-          const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+          const yAxis: BaseAxisWithScale = {
             scale: {
               // @ts-expect-error incomplete mock
               domain: () => domain,
             },
             type: axisType,
           };
-          const actual = getBaseValue('horizontal', baseValue, baseValue, xAxis, yAxis);
+          const actual = getBaseValue('horizontal', baseValue, baseValue, mockXAxisWithScale, yAxis);
           expect(actual).toBe(expected);
         },
       );
     });
+
     describe('in vertical layout behaves the same but uses X axis instead of Y', () => {
       test.each(testCases)(
         'should return $expected when $axisType axis domain is $domain',
         ({ domain, axisType, expected }) => {
-          const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+          const xAxis: BaseAxisWithScale = {
             scale: {
               // @ts-expect-error incomplete mock
               domain: () => domain,
             },
             type: axisType,
           };
-          // @ts-expect-error incomplete mock
-          const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-          const actual = getBaseValue('vertical', baseValue, baseValue, xAxis, yAxis);
+          const actual = getBaseValue('vertical', baseValue, baseValue, xAxis, mockYAxisWithScale);
           expect(actual).toBe(expected);
         },
       );
@@ -705,16 +690,14 @@ describe('getBaseValue', () => {
       test.each(testCases)(
         'should return $expected when $axisType axis domain is $domain',
         ({ domain, axisType, expected }) => {
-          // @ts-expect-error incomplete mock
-          const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-          const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+          const yAxis: BaseAxisWithScale = {
             scale: {
               // @ts-expect-error incomplete mock
               domain: () => domain,
             },
             type: axisType,
           };
-          const actual = getBaseValue('horizontal', baseValue, baseValue, xAxis, yAxis);
+          const actual = getBaseValue('horizontal', baseValue, baseValue, mockXAxisWithScale, yAxis);
           expect(actual).toBe(expected);
         },
       );
@@ -723,16 +706,14 @@ describe('getBaseValue', () => {
       test.each(testCases)(
         'should return $expected when $axisType axis domain is $domain',
         ({ domain, axisType, expected }) => {
-          const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+          const xAxis: BaseAxisWithScale = {
             scale: {
               // @ts-expect-error incomplete mock
               domain: () => domain,
             },
             type: axisType,
           };
-          // @ts-expect-error incomplete mock
-          const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-          const actual = getBaseValue('vertical', baseValue, baseValue, xAxis, yAxis);
+          const actual = getBaseValue('vertical', baseValue, baseValue, xAxis, mockYAxisWithScale);
           expect(actual).toBe(expected);
         },
       );
@@ -784,16 +765,14 @@ describe('getBaseValue', () => {
       test.each(testCases)(
         'should return $expected when $axisType axis domain is $domain',
         ({ domain, axisType, expected }) => {
-          // @ts-expect-error incomplete mock
-          const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-          const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+          const yAxis: BaseAxisWithScale = {
             scale: {
               // @ts-expect-error incomplete mock
               domain: () => domain,
             },
             type: axisType,
           };
-          const actual = getBaseValue('horizontal', baseValue, baseValue, xAxis, yAxis);
+          const actual = getBaseValue('horizontal', baseValue, baseValue, mockXAxisWithScale, yAxis);
           expect(actual).toBe(expected);
         },
       );
@@ -802,16 +781,14 @@ describe('getBaseValue', () => {
       test.each(testCases)(
         'should return $expected when $axisType axis domain is $domain',
         ({ domain, axisType, expected }) => {
-          const xAxis: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {
+          const xAxis: BaseAxisWithScale = {
             scale: {
               // @ts-expect-error incomplete mock
               domain: () => domain,
             },
             type: axisType,
           };
-          // @ts-expect-error incomplete mock
-          const yAxis: Omit<YAxisProps, 'scale'> & { scale: D3Scale<string | number> } = {};
-          const actual = getBaseValue('vertical', baseValue, baseValue, xAxis, yAxis);
+          const actual = getBaseValue('vertical', baseValue, baseValue, xAxis, mockYAxisWithScale);
           expect(actual).toBe(expected);
         },
       );
@@ -825,305 +802,255 @@ describe('getComposedData', () => {
   const mockScale2 = (n: number) => n * 3;
   mockScale2.domain = () => [0, 'auto'];
 
-  describe('points generator', () => {
-    it('should return empty points if displayedData is empty array', () => {
-      const { points } = Area.getComposedData({
-        displayedData: [],
-        // @ts-expect-error incomplete mock
-        props: { layout: 'horizontal' },
-        // @ts-expect-error incomplete mock
-        item: { props: {} },
-        // @ts-expect-error incomplete mock
-        yAxis: { scale: mockScale },
-      });
-      expect(points).toEqual([]);
+  it('should return empty points if displayedData is empty array', () => {
+    const { points } = Area.getComposedData({
+      displayedData: [],
+      // @ts-expect-error incomplete mock
+      props: { layout: 'horizontal' },
+      // @ts-expect-error incomplete mock
+      item: { props: {} },
+      // @ts-expect-error incomplete mock
+      yAxis: { scale: mockScale },
     });
+    expect(points).toEqual([]);
+  });
 
-    it('should return displayedData mapped with getCateCoordinateOfLine in horizontal layout', () => {
-      const { points } = Area.getComposedData({
-        displayedData: [{ v: 1 }, { v: 2 }, { v: 3 }],
-        dataKey: 'v',
-        // @ts-expect-error incomplete mock
-        props: { layout: 'horizontal' },
-        // @ts-expect-error incomplete mock
-        item: { props: {} },
-        // @ts-expect-error incomplete mock
-        yAxis: { scale: mockScale },
-        // @ts-expect-error incomplete mock
-        xAxis: { scale: mockScale2, dataKey: 'v' },
-      });
-      expect(points).toMatchInlineSnapshot(`
-      [
-        {
-          "payload": {
-            "v": 1,
-          },
-          "value": [
-            0,
-            1,
-          ],
-          "x": 3,
-          "y": 2,
-        },
-        {
-          "payload": {
-            "v": 2,
-          },
-          "value": [
-            0,
-            2,
-          ],
-          "x": 6,
-          "y": 4,
-        },
-        {
-          "payload": {
-            "v": 3,
-          },
-          "value": [
-            0,
-            3,
-          ],
-          "x": 9,
-          "y": 6,
-        },
-      ]
-    `);
+  it('should return displayedData mapped with getCateCoordinateOfLine in horizontal layout', () => {
+    const { points } = Area.getComposedData({
+      displayedData: [{ v: 1 }, { v: 2 }, { v: 3 }],
+      // @ts-expect-error incomplete mock
+      props: { layout: 'horizontal' },
+      // @ts-expect-error incomplete mock
+      item: { props: { dataKey: 'v' } },
+      // @ts-expect-error incomplete mock
+      yAxis: { scale: mockScale },
+      // @ts-expect-error incomplete mock
+      xAxis: { scale: mockScale2, dataKey: 'v' },
     });
+    expect(points).toEqual([
+      {
+        payload: {
+          v: 1,
+        },
+        value: [0, 1],
+        x: 3,
+        y: 2,
+      },
+      {
+        payload: {
+          v: 2,
+        },
+        value: [0, 2],
+        x: 6,
+        y: 4,
+      },
+      {
+        payload: {
+          v: 3,
+        },
+        value: [0, 3],
+        x: 9,
+        y: 6,
+      },
+    ]);
+  });
 
-    it('should return displayedData mapped with getCateCoordinateOfLine in vertical layout', () => {
-      const { points } = Area.getComposedData({
-        displayedData: [{ v: 1 }, { v: 2 }, { v: 3 }],
-        dataKey: 'v',
-        // @ts-expect-error incomplete mock
-        props: { layout: 'vertical' },
-        // @ts-expect-error incomplete mock
-        item: { props: {} },
-        // @ts-expect-error incomplete mock
-        yAxis: { scale: mockScale, dataKey: 'v' },
-        // @ts-expect-error incomplete mock
-        xAxis: { scale: mockScale2 },
-      });
-      expect(points).toMatchInlineSnapshot(`
-      [
-        {
-          "payload": {
-            "v": 1,
-          },
-          "value": [
-            0,
-            1,
-          ],
-          "x": 3,
-          "y": 2,
+  it('should return displayedData mapped with getCateCoordinateOfLine in vertical layout', () => {
+    const { points } = Area.getComposedData({
+      displayedData: [{ v: 1 }, { v: 2 }, { v: 3 }],
+      // @ts-expect-error incomplete mock
+      props: { layout: 'vertical' },
+      // @ts-expect-error incomplete mock
+      item: { props: { dataKey: 'v' } },
+      // @ts-expect-error incomplete mock
+      yAxis: { scale: mockScale, dataKey: 'v' },
+      // @ts-expect-error incomplete mock
+      xAxis: { scale: mockScale2 },
+    });
+    expect(points).toEqual([
+      {
+        payload: {
+          v: 1,
         },
-        {
-          "payload": {
-            "v": 2,
-          },
-          "value": [
-            0,
-            2,
-          ],
-          "x": 6,
-          "y": 4,
+        value: [0, 1],
+        x: 3,
+        y: 2,
+      },
+      {
+        payload: {
+          v: 2,
         },
-        {
-          "payload": {
-            "v": 3,
-          },
-          "value": [
-            0,
-            3,
-          ],
-          "x": 9,
-          "y": 6,
+        value: [0, 2],
+        x: 6,
+        y: 4,
+      },
+      {
+        payload: {
+          v: 3,
         },
-      ]
-    `);
-    });
+        value: [0, 3],
+        x: 9,
+        y: 6,
+      },
+    ]);
+  });
 
-    it('should return displayedData mapped to stackedData mapped to getCateCoordinateOfLine in horizontal chart', () => {
-      const { points } = Area.getComposedData({
-        displayedData: [{ v: 1 }, { v: 2 }, { v: 3 }],
-        stackedData: [
-          [1, 2],
-          [2, 4],
-          [3, 6],
-          [4, 8],
-          [5, 10],
-          [6, 12],
-        ],
-        dataKey: 'v',
-        dataStartIndex: 0,
-        // @ts-expect-error incomplete mock
-        props: { layout: 'horizontal' },
-        // @ts-expect-error incomplete mock
-        item: { props: {} },
-        // @ts-expect-error incomplete mock
-        yAxis: { scale: mockScale },
-        // @ts-expect-error incomplete mock
-        xAxis: { scale: mockScale2, dataKey: 'v' },
-      });
-      expect(points).toMatchInlineSnapshot(`
-        [
-          {
-            "payload": {
-              "v": 1,
-            },
-            "value": [
-              1,
-              2,
-            ],
-            "x": 3,
-            "y": 4,
-          },
-          {
-            "payload": {
-              "v": 2,
-            },
-            "value": [
-              2,
-              4,
-            ],
-            "x": 6,
-            "y": 8,
-          },
-          {
-            "payload": {
-              "v": 3,
-            },
-            "value": [
-              3,
-              6,
-            ],
-            "x": 9,
-            "y": 12,
-          },
-        ]
-      `);
+  it('should return displayedData mapped to stackedData mapped to getCateCoordinateOfLine in horizontal chart', () => {
+    const { points } = Area.getComposedData({
+      displayedData: [{ v: 1 }, { v: 2 }, { v: 3 }],
+      stackedData: [
+        [1, 2],
+        [2, 4],
+        [3, 6],
+        [4, 8],
+        [5, 10],
+        [6, 12],
+      ],
+      dataStartIndex: 0,
+      // @ts-expect-error incomplete mock
+      props: { layout: 'horizontal' },
+      // @ts-expect-error incomplete mock
+      item: {
+        props: {
+          dataKey: 'v',
+        },
+      },
+      // @ts-expect-error incomplete mock
+      yAxis: { scale: mockScale },
+      // @ts-expect-error incomplete mock
+      xAxis: { scale: mockScale2, dataKey: 'v' },
     });
+    expect(points).toEqual([
+      {
+        payload: {
+          v: 1,
+        },
+        value: [1, 2],
+        x: 3,
+        y: 4,
+      },
+      {
+        payload: {
+          v: 2,
+        },
+        value: [2, 4],
+        x: 6,
+        y: 8,
+      },
+      {
+        payload: {
+          v: 3,
+        },
+        value: [3, 6],
+        x: 9,
+        y: 12,
+      },
+    ]);
+  });
 
-    it('should return displayedData mapped to stackedData mapped to getCateCoordinateOfLine in vertical chart', () => {
-      const { points } = Area.getComposedData({
-        displayedData: [{ v: 1 }, { v: 2 }, { v: 3 }],
-        stackedData: [
-          [1, 2],
-          [2, 4],
-          [3, 6],
-          [4, 8],
-          [5, 10],
-          [6, 12],
-        ],
-        dataKey: 'v',
-        dataStartIndex: 0,
-        // @ts-expect-error incomplete mock
-        props: { layout: 'vertical' },
-        // @ts-expect-error incomplete mock
-        item: { props: {} },
-        // @ts-expect-error incomplete mock
-        yAxis: { scale: mockScale, dataKey: 'v' },
-        // @ts-expect-error incomplete mock
-        xAxis: { scale: mockScale2 },
-      });
-      expect(points).toMatchInlineSnapshot(`
-        [
-          {
-            "payload": {
-              "v": 1,
-            },
-            "value": [
-              1,
-              2,
-            ],
-            "x": 6,
-            "y": 2,
-          },
-          {
-            "payload": {
-              "v": 2,
-            },
-            "value": [
-              2,
-              4,
-            ],
-            "x": 12,
-            "y": 4,
-          },
-          {
-            "payload": {
-              "v": 3,
-            },
-            "value": [
-              3,
-              6,
-            ],
-            "x": 18,
-            "y": 6,
-          },
-        ]
-      `);
+  it('should return displayedData mapped to stackedData mapped to getCateCoordinateOfLine in vertical chart', () => {
+    const { points } = Area.getComposedData({
+      displayedData: [{ v: 1 }, { v: 2 }, { v: 3 }],
+      stackedData: [
+        [1, 2],
+        [2, 4],
+        [3, 6],
+        [4, 8],
+        [5, 10],
+        [6, 12],
+      ],
+      dataStartIndex: 0,
+      // @ts-expect-error incomplete mock
+      props: { layout: 'vertical' },
+      // @ts-expect-error incomplete mock
+      item: {
+        props: {
+          dataKey: 'v',
+        },
+      },
+      // @ts-expect-error incomplete mock
+      yAxis: { scale: mockScale, dataKey: 'v' },
+      // @ts-expect-error incomplete mock
+      xAxis: { scale: mockScale2 },
     });
+    expect(points).toEqual([
+      {
+        payload: {
+          v: 1,
+        },
+        value: [1, 2],
+        x: 6,
+        y: 2,
+      },
+      {
+        payload: {
+          v: 2,
+        },
+        value: [2, 4],
+        x: 12,
+        y: 4,
+      },
+      {
+        payload: {
+          v: 3,
+        },
+        value: [3, 6],
+        x: 18,
+        y: 6,
+      },
+    ]);
+  });
 
-    it('should return .y coordinate set to null in vertical chart when YAxis dataKey is undefined', () => {
-      const { points } = Area.getComposedData({
-        displayedData: [{ v: 1 }, { v: 2 }, { v: 3 }],
-        stackedData: [
-          [1, 2],
-          [2, 4],
-          [3, 6],
-          [4, 8],
-          [5, 10],
-          [6, 12],
-        ],
-        dataKey: 'v',
-        dataStartIndex: 0,
-        // @ts-expect-error incomplete mock
-        props: { layout: 'vertical' },
-        // @ts-expect-error incomplete mock
-        item: { props: {} },
-        // @ts-expect-error incomplete mock
-        yAxis: { scale: mockScale },
-        // @ts-expect-error incomplete mock
-        xAxis: { scale: mockScale2 },
-      });
-      expect(points).toMatchInlineSnapshot(`
-        [
-          {
-            "payload": {
-              "v": 1,
-            },
-            "value": [
-              1,
-              2,
-            ],
-            "x": 6,
-            "y": null,
-          },
-          {
-            "payload": {
-              "v": 2,
-            },
-            "value": [
-              2,
-              4,
-            ],
-            "x": 12,
-            "y": null,
-          },
-          {
-            "payload": {
-              "v": 3,
-            },
-            "value": [
-              3,
-              6,
-            ],
-            "x": 18,
-            "y": null,
-          },
-        ]
-      `);
+  it('should return .y coordinate set to null in vertical chart when YAxis dataKey is undefined', () => {
+    const { points } = Area.getComposedData({
+      displayedData: [{ v: 1 }, { v: 2 }, { v: 3 }],
+      stackedData: [
+        [1, 2],
+        [2, 4],
+        [3, 6],
+        [4, 8],
+        [5, 10],
+        [6, 12],
+      ],
+      dataStartIndex: 0,
+      // @ts-expect-error incomplete mock
+      props: { layout: 'vertical' },
+      // @ts-expect-error incomplete mock
+      item: {
+        props: {
+          dataKey: 'v',
+        },
+      },
+      // @ts-expect-error incomplete mock
+      yAxis: { scale: mockScale },
+      // @ts-expect-error incomplete mock
+      xAxis: { scale: mockScale2 },
     });
+    expect(points).toEqual([
+      {
+        payload: {
+          v: 1,
+        },
+        value: [1, 2],
+        x: 6,
+        y: null,
+      },
+      {
+        payload: {
+          v: 2,
+        },
+        value: [2, 4],
+        x: 12,
+        y: null,
+      },
+      {
+        payload: {
+          v: 3,
+        },
+        value: [3, 6],
+        x: 18,
+        y: null,
+      },
+    ]);
   });
 });

--- a/test/chart/AreaChart.spec.tsx
+++ b/test/chart/AreaChart.spec.tsx
@@ -7,6 +7,18 @@ import { testChartLayoutContext } from '../util/context';
 import { useClipPathId, useViewBox } from '../../src/context/chartLayoutContext';
 import { useAppSelector } from '../../src/state/hooks';
 
+type ExpectedArea = {
+  d: string;
+};
+
+function expectAreaCurve(container: Element, expectedAreas: ReadonlyArray<ExpectedArea>) {
+  assertNotNull(container);
+  const areaCurves = container.querySelectorAll('.recharts-area-curve');
+  assertNotNull(areaCurves);
+  const actualAreas = Array.from(areaCurves).map(area => ({ d: area.getAttribute('d') }));
+  expect(actualAreas).toEqual(expectedAreas);
+}
+
 describe('AreaChart', () => {
   const data = [
     { name: 'Page A', uv: 400, pv: 2400, amt: 2400 },
@@ -25,20 +37,27 @@ describe('AreaChart', () => {
     );
     expect(container.querySelectorAll('.recharts-area-area')).toHaveLength(1);
     expect(container.querySelectorAll('.recharts-area-curve')).toHaveLength(1);
+
+    expectAreaCurve(container, [
+      {
+        d: 'M5,5C11,10,17,15,23,15C29,15,35,15,41,15C47,15,53,25,59,25C65,25,71,17.2,77,17.2C83,17.2,89,21.65,95,26.1',
+      },
+    ]);
   });
 
   test('Renders 1 dot when data only have one element', () => {
     const { container } = render(
       <AreaChart width={100} height={50} data={data.slice(0, 1)}>
-        <Area type="monotone" dataKey="uv" stroke="#ff7300" fill="#ff7300" />
+        <Area type="monotone" dataKey="pv" stroke="#ff7300" fill="#ff7300" />
       </AreaChart>,
     );
     expect(container.querySelectorAll('.recharts-area-area')).toHaveLength(0);
     expect(container.querySelectorAll('.recharts-area-curve')).toHaveLength(0);
     expect(container.querySelectorAll('.recharts-area-dot')).toHaveLength(1);
+    expectAreaCurve(container, []);
   });
 
-  test('Renders empty path when all the data are null', () => {
+  test('Renders no path when dataKey does not match the source data', () => {
     const { container } = render(
       <AreaChart width={100} height={50} data={data}>
         <Area type="monotone" dataKey="any" stroke="#ff7300" fill="#ff7300" />
@@ -47,14 +66,8 @@ describe('AreaChart', () => {
     const areaPath = container.querySelectorAll('.recharts-area-area');
     const curvePath = container.querySelectorAll('.recharts-area-curve');
 
-    expect(areaPath).toHaveLength(1);
-    expect(curvePath).toHaveLength(1);
-    areaPath.forEach(m => {
-      expect(m).not.toHaveAttribute('d');
-    });
-    curvePath.forEach(m => {
-      expect(m).not.toHaveAttribute('d');
-    });
+    expect(areaPath).toHaveLength(0);
+    expect(curvePath).toHaveLength(0);
   });
 
   test('Renders customized active dot when activeDot is set to be a ReactElement', () => {
@@ -116,9 +129,18 @@ describe('AreaChart', () => {
     );
     expect(container.querySelectorAll('.recharts-area-area')).toHaveLength(2);
     expect(container.querySelectorAll('.recharts-area-curve')).toHaveLength(2);
+
+    expectAreaCurve(container, [
+      {
+        d: 'M5,43.4C11,43.6,17,43.8,23,43.8C29,43.8,35,43.8,41,43.8C47,43.8,53,44.2,59,44.2C65,44.2,71,43.888,77,43.888C83,43.888,89,44.066,95,44.244',
+      },
+      {
+        d: 'M5,33.8C11,29.666,17,25.532,23,25.532C29,25.532,35,38.208,41,38.208C47,38.208,53,5,59,5C65,5,71,28.256,77,28.256C83,28.256,89,26.65,95,25.044',
+      },
+    ]);
   });
 
-  test('Renders 2 path in a vertical AreaChart', () => {
+  test('Renders a path in a vertical AreaChart', () => {
     const { container } = render(
       <AreaChart width={100} height={50} data={data} layout="vertical">
         <XAxis type="number" />
@@ -128,6 +150,12 @@ describe('AreaChart', () => {
     );
     expect(container.querySelectorAll('.recharts-area-area')).toHaveLength(1);
     expect(container.querySelectorAll('.recharts-area-curve')).toHaveLength(1);
+
+    expectAreaCurve(container, [
+      {
+        d: 'M95,5C91.25,5.667,87.5,6.333,87.5,7C87.5,7.667,87.5,8.333,87.5,9C87.5,9.667,80,10.333,80,11C80,11.667,85.85,12.333,85.85,13C85.85,13.667,82.513,14.333,79.175,15',
+      },
+    ]);
   });
 
   test('Renders dots and labels when dot is set to true', () => {
@@ -387,6 +415,19 @@ describe('AreaChart', () => {
     );
 
     const [uv, pv] = container.querySelectorAll('.recharts-area-curve');
+
+    expectAreaCurve(container, [
+      {
+        d: 'M5,42.333C20,42.667,35,43,50,43C65,43,80,43,95,43',
+      },
+      {
+        d: 'M5,26.333C20,34.667,35,43,50,43C65,43,80,38.34,95,33.68',
+      },
+      {
+        d: 'M5,10.333C20,18.667,35,27,50,27C65,27,80,22.34,95,17.68',
+      },
+    ]);
+
     [uv, pv].forEach(path => {
       const commands = [...path.getAttribute('d').matchAll(/[a-zA-Z][\d ,.]+/g)];
       expect(commands).toHaveLength(3);

--- a/test/component/Tooltip/ActiveDot.spec.tsx
+++ b/test/component/Tooltip/ActiveDot.spec.tsx
@@ -109,7 +109,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, areaChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 161,

--- a/test/helper/mockAxes.ts
+++ b/test/helper/mockAxes.ts
@@ -1,0 +1,16 @@
+import { scaleLinear } from 'victory-vendor/d3-scale';
+import { BaseAxisWithScale, implicitXAxis, implicitYAxis } from '../../src/state/selectors/axisSelectors';
+import { RechartsScale } from '../../src/util/ChartUtils';
+
+// @ts-expect-error we need to figure out scale types
+export const mockScale: RechartsScale = scaleLinear().domain([0, 500]);
+
+export const mockXAxisWithScale: BaseAxisWithScale = {
+  ...implicitXAxis,
+  scale: mockScale,
+};
+
+export const mockYAxisWithScale: BaseAxisWithScale = {
+  ...implicitYAxis,
+  scale: mockScale,
+};


### PR DESCRIPTION
## Description

Area now reads its config from Redux, just like Line and Scatter.

Visual diff: https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=1293

## Related Issue

https://github.com/recharts/recharts/issues/4583