### PR TITLE
fix(label): add dataKey to implicit label props

### DIFF
--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -7,7 +7,7 @@ import { Text } from './Text';
 import { findAllByType, filterProps } from '../util/ReactUtils';
 import { isNumOrStr, isNumber, isPercent, getPercentValue, uniqueId, mathSign } from '../util/DataUtils';
 import { polarToCartesian } from '../util/PolarUtils';
-import { ViewBox, PolarViewBox, CartesianViewBox } from '../util/types';
+import { ViewBox, PolarViewBox, CartesianViewBox, DataKey } from '../util/types';
 
 export type ContentType = ReactElement | ((props: Props) => ReactNode);
 
@@ -61,7 +61,8 @@ export type ImplicitLabelType =
   | number
   | ReactElement<SVGElement>
   | ((props: any) => ReactElement<SVGElement>)
-  | Props;
+  // dataKey is only applicable when label is used implicitly from graphical element props
+  | (Props & { dataKey?: DataKey<any> });
 
 const getLabel = (props: Props) => {
   const { value, formatter } = props;

--- a/storybook/stories/Examples/BarChart/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart/BarChart.stories.tsx
@@ -484,6 +484,42 @@ export const HasBackground = {
   },
 };
 
+export const HasLabelBasedOnSeparateDataKey = {
+  render: (args: Record<string, any>) => {
+    const dataWithLabel = pageData.map(({ name, uv, pv }) => ({
+      name,
+      uv,
+      pv,
+      label: uv > pv ? 'UV greater' : 'PV greater',
+    }));
+    return (
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart {...args} data={dataWithLabel}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Legend />
+          <Bar dataKey="pv" fill="#8884d8" label={{ dataKey: 'label', position: 'top', fill: '#111' }} />
+          <Bar dataKey="uv" fill="#82ca9d" />
+          <Tooltip />
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(BarChartProps),
+    width: 500,
+    height: 300,
+    data: pageData,
+    margin: {
+      top: 5,
+      right: 30,
+      left: 20,
+      bottom: 5,
+    },
+  },
+};
+
 const dataWithMultiXAxis = [
   {
     date: '2000-01',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Since the `label` prop is essentially the same thing as rendering a `LabelList` component, the implicit label props type is able to accept a `dataKey` prop and change labels based on that

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes https://github.com/recharts/recharts/issues/4805

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
People are using this feature 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have added a storybook story or extended an existing story to show my changes
