### PR TITLE
Feat: add cutoff link option for sankey chart

### DIFF
--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -95,6 +95,7 @@ const getNodesTree = (
   { nodes, links }: SankeyData,
   width: number,
   nodeWidth: number,
+  allowCutoff: boolean,
 ): { tree: SankeyNode[]; maxDepth: number } => {
   const tree = nodes.map((entry: SankeyNode, index: number) => {
     const result = searchTargetsAndSources(links, index);
@@ -121,7 +122,7 @@ const getNodesTree = (
     for (let i = 0, len = tree.length; i < len; i++) {
       const node = tree[i];
 
-      if (!node.targetNodes.length) {
+      if (!node.targetNodes.length && !allowCutoff) {
         node.depth = maxDepth;
       }
       node.x = node.depth * childWidth;
@@ -279,6 +280,7 @@ const computeData = ({
   nodeWidth,
   nodePadding,
   sort,
+  allowCutoff,
 }: {
   data: SankeyData;
   width: number;
@@ -287,12 +289,13 @@ const computeData = ({
   nodeWidth: number;
   nodePadding: number;
   sort: boolean;
+  allowCutoff: boolean;
 }): {
   nodes: SankeyNode[];
   links: SankeyLink[];
 } => {
   const { links } = data;
-  const { tree } = getNodesTree(data, width, nodeWidth);
+  const { tree } = getNodesTree(data, width, nodeWidth, allowCutoff);
   const depthTree = getDepthTree(tree);
   const newLinks = updateYOfTree(depthTree, height, nodePadding, links);
 
@@ -421,6 +424,7 @@ interface SankeyProps {
   onMouseEnter?: (item: NodeProps | LinkProps, type: SankeyElementType, e: MouseEvent) => void;
   onMouseLeave?: (item: NodeProps | LinkProps, type: SankeyElementType, e: MouseEvent) => void;
   sort?: boolean;
+  allowCutoff?: boolean;
 }
 
 type Props = SVGProps<SVGElement> & SankeyProps;
@@ -747,6 +751,7 @@ export class Sankey extends PureComponent<Props, State> {
     iterations: 32,
     margin: { top: 5, right: 5, bottom: 5, left: 5 },
     sort: true,
+    allowCutoff: false,
   };
 
   state: State = {
@@ -758,7 +763,7 @@ export class Sankey extends PureComponent<Props, State> {
   };
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
-    const { data, width, height, margin, iterations, nodeWidth, nodePadding, sort } = nextProps;
+    const { data, width, height, margin, iterations, nodeWidth, nodePadding, sort, allowCutoff } = nextProps;
 
     if (
       data !== prevState.prevData ||
@@ -780,6 +785,7 @@ export class Sankey extends PureComponent<Props, State> {
         nodeWidth,
         nodePadding,
         sort,
+        allowCutoff,
       });
 
       return {

--- a/storybook/stories/API/chart/Sankey.stories.tsx
+++ b/storybook/stories/API/chart/Sankey.stories.tsx
@@ -18,6 +18,7 @@ export default {
     margin,
     data,
     sort: { description: 'Whether to sort the data or not' },
+    allowCutoff: { description: 'Allow the node to be cut off before the last depth' },
   },
   component: Sankey,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added an option for cutoff link for sankey chart. 
Default value of this option is false. So, if you don't turn this option on, you can use it as is.

## Description
Currently, if there is a link that is cut in the middle, it will be located at the last depth.
I would like to add an option that allows nodes to be positioned cut off in the middle rather than at the very end.

For more detail, please refer to the screenshot section below.
I updated storybook stories so you can check in storybook also.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
please check in storybook.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
|as-is|to-be|
|----|----|
|<image width=400 src="https://github.com/user-attachments/assets/ed3e8294-053b-4d5b-b3cc-d047943fe21b" />|<image width=400 src="https://github.com/user-attachments/assets/6636d7f4-c2c5-4dce-9cc1-688fdc9f036d" />





## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
