### PR TITLE
Backport `PieSectorDataItem.payload` typing

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -72,7 +72,7 @@ export type PieSectorDataItem = SectorProps & {
   value?: number;
   paddingAngle?: number;
   dataKey?: string;
-  payload?: any[];
+  payload?: any;
 };
 
 interface PieProps extends PieDef {


### PR DESCRIPTION
## Description

Backports typing of `PieSectorDataItem.payload` in `3.x` branch to `master` branch.

## Related Issue

Closes #5261

## Motivation and Context

See original issue above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
