### PR TITLE
Add more stories for RadialBarChart

### DIFF
--- a/storybook/stories/Examples/RadialBarChart.stories.tsx
+++ b/storybook/stories/Examples/RadialBarChart.stories.tsx
@@ -87,3 +87,187 @@ export const StackedRadialBar = {
     data: pageData,
   },
 };
+
+/**
+ * Three Rings for the Elven-kings under the sky,
+ * Seven for the Dwarf-lords in their halls of stone,
+ * Nine for Mortal Men doomed to die,
+ * One for the Dark Lord on his dark throne
+ * In the Land of Mordor where the Shadows lie.
+ * One Ring to rule them all, One Ring to find them,
+ * One Ring to bring them all and in the darkness bind them
+ * In the Land of Mordor where the Shadows lie.
+ *
+ * Lord of the Rings, J.R.R. Tolkien, 1954
+ */
+const ringsData = [
+  {
+    name: 'Elves',
+    rings: 3,
+    fill: 'green',
+  },
+  {
+    name: 'Dwarves',
+    rings: 7,
+    fill: 'blue',
+  },
+  {
+    name: 'Humans',
+    rings: 9,
+    fill: 'red',
+  },
+  {
+    name: 'Sauron',
+    rings: 1,
+    fill: 'black',
+  },
+];
+
+export const RingsWithImplicitAxes = {
+  render: (args: Record<string, any>) => {
+    return (
+      <RadialBarChart {...args}>
+        <RadialBar dataKey="rings" />
+        <Legend />
+        <PolarGrid gridType="circle" />
+        <Tooltip defaultIndex={0} />
+      </RadialBarChart>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(RadialBarChartProps),
+    width: 800,
+    height: 800,
+    data: ringsData,
+  },
+};
+
+export const RingsWithDefaultAxes = {
+  render: (args: Record<string, any>) => {
+    return (
+      <RadialBarChart {...args}>
+        <RadialBar dataKey="rings" />
+        <Legend />
+        <PolarGrid gridType="circle" />
+        <PolarAngleAxis />
+        <PolarRadiusAxis />
+        <Tooltip defaultIndex={0} />
+      </RadialBarChart>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(RadialBarChartProps),
+    width: 800,
+    height: 800,
+    data: ringsData,
+  },
+};
+
+export const RingsWithDataKeys = {
+  render: (args: Record<string, any>) => {
+    return (
+      <RadialBarChart {...args}>
+        <RadialBar dataKey="rings" />
+        <Legend />
+        <PolarGrid gridType="circle" />
+        <PolarAngleAxis dataKey="rings" />
+        <PolarRadiusAxis dataKey="name" stroke="black" />
+        <Tooltip defaultIndex={0} />
+      </RadialBarChart>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(RadialBarChartProps),
+    width: 800,
+    height: 800,
+    data: ringsData,
+  },
+};
+
+export const RingsWithTypes = {
+  render: (args: Record<string, any>) => {
+    return (
+      <RadialBarChart {...args}>
+        <RadialBar dataKey="rings" />
+        <Legend />
+        <PolarGrid gridType="circle" />
+        <PolarAngleAxis type="number" />
+        <PolarRadiusAxis type="category" stroke="black" />
+        <Tooltip defaultIndex={0} />
+      </RadialBarChart>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(RadialBarChartProps),
+    width: 800,
+    height: 800,
+    data: ringsData,
+  },
+};
+
+export const RingsWithDataKeysAndTypes = {
+  render: (args: Record<string, any>) => {
+    return (
+      <RadialBarChart {...args}>
+        <RadialBar dataKey="rings" />
+        <Legend />
+        <PolarGrid gridType="circle" />
+        <PolarAngleAxis dataKey="rings" type="number" />
+        <PolarRadiusAxis dataKey="name" type="category" stroke="black" />
+        <Tooltip defaultIndex={0} />
+      </RadialBarChart>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(RadialBarChartProps),
+    width: 800,
+    height: 800,
+    data: ringsData,
+  },
+};
+
+export const RingsWithCustomDomain = {
+  render: (args: Record<string, any>) => {
+    const totalCountOfRings = ringsData.reduce((acc, entry) => acc + entry.rings, 0);
+    return (
+      <RadialBarChart {...args}>
+        <RadialBar dataKey="rings" />
+        <Legend />
+        <PolarGrid gridType="circle" />
+        <PolarAngleAxis dataKey="rings" type="number" domain={[0, totalCountOfRings]} />
+        <PolarRadiusAxis dataKey="name" type="category" stroke="black" />
+        <Tooltip defaultIndex={0} />
+      </RadialBarChart>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(RadialBarChartProps),
+    width: 800,
+    height: 800,
+    data: ringsData,
+  },
+};
+
+export const RingsWithRadiusAxisVertically = {
+  render: (args: Record<string, any>) => {
+    const totalCountOfRings = ringsData.reduce((acc, entry) => acc + entry.rings, 0);
+    return (
+      <RadialBarChart {...args}>
+        <RadialBar dataKey="rings" />
+        <Legend />
+        <PolarGrid gridType="circle" />
+        <PolarAngleAxis dataKey="rings" type="number" domain={[0, totalCountOfRings]} />
+        <PolarRadiusAxis dataKey="name" type="category" orientation="left" angle={90} stroke="black" />
+        <Tooltip defaultIndex={0} />
+      </RadialBarChart>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(RadialBarChartProps),
+    width: 800,
+    height: 800,
+    data: ringsData,
+    startAngle: 90,
+    endAngle: -270,
+  },
+};


### PR DESCRIPTION
Note that there stories are not very nice charts - they are all broken in a way. The axis ticks overlap, the data don't render at all, the sectors cover each other, the axis direction and data direction do not match. I am adding these because I am planning to introduce some breaking changes and I want to demonstrate that the changes are making RadialBarChart better.

I also recreated the same stories in codesandbox to observe the behaviour in 2.x release: https://codesandbox.io/p/sandbox/lord-of-the-radial-bar-chart-5h8mlf?file=%2Fsrc%2FApp.tsx%3A166%2C3 you will notice that the last chart axis has the correct orientation in 2.x but wrong orientation in the 3.x branch, I will fix that too.

## Related Issue

https://github.com/recharts/recharts/issues/4583