### PR TITLE
Fix implicit RadiusBar angle axis defaults

### DIFF
--- a/src/state/selectors/polarAxisSelectors.ts
+++ b/src/state/selectors/polarAxisSelectors.ts
@@ -47,19 +47,19 @@ export const implicitRadiusAxis: RadiusAxisSettings = {
   unit: undefined,
 };
 
-const implicitRadialBarRadiusAxis: RadiusAxisSettings = {
-  allowDataOverflow: defaultPolarRadiusAxisProps.allowDataOverflow,
+const implicitRadialBarAngleAxis: RadiusAxisSettings = {
+  allowDataOverflow: false,
   allowDecimals: false,
-  allowDuplicatedCategory: defaultPolarRadiusAxisProps.allowDuplicatedCategory,
+  allowDuplicatedCategory: defaultPolarAngleAxisProps.allowDuplicatedCategory,
   dataKey: undefined,
-  domain: defaultPolarRadiusAxisProps.domain,
+  domain: defaultPolarAngleAxisProps.domain,
   id: undefined,
   includeHidden: false,
   name: undefined,
   reversed: false,
-  scale: defaultPolarRadiusAxisProps.scale,
-  tick: defaultPolarRadiusAxisProps.tick,
-  tickCount: defaultPolarRadiusAxisProps.tickCount,
+  scale: defaultPolarAngleAxisProps.scale,
+  tick: defaultPolarAngleAxisProps.tick,
+  tickCount: defaultPolarAngleAxisProps.tickCount,
   ticks: undefined,
   type: 'number',
   unit: undefined,
@@ -70,7 +70,7 @@ export const selectAngleAxis = (state: RechartsRootState, angleAxisId: AxisId): 
     return state.polarAxis.angleAxis[angleAxisId];
   }
   if (state.layout.layoutType === 'radial') {
-    return implicitRadialBarRadiusAxis;
+    return implicitRadialBarAngleAxis;
   }
   return implicitAngleAxis;
 };

--- a/test/polar/PolarAngleAxis.spec.tsx
+++ b/test/polar/PolarAngleAxis.spec.tsx
@@ -1672,7 +1672,7 @@ describe('<PolarAngleAxis />', () => {
           reversed: false,
           scale: 'auto',
           tick: true,
-          tickCount: 5,
+          tickCount: undefined,
           ticks: undefined,
           type: 'number',
           unit: undefined,
@@ -1736,9 +1736,13 @@ describe('<PolarAngleAxis />', () => {
         const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([
           { coordinate: 0, offset: -0, value: 0 },
+          { coordinate: 45, offset: -0, value: 50 },
           { coordinate: 90, offset: -0, value: 100 },
+          { coordinate: 135, offset: -0, value: 150 },
           { coordinate: 180, offset: -0, value: 200 },
+          { coordinate: 225, offset: -0, value: 250 },
           { coordinate: 270, offset: -0, value: 300 },
+          { coordinate: 315, offset: -0, value: 350 },
           { coordinate: 360, offset: -0, value: 400 },
         ]);
         expect(spy).toHaveBeenCalledTimes(3);

--- a/test/polar/RadialBar.spec.tsx
+++ b/test/polar/RadialBar.spec.tsx
@@ -80,7 +80,7 @@ describe('<RadialBar />', () => {
         reversed: false,
         scale: 'auto',
         tick: true,
-        tickCount: 5,
+        tickCount: undefined,
         ticks: undefined,
         type: 'number',
         unit: undefined,


### PR DESCRIPTION
## Description

When adding this workaround I mixed up angle axis and radius axis defaults. It doesn't make any difference now but it changes how the PolarGrid renders with Redux which I am working on in another branch. This change can be merged independently so let's do that.

## Related Issue

https://github.com/recharts/recharts/issues/4583