### PR TITLE
fix: make AxisDomainItem tuple type readonly

### DIFF
--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1097,7 +1097,7 @@ export type AxisDomainItem = string | number | ((d: number) => string | number) 
 export type AxisDomain =
   | ReadonlyArray<string>
   | ReadonlyArray<number>
-  | [AxisDomainItem, AxisDomainItem]
+  | Readonly<[AxisDomainItem, AxisDomainItem]>
   | (([dataMin, dataMax]: [number, number], allowDataOverflow: boolean) => [number, number]);
 
 /**

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -2314,10 +2314,11 @@ describe('<XAxis />', () => {
         });
 
         it('should render ticks from number, auto', () => {
+          const domain = [-55, 'auto'] as const;
           const spy = vi.fn();
           const { container } = render(
             <Component>
-              <XAxis dataKey="x" type="number" domain={[-55, 'auto']} allowDataOverflow={allowDataOverflow} />
+              <XAxis dataKey="x" type="number" domain={domain} allowDataOverflow={allowDataOverflow} />
               <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
             </Component>,
           );

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -445,9 +445,10 @@ describe('<YAxis />', () => {
   });
 
   it('Renders evenly distributed ticks when domain={[0, 1000]} and dataKey is "noExist", and allowDataOverflow', () => {
+    const domain = [0, 1000] as const;
     const { container } = render(
       <AreaChart width={600} height={400} data={data}>
-        <YAxis stroke="#ff7300" domain={[0, 1000]} allowDataOverflow />
+        <YAxis stroke="#ff7300" domain={domain} allowDataOverflow />
         <Area dataKey="noExist" stroke="#ff7300" fill="#ff7300" />
       </AreaChart>,
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
fix https://github.com/recharts/recharts/issues/4937

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/recharts/recharts/issues/4937

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- add as const to some types in axis tests. Failing before, working now

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
