### PR TITLE
fix: remove absolute positioning when Tooltip portal prop is passed by the user

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -207,6 +207,7 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
       wrapperStyle={wrapperStyle}
       lastBoundingBox={lastBoundingBox}
       innerRef={updateBoundingBox}
+      hasPortalFromProps={Boolean(portalFromProps)}
     >
       {renderContent(content, {
         ...props,

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -20,6 +20,7 @@ export type TooltipBoundingBoxProps = {
   wrapperStyle: CSSProperties;
   lastBoundingBox: BoundingBox;
   innerRef: SetBoundingBox;
+  hasPortalFromProps: boolean;
 };
 
 type State = {
@@ -84,6 +85,7 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
       wrapperStyle,
       lastBoundingBox,
       innerRef,
+      hasPortalFromProps,
     } = this.props;
 
     const { cssClasses, cssProperties } = getTooltipTranslate({
@@ -100,14 +102,22 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
       viewBox,
     });
 
+    // only
+    const positionStyles: CSSProperties = hasPortalFromProps
+      ? {}
+      : {
+          transition: isAnimationActive && active ? `transform ${animationDuration}ms ${animationEasing}` : undefined,
+          ...cssProperties,
+          pointerEvents: 'none',
+          visibility: !this.state.dismissed && active && hasPayload ? 'visible' : 'hidden',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+        };
+
     const outerStyle: CSSProperties = {
-      transition: isAnimationActive && active ? `transform ${animationDuration}ms ${animationEasing}` : undefined,
-      ...cssProperties,
-      pointerEvents: 'none',
+      ...positionStyles,
       visibility: !this.state.dismissed && active && hasPayload ? 'visible' : 'hidden',
-      position: 'absolute',
-      top: 0,
-      left: 0,
       ...wrapperStyle,
     };
 

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -102,7 +102,7 @@ export class TooltipBoundingBox extends PureComponent<TooltipBoundingBoxProps, S
       viewBox,
     });
 
-    // only
+    // do not use absolute styles if the user has passed a custom portal prop
     const positionStyles: CSSProperties = hasPortalFromProps
       ? {}
       : {

--- a/storybook/stories/Examples/Tooltip.stories.tsx
+++ b/storybook/stories/Examples/Tooltip.stories.tsx
@@ -379,7 +379,7 @@ export const TooltipWithPortal = {
           <LineChart data={pageData}>
             <Line dataKey="uv" fill="green" />
             <Line dataKey="pv" fill="red" />
-            {portalRef && <Tooltip {...args} portal={portalRef} />}
+            {portalRef && <Tooltip {...args} portal={portalRef} wrapperStyle={{ width: '25%', marginLeft: 10 }} />}
           </LineChart>
         </ResponsiveContainer>
         <div
@@ -390,6 +390,10 @@ export const TooltipWithPortal = {
           }}
         >
           <p>Inspect the resulting HTML to see that the Tooltip element is rendered according to the portal ref.</p>
+          <p>
+            You now control the container the Tooltip renders in, as well as style attributes such as width, height,
+            etc. Those can be managed via the Tooltip wrapperStyle prop.
+          </p>
           {/* The Tooltip will render here */}
         </div>
       </>

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -432,6 +432,44 @@ describe('Tooltip visibility', () => {
           container.querySelector('[data-testid="my-custom-portal-target"] > .recharts-tooltip-wrapper'),
         ).toBeVisible();
       });
+
+      it('should keep custom portal visible when active is true after mouseOut, should no longer have absolute styles', () => {
+        function Example() {
+          const [portalRef, setPortalRef] = useState<HTMLElement | null>(null);
+
+          return (
+            <>
+              <Wrapper>
+                <Tooltip portal={portalRef} active />
+              </Wrapper>
+              <div
+                data-testid="my-custom-portal-target"
+                ref={node => {
+                  if (portalRef == null && node != null) {
+                    setPortalRef(node);
+                  }
+                }}
+              />
+            </>
+          );
+        }
+        const { container } = render(<Example />);
+        showTooltip(container, mouseHoverSelector);
+
+        const tooltipWrapper = container.querySelector('.recharts-tooltip-wrapper');
+
+        expect(tooltipWrapper).toHaveStyle({ visibility: 'visible' });
+        expect(tooltipWrapper).not.toHaveStyle({ postition: 'absolute' });
+
+        fireEvent.mouseLeave(container, mouseHoverSelector);
+
+        expect(tooltipWrapper).toHaveStyle({ visibility: 'visible' });
+        expect(tooltipWrapper).not.toHaveStyle({ postition: 'absolute' });
+
+        expect(
+          container.querySelector('[data-testid="my-custom-portal-target"] > .recharts-tooltip-wrapper'),
+        ).toBeVisible();
+      });
     });
 
     describe('active prop', () => {

--- a/test/component/TooltipBoundingBox.spec.tsx
+++ b/test/component/TooltipBoundingBox.spec.tsx
@@ -28,6 +28,7 @@ describe('TooltipBoundingBox', () => {
     useTranslate3d: false,
     viewBox: {},
     wrapperStyle: {},
+    hasPortalFromProps: false,
   };
   it('should render children when active prop is true', () => {
     render(<TooltipBoundingBox {...defaultProps} />);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- remove absolute positioning from tooltip portal when provided by the user

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Follow up to https://github.com/recharts/recharts/issues/2458

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
the user doesn't have to fight with overriding absolute styling

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- additional tests
- storybook entry/adjustment

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/e074f6e0-f315-4d04-b3fd-767fc0f12379



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
