### PR TITLE
refactor: remove unused animateNewValues

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -49,8 +49,6 @@ export type BaseValue = number | 'dataMin' | 'dataMax';
  */
 interface InternalAreaProps {
   activeDot: ActiveDotType;
-  // TODO: this isn't used
-  animateNewValues?: boolean;
   animationBegin: number;
   animationDuration: AnimationDuration;
   animationEasing: AnimationTiming;
@@ -96,8 +94,6 @@ interface InternalAreaProps {
  */
 interface AreaProps {
   activeDot?: ActiveDotType;
-  // TODO: this isn't used
-  animateNewValues?: boolean;
   animationBegin?: number;
   animationDuration?: AnimationDuration;
   animationEasing?: AnimationTiming;

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -67,8 +67,6 @@ interface InternalFunnelProps {
   onAnimationStart?: () => void;
   onAnimationEnd?: () => void;
   isAnimationActive?: boolean;
-  // TODO: this isn't used
-  animateNewValues?: boolean;
   animationBegin?: number;
   animationDuration?: AnimationDuration;
   animationEasing?: AnimationTiming;
@@ -93,8 +91,6 @@ interface FunnelProps {
   onAnimationStart?: () => void;
   onAnimationEnd?: () => void;
   isAnimationActive?: boolean;
-  // TODO: this isn't used
-  animateNewValues?: boolean;
   animationBegin?: number;
   animationDuration?: AnimationDuration;
   animationEasing?: AnimationTiming;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
these are not doing anything and are not referenced anywhere (in Funnel or Area or the generator), remove them

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- remove misleading props

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm test` , toggling this in storybook for no difference in anything

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
