### PR TITLE
Fix labellist data key type 

### DIFF
--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -18,10 +18,11 @@ interface Data {
 
 interface LabelListProps<T extends Data> {
   id?: string;
+  // why is data a prop here, shouldn't this only come from chart data?
   data?: ReadonlyArray<T>;
   valueAccessor?: (entry: T, index: number) => string | number;
   clockWise?: boolean;
-  dataKey?: DataKey<T>;
+  dataKey?: DataKey<Record<string, any>>;
   content?: ContentType;
   textBreakAll?: boolean;
   position?: LabelPosition;

--- a/test/component/LabelList.spec.tsx
+++ b/test/component/LabelList.spec.tsx
@@ -20,7 +20,8 @@ describe('<LabelList />', () => {
         <YAxis dataKey="y" name="weight" unit="kg" />
         <ZAxis dataKey="z" range={[4, 20]} name="score" unit="km" />
         <Scatter name="A school" data={data} isAnimationActive={false}>
-          <LabelList dataKey="x" />
+          {/* should be able to use dataKey as a function with LabelList */}
+          <LabelList dataKey={d => d.x} />
         </Scatter>
       </ScatterChart>,
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
`dataKey` should take the type of your data - aka any object. The `Data` interface wasn't returned at all in the function after logging etc. This might've been for using label list alone? Lets not do that anymore

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5245

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Make types better

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
added test which was failing TS before. works noww

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
