### PR TITLE
fix: fix displayName on CategoricalChart, fixes issue with ResponsiveContainer isCharts check

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -2357,7 +2357,11 @@ export const generateCategoricalChart = ({
     }
   }
 
-  return function CategoricalChart(props: CategoricalChartProps) {
+  const CategoricalChart = function CategoricalChart(props: CategoricalChartProps) {
     return <CategoricalChartWrapper {...props} />;
   };
+
+  CategoricalChart.displayName = CategoricalChartWrapper.displayName;
+
+  return CategoricalChart;
 };


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
`displayName` got overridden when I decided to return a new function component from the generator function. This broke the `isCharts` check in ResponsiveContainer and caused issues with container responsiveness

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5173

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
fix bug

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
log display name, test this in a built project

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
