### PR TITLE
Proposing new prop for Tooltip

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -101,8 +101,8 @@ export type TooltipProps<TValue extends ValueType, TName extends NameType> = Omi
   useTranslate3d?: boolean;
   wrapperStyle?: CSSProperties;
   /**
-   * Tooltip always attaches itself to "categorical" axis. Which axis is categorical? Depends on the layout:
-   * - horizontal layout -> X axis is categorical
+   * Tooltip always attaches itself to the "Tooltip" axis. Which axis is it? Depends on the layout:
+   * - horizontal layout -> X axis
    * - vertical layout -> Y axis
    * - radial layout -> radial axis
    * - centric layout -> angle axis

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -28,6 +28,7 @@ import { useCursorPortal, useTooltipPortal } from '../context/tooltipPortalConte
 import { TooltipTrigger } from '../chart/types';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { setTooltipSettingsState, TooltipPayload } from '../state/tooltipSlice';
+import { AxisId } from '../state/cartesianAxisSlice';
 
 export type ContentType<TValue extends ValueType, TName extends NameType> =
   | ReactElement
@@ -99,6 +100,16 @@ export type TooltipProps<TValue extends ValueType, TName extends NameType> = Omi
   trigger?: TooltipTrigger;
   useTranslate3d?: boolean;
   wrapperStyle?: CSSProperties;
+  /**
+   * Tooltip always attaches itself to "categorical" axis. Which axis is categorical? Depends on the layout:
+   * - horizontal layout -> X axis is categorical
+   * - vertical layout -> Y axis
+   * - radial layout -> radial axis
+   * - centric layout -> angle axis
+   *
+   * Tooltip will use the default axis for the layout, unless you specify an axisId.
+   */
+  axisId?: AxisId;
 };
 
 const emptyPayload: TooltipPayload = [];


### PR DESCRIPTION
## Description

This is only the prop - no implementation yet. I want to have an agreement on what the external API should look like before implementing.

This option is what I think is the simplest - we let Tooltip stay sticky to the "categorical axis" and do not let users to override it (this is the same in 2.x). If in the future we do decide to allow overriding it, we can add a new prop that goes `axisType: xAxis | yAxis | radiusAxis | angleAxis`.

What's new is we will allow users to specify which of the categorical axes exactly should be the tooltip axis - in case there are multiple.

WDYT?

Alternatively we could have a bunch of props that goes like `xAxisId: AxisId; yAxisId: AxisId; radiusAxisId: AxisId; angleAxisId: AxisId;` but I selected against it because it will allow users to specify multiple conflicting axes at the same time. But now that I think of it, that's exactly what Scatter is doing.

## Related Issue

https://github.com/recharts/recharts/issues/4583