### PR TITLE
fix(axis-types): X and YAxis components now use adapted event types (2.x)

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -1,12 +1,11 @@
 /**
  * @fileOverview X Axis
  */
-import type { SVGProps } from 'react';
 import React from 'react';
 import clsx from 'clsx';
 import { useChartHeight, useChartWidth, useXAxisOrThrow } from '../context/chartLayoutContext';
 import { CartesianAxis } from './CartesianAxis';
-import { BaseAxisProps, AxisInterval } from '../util/types';
+import { BaseAxisProps, AxisInterval, PresentationAttributesAdaptChildEvent } from '../util/types';
 import { getTicksOfAxis } from '../util/ChartUtils';
 
 /** Define of XAxis props */
@@ -34,7 +33,7 @@ interface XAxisProps extends BaseAxisProps {
   tickMargin?: number;
 }
 
-export type Props = Omit<SVGProps<SVGElement>, 'scale'> & XAxisProps;
+export type Props = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>, 'scale'> & XAxisProps;
 
 function XAxisImpl({ xAxisId }: Props) {
   const width = useChartWidth();

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -2,9 +2,8 @@
  * @fileOverview Y Axis
  */
 import React from 'react';
-import type { SVGProps } from 'react';
 import clsx from 'clsx';
-import { BaseAxisProps, AxisInterval } from '../util/types';
+import { BaseAxisProps, AxisInterval, PresentationAttributesAdaptChildEvent } from '../util/types';
 import { useChartHeight, useChartWidth, useYAxisOrThrow } from '../context/chartLayoutContext';
 import { CartesianAxis } from './CartesianAxis';
 import { getTicksOfAxis } from '../util/ChartUtils';
@@ -34,7 +33,7 @@ interface YAxisProps extends BaseAxisProps {
   tickMargin?: number;
 }
 
-export type Props = Omit<SVGProps<SVGElement>, 'scale'> & YAxisProps;
+export type Props = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>, 'scale'> & YAxisProps;
 
 const YAxisImpl = ({ yAxisId }: Props) => {
   const width = useChartWidth();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix event types for x and y axis in master

I'll follow up to check for 3.x

Technically this change is breaking, but its fixing a type that has been wrong for a long time. I think an acceptable "fixing" change in 2.x

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4959

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- Types were wrong

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manual testing only (sorry)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
