### PR TITLE
feat: remove both names and values from the tooltip if formatter returns a nullish value

### DIFF
--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -85,13 +85,6 @@ export const DefaultTooltipContent = <TValue extends ValueType, TName extends Na
           return null;
         }
 
-        const finalItemStyle = {
-          display: 'block',
-          paddingTop: 4,
-          paddingBottom: 4,
-          color: entry.color || '#000',
-          ...itemStyle,
-        };
         const finalFormatter = entry.formatter || formatter || defaultFormatter;
         const { value, name } = entry;
         let finalValue: React.ReactNode = value;
@@ -100,10 +93,20 @@ export const DefaultTooltipContent = <TValue extends ValueType, TName extends Na
           const formatted = finalFormatter(value, name, entry, i, payload);
           if (Array.isArray(formatted)) {
             [finalValue, finalName] = formatted;
-          } else {
+          } else if (formatted != null) {
             finalValue = formatted;
+          } else {
+            return null;
           }
         }
+
+        const finalItemStyle = {
+          display: 'block',
+          paddingTop: 4,
+          paddingBottom: 4,
+          color: entry.color || '#000',
+          ...itemStyle,
+        };
 
         return (
           // eslint-disable-next-line react/no-array-index-key

--- a/test/component/DefaultTooltipContent.spec.tsx
+++ b/test/component/DefaultTooltipContent.spec.tsx
@@ -49,8 +49,45 @@ describe('DefaultTooltipContent', () => {
     itemSorter: (d: { name: string }) => d.name,
     labelFormatter: () => `mock labelFormatter`,
   };
+
   it('renders without crashing, finds div with default class attr', () => {
     const { container } = render(<DefaultTooltipContent {...mockProps} />);
     expect(container.querySelectorAll('div.recharts-default-tooltip').length).toBe(1);
+  });
+
+  it('does not render any name or value when tooltip formatter returns null', () => {
+    const mockPropsWithFormatter = {
+      ...mockProps,
+      formatter: (): null => null,
+    };
+    const { container } = render(<DefaultTooltipContent {...mockPropsWithFormatter} />);
+    const tooltip = container.querySelectorAll('div.recharts-default-tooltip');
+    expect(tooltip.length).toBe(1);
+
+    expect(tooltip[0]).toHaveTextContent('mock labelFormatter');
+  });
+
+  it('renders the value returned by the formatter as a recharts tooltip item', () => {
+    const mockPropsWithFormatter = {
+      ...mockProps,
+      formatter: (): string => 'SOME VALUE',
+    };
+    const { container } = render(<DefaultTooltipContent {...mockPropsWithFormatter} />);
+    const tooltip = container.querySelectorAll('div.recharts-default-tooltip');
+    expect(tooltip.length).toBe(1);
+
+    expect(tooltip[0]).toHaveTextContent('mock labelFormatteruv : SOME VALUE');
+  });
+
+  it('renders the name and value returned by the formatter as a recharts tooltip item', () => {
+    const mockPropsWithFormatter = {
+      ...mockProps,
+      formatter: (): [string, string] => ['SOME VALUE', 'SOME NAME'],
+    };
+    const { container } = render(<DefaultTooltipContent {...mockPropsWithFormatter} />);
+    const tooltip = container.querySelectorAll('div.recharts-default-tooltip');
+    expect(tooltip.length).toBe(1);
+
+    expect(tooltip[0]).toHaveTextContent('mock labelFormatterSOME NAME : SOME VALUE');
   });
 });


### PR DESCRIPTION
…

<!--- Provide a general summary of your changes in the Title above -->

## Description
This was easy but technically breaking, so take care of it. Works like a charm

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5169

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- allow better use of the formatter function

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
