### PR TITLE
refactor: move sunburst chart tooltip state to redux

### DIFF
--- a/test/chart/SunburstChart.spec.tsx
+++ b/test/chart/SunburstChart.spec.tsx
@@ -131,7 +131,7 @@ describe('<Sunburst />', () => {
           y: 250,
         },
         activeMouseOverDataKey: 'value',
-        activeMouseOverIndex: 'Child1',
+        activeMouseOverIndex: '[0]',
       });
       expect(tooltipStateSpy).toHaveBeenCalledTimes(2);
 
@@ -144,14 +144,14 @@ describe('<Sunburst />', () => {
           y: 250,
         },
         activeClickDataKey: 'value',
-        activeClickIndex: 'Child1',
+        activeClickIndex: '[0]',
         activeHover: true,
         activeMouseOverCoordinate: {
           x: 583.3333333333334,
           y: 250,
         },
         activeMouseOverDataKey: 'value',
-        activeMouseOverIndex: 'Child1',
+        activeMouseOverIndex: '[0]',
       });
       expect(tooltipStateSpy).toHaveBeenCalledTimes(3);
 
@@ -164,7 +164,7 @@ describe('<Sunburst />', () => {
           y: 250,
         },
         activeClickDataKey: 'value',
-        activeClickIndex: 'Child1',
+        activeClickIndex: '[0]',
         activeHover: false,
         activeMouseOverCoordinate: {
           x: 583.3333333333334,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- move sunburst tooltip state to redux
  - add `nameKey` property and default its value to "name" similar to treemap 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4549

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- move tooltip state to redux

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- all current tests pass
- run in storybook, see screenshot

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/54464dbc-ec0a-4f98-a432-2d51ab7e085c)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
