### PR TITLE
docs(Pie): add storybook Pie entry with different stroke/fill cells

### DIFF
--- a/storybook/stories/Examples/Pie/PieWithCells.stories.tsx
+++ b/storybook/stories/Examples/Pie/PieWithCells.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Args } from '@storybook/react';
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from '../../../../src';
+
+const data = [
+  { value: 'Luck', percent: 10, color: 'orange' },
+  { value: 'Skill', percent: 20, color: 'green' },
+  { value: 'Concentrated power of will', percent: 15, color: 'blue' },
+  { value: 'Pleasure', percent: 50, color: 'red' },
+  { value: 'Pain', percent: 50, color: 'indigo' },
+  { value: 'Reason to remember the name', percent: 100, color: 'violet' },
+];
+
+export default {
+  component: Pie,
+};
+
+export const PieWithCells = {
+  render: (args: Args) => {
+    return (
+      <ResponsiveContainer width="100%" height={500}>
+        <PieChart width={400} height={400}>
+          <Pie dataKey="percent" {...args}>
+            {data.map(d => (
+              <Cell key={`d-${d.value}`} fill={d.color} stroke="black" />
+            ))}
+          </Pie>
+          <Legend />
+          <Tooltip />
+        </PieChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    cx: '50%',
+    cy: '50%',
+    data,
+    dataKey: 'percent',
+    nameKey: 'value',
+    fill: '#8884d8',
+    label: true,
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Adding a new storybook story that accounts for cell styling with fill/stroke

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Me failing to finish refactoring Pie


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To prevent visual diff

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran locally

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/bd332637-8e1a-4608-bba5-929e4a8324e8)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
