### PR TITLE
fix(brush): don't re-run index-from-props effect every state change

### DIFF
--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -11,7 +11,6 @@ import React, {
   SVGProps,
   TouchEvent,
   useCallback,
-  useContext,
   useEffect,
 } from 'react';
 import clsx from 'clsx';
@@ -27,7 +26,7 @@ import { DataKey, Padding } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { useUpdateId } from '../context/chartLayoutContext';
 import { useChartData, useDataIndex } from '../context/chartDataContext';
-import { BrushStartEndIndex, BrushUpdateDispatchContext, OnBrushUpdate } from '../context/brushUpdateContext';
+import { BrushStartEndIndex, OnBrushUpdate } from '../context/brushUpdateContext';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { setDataStartEndIndexes } from '../state/chartDataSlice';
 import { BrushSettings, setBrushSettings } from '../state/brushSlice';
@@ -863,25 +862,24 @@ function BrushInternal(props: Props) {
   const chartData = useChartData();
   const { startIndex, endIndex } = useDataIndex();
   const updateId = useUpdateId();
-  const onChangeFromContext = useContext(BrushUpdateDispatchContext);
   const onChangeFromProps = props.onChange;
   const { startIndex: startIndexFromProps, endIndex: endIndexFromProps } = props;
+
   useEffect(() => {
     // start and end index can be controlled from props, and we need them to stay up-to-date in the Redux state too
-    if (startIndexFromProps !== startIndex || endIndexFromProps !== endIndex) {
-      dispatch(setDataStartEndIndexes({ startIndex: startIndexFromProps, endIndex: endIndexFromProps }));
-    }
-  }, [dispatch, startIndexFromProps, endIndexFromProps, startIndex, endIndex]);
+    dispatch(setDataStartEndIndexes({ startIndex: startIndexFromProps, endIndex: endIndexFromProps }));
+  }, [dispatch, endIndexFromProps, startIndexFromProps]);
+
   const onChange = useCallback(
     (nextState: BrushStartEndIndex) => {
       if (nextState.startIndex !== startIndex || nextState.endIndex !== endIndex) {
-        onChangeFromContext?.(nextState);
         onChangeFromProps?.(nextState);
         dispatch(setDataStartEndIndexes(nextState));
       }
     },
-    [onChangeFromProps, onChangeFromContext, dispatch, startIndex, endIndex],
+    [onChangeFromProps, dispatch, startIndex, endIndex],
   );
+
   const { x, y, width } = useAppSelector(selectBrushDimensions);
   const contextProperties: PropertiesFromContext = {
     data: chartData,

--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -11,6 +11,7 @@ import React, {
   SVGProps,
   TouchEvent,
   useCallback,
+  useContext,
   useEffect,
 } from 'react';
 import clsx from 'clsx';
@@ -26,7 +27,7 @@ import { DataKey, Padding } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { useUpdateId } from '../context/chartLayoutContext';
 import { useChartData, useDataIndex } from '../context/chartDataContext';
-import { BrushStartEndIndex, OnBrushUpdate } from '../context/brushUpdateContext';
+import { BrushStartEndIndex, OnBrushUpdate, BrushUpdateDispatchContext } from '../context/brushUpdateContext';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { setDataStartEndIndexes } from '../state/chartDataSlice';
 import { BrushSettings, setBrushSettings } from '../state/brushSlice';
@@ -862,6 +863,7 @@ function BrushInternal(props: Props) {
   const chartData = useChartData();
   const { startIndex, endIndex } = useDataIndex();
   const updateId = useUpdateId();
+  const onChangeFromContext = useContext(BrushUpdateDispatchContext);
   const onChangeFromProps = props.onChange;
   const { startIndex: startIndexFromProps, endIndex: endIndexFromProps } = props;
 
@@ -873,11 +875,12 @@ function BrushInternal(props: Props) {
   const onChange = useCallback(
     (nextState: BrushStartEndIndex) => {
       if (nextState.startIndex !== startIndex || nextState.endIndex !== endIndex) {
+        onChangeFromContext?.(nextState);
         onChangeFromProps?.(nextState);
         dispatch(setDataStartEndIndexes(nextState));
       }
     },
-    [onChangeFromProps, dispatch, startIndex, endIndex],
+    [onChangeFromProps, onChangeFromContext, dispatch, startIndex, endIndex],
   );
 
   const { x, y, width } = useAppSelector(selectBrushDimensions);

--- a/src/state/brushSlice.ts
+++ b/src/state/brushSlice.ts
@@ -20,6 +20,7 @@ const initialState: BrushSettings = {
   height: 0,
   padding: { top: 0, right: 0, bottom: 0, left: 0 },
 };
+
 export const brushSlice = createSlice({
   name: 'brush',
   initialState,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Partial bug fix for linked issue. This fixes where the `startIndex` does not update at all because `useEffect` ran every single render and always overrode the new startIndex.

Bugs remaining:

* brush panorama has the same state as the chart, it should have its own state and not get sliced
* controlled brush (`examples-cartesian-brush--controlled-brush`) when moving the handles breaks mouse event when the index is changed. If the brush is controlled it should still allow indices to be updated by normal brush activity

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4546

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
fix part of the brush bug for 3.x

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- npm test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
