### PR TITLE
Brush Panorama should not contribute to Tooltip payload

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -70,7 +70,7 @@ export interface BarRectangleItem extends RectangleProps {
 }
 
 interface InternalBarProps {
-  data?: BarRectangleItem[];
+  data?: ReadonlyArray<BarRectangleItem>;
   needClip?: boolean;
   width?: number;
   height?: number;
@@ -114,14 +114,14 @@ export type Props = Omit<PresentationAttributesAdaptChildEvent<BarRectangleItem,
 
 interface State {
   readonly isAnimationFinished?: boolean;
-  readonly prevData?: BarRectangleItem[];
-  readonly curData?: BarRectangleItem[];
+  readonly prevData?: ReadonlyArray<BarRectangleItem>;
+  readonly curData?: ReadonlyArray<BarRectangleItem>;
   readonly prevAnimationId?: number;
 }
 
 type BarComposedData = ChartOffset & {
   layout: LayoutType;
-  data: BarRectangleItem[];
+  data: ReadonlyArray<BarRectangleItem>;
 };
 
 const computeLegendPayloadFromBarData = (props: Props): Array<LegendPayload> => {
@@ -164,7 +164,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
 
 type BarBackgroundProps = {
   background?: ActiveShape<BarProps, SVGPathElement>;
-  data: BarRectangleItem[];
+  data: ReadonlyArray<BarRectangleItem>;
   dataKey: DataKey<any>;
   onAnimationStart: () => void;
   onAnimationEnd: () => void;
@@ -239,7 +239,7 @@ function BarBackground(props: BarBackgroundProps) {
 }
 
 type BarRectanglesProps = Props & {
-  data: BarRectangleItem[];
+  data: ReadonlyArray<BarRectangleItem>;
   onAnimationStart: () => void;
   onAnimationEnd: () => void;
 };
@@ -369,7 +369,7 @@ class BarWithState extends PureComponent<Props, State> {
     }
   };
 
-  renderRectanglesStatically(data: BarRectangleItem[]) {
+  renderRectanglesStatically(data: ReadonlyArray<BarRectangleItem>) {
     return (
       <BarRectangles
         {...this.props}

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -557,7 +557,13 @@ export class Bar extends PureComponent<Props> {
     offset,
   }: {
     props: Props;
+    /**
+     * @deprecated do not use - depends on passing around DOM elements
+     */
     item: ReactElement;
+    /**
+     * @deprecated do not use - depends on passing around DOM elements
+     */
     barPosition: ReadonlyArray<BarPosition>;
     bandSize: number;
     xAxis?: Omit<XAxisProps, 'scale'> & { scale: D3Scale<string | number>; x?: number; width?: number };

--- a/src/state/SetTooltipEntrySettings.tsx
+++ b/src/state/SetTooltipEntrySettings.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useAppDispatch } from './hooks';
 import { addTooltipEntrySettings, removeTooltipEntrySettings, TooltipPayloadConfiguration } from './tooltipSlice';
+import { useIsPanorama } from '../context/PanoramaContext';
 
 type SetTooltipEntrySettingsProps<T> = {
   args: T;
@@ -9,12 +10,17 @@ type SetTooltipEntrySettingsProps<T> = {
 
 export function SetTooltipEntrySettings<T>({ fn, args }: SetTooltipEntrySettingsProps<T>): null {
   const dispatch = useAppDispatch();
+  const isPanorama = useIsPanorama();
   useEffect(() => {
+    if (isPanorama) {
+      // Panorama graphical items should never contribute to Tooltip payload.
+      return undefined;
+    }
     const tooltipEntrySettings: TooltipPayloadConfiguration = fn(args);
     dispatch(addTooltipEntrySettings(tooltipEntrySettings));
     return () => {
       dispatch(removeTooltipEntrySettings(tooltipEntrySettings));
     };
-  }, [fn, args, dispatch]);
+  }, [fn, args, dispatch, isPanorama]);
   return null;
 }

--- a/src/state/selectors/containerSelectors.ts
+++ b/src/state/selectors/containerSelectors.ts
@@ -8,6 +8,21 @@ import { Margin } from '../../util/types';
 export const selectRootContainer = (state: RechartsRootState): RechartsHTMLContainer | undefined =>
   state.layout.container;
 
+/**
+ * This selector is not stable, and it is important that it is not stable
+ * - because browser will return different instances of getBoundingClientRect() even if the element is the same.
+ *
+ * This results in Reselect showing this error:
+ * An input selector returned a different result when passed same arguments.
+ * This means your output selector will likely run more frequently than intended
+ *
+ * Which is correct and unfortunate but good enough for now.
+ * The fix is to listen for resize events in the container element,
+ * and store only the resulting DOMRect instead of the whole container in Redux store.
+ *
+ * @param state RechartsRootState
+ * @return DOMRect
+ */
 export const selectRootContainerDomRect: (state: RechartsRootState) => DOMRect | undefined = (
   state: RechartsRootState,
 ) => selectRootContainer(state)?.getBoundingClientRect();

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -131,7 +131,7 @@ export type TooltipState = {
    * This is the state of interaction with the bar background - which will get mapped
    * to the axis index.
    *
-   * Axis interaction is independent from item interaction so the state must also be independent.
+   * Axis interaction is independent of item interaction so the state must also be independent.
    */
   axisInteraction: {
     activeClick: boolean;

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -220,6 +220,9 @@ export const getMainColorOfGraphicItem = (item: {
   return result;
 };
 
+/**
+ * @deprecated do not use - depends on passing around DOM elements
+ */
 export type BarSetup = {
   barSize: number | string;
   stackList: ReadonlyArray<ReactElement>;
@@ -227,6 +230,8 @@ export type BarSetup = {
 };
 
 /**
+ * @deprecated do not use - depends on passing around DOM elements
+ *
  * Calculate the size of all groups for stacked bar graph
  * @param  {Object} stackGroups The items grouped by axisId and stackId
  * @return {Object} The size of all groups
@@ -237,6 +242,9 @@ export const getBarSizeList = ({
   stackGroups = {},
 }: {
   barSize: number | string;
+  /**
+   * @deprecated do not use - depends on passing around DOM elements
+   */
   stackGroups: AxisStackGroups;
   totalSize: number;
 }): Record<string, ReadonlyArray<BarSetup>> => {
@@ -289,11 +297,14 @@ export type BarPositionPosition = {
   /**
    * Size of the bar.
    * This will be usually a number.
-   * But if the input data is not well formed, undefined or NaN will be on the output too.
+   * But if the input data is not well-formed, undefined or NaN will be on the output too.
    */
   size: number | undefined | typeof NaN;
 };
 
+/**
+ * @deprecated do not use - depends on passing around DOM elements
+ */
 export type BarPosition = {
   item: ReactElement;
   position: BarPositionPosition;
@@ -716,6 +727,10 @@ export const checkDomainOfScale = (scale: any) => {
   }
 };
 
+// eslint-disable-next-line valid-jsdoc
+/**
+ * @deprecated do not use - depends on passing around DOM elements
+ */
 export const findPositionOfBar = (
   barPosition: ReadonlyArray<BarPosition>,
   child: ReactNode,
@@ -886,11 +901,17 @@ export const getStackedData = (
 type AxisId = string;
 export type StackId = string | number | symbol;
 
+/**
+ * @deprecated do not use - depends on passing around DOM elements
+ */
 export type ParentStackGroup = {
   hasStack: boolean;
   stackGroups: Record<StackId, ChildStackGroup>;
 };
 
+/**
+ * @deprecated do not use - depends on passing around DOM elements
+ */
 export type GenericChildStackGroup<T> = {
   numericAxisId: string;
   cateAxisId: string;
@@ -898,10 +919,20 @@ export type GenericChildStackGroup<T> = {
   stackedData?: ReadonlyArray<T>;
 };
 
+/**
+ * @deprecated do not use - depends on passing around DOM elements
+ */
 export type ChildStackGroup = GenericChildStackGroup<Series<Record<string, unknown>, DataKey<any>>>;
 
+/**
+ * @deprecated do not use - depends on passing around DOM elements
+ */
 export type AxisStackGroups = Record<AxisId, ParentStackGroup>;
 
+// eslint-disable-next-line valid-jsdoc
+/**
+ * @deprecated do not use - depends on passing around DOM elements
+ */
 export const getStackGroupsByAxisId = (
   data: ReadonlyArray<Record<string, unknown>> | undefined,
   _items: Array<ReactElement>,
@@ -1387,6 +1418,10 @@ export const getCartesianAxisSize = (axisObj: AxisObj, axisName: 'xAxis' | 'yAxi
   return undefined;
 };
 
+// eslint-disable-next-line valid-jsdoc
+/**
+ * @deprecated do not use - depends on passing around DOM elements
+ */
 export function getBarPositions({
   axisObj,
   hasBar,

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentType, FC, ReactNode } from 'react';
 import { describe, expect, it, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { Area, Customized, XAxis, YAxis } from '../../src';
+import { Area, Brush, Customized, Tooltip, XAxis, YAxis } from '../../src';
 import { getBaseValue, Props } from '../../src/cartesian/Area';
 import { LayoutType } from '../../src/util/types';
 import {
@@ -14,6 +14,8 @@ import { useAppSelector } from '../../src/state/hooks';
 import { CartesianGraphicalItemSettings } from '../../src/state/graphicalItemsSlice';
 import { BaseAxisWithScale, implicitYAxis } from '../../src/state/selectors/axisSelectors';
 import { mockXAxisWithScale, mockYAxisWithScale } from '../helper/mockAxes';
+import { useLegendPayload } from '../../src/context/legendPayloadContext';
+import { selectTooltipPayloadConfigurations } from '../../src/state/selectors/selectors';
 
 type TestCase = {
   ChartElement: ComponentType<{
@@ -22,6 +24,7 @@ type TestCase = {
     height?: number;
     data?: any[];
     layout?: LayoutType;
+    className?: string;
   }>;
   testName: string;
 };
@@ -501,6 +504,214 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
         },
       ];
       expect(spy).toHaveBeenLastCalledWith(expected);
+    });
+
+    it('should add a record to Legend and Tooltip payloads', () => {
+      const legendSpy = vi.fn();
+      const tooltipSpy = vi.fn();
+
+      const Comp = (): null => {
+        legendSpy(useLegendPayload());
+        tooltipSpy(useAppSelector(state => selectTooltipPayloadConfigurations(state, 'axis', 'hover')));
+        return null;
+      };
+
+      render(
+        <ChartElement data={data}>
+          <Area dataKey="value" />
+          <Tooltip />
+          <Customized component={<Comp />} />
+        </ChartElement>,
+      );
+
+      expect(legendSpy).toHaveBeenLastCalledWith([
+        {
+          color: '#3182bd',
+          dataKey: 'value',
+          inactive: false,
+          payload: {
+            activeDot: true,
+            animationBegin: 0,
+            animationDuration: 1500,
+            animationEasing: 'ease',
+            animationId: 0,
+            baseLine: 495,
+            bottom: 5,
+            brushBottom: 5,
+            connectNulls: false,
+            dataKey: 'value',
+            dot: false,
+            fill: '#3182bd',
+            fillOpacity: 0.6,
+            height: 490,
+            hide: false,
+            isAnimationActive: true,
+            isRange: false,
+            layout: 'horizontal',
+            left: 5,
+            legendType: 'line',
+            points: [
+              {
+                payload: {
+                  value: 100,
+                  x: 10,
+                  y: 50,
+                },
+                value: [0, 100],
+                x: 5,
+                y: 5,
+              },
+              {
+                payload: {
+                  value: 100,
+                  x: 50,
+                  y: 50,
+                },
+                value: [0, 100],
+                x: 127.5,
+                y: 5,
+              },
+              {
+                payload: {
+                  value: 100,
+                  x: 90,
+                  y: 50,
+                },
+                value: [0, 100],
+                x: 250,
+                y: 5,
+              },
+              {
+                payload: {
+                  value: 100,
+                  x: 130,
+                  y: 50,
+                },
+                value: [0, 100],
+                x: 372.5,
+                y: 5,
+              },
+              {
+                payload: {
+                  value: 100,
+                  x: 170,
+                  y: 50,
+                },
+                value: [0, 100],
+                x: 495,
+                y: 5,
+              },
+            ],
+            right: 5,
+            stroke: '#3182bd',
+            top: 5,
+            width: 490,
+            xAxis: {
+              allowDataOverflow: false,
+              allowDecimals: true,
+              allowDuplicatedCategory: true,
+              axisType: 'xAxis',
+              bandSize: 0,
+              domain: [0, 1, 2, 3, 4],
+              height: 30,
+              hide: true,
+              isCategorical: true,
+              layout: 'horizontal',
+              mirror: false,
+              orientation: 'bottom',
+              originalDomain: [0, 'auto'],
+              padding: {
+                left: 0,
+                right: 0,
+              },
+              realScaleType: 'point',
+              reversed: false,
+              scale: expect.any(Function),
+              tickCount: 5,
+              type: 'category',
+              width: 490,
+              x: 5,
+              xAxisId: 0,
+              y: 495,
+            },
+            xAxisId: 0,
+            yAxis: {
+              allowDataOverflow: false,
+              allowDecimals: true,
+              allowDuplicatedCategory: true,
+              axisType: 'yAxis',
+              bandSize: 0,
+              domain: [0, 100],
+              height: 490,
+              hide: true,
+              isCategorical: false,
+              layout: 'horizontal',
+              mirror: false,
+              niceTicks: [0, 25, 50, 75, 100],
+              orientation: 'left',
+              originalDomain: [0, 'auto'],
+              padding: {
+                bottom: 0,
+                top: 0,
+              },
+              realScaleType: 'linear',
+              reversed: false,
+              scale: expect.any(Function),
+              tickCount: 5,
+              type: 'number',
+              width: 60,
+              x: -55,
+              y: 5,
+              yAxisId: 0,
+            },
+            yAxisId: 0,
+          },
+          type: 'line',
+          value: 'value',
+        },
+      ]);
+      expect(tooltipSpy).toHaveBeenLastCalledWith([
+        {
+          dataDefinedOnItem: undefined,
+          settings: {
+            color: '#3182bd',
+            dataKey: 'value',
+            fill: '#3182bd',
+            hide: false,
+            name: 'value',
+            nameKey: undefined,
+            stroke: '#3182bd',
+            strokeWidth: undefined,
+            type: undefined,
+            unit: undefined,
+          },
+        },
+      ]);
+    });
+
+    it('should add no record to Legend and Tooltip payloads when inside Brush Panorama', () => {
+      const legendSpy = vi.fn();
+      const tooltipSpy = vi.fn();
+
+      const Comp = (): null => {
+        legendSpy(useLegendPayload());
+        tooltipSpy(useAppSelector(state => selectTooltipPayloadConfigurations(state, 'axis', 'hover')));
+        return null;
+      };
+
+      render(
+        <ChartElement data={data} className="my-unique-classname">
+          <Customized component={<Comp />} />
+          <Brush>
+            <ChartElement>
+              <Area dataKey="value" />
+            </ChartElement>
+          </Brush>
+        </ChartElement>,
+      );
+
+      expect(legendSpy).toHaveBeenLastCalledWith([]);
+      expect(tooltipSpy).toHaveBeenLastCalledWith([]);
     });
   });
 

--- a/test/state/selectors/containerSelectors.spec.tsx
+++ b/test/state/selectors/containerSelectors.spec.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { getMockDomRect } from '../../helper/mockGetBoundingClientRect';
 import { useAppSelector } from '../../../src/state/hooks';
 import { RechartsHTMLContainer, setContainer } from '../../../src/state/layoutSlice';
 import {
-  selectRootContainerDomRect,
   selectContainerScale,
   selectMargin,
+  selectRootContainerDomRect,
 } from '../../../src/state/selectors/containerSelectors';
 import { createRechartsStore } from '../../../src/state/store';
 import { BarChart, Customized } from '../../../src';


### PR DESCRIPTION
## Description

Following up from https://www.chromatic.com/test?appId=63da8268a0da9970db6992aa&id=66bb689478d8c804a6094607 - Panorama graphical items should not contribute to Tooltip payloads.

Also includes some Bar refactoring I started but didn't get too far.

## Related Issue

https://github.com/recharts/recharts/issues/4549