### PR TITLE
fix(axis-types): X and YAxis components now use adapted event types

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -1,11 +1,10 @@
 /**
  * @fileOverview X Axis
  */
-import type { SVGProps } from 'react';
 import React, { Component, useEffect } from 'react';
 import clsx from 'clsx';
 import { CartesianAxis } from './CartesianAxis';
-import { AxisInterval, AxisTick, BaseAxisProps } from '../util/types';
+import { AxisInterval, AxisTick, BaseAxisProps, PresentationAttributesAdaptChildEvent } from '../util/types';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { addXAxis, removeXAxis, XAxisOrientation, XAxisPadding, XAxisSettings } from '../state/cartesianAxisSlice';
 import {
@@ -39,7 +38,7 @@ interface XAxisProps extends BaseAxisProps {
   tickMargin?: number;
 }
 
-export type Props = Omit<SVGProps<SVGLineElement>, 'scale'> & XAxisProps;
+export type Props = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>, 'scale'> & XAxisProps;
 
 function SetXAxisSettings(settings: XAxisSettings): null {
   const dispatch = useAppDispatch();

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -1,6 +1,6 @@
-import React, { Component, FunctionComponent, SVGProps, useEffect } from 'react';
+import React, { Component, FunctionComponent, useEffect } from 'react';
 import clsx from 'clsx';
-import { AxisInterval, AxisTick, BaseAxisProps } from '../util/types';
+import { AxisInterval, AxisTick, BaseAxisProps, PresentationAttributesAdaptChildEvent } from '../util/types';
 import { CartesianAxis } from './CartesianAxis';
 import { addYAxis, removeYAxis, YAxisOrientation, YAxisPadding, YAxisSettings } from '../state/cartesianAxisSlice';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
@@ -35,7 +35,7 @@ interface YAxisProps extends BaseAxisProps {
   angle?: number;
 }
 
-export type Props = Omit<SVGProps<SVGElement>, 'scale'> & YAxisProps;
+export type Props = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>, 'scale'> & YAxisProps;
 
 function SetYAxisSettings(settings: YAxisSettings): null {
   const dispatch = useAppDispatch();

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, test, vi } from 'vitest';
 import { timeFormat } from 'd3-time-format';
 import { scaleTime } from 'victory-vendor/d3-scale';
@@ -126,6 +126,35 @@ describe('<XAxis />', () => {
       },
     ]);
     expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+  });
+
+  it('Should pass data, index, and event to the onClick event handler', () => {
+    const onClickFn = vi.fn();
+    const { container } = render(
+      <LineChart width={400} height={400} data={lineData}>
+        <XAxis ticks={[0, 4]} onClick={onClickFn} />
+        <Line type="monotone" dataKey="uv" stroke="#ff7300" />
+      </LineChart>,
+    );
+
+    const ticksGroup = container.getElementsByClassName('recharts-cartesian-axis-tick');
+    expect(ticksGroup).toHaveLength(2);
+
+    const firstTick = ticksGroup[0];
+
+    const eventData = {
+      coordinate: 5,
+      isShow: true,
+      offset: 0,
+      tickCoord: 5,
+      value: 0,
+    };
+    const eventIndex = 0;
+    const eventExpect = expect.objectContaining({ type: 'click', pageX: 0, pageY: 0, target: expect.any(Object) });
+
+    // click
+    fireEvent.click(firstTick);
+    expect(onClickFn).toHaveBeenCalledWith(eventData, eventIndex, eventExpect);
   });
 
   it('Render ticks with tickFormatter', () => {

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { describe, test, it, expect, vi } from 'vitest';
 import {
   AreaChart,
@@ -543,6 +543,36 @@ describe('<YAxis />', () => {
         y: '5',
       },
     ]);
+  });
+
+  it('Should pass data, index, and event to the onClick event handler', () => {
+    const onClickFn = vi.fn();
+    const { container } = render(
+      <AreaChart width={600} height={400} data={data}>
+        <YAxis type="number" stroke="#ff7300" ticks={[0, 400, 800, 1200]} onClick={onClickFn} />
+        <Area dataKey="uv" stroke="#ff7300" fill="#ff7300" />
+      </AreaChart>,
+    );
+    const ticksGroup = container.getElementsByClassName('recharts-cartesian-axis-tick');
+    expect(ticksGroup).toHaveLength(4);
+
+    const firstTick = ticksGroup[0];
+
+    const eventData = {
+      coordinate: 395,
+      isShow: true,
+      offset: 0,
+      tickCoord: 395,
+      value: 0,
+    };
+    const eventIndex = 0;
+    const eventExpect = expect.objectContaining({ type: 'click', pageX: 0, pageY: 0, target: expect.any(Object) });
+
+    // click
+    fireEvent.click(firstTick);
+    expect(onClickFn).toHaveBeenCalledWith(eventData, eventIndex, eventExpect);
+
+    // onMouseEnter/onMouseLeave cause vitest to exit unexpectedly, why?
   });
 
   it('Renders axis based on specified domain when data overflow is allowed', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Same as https://github.com/recharts/recharts/pull/4967 but for 3.x

- added unit test (for 1 event)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4959

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
the types were quite wrong

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- onClick unit test for both axes

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
