### PR TITLE
fix: always update dataEndIndex unless they are equal/undefined

### DIFF
--- a/src/state/chartDataSlice.ts
+++ b/src/state/chartDataSlice.ts
@@ -48,7 +48,7 @@ const chartDataSlice = createSlice({
   reducers: {
     setChartData(state, action: PayloadAction<ChartData | undefined>) {
       state.chartData = action.payload;
-      if (state.dataEndIndex <= 0 && action.payload != null) {
+      if (action.payload != null && state.dataEndIndex !== action.payload.length - 1) {
         state.dataEndIndex = action.payload.length - 1;
       }
     },

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -1,5 +1,5 @@
-import React, { FC } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import React, { FC, useState } from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, MockInstance, test, vi } from 'vitest';
 import {
   Brush,
@@ -475,6 +475,41 @@ describe('<LineChart />', () => {
 
     const labels = container.querySelectorAll('.customized-label');
     expect(labels).toHaveLength(6);
+  });
+
+  test('Adds a tick and datapoint when adding values to data array in state', () => {
+    const Example = () => {
+      const [_data, setData] = useState(PageData);
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              setData(d => [...d, { name: 'Page X', uv: 23092, pv: 223, amt: 2322 }]);
+            }}
+          >
+            Click Me
+          </button>
+          <LineChart width={400} height={400} data={_data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+            <Line isAnimationActive={false} label dataKey="uv" stroke="#ff7300" />
+            <XAxis dataKey="name" />
+          </LineChart>
+        </>
+      );
+    };
+
+    const { container } = render(<Example />);
+
+    const labels = container.querySelectorAll('.recharts-label');
+    expect(labels).toHaveLength(6);
+
+    act(() => {
+      screen.getByText('Click Me').click();
+    });
+
+    expect(container.querySelectorAll('.recharts-label')).toHaveLength(7);
+
+    expect(screen.getByText('Page X')).toBeInTheDocument();
   });
 
   test('Renders 6 labels when label is a react element', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Right now in 3.x updating `data` via state causes nothing to happen (or some things, but not what we want). This is because dataEndIndex isn't being updated. 

Fix action logic to update the end index unless they are equal or there is no payload

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Didn't make one

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix bugs

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- see unit test
- tested in storybook (then removed that story)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
