### PR TITLE
Separate Funnel types internal and external

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -49,6 +49,7 @@ export type BaseValue = number | 'dataMin' | 'dataMax';
  */
 interface InternalAreaProps {
   activeDot: ActiveDotType;
+  // TODO: this isn't used
   animateNewValues?: boolean;
   animationBegin: number;
   animationDuration: AnimationDuration;
@@ -95,6 +96,7 @@ interface InternalAreaProps {
  */
 interface AreaProps {
   activeDot?: ActiveDotType;
+  // TODO: this isn't used
   animateNewValues?: boolean;
   animationBegin?: number;
   animationDuration?: AnimationDuration;

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -39,6 +39,7 @@ import {
 } from '../context/tooltipContext';
 import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
+import { UpdateId } from '../context/chartLayoutContext';
 
 export interface FunnelTrapezoidItem extends TrapezoidProps {
   value?: number | string;
@@ -46,7 +47,12 @@ export interface FunnelTrapezoidItem extends TrapezoidProps {
   isActive: boolean;
 }
 
+/**
+ * Internal props, combination of external props + defaultProps + private Recharts state
+ */
 interface InternalFunnelProps {
+  animationId?: UpdateId;
+  trapezoids?: FunnelTrapezoidItem[];
   className?: string;
   dataKey: DataKey<any>;
   nameKey?: DataKey<any>;
@@ -58,26 +64,51 @@ interface InternalFunnelProps {
   tooltipType?: TooltipType;
   lastShapeType?: 'triangle' | 'rectangle';
   reversed?: boolean;
-
   onAnimationStart?: () => void;
   onAnimationEnd?: () => void;
-
   isAnimationActive?: boolean;
+  // TODO: this isn't used
   animateNewValues?: boolean;
   animationBegin?: number;
   animationDuration?: AnimationDuration;
   animationEasing?: AnimationTiming;
   id?: string;
-  trapezoids?: FunnelTrapezoidItem[];
-  animationId?: number;
 }
 
-export type FunnelProps = PresentationAttributesAdaptChildEvent<any, SVGElement> & TrapezoidProps & InternalFunnelProps;
+/**
+ * External props, intended for end users to fill in
+ */
+interface FunnelProps {
+  className?: string;
+  dataKey: DataKey<any>;
+  nameKey?: DataKey<any>;
+  data?: any[];
+  hide?: boolean;
+  shape?: ActiveShape<FunnelTrapezoidItem, SVGPathElement>;
+  activeShape?: ActiveShape<FunnelTrapezoidItem, SVGPathElement>;
+  legendType?: LegendType;
+  tooltipType?: TooltipType;
+  lastShapeType?: 'triangle' | 'rectangle';
+  reversed?: boolean;
+  onAnimationStart?: () => void;
+  onAnimationEnd?: () => void;
+  isAnimationActive?: boolean;
+  // TODO: this isn't used
+  animateNewValues?: boolean;
+  animationBegin?: number;
+  animationDuration?: AnimationDuration;
+  animationEasing?: AnimationTiming;
+  id?: string;
+}
+
+type FunnelSvgProps = PresentationAttributesAdaptChildEvent<any, SVGElement> & TrapezoidProps;
+
+export type Props = FunnelSvgProps & FunnelProps & InternalFunnelProps;
 
 interface State {
   readonly prevTrapezoids?: FunnelTrapezoidItem[];
   readonly curTrapezoids?: FunnelTrapezoidItem[];
-  readonly prevAnimationId?: number;
+  readonly prevAnimationId?: UpdateId;
   readonly isAnimationFinished?: boolean;
 }
 
@@ -92,10 +123,10 @@ type FunnelTrapezoidsProps = {
   trapezoids: FunnelTrapezoidItem[];
   shape: ActiveShape<FunnelTrapezoidItem, SVGPathElement>;
   activeShape: ActiveShape<FunnelTrapezoidItem, SVGPathElement>;
-  allOtherFunnelProps: FunnelProps;
+  allOtherFunnelProps: Props;
 };
 
-function getTooltipEntrySettings(props: FunnelProps): TooltipPayloadConfiguration {
+function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
   const { dataKey, nameKey, trapezoids, stroke, strokeWidth, fill, name, hide, tooltipType } = props;
   return {
     dataDefinedOnItem: trapezoids,
@@ -159,7 +190,7 @@ function FunnelTrapezoids(props: FunnelTrapezoidsProps) {
   });
 }
 
-export class Funnel extends PureComponent<FunnelProps, State> {
+export class Funnel extends PureComponent<Props, State> {
   static displayName = 'Funnel';
 
   static defaultProps = {
@@ -313,7 +344,7 @@ export class Funnel extends PureComponent<FunnelProps, State> {
 
   state: State = { isAnimationFinished: false };
 
-  static getDerivedStateFromProps(nextProps: FunnelProps, prevState: State): State {
+  static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
     if (nextProps.animationId !== prevState.prevAnimationId) {
       return {
         prevAnimationId: nextProps.animationId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export { ComposedChart } from './chart/ComposedChart';
 export { SunburstChart } from './chart/SunburstChart';
 
 export { Funnel } from './cartesian/Funnel';
-export type { FunnelProps } from './cartesian/Funnel';
+export type { Props as FunnelProps } from './cartesian/Funnel';
 export { FunnelChart } from './chart/FunnelChart';
 export { Trapezoid } from './shape/Trapezoid';
 export type { Props as TrapezoidProps } from './shape/Trapezoid';

--- a/src/util/FunnelUtils.tsx
+++ b/src/util/FunnelUtils.tsx
@@ -1,5 +1,5 @@
 import React, { SVGProps } from 'react';
-import { FunnelProps, FunnelTrapezoidItem } from '../cartesian/Funnel';
+import { Props as FunnelProps, FunnelTrapezoidItem } from '../cartesian/Funnel';
 import { Props as TrapezoidProps } from '../shape/Trapezoid';
 import { Shape, getPropsFromShapeOption } from './ActiveShapeUtils';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Small change getting Funnel ready to move to the current selector pattern. Separate internal and external types, allow them all to extend eachother temporarily until selector is in place, update references

* Since all our other components call their prop types "Props" I did the same here...its just less confusing for the patterns sake.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
move forwards

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run build, tests passing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
