### PR TITLE
Radial chart uses different implicit angle axis

### DIFF
--- a/src/state/selectors/polarAxisSelectors.ts
+++ b/src/state/selectors/polarAxisSelectors.ts
@@ -47,8 +47,33 @@ export const implicitRadiusAxis: RadiusAxisSettings = {
   unit: undefined,
 };
 
-export const selectAngleAxis = (state: RechartsRootState, angleAxisId: AxisId): AngleAxisSettings | undefined =>
-  state.polarAxis.angleAxis[angleAxisId] ?? implicitAngleAxis;
+const implicitRadialBarRadiusAxis: RadiusAxisSettings = {
+  allowDataOverflow: defaultPolarRadiusAxisProps.allowDataOverflow,
+  allowDecimals: false,
+  allowDuplicatedCategory: defaultPolarRadiusAxisProps.allowDuplicatedCategory,
+  dataKey: undefined,
+  domain: defaultPolarRadiusAxisProps.domain,
+  id: undefined,
+  includeHidden: false,
+  name: undefined,
+  reversed: false,
+  scale: defaultPolarRadiusAxisProps.scale,
+  tick: defaultPolarRadiusAxisProps.tick,
+  tickCount: defaultPolarRadiusAxisProps.tickCount,
+  ticks: undefined,
+  type: 'number',
+  unit: undefined,
+};
+
+export const selectAngleAxis = (state: RechartsRootState, angleAxisId: AxisId): AngleAxisSettings | undefined => {
+  if (state.polarAxis.angleAxis[angleAxisId] != null) {
+    return state.polarAxis.angleAxis[angleAxisId];
+  }
+  if (state.layout.layoutType === 'radial') {
+    return implicitRadialBarRadiusAxis;
+  }
+  return implicitAngleAxis;
+};
 
 export const selectRadiusAxis = (state: RechartsRootState, radiusAxisId: AxisId): RadiusAxisSettings | undefined =>
   state.polarAxis.radiusAxis[radiusAxisId] ?? implicitRadiusAxis;

--- a/test/polar/PolarAngleAxis.spec.tsx
+++ b/test/polar/PolarAngleAxis.spec.tsx
@@ -1662,7 +1662,7 @@ describe('<PolarAngleAxis />', () => {
         expect(spy).toHaveBeenLastCalledWith({
           allowDataOverflow: false,
           allowDecimals: false,
-          allowDuplicatedCategory: false,
+          allowDuplicatedCategory: true,
           dataKey: undefined,
           domain: undefined,
           id: undefined,
@@ -1671,9 +1671,9 @@ describe('<PolarAngleAxis />', () => {
           reversed: false,
           scale: 'auto',
           tick: true,
-          tickCount: undefined,
+          tickCount: 5,
           ticks: undefined,
-          type: 'category',
+          type: 'number',
           unit: undefined,
         });
       });
@@ -1693,7 +1693,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([400, 300, 200, 278, 189]);
+        expect(spy).toHaveBeenLastCalledWith([0, 400]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
@@ -1705,7 +1705,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select scale', () => {
         const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
-        expectScale(spy, { domain: [400, 189], range: [0, 360] });
+        expectScale(spy, { domain: [0, 400], range: [0, 360] });
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
@@ -1734,17 +1734,11 @@ describe('<PolarAngleAxis />', () => {
       it('should select ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([
-          { coordinate: 0, value: 400, offset: -0 },
-          { coordinate: 34.12322274881516, value: 380, offset: -0 },
-          { coordinate: 68.24644549763032, value: 360, offset: -0 },
-          { coordinate: 102.36966824644551, value: 340, offset: -0 },
-          { coordinate: 136.49289099526067, value: 320, offset: -0 },
-          { coordinate: 170.61611374407585, value: 300, offset: -0 },
-          { coordinate: 204.739336492891, value: 280, offset: -0 },
-          { coordinate: 238.86255924170615, value: 260, offset: -0 },
-          { coordinate: 272.98578199052133, value: 240, offset: -0 },
-          { coordinate: 307.1090047393365, value: 220, offset: -0 },
-          { coordinate: 341.2322274881517, value: 200, offset: -0 },
+          { coordinate: 0, offset: -0, value: 0 },
+          { coordinate: 90, offset: -0, value: 100 },
+          { coordinate: 180, offset: -0, value: 200 },
+          { coordinate: 270, offset: -0, value: 300 },
+          { coordinate: 360, offset: -0, value: 400 },
         ]);
         expect(spy).toHaveBeenCalledTimes(3);
       });

--- a/test/polar/RadialBar.spec.tsx
+++ b/test/polar/RadialBar.spec.tsx
@@ -71,7 +71,7 @@ describe('<RadialBar />', () => {
         allowDataOverflow: false,
         allowDecimals: false,
         // generator has allowDuplicatedCategory set to true, but the actual axis rendering ignores the prop
-        allowDuplicatedCategory: false,
+        allowDuplicatedCategory: true,
         dataKey: undefined,
         domain: undefined,
         id: undefined,
@@ -80,15 +80,15 @@ describe('<RadialBar />', () => {
         reversed: false,
         scale: 'auto',
         tick: true,
-        tickCount: undefined,
+        tickCount: 5,
         ticks: undefined,
-        type: 'category',
+        type: 'number',
         unit: undefined,
       });
     });
 
     it.fails('should select angle axis scale', () => {
-      // this selects different domain than generator, TODO find out why
+      // this selects different domain than generator because it includes nice ticks but generator doesn't
       const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
       expectScale(spy, {
         domain: [0, 9800],


### PR DESCRIPTION
## Description

I think this is a horrible change from an API design perspective and I would like to change that in 4.0 but for now I am trying to not change how the generator behaves too much so here we are.

RadialBar still doesn't render 100% the same but it's closer now. Next I need to look at `niceTicks`.

## Related Issue

https://github.com/recharts/recharts/issues/4583