### PR TITLE
refactor/fix(ResponsiveContainer): remove display name and isElement checks

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -14,7 +14,6 @@ import React, {
 import throttle from 'lodash/throttle';
 import { isPercent } from '../util/DataUtils';
 import { warn } from '../util/LogUtils';
-import { getDisplayName } from '../util/ReactUtils';
 
 export interface Props {
   aspect?: number;
@@ -158,29 +157,20 @@ export const ResponsiveContainer = forwardRef<HTMLDivElement, Props>(
         aspect,
       );
 
-      const isCharts = !Array.isArray(children) && getDisplayName(children.type).endsWith('Chart');
-
       return React.Children.map(children, child => {
-        if (React.isValidElement<any>(child)) {
-          return cloneElement(child, {
-            width: calculatedWidth,
-            height: calculatedHeight,
-            // calculate the actual size and override it.
-            ...(isCharts
-              ? {
-                  style: {
-                    height: '100%',
-                    width: '100%',
-                    maxHeight: calculatedHeight,
-                    maxWidth: calculatedWidth,
-                    // keep components style
-                    ...child.props.style,
-                  },
-                }
-              : {}),
-          });
-        }
-        return child;
+        return cloneElement(child, {
+          width: calculatedWidth,
+          height: calculatedHeight,
+          // calculate the actual size and override it.
+          style: {
+            height: '100%',
+            width: '100%',
+            maxHeight: calculatedHeight,
+            maxWidth: calculatedWidth,
+            // keep components style
+            ...child.props.style,
+          },
+        });
       });
     }, [aspect, children, height, maxHeight, minHeight, minWidth, sizes, width]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

A bunch of issues stemmed from adding these `isElement` checks to recharts in responisve container. Remove it all, let everything render. If you use ResponsiveContainer incorrectly, you will get incorrect results and that is your fault

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- less problems, more rendering
- do a breaking change

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
npm test, run storybook

## Screenshots (if appropriate):
still working
<img width="657" alt="image" src="https://github.com/user-attachments/assets/0b917726-6374-437f-afa7-87be29371a6a">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
