### PR TITLE
fix(types): return JSX in a function instead of a class component

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1097,7 +1097,7 @@ export const generateCategoricalChart = ({
     };
   };
 
-  return class CategoricalChartWrapper extends Component<CategoricalChartProps, CategoricalChartState> {
+  class CategoricalChartWrapper extends Component<CategoricalChartProps, CategoricalChartState> {
     static displayName = chartName;
 
     readonly eventEmitterSymbol: Symbol = Symbol('rechartsEventEmitter');
@@ -2355,5 +2355,9 @@ export const generateCategoricalChart = ({
         </ChartLayoutContextProvider>
       );
     }
+  }
+
+  return function CategoricalChart(props: CategoricalChartProps) {
+    return <CategoricalChartWrapper {...props} />;
   };
 };


### PR DESCRIPTION
… so generator type can be inferred correctly

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
In 3.x we return a function component from the generator function which results in the return type being `React.JSX`. In 2.x we return a class component which has a complex return type that R19 does not like. Affects all generator charts
`PieChart cannot be used as a JSX component...`, etc.

This change does nothing but return the generator class wrapped in another function, just like 3.x but without any of the additional work of 3.x


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4558#issuecomment-2330578162

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- 2.x is usable when R19 comes out before 3.x

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- pre-change get errror in code with R19
- post change error is resolved in code with R19
- tests pass

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
