### PR TITLE
Polar graphical elements now send their stack props to store

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -879,6 +879,9 @@ export class Pie extends PureComponent<Props, State> {
           hide={this.props.hide}
           angleAxisId={0}
           radiusAxisId={0}
+          stackId={undefined}
+          barSize={undefined}
+          type="pie"
         />
         <SetPiePayloadLegend {...this.props} />
         <PieImpl {...this.props} />

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -477,6 +477,9 @@ export class Radar extends PureComponent<Props> {
           hide={this.props.hide}
           angleAxisId={this.props.angleAxisId}
           radiusAxisId={this.props.radiusAxisId}
+          stackId={undefined}
+          barSize={undefined}
+          type="radar"
         />
         <SetRadarPayloadLegend {...this.props} />
         <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -129,6 +129,10 @@ interface InternalRadialBarProps {
   forceCornerRadius?: boolean;
   cornerIsExternal?: boolean;
   minPointSize?: number;
+  /**
+   * So in Bar, this can be a percent value - but that won't work in RadialBar. RadialBar: only numbers.
+   */
+  barSize?: number;
   maxBarSize?: number;
   data?: RadialBarDataItem[];
   legendType?: LegendType;
@@ -506,6 +510,9 @@ export class RadialBar extends PureComponent<RadialBarProps> {
           hide={this.props.hide}
           angleAxisId={this.props.angleAxisId}
           radiusAxisId={this.props.radiusAxisId}
+          stackId={this.props.stackId}
+          barSize={this.props.barSize}
+          type="radialBar"
         />
         <RadialBarImpl {...this.props} />
       </>

--- a/src/state/graphicalItemsSlice.ts
+++ b/src/state/graphicalItemsSlice.ts
@@ -5,6 +5,7 @@ import { AxisId } from './cartesianAxisSlice';
 import { DataKey } from '../util/types';
 import { ErrorBarDirection } from '../cartesian/ErrorBar';
 import { StackId } from '../util/ChartUtils';
+import { MaybeStackedGraphicalItem } from './selectors/barSelectors';
 
 /**
  * ErrorBars have lot more settings but all the others are scoped to the component itself.
@@ -29,8 +30,9 @@ export type ErrorBarsSettings = {
 };
 
 export type CartesianGraphicalItemType = 'area' | 'bar' | 'line' | 'scatter';
+export type PolarGraphicalItemType = 'pie' | 'radar' | 'radialBar';
 
-export interface GraphicalItemSettings {
+export interface GraphicalItemSettings extends MaybeStackedGraphicalItem {
   data: ChartData;
   dataKey: DataKey<any> | undefined;
   /**
@@ -70,6 +72,7 @@ export type CartesianGraphicalItemSettings = GraphicalItemSettings & {
 };
 
 export type PolarGraphicalItemSettings = GraphicalItemSettings & {
+  type: PolarGraphicalItemType;
   angleAxisId: AxisId;
   radiusAxisId: AxisId;
 };

--- a/src/state/selectors/barSelectors.ts
+++ b/src/state/selectors/barSelectors.ts
@@ -127,6 +127,16 @@ export const selectBarCartesianAxisSize = (state: RechartsRootState, xAxisId: Ax
   return selectCartesianAxisSize(state, 'yAxis', yAxisId);
 };
 
+/**
+ * Some graphical items allow data stacking. The stacks are optional,
+ * so all props here are optional too.
+ */
+export interface MaybeStackedGraphicalItem {
+  stackId: StackId | undefined;
+  dataKey: DataKey<any> | undefined;
+  barSize: number | string | undefined;
+}
+
 export const selectBarSizeList: (
   state: RechartsRootState,
   xAxisId: AxisId,
@@ -135,13 +145,13 @@ export const selectBarSizeList: (
   barSettings: BarSettings,
 ) => SizeList | undefined = createSelector(
   [selectAllVisibleBars, selectRootBarSize, selectBarCartesianAxisSize],
-  (allBars: ReadonlyArray<CartesianGraphicalItemSettings>, globalSize: number | undefined, totalSize) => {
-    const initialValue: Record<StackId, Array<CartesianGraphicalItemSettings>> = {};
+  (allBars: ReadonlyArray<MaybeStackedGraphicalItem>, globalSize: number | undefined, totalSize) => {
+    const initialValue: Record<StackId, Array<MaybeStackedGraphicalItem>> = {};
 
     const stackedBars = allBars.filter(b => b.stackId != null);
     const unstackedBars = allBars.filter(b => b.stackId == null);
 
-    const groupByStack: Record<StackId, Array<CartesianGraphicalItemSettings>> = stackedBars.reduce((acc, bar) => {
+    const groupByStack: Record<StackId, Array<MaybeStackedGraphicalItem>> = stackedBars.reduce((acc, bar) => {
       if (!acc[bar.stackId]) {
         acc[bar.stackId] = [];
       }

--- a/test/polar/PolarAngleAxis.spec.tsx
+++ b/test/polar/PolarAngleAxis.spec.tsx
@@ -92,6 +92,9 @@ describe('<PolarAngleAxis />', () => {
 
       expect(polarItemsSpy).toHaveBeenLastCalledWith([
         {
+          barSize: undefined,
+          stackId: undefined,
+          type: 'radar',
           angleAxisId: 0,
           data: undefined,
           dataKey: 'value',
@@ -919,6 +922,9 @@ describe('<PolarAngleAxis />', () => {
 
       expect(polarItemsSpy).toHaveBeenLastCalledWith([
         {
+          barSize: undefined,
+          stackId: undefined,
+          type: 'radialBar',
           angleAxisId: 0,
           data: undefined,
           dataKey: 'uv',

--- a/test/polar/Radar.spec.tsx
+++ b/test/polar/Radar.spec.tsx
@@ -134,6 +134,9 @@ describe('<Radar />', () => {
       );
 
       const expectedPolarItemsSettings: PolarGraphicalItemSettings = {
+        barSize: undefined,
+        stackId: undefined,
+        type: 'radar',
         angleAxisId: 0,
         data: undefined,
         dataKey: 'value',

--- a/test/polar/RadialBar.spec.tsx
+++ b/test/polar/RadialBar.spec.tsx
@@ -93,6 +93,9 @@ describe('<RadialBar />', () => {
       );
 
       const expectedPolarItemsSettings: PolarGraphicalItemSettings = {
+        barSize: undefined,
+        stackId: undefined,
+        type: 'radialBar',
         angleAxisId: 0,
         data: undefined,
         dataKey: 'value',


### PR DESCRIPTION
## Description

To write RadialBar selectors I need this information in Polar item store.

## Related Issue

https://github.com/recharts/recharts/issues/4583