### PR TITLE
Add support for customizable radius per sector in Pie Chart

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -59,7 +59,7 @@ interface PieDef {
   /** The inner radius of sectors */
   innerRadius?: number | string;
   /** The outer radius of sectors */
-  outerRadius?: number | string | ((element: any) => number);
+  outerRadius?: number | string | ((dataPoint: any) => number);
   cornerRadius?: number | string;
 }
 
@@ -340,16 +340,27 @@ const getTextAnchor = (x: number, cx: number) => {
   return 'middle';
 };
 
+const getOuterRadius = (
+  dataPoint: any,
+  outerRadius?: number | string | ((element: any) => number),
+  maxPieRadius?: number,
+) => {
+  if (typeof outerRadius === 'function') {
+    return outerRadius(dataPoint);
+  }
+  return getPercentValue(outerRadius, maxPieRadius, maxPieRadius * 0.8);
+};
+
 const parseCoordinateOfPie = (
   item: {
     cx?: number | string;
     cy?: number | string;
     innerRadius?: number | string;
-    outerRadius?: number | string | ((element: any) => number);
+    outerRadius?: number | string | ((dataPoint: any) => number);
     maxRadius?: number;
   },
   offset: ChartOffset,
-  element: any,
+  dataPoint: any,
 ): PieCoordinate => {
   const { top, left, width, height } = offset;
   const maxPieRadius = getMaxRadius(width, height);
@@ -357,12 +368,7 @@ const parseCoordinateOfPie = (
   const cy = top + getPercentValue(item.cy, height, height / 2);
   const innerRadius = getPercentValue(item.innerRadius, maxPieRadius, 0);
 
-  let outerRadius;
-  if (typeof item.outerRadius === 'function') {
-    outerRadius = item.outerRadius(element);
-  } else {
-    outerRadius = getPercentValue(item.outerRadius, maxPieRadius, maxPieRadius * 0.8);
-  }
+  const outerRadius = getOuterRadius(dataPoint, item.outerRadius, maxPieRadius);
 
   const maxRadius = item.maxRadius || Math.sqrt(width * width + height * height) / 2;
 

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -137,6 +137,7 @@ interface PieProps extends PieDef {
   className?: string;
   dataKey: DataKey<any>;
   nameKey?: DataKey<any>;
+  radiusKey?: DataKey<any>;
   /** Match each sector's stroke color to it's fill color */
   blendStroke?: boolean;
   /** The minimum angle for no-zero element */
@@ -416,6 +417,7 @@ export function computePieSectors({
     tooltipType?: TooltipType;
     name?: string | number;
     nameKey?: DataKey<any>;
+    radiusKey?: DataKey<any>;
     cx?: number | string;
     cy?: number | string;
     startAngle?: number;
@@ -429,7 +431,7 @@ export function computePieSectors({
   };
   offset: ChartOffset;
 }): { sectors: ReadonlyArray<PieSectorDataItem>; coordinate: PieCoordinate } {
-  const { cornerRadius, startAngle, endAngle, dataKey, nameKey, tooltipType } = pieSettings;
+  const { cornerRadius, startAngle, endAngle, dataKey, nameKey, tooltipType, radiusKey } = pieSettings;
   const minAngle = Math.abs(pieSettings.minAngle);
   const coordinate = parseCoordinateOfPie(pieSettings, offset);
   const deltaAngle = parseDeltaAngle(startAngle, endAngle);
@@ -479,6 +481,12 @@ export function computePieSectors({
         },
       ];
       const tooltipPosition = polarToCartesian(coordinate.cx, coordinate.cy, middleRadius, midAngle);
+      const outerRadiusParam = getValueByDataKey(entry, radiusKey, coordinate.outerRadius);
+
+      let calculatedOuterRadius = coordinate.outerRadius;
+      if (typeof outerRadiusParam === 'string' || typeof outerRadiusParam === 'number') {
+        calculatedOuterRadius = getPercentValue(outerRadiusParam, coordinate.outerRadius, coordinate.outerRadius);
+      }
 
       prev = {
         ...pieSettings.presentationProps,
@@ -496,12 +504,11 @@ export function computePieSectors({
         endAngle: tempEndAngle,
         payload: entryWithCellInfo,
         paddingAngle: mathSign(deltaAngle) * paddingAngle,
+        outerRadius: calculatedOuterRadius,
       };
-
       return prev;
     });
   }
-
   return { sectors, coordinate };
 }
 
@@ -798,6 +805,7 @@ function PieImpl(props: Props) {
       tooltipType: props.tooltipType,
       data: props.data,
       dataKey: props.dataKey,
+      radiusKey: props.radiusKey,
       cx: props.cx,
       cy: props.cy,
       startAngle: props.startAngle,
@@ -817,6 +825,7 @@ function PieImpl(props: Props) {
       props.cy,
       props.data,
       props.dataKey,
+      props.radiusKey,
       props.endAngle,
       props.innerRadius,
       props.minAngle,

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -437,7 +437,7 @@ export function computePieSectors({
     paddingAngle?: number;
     minAngle?: number;
     innerRadius?: number | string;
-    outerRadius?: number | string | ((element: any) => number);
+    outerRadius?: number | string | ((dataPoint: any) => number);
     cornerRadius?: number | string;
     presentationProps?: Record<string, string>;
   };

--- a/src/state/selectors/pieSelectors.ts
+++ b/src/state/selectors/pieSelectors.ts
@@ -17,6 +17,7 @@ export type ResolvedPieSettings = {
   data: ChartData | undefined;
   dataKey: DataKey<any> | undefined;
   tooltipType?: TooltipType | undefined;
+  radiusKey?: DataKey<any> | undefined;
 
   legendType: LegendType;
   fill: string;

--- a/src/state/selectors/pieSelectors.ts
+++ b/src/state/selectors/pieSelectors.ts
@@ -17,7 +17,6 @@ export type ResolvedPieSettings = {
   data: ChartData | undefined;
   dataKey: DataKey<any> | undefined;
   tooltipType?: TooltipType | undefined;
-  radiusKey?: DataKey<any> | undefined;
 
   legendType: LegendType;
   fill: string;
@@ -29,7 +28,7 @@ export type ResolvedPieSettings = {
   paddingAngle?: number;
   minAngle?: number;
   innerRadius?: number | string;
-  outerRadius?: number | string;
+  outerRadius?: number | string | ((element: any) => number);
   cornerRadius?: number | string;
   presentationProps?: Record<string, string>;
 };

--- a/storybook/stories/API/polar/Pie.stories.tsx
+++ b/storybook/stories/API/polar/Pie.stories.tsx
@@ -33,9 +33,10 @@ const GeneralProps: Args = {
   },
   outerRadius: {
     description: `The outer radius of all the sectors. If set a percentage, the final value is
-      obtained by multiplying the percentage of maxRadius which is calculated by the width, height, cx, cy.`,
+      obtained by multiplying the percentage of maxRadius which is calculated by the width, height, cx, cy.
+      If set a function, the function will be called to return customized radius.`,
     table: {
-      type: { summary: 'percentage | number', defaultValue: '80%' },
+      type: { summary: 'percentage | number | Function', defaultValue: '80%' },
       category: 'General',
     },
   },
@@ -74,13 +75,6 @@ const GeneralProps: Args = {
   dataKey: {
     description: "The key of each sector's value.",
     table: { type: { summary: 'string | number | Function' }, category: 'General' },
-  },
-  radiusKey: {
-    description: `The key of each sector's radius.`,
-    table: {
-      type: { summary: 'percentage | number', defaultValue: '100%' },
-      category: 'General',
-    },
   },
   legendType: {
     description: 'The type of icon in legend. If set to "none", no legend item will be rendered.',

--- a/storybook/stories/API/polar/Pie.stories.tsx
+++ b/storybook/stories/API/polar/Pie.stories.tsx
@@ -39,7 +39,6 @@ const GeneralProps: Args = {
       category: 'General',
     },
   },
-
   startAngle: {
     description: 'The start angle of first sector.',
     table: {
@@ -75,6 +74,13 @@ const GeneralProps: Args = {
   dataKey: {
     description: "The key of each sector's value.",
     table: { type: { summary: 'string | number | Function' }, category: 'General' },
+  },
+  radiusKey: {
+    description: `The key of each sector's radius.`,
+    table: {
+      type: { summary: 'percentage | number', defaultValue: '100%' },
+      category: 'General',
+    },
   },
   legendType: {
     description: 'The type of icon in legend. If set to "none", no legend item will be rendered.',

--- a/storybook/stories/Examples/Pie/PieWithStep.stories.tsx
+++ b/storybook/stories/Examples/Pie/PieWithStep.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Args } from '@storybook/react';
+import { Pie, PieChart, ResponsiveContainer } from '../../../../src';
+
+const data = [
+  { value: 'Luck', percent: 10, radius: '45%' },
+  { value: 'Skill', percent: 20, radius: '50%' },
+  { value: 'Concentrated power of will', percent: 15, radius: '60%' },
+  { value: 'Pleasure', percent: 50, radius: '80%' },
+  { value: 'Pain', percent: 50, radius: '80%' },
+  { value: 'Reason to remember the name', percent: 100, radius: '100%' },
+];
+
+export default {
+  component: Pie,
+};
+
+export const PieWithStep = {
+  render: (args: Args) => {
+    return (
+      <ResponsiveContainer width="100%" height={500}>
+        <PieChart width={400} height={400}>
+          <Pie dataKey="percent" {...args} />
+        </PieChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    cx: '50%',
+    cy: '50%',
+    data,
+    dataKey: 'percent',
+    nameKey: 'value',
+    fill: '#8884d8',
+    label: true,
+    radiusKey: 'radius',
+  },
+};

--- a/storybook/stories/Examples/Pie/PieWithStep.stories.tsx
+++ b/storybook/stories/Examples/Pie/PieWithStep.stories.tsx
@@ -3,12 +3,12 @@ import { Args } from '@storybook/react';
 import { Pie, PieChart, ResponsiveContainer } from '../../../../src';
 
 const data = [
-  { value: 'Luck', percent: 10, radius: '45%' },
-  { value: 'Skill', percent: 20, radius: '50%' },
-  { value: 'Concentrated power of will', percent: 15, radius: '60%' },
-  { value: 'Pleasure', percent: 50, radius: '80%' },
-  { value: 'Pain', percent: 50, radius: '80%' },
-  { value: 'Reason to remember the name', percent: 100, radius: '100%' },
+  { value: 'Luck', percent: 10, customRadius: 140 },
+  { value: 'Skill', percent: 20, customRadius: 160 },
+  { value: 'Concentrated power of will', percent: 15, customRadius: 150 },
+  { value: 'Pleasure', percent: 50, customRadius: 190 },
+  { value: 'Pain', percent: 50, customRadius: 190 },
+  { value: 'Reason to remember the name', percent: 100, customRadius: 220 },
 ];
 
 export default {
@@ -33,6 +33,8 @@ export const PieWithStep = {
     nameKey: 'value',
     fill: '#8884d8',
     label: true,
-    radiusKey: 'radius',
+    outerRadius: (element: any) => {
+      return element.customRadius;
+    },
   },
 };

--- a/test/chart/PieChart.spec.tsx
+++ b/test/chart/PieChart.spec.tsx
@@ -408,8 +408,6 @@ describe('<PieChart />', () => {
   });
 
   describe('PieChart sector radius rendering', () => {
-    const outerRadius = 80;
-
     const assertSectorRadius = (element: Element, radius: number) => {
       // Checks if the 'd' attribute has an arc with the specified radius.
       const dAttribute = element.getAttribute('d');
@@ -417,7 +415,8 @@ describe('<PieChart />', () => {
       expect(dAttribute).toMatch(arcRadius);
     };
 
-    test('should render sectors with default radius when no radius is specified', () => {
+    it('renders sectors with a constant radius', () => {
+      const outerRadius = 80;
       const { container } = render(
         <PieChart width={800} height={400}>
           <Pie
@@ -431,7 +430,6 @@ describe('<PieChart />', () => {
             cy={200}
             outerRadius={outerRadius}
             fill="#ff7300"
-            radiusKey="r"
           />
         </PieChart>,
       );
@@ -443,56 +441,31 @@ describe('<PieChart />', () => {
       assertSectorRadius(elementB, outerRadius);
     });
 
-    test('should render sectors with specified fixed radius values', () => {
+    it('renders sectors with radius based on outerRadius function', () => {
       const { container } = render(
         <PieChart width={800} height={400}>
           <Pie
             dataKey="value"
             isAnimationActive={false}
             data={[
-              { name: 'Group C', value: 200, r: 102 },
-              { name: 'Group D', value: 200, r: 120 },
+              { name: 'Group A', value: 400 },
+              { name: 'Group B', value: 300 },
             ]}
             cx={200}
             cy={200}
-            outerRadius={outerRadius}
+            outerRadius={(element: any) => {
+              return element.value / 10;
+            }}
             fill="#ff7300"
-            radiusKey="r"
           />
         </PieChart>,
       );
 
-      const elementC = container.querySelector('path[name="Group C"]');
-      assertSectorRadius(elementC, 102);
+      const elementA = container.querySelector('path[name="Group A"]');
+      assertSectorRadius(elementA, 40);
 
-      const elementD = container.querySelector('path[name="Group D"]');
-      assertSectorRadius(elementD, 120);
-    });
-
-    test('should render sectors with radius values as a percentage of outer radius', () => {
-      const { container } = render(
-        <PieChart width={800} height={400}>
-          <Pie
-            dataKey="value"
-            isAnimationActive={false}
-            data={[
-              { name: 'Group E', value: 278, r: '45%' },
-              { name: 'Group F', value: 189, r: '21%' },
-            ]}
-            cx={200}
-            cy={200}
-            outerRadius={outerRadius}
-            fill="#ff7300"
-            radiusKey="r"
-          />
-        </PieChart>,
-      );
-
-      const elementE = container.querySelector('path[name="Group E"]');
-      assertSectorRadius(elementE, outerRadius * 0.45);
-
-      const elementF = container.querySelector('path[name="Group F"]');
-      assertSectorRadius(elementF, outerRadius * 0.21);
+      const elementB = container.querySelector('path[name="Group B"]');
+      assertSectorRadius(elementB, 30);
     });
   });
 });

--- a/test/chart/PieChart.spec.tsx
+++ b/test/chart/PieChart.spec.tsx
@@ -406,4 +406,93 @@ describe('<PieChart />', () => {
     expect(container.querySelectorAll('.label-custom-className')).toHaveLength(6);
     expect(container.querySelectorAll('.label-line-custom-className')).toHaveLength(6);
   });
+
+  describe('PieChart sector radius rendering', () => {
+    const outerRadius = 80;
+
+    const assertSectorRadius = (element: Element, radius: number) => {
+      // Checks if the 'd' attribute has an arc with the specified radius.
+      const dAttribute = element.getAttribute('d');
+      const arcRadius = new RegExp(`A ${radius},${radius}`);
+      expect(dAttribute).toMatch(arcRadius);
+    };
+
+    test('should render sectors with default radius when no radius is specified', () => {
+      const { container } = render(
+        <PieChart width={800} height={400}>
+          <Pie
+            dataKey="value"
+            isAnimationActive={false}
+            data={[
+              { name: 'Group A', value: 400 },
+              { name: 'Group B', value: 300 },
+            ]}
+            cx={200}
+            cy={200}
+            outerRadius={outerRadius}
+            fill="#ff7300"
+            radiusKey="r"
+          />
+        </PieChart>,
+      );
+
+      const elementA = container.querySelector('path[name="Group A"]');
+      assertSectorRadius(elementA, outerRadius);
+
+      const elementB = container.querySelector('path[name="Group B"]');
+      assertSectorRadius(elementB, outerRadius);
+    });
+
+    test('should render sectors with specified fixed radius values', () => {
+      const { container } = render(
+        <PieChart width={800} height={400}>
+          <Pie
+            dataKey="value"
+            isAnimationActive={false}
+            data={[
+              { name: 'Group C', value: 200, r: 102 },
+              { name: 'Group D', value: 200, r: 120 },
+            ]}
+            cx={200}
+            cy={200}
+            outerRadius={outerRadius}
+            fill="#ff7300"
+            radiusKey="r"
+          />
+        </PieChart>,
+      );
+
+      const elementC = container.querySelector('path[name="Group C"]');
+      assertSectorRadius(elementC, 102);
+
+      const elementD = container.querySelector('path[name="Group D"]');
+      assertSectorRadius(elementD, 120);
+    });
+
+    test('should render sectors with radius values as a percentage of outer radius', () => {
+      const { container } = render(
+        <PieChart width={800} height={400}>
+          <Pie
+            dataKey="value"
+            isAnimationActive={false}
+            data={[
+              { name: 'Group E', value: 278, r: '45%' },
+              { name: 'Group F', value: 189, r: '21%' },
+            ]}
+            cx={200}
+            cy={200}
+            outerRadius={outerRadius}
+            fill="#ff7300"
+            radiusKey="r"
+          />
+        </PieChart>,
+      );
+
+      const elementE = container.querySelector('path[name="Group E"]');
+      assertSectorRadius(elementE, outerRadius * 0.45);
+
+      const elementF = container.querySelector('path[name="Group F"]');
+      assertSectorRadius(elementF, outerRadius * 0.21);
+    });
+  });
 });


### PR DESCRIPTION
When creating a pie chart, users can currently specify only a single radius (outer radius), which applies uniformly to all pie sectors. This PR proposes allowing developers to define different radius sizes for each pie sector, enabling more customized and varied visualizations.

## Description

A function type has been added to the `outerRadius` parameter. Users can now pass a function to `outerRadius` to calculate the radius dynamically. This function takes an element as a parameter and expects a number to be returned.

## Related Issue

#5224 

## How Has This Been Tested?

Run the existing unit tests and added unit tests for the new feature.

## Screenshots:

![Screenshot from 2024-11-13 15-37-47](https://github.com/user-attachments/assets/52a6af14-7047-4875-aa31-f0a920c6683a)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
