### PR TITLE
docs: add custom cursor bar chart example

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -266,7 +266,6 @@ export class Tooltip<TValue extends ValueType, TName extends NameType> extends P
     contentStyle: {},
     coordinate: { x: 0, y: 0 },
     cursor: true,
-    cursorStyle: {},
     filterNull: true,
     isAnimationActive: !Global.isSsr,
     itemStyle: {},

--- a/storybook/stories/Examples/BarChart/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart/BarChart.stories.tsx
@@ -802,3 +802,38 @@ export const RangedBarChart = {
     barSize: '30%',
   },
 };
+
+const MyCustomCursor = (props: any) => {
+  // do something here to make your cursor different
+  return <Rectangle {...props} fill="red" fillOpacity={0.6} stroke="#111" />;
+};
+
+export const CustomCursorBarChart = {
+  render: (args: Record<string, any>) => {
+    return (
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart {...args}>
+          <XAxis dataKey="name" />
+          <YAxis />
+          <CartesianGrid strokeDasharray="3 3" />
+          <Bar dataKey="uv" fill="violet" stroke="indigo" />
+          <Tooltip cursor={<MyCustomCursor />} />
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(BarChartProps),
+    width: 500,
+    height: 300,
+    data: pageData,
+    margin: {
+      top: 5,
+      right: 30,
+      left: 20,
+      bottom: 5,
+    },
+    /* When there's only one data point on a numerical domain, we cannot automatically calculate the bar size */
+    barSize: '30%',
+  },
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- add an example for custom cursor
- **remove `cursorStyle` defaultProps from Tooltip. It was not being used anywhere and was not in types

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5243

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
https://github.com/recharts/recharts/issues/5243

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
example addition only

## Screenshots (if appropriate):

<img width="444" alt="image" src="https://github.com/user-attachments/assets/f3c4f412-72c4-4065-be9f-bc1a74327650">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have added a storybook story or extended an existing story to show my changes
