### PR TITLE
refactor(tooltip): return event callback from context

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -201,18 +201,13 @@ function BarBackground(props: BarBackgroundProps) {
           return null;
         }
 
-        const onMouseEnter = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-          // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
-          onMouseEnterFromContext(entry, i, e);
-        };
-        const onMouseLeave = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-          // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
-          onMouseLeaveFromContext(entry, i, e);
-        };
-        const onClick = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-          // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
-          onClickFromContext(entry, i, e);
-        };
+        // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
+        const onMouseEnter = onMouseEnterFromContext(entry, i);
+        // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
+        const onMouseLeave = onMouseLeaveFromContext(entry, i);
+        // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
+        const onClick = onClickFromContext(entry, i);
+
         const barRectangleProps: BarRectangleProps = {
           option: backgroundFromProps,
           isActive: i === activeIndex,
@@ -280,25 +275,17 @@ function BarRectangles(props: BarRectanglesProps) {
           onAnimationStart,
           onAnimationEnd,
         };
-        const onMouseEnter = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-          // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
-          onMouseEnterFromContext(entry, i, e);
-        };
-        const onMouseLeave = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-          // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
-          onMouseLeaveFromContext(entry, i, e);
-        };
-        const onClick = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-          // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
-          onClickFromContext(entry, i, e);
-        };
+
         return (
           <Layer
             className="recharts-bar-rectangle"
             {...adaptEventsOfChild(restOfAllOtherProps, entry, i)}
-            onMouseEnter={onMouseEnter}
-            onMouseLeave={onMouseLeave}
-            onClick={onClick}
+            // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
+            onMouseEnter={onMouseEnterFromContext(entry, i)}
+            // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
+            onMouseLeave={onMouseLeaveFromContext(entry, i)}
+            // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
+            onClick={onClickFromContext(entry, i)}
             key={`rectangle-${entry?.x}-${entry?.y}-${entry?.value}`}
           >
             <BarRectangle {...barRectangleProps} />

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -201,26 +201,16 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
         const option = isActive ? activeShape : shape;
         const symbolProps = { key: `symbol-${i}`, ...baseProps, ...entry };
 
-        const onMouseEnter = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-          // @ts-expect-error the types need a bit of attention
-          onMouseEnterFromContext(entry, i, e);
-        };
-        const onMouseLeave = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-          // @ts-expect-error the types need a bit of attention
-          onMouseLeaveFromContext(entry, i, e);
-        };
-        const onClick = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-          // @ts-expect-error the types need a bit of attention
-          onClickFromContext(entry, i, e);
-        };
-
         return (
           <Layer
             className="recharts-scatter-symbol"
             {...adaptEventsOfChild(restOfAllOtherProps, entry, i)}
-            onMouseEnter={onMouseEnter}
-            onMouseLeave={onMouseLeave}
-            onClick={onClick}
+            // @ts-expect-error the types need a bit of attention
+            onMouseEnter={onMouseEnterFromContext(entry, i)}
+            // @ts-expect-error the types need a bit of attention
+            onMouseLeave={onMouseLeaveFromContext(entry, i)}
+            // @ts-expect-error the types need a bit of attention
+            onClick={onClickFromContext(entry, i)}
             // eslint-disable-next-line react/no-array-index-key
             key={`symbol-${entry?.cx}-${entry?.cy}-${entry?.size}-${i}`}
             role="img"

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -64,10 +64,10 @@ export const MouseClickItemDispatchContext = createContext<ActivateTooltipAction
 export const useMouseEnterItemDispatch = <T extends TooltipPayloadType>(
   onMouseEnterFromProps: ActivateTooltipAction<T> | undefined,
   dataKey: DataKey<any>,
-): ActivateTooltipAction<T> => {
+) => {
   const dispatch = useAppDispatch();
   const onMouseEnterFromContext: undefined | ActivateTooltipAction<T> = useContext(MouseEnterItemDispatchContext);
-  return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
+  return (data: TooltipTriggerInfo<T>, index: number) => (event: React.MouseEvent<SVGElement>) => {
     onMouseEnterFromProps?.(data, index, event);
     onMouseEnterFromContext?.(data, index, event);
     dispatch(
@@ -82,10 +82,10 @@ export const useMouseEnterItemDispatch = <T extends TooltipPayloadType>(
 
 export const useMouseLeaveItemDispatch = <T extends TooltipPayloadType>(
   onMouseLeaveFromProps: undefined | ActivateTooltipAction<T>,
-): ActivateTooltipAction<T> => {
+) => {
   const dispatch = useAppDispatch();
   const onMouseLeaveFromContext: undefined | ActivateTooltipAction<T> = useContext(MouseLeaveItemDispatchContext);
-  return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
+  return (data: TooltipTriggerInfo<T>, index: number) => (event: React.MouseEvent<SVGElement>) => {
     onMouseLeaveFromProps?.(data, index, event);
     onMouseLeaveFromContext?.(data, index, event);
     dispatch(mouseLeaveItem());
@@ -95,10 +95,10 @@ export const useMouseLeaveItemDispatch = <T extends TooltipPayloadType>(
 export const useMouseClickItemDispatch = <T extends TooltipPayloadType>(
   onMouseClickFromProps: ActivateTooltipAction<T> | undefined,
   dataKey: DataKey<any>,
-): ActivateTooltipAction<T> | undefined => {
+) => {
   const dispatch = useAppDispatch();
   const onMouseClickFromContext: undefined | ActivateTooltipAction<T> = useContext(MouseClickItemDispatchContext);
-  return (data: TooltipTriggerInfo<T>, index: number, event: React.MouseEvent<SVGElement>) => {
+  return (data: TooltipTriggerInfo<T>, index: number) => (event: React.MouseEvent<SVGElement>) => {
     onMouseClickFromProps?.(data, index, event);
     onMouseClickFromContext?.(data, index, event);
     dispatch(

--- a/src/numberAxis/Funnel.tsx
+++ b/src/numberAxis/Funnel.tsx
@@ -139,26 +139,17 @@ function FunnelTrapezoids(props: FunnelTrapezoidsProps) {
       isActive: isActiveIndex,
       stroke: entry.stroke,
     };
-    const onMouseEnter = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-      // @ts-expect-error the types need a bit of attention
-      onMouseEnterFromContext(entry, i, e);
-    };
-    const onMouseLeave = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-      // @ts-expect-error the types need a bit of attention
-      onMouseLeaveFromContext(entry, i, e);
-    };
-    const onClick = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-      // @ts-expect-error the types need a bit of attention
-      onClickFromContext(entry, i, e);
-    };
 
     return (
       <Layer
         className="recharts-funnel-trapezoid"
         {...adaptEventsOfChild(restOfAllOtherProps, entry, i)}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        onClick={onClick}
+        // @ts-expect-error the types need a bit of attention
+        onMouseEnter={onMouseEnterFromContext(entry, i)}
+        // @ts-expect-error the types need a bit of attention
+        onMouseLeave={onMouseLeaveFromContext(entry, i)}
+        // @ts-expect-error the types need a bit of attention
+        onClick={onClickFromContext(entry, i)}
         key={`trapezoid-${entry?.x}-${entry?.y}-${entry?.name}-${entry?.value}`}
         role="img"
       >

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -242,18 +242,7 @@ function PieSectors(props: PieSectorsProps) {
       stroke: blendStroke ? entry.fill : entry.stroke,
       tabIndex: -1,
     };
-    const onMouseEnter = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-      // @ts-expect-error the types need a bit of attention
-      onMouseEnterFromContext(entry, i, e);
-    };
-    const onMouseLeave = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-      // @ts-expect-error the types need a bit of attention
-      onMouseLeaveFromContext(entry, i, e);
-    };
-    const onClick = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-      // @ts-expect-error the types need a bit of attention
-      onClickFromContext(entry, i, e);
-    };
+
     return (
       <Layer
         ref={(ref: SVGGElement) => {
@@ -264,9 +253,12 @@ function PieSectors(props: PieSectorsProps) {
         tabIndex={-1}
         className="recharts-pie-sector"
         {...adaptEventsOfChild(restOfAllOtherProps, entry, i)}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        onClick={onClick}
+        // @ts-expect-error the types need a bit of attention
+        onMouseEnter={onMouseEnterFromContext(entry, i)}
+        // @ts-expect-error the types need a bit of attention
+        onMouseLeave={onMouseLeaveFromContext(entry, i)}
+        // @ts-expect-error the types need a bit of attention
+        onClick={onClickFromContext(entry, i)}
         // eslint-disable-next-line react/no-array-index-key
         key={`sector-${entry?.startAngle}-${entry?.endAngle}-${entry.midAngle}-${i}`}
       >

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -84,18 +84,12 @@ function RadialBarSectors(props: RadialBarSectorsProps) {
     <>
       {sectors.map((entry, i) => {
         const isActive = isTooltipActive && activeShape && i === activeIndex;
-        const onMouseEnter = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-          // @ts-expect-error the types need a bit of attention
-          onMouseEnterFromContext(entry, i, e);
-        };
-        const onMouseLeave = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-          // @ts-expect-error the types need a bit of attention
-          onMouseLeaveFromContext(entry, i, e);
-        };
-        const onClick = (e: React.MouseEvent<SVGPathElement, MouseEvent>) => {
-          // @ts-expect-error the types need a bit of attention
-          onClickFromContext(entry, i, e);
-        };
+        // @ts-expect-error the types need a bit of attention
+        const onMouseEnter = onMouseEnterFromContext(entry, i);
+        // @ts-expect-error the types need a bit of attention
+        const onMouseLeave = onMouseLeaveFromContext(entry, i);
+        // @ts-expect-error the types need a bit of attention
+        const onClick = onClickFromContext(entry, i);
 
         const radialBarSectorProps: RadialBarSectorProps = {
           ...baseProps,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`useMouseEnterItemDispatch`,  `useMouseLeaveItemDispatch`  and `useMouseClickItemDispatch`
return function that gets `entry` and `index` and returns a dom event callback function to make the API
simpler and fewer function definitions. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

working on a boxplot and noted that tooltip event dispatchers could be made simpler

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
