### PR TITLE
refactor(Sankey): move Sankey tooltip state to redux

### DIFF
--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -18,7 +18,6 @@ import { Global } from '../util/Global';
 import { findChildByType, validateWidthHeight, filterProps } from '../util/ReactUtils';
 import { AnimationDuration, AnimationTiming, DataKey, Margin } from '../util/types';
 import { ReportChartMargin, ReportChartSize } from '../context/chartLayoutContext';
-import { TooltipContextValue } from '../context/tooltipContext';
 import { CursorPortalContext, TooltipPortalContext } from '../context/tooltipPortalContext';
 import { RechartsWrapper } from './RechartsWrapper';
 import {
@@ -507,16 +506,6 @@ function getTooltipEntrySettings({
   };
 }
 
-function createTooltipPayload(activeNode: TreemapNode) {
-  return [
-    {
-      payload: activeNode,
-      name: activeNode.name,
-      value: activeNode.value,
-    },
-  ];
-}
-
 // Why is margin not a treemap prop? No clue. Probably it should be
 const defaultTreemapMargin: Margin = {
   top: 0,
@@ -868,25 +857,6 @@ export class Treemap extends PureComponent<Props, State> {
         })}
       </div>
     );
-  }
-
-  getTooltipContext(): TooltipContextValue {
-    const { isTooltipActive, activeNode } = this.state;
-    const coordinate = activeNode
-      ? {
-          x: activeNode.x + activeNode.width / 2,
-          y: activeNode.y + activeNode.height / 2,
-        }
-      : null;
-    const payload = isTooltipActive && activeNode ? createTooltipPayload(activeNode) : [];
-
-    return {
-      active: isTooltipActive,
-      coordinate,
-      label: '',
-      payload,
-      index: 0,
-    };
   }
 
   render() {

--- a/src/context/chartDataContext.tsx
+++ b/src/context/chartDataContext.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { ChartData, setChartData } from '../state/chartDataSlice';
+import { ChartData, setChartData, setComputedData } from '../state/chartDataSlice';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { RechartsRootState } from '../state/store';
 import { BrushStartEndIndex } from './brushUpdateContext';
@@ -13,6 +13,18 @@ export const ChartDataContextProvider = (props: { chartData: ChartData }): null 
       dispatch(setChartData([]));
     };
   }, [chartData, dispatch]);
+  return null;
+};
+
+export const SetComputedData = (props: { computedData: any }): null => {
+  const { computedData } = props;
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    dispatch(setComputedData(computedData));
+    return () => {
+      dispatch(setChartData([]));
+    };
+  }, [computedData, dispatch]);
   return null;
 };
 

--- a/src/state/chartDataSlice.ts
+++ b/src/state/chartDataSlice.ts
@@ -23,6 +23,11 @@ export type AppliedChartData = ReadonlyArray<{ value: unknown }>;
 export type ChartDataState = {
   chartData: ChartData | undefined;
   /**
+   * store a copy of chart data after it has been processed by each chart's specific
+   * compute functions. TODO: add other charts besides Sankey
+   */
+  computedData: unknown | undefined;
+  /**
    * Using Brush, users can choose where they want to zoom in.
    * This is zero-based index of the starting data point.
    */
@@ -36,6 +41,7 @@ export type ChartDataState = {
 
 export const initialChartDataState: ChartDataState = {
   chartData: undefined,
+  computedData: undefined,
   dataStartIndex: 0,
   dataEndIndex: 0,
 };
@@ -52,6 +58,9 @@ const chartDataSlice = createSlice({
         state.dataEndIndex = action.payload.length - 1;
       }
     },
+    setComputedData(state, action: PayloadAction<unknown | undefined>) {
+      state.computedData = action.payload;
+    },
     setDataStartEndIndexes(state, action: PayloadAction<BrushStartEndIndexActionPayload>) {
       const { startIndex, endIndex } = action.payload;
       if (startIndex != null) {
@@ -64,6 +73,6 @@ const chartDataSlice = createSlice({
   },
 });
 
-export const { setChartData, setDataStartEndIndexes } = chartDataSlice.actions;
+export const { setChartData, setDataStartEndIndexes, setComputedData } = chartDataSlice.actions;
 
 export const chartDataReducer = chartDataSlice.reducer;

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -200,7 +200,7 @@ export const combineTooltipPayload = (
   if (activeIndex == null || tooltipPayloadSearcher == null) {
     return undefined;
   }
-  const { chartData, dataStartIndex, dataEndIndex } = chartDataState;
+  const { chartData, computedData, dataStartIndex, dataEndIndex } = chartDataState;
 
   const init: Array<TooltipPayloadEntry> = [];
 
@@ -216,7 +216,7 @@ export const combineTooltipPayload = (
     if (tooltipAxis?.dataKey && !tooltipAxis?.allowDuplicatedCategory && Array.isArray(sliced)) {
       tooltipPayload = findEntryInArray(sliced, tooltipAxis.dataKey, activeLabel);
     } else {
-      tooltipPayload = tooltipPayloadSearcher(sliced, activeIndex);
+      tooltipPayload = tooltipPayloadSearcher(sliced, activeIndex, computedData, finalNameKey);
     }
 
     if (Array.isArray(tooltipPayload)) {

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -43,7 +43,7 @@ export type TooltipIndex = string | null;
 export type TooltipPayloadSearcher<T = unknown, R = unknown> = (
   data: T,
   index: TooltipIndex,
-  computedData: unknown,
+  computedData?: unknown,
   nameKey?: DataKey<any>,
 ) => R | undefined;
 

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -40,7 +40,12 @@ export type TooltipIndex = string | null;
  * the only requirement is that the chart also provides a searcher function
  * that accepts the data, and a key, and returns whatever the payload in Tooltip should be.
  */
-export type TooltipPayloadSearcher<T = unknown, R = unknown> = (data: T, index: TooltipIndex) => R | undefined;
+export type TooltipPayloadSearcher<T = unknown, R = unknown> = (
+  data: T,
+  index: TooltipIndex,
+  computedData: unknown,
+  nameKey?: DataKey<any>,
+) => R | undefined;
 
 export type TooltipPayloadConfiguration = {
   // This is the data that is the same for all tooltip payloads, regardless of activeIndex

--- a/test/state/selectors/dataSelectors.spec.tsx
+++ b/test/state/selectors/dataSelectors.spec.tsx
@@ -18,6 +18,7 @@ describe('selectChartDataWithIndexes', () => {
     chartData: undefined,
     dataEndIndex: 0,
     dataStartIndex: 0,
+    computedData: undefined,
   });
 
   it('should return undefined in an empty chart', () => {
@@ -33,7 +34,12 @@ describe('selectChartDataWithIndexes', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenCalledTimes(1);
-    const expected: ChartDataState = { chartData: undefined, dataEndIndex: 0, dataStartIndex: 0 };
+    const expected: ChartDataState = {
+      chartData: undefined,
+      dataEndIndex: 0,
+      dataStartIndex: 0,
+      computedData: undefined,
+    };
     expect(spy).toHaveBeenLastCalledWith(expected);
   });
 
@@ -55,7 +61,12 @@ describe('selectChartDataWithIndexes', () => {
         <Customized component={Comp} />
       </ComposedChart>,
     );
-    const expected: ChartDataState = { chartData: undefined, dataEndIndex: 0, dataStartIndex: 0 };
+    const expected: ChartDataState = {
+      chartData: undefined,
+      dataEndIndex: 0,
+      dataStartIndex: 0,
+      computedData: undefined,
+    };
     expect(spy).toHaveBeenCalledWith(expected);
   });
 
@@ -72,7 +83,12 @@ describe('selectChartDataWithIndexes', () => {
       </BarChart>,
     );
     expect(pageData.length).toBeGreaterThan(1);
-    const expected: ChartDataState = { chartData: PageData, dataEndIndex: PageData.length - 1, dataStartIndex: 0 };
+    const expected: ChartDataState = {
+      chartData: PageData,
+      dataEndIndex: PageData.length - 1,
+      dataStartIndex: 0,
+      computedData: undefined,
+    };
     expect(spy).toHaveBeenLastCalledWith(expected);
   });
 
@@ -89,7 +105,12 @@ describe('selectChartDataWithIndexes', () => {
         <Customized component={Comp} />
       </BarChart>,
     );
-    const expected: ChartDataState = { chartData: PageData, dataEndIndex: 4, dataStartIndex: 3 };
+    const expected: ChartDataState = {
+      chartData: PageData,
+      dataEndIndex: 4,
+      dataStartIndex: 3,
+      computedData: undefined,
+    };
     expect(spy).toHaveBeenLastCalledWith(expected);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
move Sankey tooltip state to redux. Little more complicated than the others, not my best work

- move calculating node and link props to the getDerivedStateFromProps
- set node and link prop arrays to state and make the payload off of those
- misc changes

Note that the tooltip fallback is still in place in the Tooltip component

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4549

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit tests pass
- node and link both show tooltip when fallback is removed

## Screenshots (if appropriate):
<img width="276" alt="image" src="https://github.com/user-attachments/assets/50283028-1416-4473-930b-702fafe01b8d">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
