### PR TITLE
Preserve JSDoc Comments on 2.x

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "./build/",
     "declarationDir": "./types" /* Output directory for generated declaration files. */,
     "preserveConstEnums": true,
-    "removeComments": true,
+    "removeComments": false,
     "esModuleInterop": true,
     "sourceMap": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Description

By preserving comments, we enable better IDE integration and better documentation.

It’s worth noting that JSDocs type comments can be [automatically picked up by Storybook, too](https://storybook.js.org/docs/writing-docs).

## Related Issue

Redo of #5068 for the `2.x` branch.

## Motivation and Context

Currently, JSDoc comments are removed, which means that consumer have to use the online Docs to get more detailed information.

## How Has This Been Tested?

I’ve build the project locally and consumed it in my IDE of choice.

## Screenshots (if appropriate):

<img width="533" alt="ticks information on hover in IDE" src="https://github.com/user-attachments/assets/01b13b08-e4f5-409a-837d-865d05b2cb8e">

<img width="526" alt="domain scale information on hover in IDE" src="https://github.com/user-attachments/assets/5f41db72-6091-407f-834d-eb4ebec4c4e0">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
