### PR TITLE
feat(CartesianGrid): add support for ry prop

### DIFF
--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -131,23 +131,24 @@ interface CartesianGridProps extends InternalCartesianGridProps {
   yAxisId?: AxisId;
 }
 
-type AcceptedSvgProps = Omit<SVGProps<SVGElement>, 'offset'>;
+type AcceptedSvgProps = Omit<SVGProps<SVGRectElement>, 'offset'>;
 
 export type Props = AcceptedSvgProps & CartesianGridProps;
 
-const Background = (props: Pick<AcceptedSvgProps, 'fill' | 'fillOpacity' | 'x' | 'y' | 'width' | 'height'>) => {
+const Background = (props: Pick<AcceptedSvgProps, 'fill' | 'fillOpacity' | 'x' | 'y' | 'width' | 'height' | 'ry'>) => {
   const { fill } = props;
 
   if (!fill || fill === 'none') {
     return null;
   }
 
-  const { fillOpacity, x, y, width, height } = props;
+  const { fillOpacity, x, y, width, height, ry } = props;
 
   return (
     <rect
       x={x}
       y={y}
+      ry={ry}
       width={width}
       height={height}
       stroke="none"
@@ -490,6 +491,7 @@ export function CartesianGrid(props: Props) {
         y={propsIncludingDefaults.y}
         width={propsIncludingDefaults.width}
         height={propsIncludingDefaults.height}
+        ry={propsIncludingDefaults.ry}
       />
       <HorizontalGridLines
         {...propsIncludingDefaults}

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -345,6 +345,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             <CartesianGrid
               {...exampleCartesianGridDimensions}
               fill="green"
+              ry={10}
               verticalPoints={verticalPoints}
               horizontalPoints={horizontalPoints}
             />
@@ -355,6 +356,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
         expect.soft(background).toHaveAttribute('y', '2');
         expect.soft(background).toHaveAttribute('width', '300');
         expect.soft(background).toHaveAttribute('height', '200');
+        expect.soft(background).toHaveAttribute('ry', '10');
       });
 
       it('should put x, y, width and height as coordinates to all lines', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- add support for `ry` in `CartesianGrid` background for 3.x

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/recharts/recharts/issues/3062 doesn't entirely close it but easy enough to add

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

- easy property to add

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

assert that the prop makes it to the rect

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/9de1a25a-93e3-4716-898d-636f5c52260b)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
