### PR TITLE
fix: tooltip defaultIndex can be out of range by 1

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1091,7 +1091,7 @@ export const generateCategoricalChart = ({
       const { defaultIndex } = tooltipElem.props;
 
       // Protect against runtime errors
-      if (typeof defaultIndex !== 'number' || defaultIndex < 0 || defaultIndex > this.state.tooltipTicks.length) {
+      if (typeof defaultIndex !== 'number' || defaultIndex < 0 || defaultIndex > this.state.tooltipTicks.length - 1) {
         return;
       }
 

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -638,6 +638,22 @@ describe('Tooltip visibility', () => {
         expect(tooltip).toBeInTheDocument();
         expect(tooltip).not.toBeVisible();
       });
+
+      it('should not fail when defaultIndex is data.length', context => {
+        if (name === 'FunnelChart') {
+          // FunnelChart throws an error when called with defaultIndex
+          context.skip();
+        }
+        const { container } = render(
+          <Wrapper>
+            <Tooltip defaultIndex={commonChartProps.data.length} />
+          </Wrapper>,
+        );
+
+        const tooltip = getTooltip(container);
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip).not.toBeVisible();
+      });
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Same as https://github.com/recharts/recharts/pull/5054 but 3.x

<!--- Describe your changes in detail -->
- when defaultIndex is set to data.length we get an out of bounds exception
- adjust the check to `tooltipTicks.length - 1` instead of just `.length` since defaultIndex is 0 based

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5050

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix bug in master

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- See unit test
- Manual test in storybook

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
