### PR TITLE
fix: dataKey prop for LabelList should accept any object

### DIFF
--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -21,7 +21,7 @@ interface LabelListProps<T extends Data> {
   data?: Array<T>;
   valueAccessor?: Function;
   clockWise?: boolean;
-  dataKey?: DataKey<T>;
+  dataKey?: DataKey<Record<string, any>>;
   content?: ContentType;
   textBreakAll?: boolean;
   position?: LabelPosition;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

same as https://github.com/recharts/recharts/pull/5250/files but for 2.x

issue : https://github.com/recharts/recharts/issues/5245
