### PR TITLE
Graphical items report if they are in panorama our outside

### DIFF
--- a/src/context/CartesianGraphicalItemContext.tsx
+++ b/src/context/CartesianGraphicalItemContext.tsx
@@ -6,6 +6,7 @@ import { AxisId } from '../state/axisMapSlice';
 import { DataKey } from '../util/types';
 import { StackId } from '../util/ChartUtils';
 import { ErrorBarDataPointFormatter } from '../cartesian/ErrorBar';
+import { useIsPanorama } from './PanoramaContext';
 
 const noop = () => {};
 
@@ -83,6 +84,7 @@ export const CartesianGraphicalItemContext = ({
     },
     [updateErrorBars],
   );
+  const isPanorama = useIsPanorama();
   return (
     <ErrorBarDirectionDispatchContext.Provider value={{ addErrorBar, removeErrorBar }}>
       <SetCartesianGraphicalItem
@@ -96,6 +98,7 @@ export const CartesianGraphicalItemContext = ({
         stackId={stackId}
         hide={hide}
         barSize={barSize}
+        isPanorama={isPanorama}
       />
       {children}
     </ErrorBarDirectionDispatchContext.Provider>

--- a/src/state/graphicalItemsSlice.ts
+++ b/src/state/graphicalItemsSlice.ts
@@ -32,6 +32,11 @@ export type CartesianGraphicalItemType = 'area' | 'bar' | 'line' | 'scatter';
 
 export type CartesianGraphicalItemSettings = {
   type: CartesianGraphicalItemType;
+  /**
+   * Graphical items that are inside Brush panorama should not interact with the main area graphical items
+   * and vice versa.
+   */
+  isPanorama: boolean;
   data: ChartData;
   /**
    * Each of the graphical items explicitly says which axis it uses;

--- a/src/state/selectors/barSelectors.ts
+++ b/src/state/selectors/barSelectors.ts
@@ -38,6 +38,9 @@ const pickXAxisId = (_state: RechartsRootState, xAxisId: AxisId): AxisId => xAxi
 
 const pickYAxisId = (_state: RechartsRootState, _xAxisId: AxisId, yAxisId: AxisId): AxisId => yAxisId;
 
+const pickIsPanorama = (_state: RechartsRootState, _xAxisId: AxisId, _yAxisId: AxisId, isPanorama: boolean): boolean =>
+  isPanorama;
+
 const pickBarSettings = (
   _state: RechartsRootState,
   _xAxisId: AxisId,
@@ -69,9 +72,10 @@ export const selectAllVisibleBars: (
   state: RechartsRootState,
   xAxisId: AxisId,
   yAxisId: AxisId,
+  isPanorama: boolean,
 ) => ReadonlyArray<CartesianGraphicalItemSettings> = createSelector(
-  [selectChartLayout, selectUnfilteredCartesianItems, pickXAxisId, pickYAxisId],
-  (layout: LayoutType, allItems, xAxisId, yAxisId) =>
+  [selectChartLayout, selectUnfilteredCartesianItems, pickXAxisId, pickYAxisId, pickIsPanorama],
+  (layout: LayoutType, allItems, xAxisId, yAxisId, isPanorama) =>
     allItems
       .filter(i => {
         if (layout === 'horizontal') {
@@ -79,6 +83,7 @@ export const selectAllVisibleBars: (
         }
         return i.yAxisId === yAxisId;
       })
+      .filter(i => i.isPanorama === isPanorama)
       .filter(i => i.hide === false)
       .filter(i => i.type === 'bar'),
 );

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -456,6 +456,7 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
       );
       const expected: ReadonlyArray<CartesianGraphicalItemSettings> = [
         {
+          isPanorama: false,
           type: 'area',
           data: data2,
           dataKey: 'value',
@@ -495,6 +496,7 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
       );
       const expected: ReadonlyArray<CartesianGraphicalItemSettings> = [
         {
+          isPanorama: false,
           type: 'area',
           data: data2,
           dataKey: 'value',

--- a/test/cartesian/Bar.spec.tsx
+++ b/test/cartesian/Bar.spec.tsx
@@ -1177,6 +1177,7 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
       );
       const expected: ReadonlyArray<CartesianGraphicalItemSettings> = [
         {
+          isPanorama: false,
           type: 'bar',
           data: null,
           dataKey: 'value',
@@ -1215,6 +1216,7 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
       );
       const expected: ReadonlyArray<CartesianGraphicalItemSettings> = [
         {
+          isPanorama: false,
           type: 'bar',
           data: null,
           dataKey: 'value',

--- a/test/cartesian/Scatter.spec.tsx
+++ b/test/cartesian/Scatter.spec.tsx
@@ -168,6 +168,7 @@ describe('<Scatter />', () => {
       );
 
       const expected: CartesianGraphicalItemSettings = {
+        isPanorama: false,
         type: 'scatter',
         data,
         dataKey: 'cx',

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -20,6 +20,7 @@ import {
 import { selectUnfilteredCartesianItems } from '../../src/state/selectors/axisSelectors';
 import { pageData } from '../../storybook/stories/data';
 import { boxPlotData } from '../_data';
+import { CartesianGraphicalItemSettings } from '../../src/state/graphicalItemsSlice';
 
 type DataType = {
   name: string;
@@ -267,7 +268,7 @@ describe('<BarChart />', () => {
       const barSpy = vi.fn();
       const sizeListSpy = vi.fn();
       const Comp = (): null => {
-        barSpy(useAppSelector(state => selectAllVisibleBars(state, 0, 0)));
+        barSpy(useAppSelector(state => selectAllVisibleBars(state, 0, 0, false)));
         sizeListSpy(useAppSelector(state => selectBarSizeList(state, 0, 0, false, barSettings)));
         return null;
       };
@@ -278,20 +279,20 @@ describe('<BarChart />', () => {
         </BarChart>,
       );
 
-      expect(barSpy).toHaveBeenLastCalledWith([
-        {
-          barSize: undefined,
-          data: null,
-          dataKey: 'uv',
-          errorBars: [],
-          hide: false,
-          stackId: undefined,
-          type: 'bar',
-          xAxisId: 0,
-          yAxisId: 0,
-          zAxisId: 0,
-        },
-      ]);
+      const expectedBar: CartesianGraphicalItemSettings = {
+        isPanorama: false,
+        barSize: undefined,
+        data: null,
+        dataKey: 'uv',
+        errorBars: [],
+        hide: false,
+        stackId: undefined,
+        type: 'bar',
+        xAxisId: 0,
+        yAxisId: 0,
+        zAxisId: 0,
+      };
+      expect(barSpy).toHaveBeenLastCalledWith([expectedBar]);
       expect(barSpy).toHaveBeenCalledTimes(3);
 
       expect(sizeListSpy).toHaveBeenLastCalledWith([
@@ -923,8 +924,8 @@ describe('<BarChart />', () => {
 
         const Comp = (): null => {
           allCartesianGraphicalItemsSpy(useAppSelector(selectUnfilteredCartesianItems));
-          axisOneBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 'one', 0)));
-          axisTwoBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 'two', 0)));
+          axisOneBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 'one', 0, false)));
+          axisTwoBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 'two', 0, false)));
           return null;
         };
 
@@ -940,8 +941,9 @@ describe('<BarChart />', () => {
           </BarChart>,
         );
 
-        expect(allCartesianGraphicalItemsSpy).toHaveBeenLastCalledWith([
+        const expectedItems: ReadonlyArray<CartesianGraphicalItemSettings> = [
           {
+            isPanorama: false,
             barSize: 50,
             data: null,
             dataKey: 'uv',
@@ -954,6 +956,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
           {
+            isPanorama: false,
             barSize: 30,
             data: null,
             dataKey: 'pv',
@@ -965,11 +968,13 @@ describe('<BarChart />', () => {
             yAxisId: 0,
             zAxisId: 0,
           },
-        ]);
+        ];
+        expect(allCartesianGraphicalItemsSpy).toHaveBeenLastCalledWith(expectedItems);
         expect(allCartesianGraphicalItemsSpy).toHaveBeenCalledTimes(3);
 
         expect(axisOneBarsSpy).toHaveBeenLastCalledWith([
           {
+            isPanorama: false,
             barSize: 50,
             data: null,
             dataKey: 'uv',
@@ -985,6 +990,7 @@ describe('<BarChart />', () => {
         expect(axisOneBarsSpy).toHaveBeenCalledTimes(3);
         expect(axisTwoBarsSpy).toHaveBeenLastCalledWith([
           {
+            isPanorama: false,
             barSize: 30,
             data: null,
             dataKey: 'pv',
@@ -1097,8 +1103,8 @@ describe('<BarChart />', () => {
 
         const Comp = (): null => {
           allCartesianGraphicalItemsSpy(useAppSelector(selectUnfilteredCartesianItems));
-          axisLeftBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 0, 'left')));
-          axisRightBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 0, 'right')));
+          axisLeftBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 0, 'left', false)));
+          axisRightBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 0, 'right', false)));
           barSizeListLeftSpy(useAppSelector(state => selectBarSizeList(state, 0, 'left', false, leftBarSettings)));
           barSizeListRightSpy(useAppSelector(state => selectBarSizeList(state, 0, 'right', false, rightBarSettings)));
           barPositionsLeftSpy(useAppSelector(state => selectAllBarPositions(state, 0, 'left', false, leftBarSettings)));
@@ -1119,8 +1125,9 @@ describe('<BarChart />', () => {
           </BarChart>,
         );
 
-        expect(allCartesianGraphicalItemsSpy).toHaveBeenLastCalledWith([
+        const expectedItems: ReadonlyArray<CartesianGraphicalItemSettings> = [
           {
+            isPanorama: false,
             barSize: undefined,
             data: null,
             dataKey: 'pv',
@@ -1133,6 +1140,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
           {
+            isPanorama: false,
             barSize: undefined,
             data: null,
             dataKey: 'uv',
@@ -1144,11 +1152,13 @@ describe('<BarChart />', () => {
             yAxisId: 'right',
             zAxisId: 0,
           },
-        ]);
+        ];
+        expect(allCartesianGraphicalItemsSpy).toHaveBeenLastCalledWith(expectedItems);
         expect(allCartesianGraphicalItemsSpy).toHaveBeenCalledTimes(3);
 
         expect(axisLeftBarsSpy).toHaveBeenLastCalledWith([
           {
+            isPanorama: false,
             barSize: undefined,
             data: null,
             dataKey: 'pv',
@@ -1161,6 +1171,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
           {
+            isPanorama: false,
             barSize: undefined,
             data: null,
             dataKey: 'uv',
@@ -1177,6 +1188,7 @@ describe('<BarChart />', () => {
 
         expect(axisRightBarsSpy).toHaveBeenLastCalledWith([
           {
+            isPanorama: false,
             barSize: undefined,
             data: null,
             dataKey: 'pv',
@@ -1189,6 +1201,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
           {
+            isPanorama: false,
             barSize: undefined,
             data: null,
             dataKey: 'uv',
@@ -1351,8 +1364,8 @@ describe('<BarChart />', () => {
 
         const Comp = (): null => {
           allCartesianGraphicalItemsSpy(useAppSelector(selectUnfilteredCartesianItems));
-          axisOneBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 'one', 0)));
-          axisTwoBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 'two', 0)));
+          axisOneBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 'one', 0, false)));
+          axisTwoBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 'two', 0, false)));
           return null;
         };
 
@@ -1367,8 +1380,9 @@ describe('<BarChart />', () => {
           </BarChart>,
         );
 
-        expect(allCartesianGraphicalItemsSpy).toHaveBeenLastCalledWith([
+        const expectedItems: ReadonlyArray<CartesianGraphicalItemSettings> = [
           {
+            isPanorama: false,
             barSize: 40,
             data: null,
             dataKey: 'uv',
@@ -1381,6 +1395,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
           {
+            isPanorama: false,
             barSize: 30,
             data: null,
             dataKey: 'pv',
@@ -1392,11 +1407,13 @@ describe('<BarChart />', () => {
             yAxisId: 0,
             zAxisId: 0,
           },
-        ]);
+        ];
+        expect(allCartesianGraphicalItemsSpy).toHaveBeenLastCalledWith(expectedItems);
         expect(allCartesianGraphicalItemsSpy).toHaveBeenCalledTimes(3);
 
         expect(axisOneBarsSpy).toHaveBeenLastCalledWith([
           {
+            isPanorama: false,
             barSize: 40,
             data: null,
             dataKey: 'uv',
@@ -1409,6 +1426,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
           {
+            isPanorama: false,
             barSize: 30,
             data: null,
             dataKey: 'pv',
@@ -1425,6 +1443,7 @@ describe('<BarChart />', () => {
 
         expect(axisTwoBarsSpy).toHaveBeenLastCalledWith([
           {
+            isPanorama: false,
             barSize: 40,
             data: null,
             dataKey: 'uv',
@@ -1437,6 +1456,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
           {
+            isPanorama: false,
             barSize: 30,
             data: null,
             dataKey: 'pv',
@@ -1549,8 +1569,8 @@ describe('<BarChart />', () => {
 
         const Comp = (): null => {
           allCartesianGraphicalItemsSpy(useAppSelector(selectUnfilteredCartesianItems));
-          axisLeftBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 0, 'left')));
-          axisRightBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 0, 'right')));
+          axisLeftBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 0, 'left', false)));
+          axisRightBarsSpy(useAppSelector(state => selectAllVisibleBars(state, 0, 'right', false)));
           barSizeListLeftSpy(useAppSelector(state => selectBarSizeList(state, 0, 'left', false, leftBarSettings)));
           barSizeListRightSpy(useAppSelector(state => selectBarSizeList(state, 0, 'right', false, rightBarSettings)));
           barPositionsLeftSpy(useAppSelector(state => selectAllBarPositions(state, 0, 'left', false, leftBarSettings)));
@@ -1571,8 +1591,9 @@ describe('<BarChart />', () => {
           </BarChart>,
         );
 
-        expect(allCartesianGraphicalItemsSpy).toHaveBeenLastCalledWith([
+        const expectedItems: ReadonlyArray<CartesianGraphicalItemSettings> = [
           {
+            isPanorama: false,
             barSize: 30,
             data: null,
             dataKey: 'uv',
@@ -1585,6 +1606,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
           {
+            isPanorama: false,
             barSize: 20,
             data: null,
             dataKey: 'pv',
@@ -1596,11 +1618,13 @@ describe('<BarChart />', () => {
             yAxisId: 'right',
             zAxisId: 0,
           },
-        ]);
+        ];
+        expect(allCartesianGraphicalItemsSpy).toHaveBeenLastCalledWith(expectedItems);
         expect(allCartesianGraphicalItemsSpy).toHaveBeenCalledTimes(3);
 
         expect(axisLeftBarsSpy).toHaveBeenLastCalledWith([
           {
+            isPanorama: false,
             barSize: 30,
             data: null,
             dataKey: 'uv',
@@ -1617,6 +1641,7 @@ describe('<BarChart />', () => {
 
         expect(axisRightBarsSpy).toHaveBeenLastCalledWith([
           {
+            isPanorama: false,
             barSize: 20,
             data: null,
             dataKey: 'pv',
@@ -1742,8 +1767,7 @@ describe('<BarChart />', () => {
       });
     });
 
-    // this test requires that all graphical items report if they are in the brush panorama or outside; I will fix in separate PR.
-    test.fails('renders bars in Brush panorama', () => {
+    test('renders bars in Brush panorama', () => {
       const barPositionsSpy = vi.fn();
 
       const barSettings: BarSettings = {
@@ -1777,13 +1801,13 @@ describe('<BarChart />', () => {
         {
           dataKeys: ['uv'],
           position: {
-            offset: 32.785714285714285,
+            offset: 56.285714285714285,
             size: 0,
           },
           stackId: undefined,
         },
       ]);
-      expect(barPositionsSpy).toHaveBeenCalledTimes(2);
+      expect(barPositionsSpy).toHaveBeenCalledTimes(3);
 
       expectBars(container, [
         {

--- a/test/state/graphicalItemsSlice.spec.ts
+++ b/test/state/graphicalItemsSlice.spec.ts
@@ -13,6 +13,7 @@ describe('graphicalItemsSlice', () => {
     expect(store.getState().graphicalItems.cartesianItems).toHaveLength(0);
 
     const item: CartesianGraphicalItemSettings = {
+      isPanorama: false,
       type: 'bar',
       stackId: undefined,
       errorBars: undefined,

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -1616,6 +1616,7 @@ describe('selectCartesianGraphicalItemsData', () => {
   it('should be stable', () => {
     const store = createRechartsStore();
     const settings: CartesianGraphicalItemSettings = {
+      isPanorama: false,
       type: 'bar',
       hide: false,
       stackId: 's-id',
@@ -2751,6 +2752,7 @@ describe('selectErrorBarsSettings', () => {
   it('should be stable with data', () => {
     const store = createRechartsStore();
     const settings: CartesianGraphicalItemSettings = {
+      isPanorama: false,
       barSize: undefined,
       type: 'bar',
       hide: false,


### PR DESCRIPTION
## Description

Usually graphical elements render the same regardless of panorama or not, but Bar and barSizeList means that each new bar will collide with all other bars. So we need to know if it's in panorama or not so that main area does not squish panorama bars and vice versa.

## Related Issue

Followup from https://github.com/recharts/recharts/pull/4927 where I broke this thing and now I am fixing it.

Also https://github.com/recharts/recharts/issues/4583