### PR TITLE
Replace lodash functions with native code

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -2,17 +2,14 @@
 import React, { PureComponent } from 'react';
 import clsx from 'clsx';
 import Animate from 'react-smooth';
-import isFunction from 'lodash/isFunction';
 import max from 'lodash/max';
-import isNil from 'lodash/isNil';
-import isNan from 'lodash/isNaN';
 import isEqual from 'lodash/isEqual';
 import { Curve, CurveType, Point as CurvePoint, Props as CurveProps } from '../shape/Curve';
 import { Dot } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 import { LabelList } from '../component/LabelList';
 import { Global } from '../util/Global';
-import { interpolateNumber, isNumber, uniqueId } from '../util/DataUtils';
+import { interpolateNumber, isNullOrUndefined, isNumber, uniqueId } from '../util/DataUtils';
 import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
 import {
   ActiveDotType,
@@ -190,7 +187,7 @@ const renderDotItem = (option: ActiveDotType, props: any) => {
 
   if (React.isValidElement(option)) {
     dotItem = React.cloneElement(option, props);
-  } else if (isFunction(option)) {
+  } else if (typeof option === 'function') {
     dotItem = option(props);
   } else {
     const className = clsx('recharts-area-dot', typeof option !== 'boolean' ? option.className : '');
@@ -232,7 +229,7 @@ class AreaWithState extends PureComponent<InternalProps, State> {
 
     this.setState({ isAnimationFinished: true });
 
-    if (isFunction(onAnimationEnd)) {
+    if (typeof onAnimationEnd === 'function') {
       onAnimationEnd();
     }
   };
@@ -241,7 +238,7 @@ class AreaWithState extends PureComponent<InternalProps, State> {
     const { onAnimationStart } = this.props;
     this.setState({ isAnimationFinished: false });
 
-    if (isFunction(onAnimationStart)) {
+    if (typeof onAnimationStart === 'function') {
       onAnimationStart();
     }
   };
@@ -399,7 +396,7 @@ class AreaWithState extends PureComponent<InternalProps, State> {
     const { points, baseLine, isAnimationActive, animationBegin, animationDuration, animationEasing, animationId } =
       this.props;
     const { prevPoints, prevBaseLine } = this.state;
-    // const clipPathId = isNil(id) ? this.id : id;
+    // const clipPathId = isNullOrUndefined(id) ? this.id : id;
 
     return (
       <Animate
@@ -434,7 +431,7 @@ class AreaWithState extends PureComponent<InternalProps, State> {
             if (isNumber(baseLine) && typeof baseLine === 'number') {
               const interpolator = interpolateNumber(prevBaseLine as number, baseLine);
               stepBaseLine = interpolator(t);
-            } else if (isNil(baseLine) || isNan(baseLine)) {
+            } else if (isNullOrUndefined(baseLine) || Number.isNaN(baseLine)) {
               const interpolator = interpolateNumber(prevBaseLine as number, 0);
               stepBaseLine = interpolator(t);
             } else {
@@ -511,7 +508,7 @@ class AreaWithState extends PureComponent<InternalProps, State> {
     const { isAnimationFinished } = this.state;
     const hasSinglePoint = points.length === 1;
     const layerClass = clsx('recharts-area', className);
-    const clipPathId = isNil(id) ? this.id : id;
+    const clipPathId = isNullOrUndefined(id) ? this.id : id;
     const { r = 3, strokeWidth = 2 } = filterProps(dot, false) ?? { r: 3, strokeWidth: 2 };
     const { clipDot = true } = hasClipDot(dot) ? dot : {};
     const dotSize = r * 2 + strokeWidth;

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -9,7 +9,7 @@ import { Dot } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 import { LabelList } from '../component/LabelList';
 import { Global } from '../util/Global';
-import { interpolateNumber, isNullish, isNumber, uniqueId } from '../util/DataUtils';
+import { interpolateNumber, isNan, isNullish, isNumber, uniqueId } from '../util/DataUtils';
 import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
 import {
   ActiveDotType,
@@ -431,7 +431,7 @@ class AreaWithState extends PureComponent<InternalProps, State> {
             if (isNumber(baseLine)) {
               const interpolator = interpolateNumber(prevBaseLine as number, baseLine);
               stepBaseLine = interpolator(t);
-            } else if (isNullish(baseLine) || Number.isNaN(baseLine)) {
+            } else if (isNullish(baseLine) || isNan(baseLine)) {
               const interpolator = interpolateNumber(prevBaseLine as number, 0);
               stepBaseLine = interpolator(t);
             } else {

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -9,7 +9,7 @@ import { Dot } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 import { LabelList } from '../component/LabelList';
 import { Global } from '../util/Global';
-import { interpolateNumber, isNullOrUndefined, isNumber, uniqueId } from '../util/DataUtils';
+import { interpolateNumber, isNullish, isNumber, uniqueId } from '../util/DataUtils';
 import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
 import {
   ActiveDotType,
@@ -289,7 +289,7 @@ class AreaWithState extends PureComponent<InternalProps, State> {
     const width = alpha * Math.abs(startX - endX);
     let maxY = max(points.map(entry => entry.y || 0));
 
-    if (isNumber(baseLine) && typeof baseLine === 'number') {
+    if (isNumber(baseLine)) {
       maxY = Math.max(baseLine, maxY);
     } else if (baseLine && Array.isArray(baseLine) && baseLine.length) {
       maxY = Math.max(max(baseLine.map(entry => entry.y || 0)), maxY);
@@ -316,7 +316,7 @@ class AreaWithState extends PureComponent<InternalProps, State> {
     const height = alpha * Math.abs(startY - endY);
     let maxX = max(points.map(entry => entry.x || 0));
 
-    if (isNumber(baseLine) && typeof baseLine === 'number') {
+    if (isNumber(baseLine)) {
       maxX = Math.max(baseLine, maxX);
     } else if (baseLine && Array.isArray(baseLine) && baseLine.length) {
       maxX = Math.max(max(baseLine.map(entry => entry.x || 0)), maxX);
@@ -396,7 +396,7 @@ class AreaWithState extends PureComponent<InternalProps, State> {
     const { points, baseLine, isAnimationActive, animationBegin, animationDuration, animationEasing, animationId } =
       this.props;
     const { prevPoints, prevBaseLine } = this.state;
-    // const clipPathId = isNullOrUndefined(id) ? this.id : id;
+    // const clipPathId = isNullish(id) ? this.id : id;
 
     return (
       <Animate
@@ -428,10 +428,10 @@ class AreaWithState extends PureComponent<InternalProps, State> {
             });
             let stepBaseLine;
 
-            if (isNumber(baseLine) && typeof baseLine === 'number') {
+            if (isNumber(baseLine)) {
               const interpolator = interpolateNumber(prevBaseLine as number, baseLine);
               stepBaseLine = interpolator(t);
-            } else if (isNullOrUndefined(baseLine) || Number.isNaN(baseLine)) {
+            } else if (isNullish(baseLine) || Number.isNaN(baseLine)) {
               const interpolator = interpolateNumber(prevBaseLine as number, 0);
               stepBaseLine = interpolator(t);
             } else {
@@ -508,7 +508,7 @@ class AreaWithState extends PureComponent<InternalProps, State> {
     const { isAnimationFinished } = this.state;
     const hasSinglePoint = points.length === 1;
     const layerClass = clsx('recharts-area', className);
-    const clipPathId = isNullOrUndefined(id) ? this.id : id;
+    const clipPathId = isNullish(id) ? this.id : id;
     const { r = 3, strokeWidth = 2 } = filterProps(dot, false) ?? { r: 3, strokeWidth: 2 };
     const { clipDot = true } = hasClipDot(dot) ? dot : {};
     const dotSize = r * 2 + strokeWidth;
@@ -659,7 +659,7 @@ export const getBaseValue = (
   // The value for the item takes precedence.
   const baseValue = itemBaseValue ?? chartBaseValue;
 
-  if (isNumber(baseValue) && typeof baseValue === 'number') {
+  if (isNumber(baseValue)) {
     return baseValue;
   }
 

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -12,7 +12,7 @@ import { Layer } from '../container/Layer';
 import { ErrorBarDataItem, ErrorBarDataPointFormatter, SetErrorBarPreferredDirection } from './ErrorBar';
 import { Cell } from '../component/Cell';
 import { LabelList } from '../component/LabelList';
-import { interpolateNumber, isNullish, mathSign, uniqueId } from '../util/DataUtils';
+import { interpolateNumber, isNan, isNullish, mathSign, uniqueId } from '../util/DataUtils';
 import { filterProps, findAllByType } from '../util/ReactUtils';
 import { Global } from '../util/Global';
 import {
@@ -659,7 +659,7 @@ export function computeBarRectangles({
       y = currentValueScale ?? baseValueScale ?? undefined;
       width = pos.size;
       const computedHeight = baseValueScale - currentValueScale;
-      height = Number.isNaN(computedHeight) ? 0 : computedHeight;
+      height = isNan(computedHeight) ? 0 : computedHeight;
       background = { x, y: offset.top, width, height: offset.height };
 
       if (Math.abs(minPointSize) > 0 && Math.abs(height) < Math.abs(minPointSize)) {

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -6,14 +6,13 @@ import React, { Key, PureComponent, ReactElement } from 'react';
 import clsx from 'clsx';
 import Animate from 'react-smooth';
 import isEqual from 'lodash/isEqual';
-import isNil from 'lodash/isNil';
 import { Series } from 'victory-vendor/d3-shape';
 import { Props as RectangleProps } from '../shape/Rectangle';
 import { Layer } from '../container/Layer';
 import { ErrorBarDataItem, ErrorBarDataPointFormatter, SetErrorBarPreferredDirection } from './ErrorBar';
 import { Cell } from '../component/Cell';
 import { LabelList } from '../component/LabelList';
-import { interpolateNumber, mathSign, uniqueId } from '../util/DataUtils';
+import { interpolateNumber, isNullOrUndefined, mathSign, uniqueId } from '../util/DataUtils';
 import { filterProps, findAllByType } from '../util/ReactUtils';
 import { Global } from '../util/Global';
 import {
@@ -481,7 +480,7 @@ class BarWithState extends PureComponent<InternalProps, State> {
 
     const { isAnimationFinished } = this.state;
     const layerClass = clsx('recharts-bar', className);
-    const clipPathId = isNil(id) ? this.id : id;
+    const clipPathId = isNullOrUndefined(id) ? this.id : id;
 
     return (
       <Layer className={layerClass}>

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -12,7 +12,7 @@ import { Layer } from '../container/Layer';
 import { ErrorBarDataItem, ErrorBarDataPointFormatter, SetErrorBarPreferredDirection } from './ErrorBar';
 import { Cell } from '../component/Cell';
 import { LabelList } from '../component/LabelList';
-import { interpolateNumber, isNullOrUndefined, mathSign, uniqueId } from '../util/DataUtils';
+import { interpolateNumber, isNullish, mathSign, uniqueId } from '../util/DataUtils';
 import { filterProps, findAllByType } from '../util/ReactUtils';
 import { Global } from '../util/Global';
 import {
@@ -480,7 +480,7 @@ class BarWithState extends PureComponent<InternalProps, State> {
 
     const { isAnimationFinished } = this.state;
     const layerClass = clsx('recharts-bar', className);
-    const clipPathId = isNullOrUndefined(id) ? this.id : id;
+    const clipPathId = isNullish(id) ? this.id : id;
 
     return (
       <Layer className={layerClass}>

--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -16,7 +16,6 @@ import React, {
 } from 'react';
 import clsx from 'clsx';
 import { scalePoint, ScalePoint } from 'victory-vendor/d3-scale';
-import isFunction from 'lodash/isFunction';
 import range from 'lodash/range';
 import { Layer } from '../container/Layer';
 import { Text } from '../component/Text';
@@ -101,7 +100,7 @@ function Traveller(props: { travellerType: BrushTravellerType; travellerProps: T
     // @ts-expect-error element cloning disagrees with the types (and it should)
     return React.cloneElement(travellerType, travellerProps);
   }
-  if (isFunction(travellerType)) {
+  if (typeof travellerType === 'function') {
     return travellerType(travellerProps);
   }
   return <DefaultTraveller {...travellerProps} />;
@@ -186,7 +185,7 @@ function getTextOfTick(props: TextOfTickProps): ReactText {
   const text = getValueByDataKey(data[index], dataKey, index);
 
   // @ts-expect-error getValueByDataKey does not validate the output type
-  return isFunction(tickFormatter) ? tickFormatter(text, index) : text;
+  return typeof tickFormatter === 'function' ? tickFormatter(text, index) : text;
 }
 
 function getIndexInRange(valueRange: number[], x: number) {

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -3,7 +3,6 @@
  */
 import React, { ReactElement, ReactNode, Component, SVGProps } from 'react';
 
-import isFunction from 'lodash/isFunction';
 import get from 'lodash/get';
 import clsx from 'clsx';
 import { shallowEqual } from '../util/ShallowEqual';
@@ -257,7 +256,7 @@ export class CartesianAxis extends Component<Props, IState> {
 
     if (React.isValidElement(option)) {
       tickItem = React.cloneElement(option, props);
-    } else if (isFunction(option)) {
+    } else if (typeof option === 'function') {
       tickItem = option(props);
     } else {
       tickItem = (
@@ -327,7 +326,7 @@ export class CartesianAxis extends Component<Props, IState> {
             CartesianAxis.renderTickItem(
               tick,
               tickProps,
-              `${isFunction(tickFormatter) ? tickFormatter(entry.value, i) : entry.value}${unit || ''}`,
+              `${typeof tickFormatter === 'function' ? tickFormatter(entry.value, i) : entry.value}${unit || ''}`,
             )}
         </Layer>
       );

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -2,7 +2,6 @@
  * @fileOverview Cartesian Grid
  */
 import React, { ReactElement, SVGProps } from 'react';
-import isFunction from 'lodash/isFunction';
 
 import { warn } from '../util/LogUtils';
 import { isNumber } from '../util/DataUtils';
@@ -177,7 +176,7 @@ function renderLineItem(option: GridLineType, props: LineItemProps) {
   if (React.isValidElement(option)) {
     // @ts-expect-error typescript does not see the props type when cloning an element
     lineItem = React.cloneElement(option, props);
-  } else if (isFunction(option)) {
+  } else if (typeof option === 'function') {
     lineItem = option(props);
   } else {
     const { x1, y1, x2, y2, key, ...others } = props;
@@ -429,7 +428,7 @@ export function CartesianGrid(props: Props) {
   let { horizontalPoints, verticalPoints } = propsIncludingDefaults;
 
   // No horizontal points are specified
-  if ((!horizontalPoints || !horizontalPoints.length) && isFunction(horizontalCoordinatesGenerator)) {
+  if ((!horizontalPoints || !horizontalPoints.length) && typeof horizontalCoordinatesGenerator === 'function') {
     const isHorizontalValues = horizontalValues && horizontalValues.length;
 
     const generatorResult = horizontalCoordinatesGenerator(
@@ -457,7 +456,7 @@ export function CartesianGrid(props: Props) {
   }
 
   // No vertical points are specified
-  if ((!verticalPoints || !verticalPoints.length) && isFunction(verticalCoordinatesGenerator)) {
+  if ((!verticalPoints || !verticalPoints.length) && typeof verticalCoordinatesGenerator === 'function') {
     const isVerticalValues = verticalValues && verticalValues.length;
     const generatorResult = verticalCoordinatesGenerator(
       {

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -11,7 +11,7 @@ import { Layer } from '../container/Layer';
 import { Props as TrapezoidProps } from '../shape/Trapezoid';
 import { LabelList } from '../component/LabelList';
 import { Global } from '../util/Global';
-import { interpolateNumber } from '../util/DataUtils';
+import { interpolateNumber, isNumber } from '../util/DataUtils';
 import { getValueByDataKey } from '../util/ChartUtils';
 import {
   LegendType,
@@ -189,7 +189,7 @@ const getRealWidthHeight = ({ customWidth }: { customWidth: number | string }, o
   const realHeight = height;
   let realWidth = width;
 
-  if (typeof customWidth === 'number') {
+  if (isNumber(customWidth)) {
     realWidth = customWidth;
   } else if (typeof customWidth === 'string') {
     realWidth = (realWidth * parseFloat(customWidth)) / 100;

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -1,9 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import React, { PureComponent } from 'react';
 import Animate from 'react-smooth';
-import isFunction from 'lodash/isFunction';
-import isNumber from 'lodash/isNumber';
-import isString from 'lodash/isString';
 import omit from 'lodash/omit';
 import isEqual from 'lodash/isEqual';
 
@@ -192,9 +189,9 @@ const getRealWidthHeight = ({ customWidth }: { customWidth: number | string }, o
   const realHeight = height;
   let realWidth = width;
 
-  if (isNumber(customWidth)) {
+  if (typeof customWidth === 'number') {
     realWidth = customWidth;
-  } else if (isString(customWidth)) {
+  } else if (typeof customWidth === 'string') {
     realWidth = (realWidth * parseFloat(customWidth)) / 100;
   }
 
@@ -230,7 +227,7 @@ export class FunnelWithState extends PureComponent<InternalProps, State> {
     const { onAnimationEnd } = this.props;
     this.setState({ isAnimationFinished: true });
 
-    if (isFunction(onAnimationEnd)) {
+    if (typeof onAnimationEnd === 'function') {
       onAnimationEnd();
     }
   };
@@ -239,7 +236,7 @@ export class FunnelWithState extends PureComponent<InternalProps, State> {
     const { onAnimationStart } = this.props;
     this.setState({ isAnimationFinished: false });
 
-    if (isFunction(onAnimationStart)) {
+    if (typeof onAnimationStart === 'function') {
       onAnimationStart();
     }
   };

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -1,8 +1,6 @@
 // eslint-disable-next-line max-classes-per-file
 import React, { Component, PureComponent } from 'react';
 import Animate from 'react-smooth';
-import isFunction from 'lodash/isFunction';
-import isNil from 'lodash/isNil';
 import isEqual from 'lodash/isEqual';
 
 import clsx from 'clsx';
@@ -12,7 +10,7 @@ import { Layer } from '../container/Layer';
 import { ImplicitLabelType } from '../component/Label';
 import { LabelList } from '../component/LabelList';
 import { ErrorBarDataItem, ErrorBarDataPointFormatter, SetErrorBarPreferredDirection } from './ErrorBar';
-import { interpolateNumber, uniqueId } from '../util/DataUtils';
+import { interpolateNumber, isNullOrUndefined, uniqueId } from '../util/DataUtils';
 import { filterProps, hasClipDot } from '../util/ReactUtils';
 import { Global } from '../util/Global';
 import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
@@ -217,7 +215,7 @@ function renderDotItem(option: ActiveDotType, props: any) {
 
   if (React.isValidElement(option)) {
     dotItem = React.cloneElement(option, props);
-  } else if (isFunction(option)) {
+  } else if (typeof option === 'function') {
     dotItem = option(props);
   } else {
     const className = clsx('recharts-line-dot', typeof option !== 'boolean' ? option.className : '');
@@ -485,7 +483,7 @@ class LineWithState extends Component<InternalProps, State> {
     const { isAnimationFinished } = this.state;
     const hasSinglePoint = points.length === 1;
     const layerClass = clsx('recharts-line', className);
-    const clipPathId = isNil(id) ? this.id : id;
+    const clipPathId = isNullOrUndefined(id) ? this.id : id;
     const { r = 3, strokeWidth = 2 } = filterProps(dot, false) ?? { r: 3, strokeWidth: 2 };
     const { clipDot = true } = hasClipDot(dot) ? dot : {};
     const dotSize = r * 2 + strokeWidth;
@@ -639,14 +637,14 @@ export function computeLinePoints({
     if (layout === 'horizontal') {
       return {
         x: getCateCoordinateOfLine({ axis: xAxis, ticks: xAxisTicks, bandSize, entry, index }),
-        y: isNil(value) ? null : yAxis.scale(value),
+        y: isNullOrUndefined(value) ? null : yAxis.scale(value),
         value,
         payload: entry,
       };
     }
 
     return {
-      x: isNil(value) ? null : xAxis.scale(value),
+      x: isNullOrUndefined(value) ? null : xAxis.scale(value),
       y: getCateCoordinateOfLine({ axis: yAxis, ticks: yAxisTicks, bandSize, entry, index }),
       value,
       payload: entry,

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -10,7 +10,7 @@ import { Layer } from '../container/Layer';
 import { ImplicitLabelType } from '../component/Label';
 import { LabelList } from '../component/LabelList';
 import { ErrorBarDataItem, ErrorBarDataPointFormatter, SetErrorBarPreferredDirection } from './ErrorBar';
-import { interpolateNumber, isNullOrUndefined, uniqueId } from '../util/DataUtils';
+import { interpolateNumber, isNullish, uniqueId } from '../util/DataUtils';
 import { filterProps, hasClipDot } from '../util/ReactUtils';
 import { Global } from '../util/Global';
 import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
@@ -483,7 +483,7 @@ class LineWithState extends Component<InternalProps, State> {
     const { isAnimationFinished } = this.state;
     const hasSinglePoint = points.length === 1;
     const layerClass = clsx('recharts-line', className);
-    const clipPathId = isNullOrUndefined(id) ? this.id : id;
+    const clipPathId = isNullish(id) ? this.id : id;
     const { r = 3, strokeWidth = 2 } = filterProps(dot, false) ?? { r: 3, strokeWidth: 2 };
     const { clipDot = true } = hasClipDot(dot) ? dot : {};
     const dotSize = r * 2 + strokeWidth;
@@ -637,14 +637,14 @@ export function computeLinePoints({
     if (layout === 'horizontal') {
       return {
         x: getCateCoordinateOfLine({ axis: xAxis, ticks: xAxisTicks, bandSize, entry, index }),
-        y: isNullOrUndefined(value) ? null : yAxis.scale(value),
+        y: isNullish(value) ? null : yAxis.scale(value),
         value,
         payload: entry,
       };
     }
 
     return {
-      x: isNullOrUndefined(value) ? null : xAxis.scale(value),
+      x: isNullish(value) ? null : xAxis.scale(value),
       y: getCateCoordinateOfLine({ axis: yAxis, ticks: yAxisTicks, bandSize, entry, index }),
       value,
       payload: entry,

--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -1,5 +1,4 @@
 import React, { Component, ReactElement, useEffect } from 'react';
-import isFunction from 'lodash/isFunction';
 import clsx from 'clsx';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelType, Label } from '../component/Label';
@@ -71,7 +70,7 @@ const renderRect = (option: ReferenceAreaProps['shape'], props: any) => {
 
   if (React.isValidElement(option)) {
     rect = React.cloneElement(option, props);
-  } else if (isFunction(option)) {
+  } else if (typeof option === 'function') {
     rect = option(props);
   } else {
     rect = <Rectangle {...props} className="recharts-reference-area-rect" />;

--- a/src/cartesian/ReferenceDot.tsx
+++ b/src/cartesian/ReferenceDot.tsx
@@ -1,5 +1,4 @@
 import React, { Component, ReactElement, useEffect } from 'react';
-import isFunction from 'lodash/isFunction';
 import clsx from 'clsx';
 import { Layer } from '../container/Layer';
 import { Dot, Props as DotProps } from '../shape/Dot';
@@ -79,7 +78,7 @@ const renderDot = (option: Props['shape'], props: any) => {
 
   if (React.isValidElement(option)) {
     dot = React.cloneElement(option, props);
-  } else if (isFunction(option)) {
+  } else if (typeof option === 'function') {
     dot = option(props);
   } else {
     dot = <Dot {...props} cx={props.cx} cy={props.cy} className="recharts-reference-dot-dot" />;

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -2,7 +2,6 @@
  * @fileOverview Reference Line
  */
 import React, { Component, ReactElement, SVGProps, useEffect } from 'react';
-import isFunction from 'lodash/isFunction';
 import some from 'lodash/some';
 import clsx from 'clsx';
 import { Layer } from '../container/Layer';
@@ -69,7 +68,7 @@ const renderLine = (option: ReferenceLineProps['shape'], props: any) => {
 
   if (React.isValidElement(option)) {
     line = React.cloneElement(option, props);
-  } else if (isFunction(option)) {
+  } else if (typeof option === 'function') {
     line = option(props);
   } else {
     line = <line {...props} className="recharts-reference-line-line" />;

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelType, Label } from '../component/Label';
 import { IfOverflow } from '../util/IfOverflow';
-import { isNumOrStr } from '../util/DataUtils';
+import { isNan, isNumOrStr } from '../util/DataUtils';
 import { createLabeledScales, rectWithCoords } from '../util/CartesianUtils';
 import { CartesianViewBox } from '../util/types';
 import { Props as XAxisProps } from './XAxis';
@@ -101,7 +101,7 @@ export const getEndPoints = (
     const { y: yCoord } = props;
     const coord = scales.y.apply(yCoord, { position });
     // don't render the line if the scale can't compute a result that makes sense
-    if (Number.isNaN(coord)) return null;
+    if (isNan(coord)) return null;
 
     if (props.ifOverflow === 'discard' && !scales.y.isInRange(coord)) {
       return null;
@@ -117,7 +117,7 @@ export const getEndPoints = (
     const { x: xCoord } = props;
     const coord = scales.x.apply(xCoord, { position });
     // don't render the line if the scale can't compute a result that makes sense
-    if (Number.isNaN(coord)) return null;
+    if (isNan(coord)) return null;
 
     if (props.ifOverflow === 'discard' && !scales.x.isInRange(coord)) {
       return null;

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -2,9 +2,7 @@
 import React, { Component, PureComponent, ReactElement, useMemo } from 'react';
 import Animate from 'react-smooth';
 
-import isNil from 'lodash/isNil';
 import isEqual from 'lodash/isEqual';
-import isFunction from 'lodash/isFunction';
 import clsx from 'clsx';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelListType, LabelList } from '../component/LabelList';
@@ -14,7 +12,7 @@ import { ZAxis } from './ZAxis';
 import { Curve, CurveType, Props as CurveProps } from '../shape/Curve';
 import type { ErrorBarDataItem, ErrorBarDirection } from './ErrorBar';
 import { Cell } from '../component/Cell';
-import { getLinearRegression, interpolateNumber, uniqueId } from '../util/DataUtils';
+import { getLinearRegression, interpolateNumber, isNullOrUndefined, uniqueId } from '../util/DataUtils';
 import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
 import {
   ActiveShape,
@@ -269,8 +267,8 @@ export function computeScatterPoints({
   yAxisTicks: TickItem[];
   cells: ReadonlyArray<ReactElement> | undefined;
 }): ReadonlyArray<ScatterPointItem> {
-  const xAxisDataKey = isNil(xAxis.dataKey) ? scatterSettings.dataKey : xAxis.dataKey;
-  const yAxisDataKey = isNil(yAxis.dataKey) ? scatterSettings.dataKey : yAxis.dataKey;
+  const xAxisDataKey = isNullOrUndefined(xAxis.dataKey) ? scatterSettings.dataKey : xAxis.dataKey;
+  const yAxisDataKey = isNullOrUndefined(yAxis.dataKey) ? scatterSettings.dataKey : yAxis.dataKey;
   const zAxisDataKey = zAxis && zAxis.dataKey;
   const defaultRangeZ = zAxis ? zAxis.range : ZAxis.defaultProps.range;
   const defaultZ = defaultRangeZ && defaultRangeZ[0];
@@ -279,12 +277,12 @@ export function computeScatterPoints({
   return displayedData.map((entry, index): ScatterPointItem => {
     const x = getValueByDataKey(entry, xAxisDataKey);
     const y = getValueByDataKey(entry, yAxisDataKey);
-    const z = (!isNil(zAxisDataKey) && getValueByDataKey(entry, zAxisDataKey)) || '-';
+    const z = (!isNullOrUndefined(zAxisDataKey) && getValueByDataKey(entry, zAxisDataKey)) || '-';
 
     const tooltipPayload: Array<TooltipPayloadEntry> = [
       {
         // @ts-expect-error name prop should not have dataKey in it
-        name: isNil(xAxis.dataKey) ? scatterSettings.name : xAxis.name || xAxis.dataKey,
+        name: isNullOrUndefined(xAxis.dataKey) ? scatterSettings.name : xAxis.name || xAxis.dataKey,
         unit: xAxis.unit || '',
         // @ts-expect-error getValueByDataKey does not validate the output type
         value: x,
@@ -294,7 +292,7 @@ export function computeScatterPoints({
       },
       {
         // @ts-expect-error name prop should not have dataKey in it
-        name: isNil(yAxis.dataKey) ? scatterSettings.name : yAxis.name || yAxis.dataKey,
+        name: isNullOrUndefined(yAxis.dataKey) ? scatterSettings.name : yAxis.name || yAxis.dataKey,
         unit: yAxis.unit || '',
         // @ts-expect-error getValueByDataKey does not validate the output type
         value: y,
@@ -385,7 +383,7 @@ function ScatterLine(props: InternalProps) {
 
   if (React.isValidElement(line)) {
     lineItem = React.cloneElement(line as any, lineProps);
-  } else if (isFunction(line)) {
+  } else if (typeof line === 'function') {
     lineItem = line(lineProps);
   } else {
     lineItem = <Curve {...lineProps} type={lineJointType} />;
@@ -508,7 +506,7 @@ class ScatterWithState extends PureComponent<InternalProps, State> {
     }
     const { isAnimationFinished } = this.state;
     const layerClass = clsx('recharts-scatter', className);
-    const clipPathId = isNil(id) ? this.id : id;
+    const clipPathId = isNullOrUndefined(id) ? this.id : id;
     return (
       <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
         {needClip && (

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -12,7 +12,7 @@ import { ZAxis } from './ZAxis';
 import { Curve, CurveType, Props as CurveProps } from '../shape/Curve';
 import type { ErrorBarDataItem, ErrorBarDirection } from './ErrorBar';
 import { Cell } from '../component/Cell';
-import { getLinearRegression, interpolateNumber, isNullOrUndefined, uniqueId } from '../util/DataUtils';
+import { getLinearRegression, interpolateNumber, isNullish, uniqueId } from '../util/DataUtils';
 import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
 import {
   ActiveShape,
@@ -267,8 +267,8 @@ export function computeScatterPoints({
   yAxisTicks: TickItem[];
   cells: ReadonlyArray<ReactElement> | undefined;
 }): ReadonlyArray<ScatterPointItem> {
-  const xAxisDataKey = isNullOrUndefined(xAxis.dataKey) ? scatterSettings.dataKey : xAxis.dataKey;
-  const yAxisDataKey = isNullOrUndefined(yAxis.dataKey) ? scatterSettings.dataKey : yAxis.dataKey;
+  const xAxisDataKey = isNullish(xAxis.dataKey) ? scatterSettings.dataKey : xAxis.dataKey;
+  const yAxisDataKey = isNullish(yAxis.dataKey) ? scatterSettings.dataKey : yAxis.dataKey;
   const zAxisDataKey = zAxis && zAxis.dataKey;
   const defaultRangeZ = zAxis ? zAxis.range : ZAxis.defaultProps.range;
   const defaultZ = defaultRangeZ && defaultRangeZ[0];
@@ -277,12 +277,12 @@ export function computeScatterPoints({
   return displayedData.map((entry, index): ScatterPointItem => {
     const x = getValueByDataKey(entry, xAxisDataKey);
     const y = getValueByDataKey(entry, yAxisDataKey);
-    const z = (!isNullOrUndefined(zAxisDataKey) && getValueByDataKey(entry, zAxisDataKey)) || '-';
+    const z = (!isNullish(zAxisDataKey) && getValueByDataKey(entry, zAxisDataKey)) || '-';
 
     const tooltipPayload: Array<TooltipPayloadEntry> = [
       {
         // @ts-expect-error name prop should not have dataKey in it
-        name: isNullOrUndefined(xAxis.dataKey) ? scatterSettings.name : xAxis.name || xAxis.dataKey,
+        name: isNullish(xAxis.dataKey) ? scatterSettings.name : xAxis.name || xAxis.dataKey,
         unit: xAxis.unit || '',
         // @ts-expect-error getValueByDataKey does not validate the output type
         value: x,
@@ -292,7 +292,7 @@ export function computeScatterPoints({
       },
       {
         // @ts-expect-error name prop should not have dataKey in it
-        name: isNullOrUndefined(yAxis.dataKey) ? scatterSettings.name : yAxis.name || yAxis.dataKey,
+        name: isNullish(yAxis.dataKey) ? scatterSettings.name : yAxis.name || yAxis.dataKey,
         unit: yAxis.unit || '',
         // @ts-expect-error getValueByDataKey does not validate the output type
         value: y,
@@ -506,7 +506,7 @@ class ScatterWithState extends PureComponent<InternalProps, State> {
     }
     const { isAnimationFinished } = this.state;
     const layerClass = clsx('recharts-scatter', className);
-    const clipPathId = isNullOrUndefined(id) ? this.id : id;
+    const clipPathId = isNullish(id) ? this.id : id;
     return (
       <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
         {needClip && (

--- a/src/cartesian/getTicks.ts
+++ b/src/cartesian/getTicks.ts
@@ -1,4 +1,3 @@
-import isFunction from 'lodash/isFunction';
 import { CartesianTickItem, CartesianViewBox, Size } from '../util/types';
 import { mathSign, isNumber } from '../util/DataUtils';
 import { getStringSize } from '../util/DOMUtils';
@@ -153,7 +152,7 @@ export function getTicks(
     unit && sizeKey === 'width' ? getStringSize(unit, { fontSize, letterSpacing }) : { width: 0, height: 0 };
 
   const getTickSize = (content: CartesianTickItem, index: number) => {
-    const value = isFunction(tickFormatter) ? tickFormatter(content.value, index) : content.value;
+    const value = typeof tickFormatter === 'function' ? tickFormatter(content.value, index) : content.value;
     // Recharts only supports angles when sizeKey === 'width'
     return sizeKey === 'width'
       ? getAngledTickWidth(getStringSize(value, { fontSize, letterSpacing }), unitSize, angle)

--- a/src/cartesian/getTicks.ts
+++ b/src/cartesian/getTicks.ts
@@ -142,7 +142,7 @@ export function getTicks(
   }
 
   if (isNumber(interval) || Global.isSsr) {
-    return getNumberIntervalTicks(ticks, typeof interval === 'number' && isNumber(interval) ? interval : 0);
+    return getNumberIntervalTicks(ticks, isNumber(interval) ? interval : 0);
   }
 
   let candidates: ReadonlyArray<CartesianTickItem> = [];

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -3,8 +3,6 @@ import maxBy from 'lodash/maxBy';
 import min from 'lodash/min';
 import get from 'lodash/get';
 import sumBy from 'lodash/sumBy';
-import isFunction from 'lodash/isFunction';
-
 import { Surface } from '../container/Surface';
 import { Layer } from '../container/Layer';
 import { Tooltip } from '../component/Tooltip';
@@ -510,7 +508,7 @@ function renderLinkItem(option: SankeyLinkOptions, props: LinkProps) {
   if (React.isValidElement(option)) {
     return React.cloneElement(option, props);
   }
-  if (isFunction(option)) {
+  if (typeof option === 'function') {
     return option(props);
   }
 
@@ -672,7 +670,7 @@ function renderNodeItem(option: SankeyNodeOptions, props: NodeProps) {
   if (React.isValidElement(option)) {
     return React.cloneElement(option, props);
   }
-  if (isFunction(option)) {
+  if (typeof option === 'function') {
     return option(props);
   }
 

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -10,7 +10,7 @@ import { Polygon } from '../shape/Polygon';
 import { Rectangle } from '../shape/Rectangle';
 import { getValueByDataKey } from '../util/ChartUtils';
 import { COLOR_PANEL } from '../util/Constants';
-import { uniqueId } from '../util/DataUtils';
+import { isNan, uniqueId } from '../util/DataUtils';
 import { getStringSize } from '../util/DOMUtils';
 import { Global } from '../util/Global';
 import { findChildByType, validateWidthHeight, filterProps } from '../util/ReactUtils';
@@ -116,7 +116,7 @@ export const computeNode = ({
     nodeValue = computedChildren.reduce((result: any, child: TreemapNode) => result + child[NODE_VALUE_KEY], 0);
   } else {
     // TODO need to verify dataKey
-    nodeValue = Number.isNaN(node[dataKey as string]) || node[dataKey as string] <= 0 ? 0 : node[dataKey as string];
+    nodeValue = isNan(node[dataKey as string]) || node[dataKey as string] <= 0 ? 0 : node[dataKey as string];
   }
 
   return {
@@ -142,7 +142,7 @@ const getAreaOfChildren = (children: ReadonlyArray<TreemapNode>, areaValueRatio:
 
     return {
       ...child,
-      area: Number.isNaN(area) || area <= 0 ? 0 : area,
+      area: isNan(area) || area <= 0 ? 0 : area,
     };
   });
 };

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -1,6 +1,4 @@
 import React, { PureComponent } from 'react';
-import isNan from 'lodash/isNaN';
-import isFunction from 'lodash/isFunction';
 import omit from 'lodash/omit';
 import get from 'lodash/get';
 import Smooth from 'react-smooth';
@@ -118,7 +116,7 @@ export const computeNode = ({
     nodeValue = computedChildren.reduce((result: any, child: TreemapNode) => result + child[NODE_VALUE_KEY], 0);
   } else {
     // TODO need to verify dataKey
-    nodeValue = isNan(node[dataKey as string]) || node[dataKey as string] <= 0 ? 0 : node[dataKey as string];
+    nodeValue = Number.isNaN(node[dataKey as string]) || node[dataKey as string] <= 0 ? 0 : node[dataKey as string];
   }
 
   return {
@@ -144,7 +142,7 @@ const getAreaOfChildren = (children: ReadonlyArray<TreemapNode>, areaValueRatio:
 
     return {
       ...child,
-      area: isNan(area) || area <= 0 ? 0 : area,
+      area: Number.isNaN(area) || area <= 0 ? 0 : area,
     };
   });
 };
@@ -402,7 +400,7 @@ function ContentItem({
   if (React.isValidElement(content)) {
     return React.cloneElement(content, nodeProps);
   }
-  if (isFunction(content)) {
+  if (typeof content === 'function') {
     return content(nodeProps);
   }
   // optimize default shape
@@ -617,7 +615,7 @@ export class Treemap extends PureComponent<Props, State> {
     const { onAnimationEnd } = this.props;
     this.setState({ isAnimationFinished: true });
 
-    if (isFunction(onAnimationEnd)) {
+    if (typeof onAnimationEnd === 'function') {
       onAnimationEnd();
     }
   };
@@ -626,7 +624,7 @@ export class Treemap extends PureComponent<Props, State> {
     const { onAnimationStart } = this.props;
     this.setState({ isAnimationFinished: false });
 
-    if (isFunction(onAnimationStart)) {
+    if (typeof onAnimationStart === 'function') {
       onAnimationStart();
     }
   };
@@ -830,7 +828,7 @@ export class Treemap extends PureComponent<Props, State> {
           if (React.isValidElement(nestIndexContent)) {
             content = React.cloneElement(nestIndexContent, item, i);
           }
-          if (isFunction(nestIndexContent)) {
+          if (typeof nestIndexContent === 'function') {
             content = nestIndexContent(item, i);
           } else {
             content = name;

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1,6 +1,4 @@
 import React, { Component, forwardRef, ReactElement } from 'react';
-import isNil from 'lodash/isNil';
-import isFunction from 'lodash/isFunction';
 import range from 'lodash/range';
 import get from 'lodash/get';
 import sortBy from 'lodash/sortBy';
@@ -24,7 +22,14 @@ import {
 
 import { Brush } from '../cartesian/Brush';
 import { getOffset } from '../util/DOMUtils';
-import { findEntryInArray, getAnyElementOfObject, hasDuplicate, isNumber, uniqueId } from '../util/DataUtils';
+import {
+  findEntryInArray,
+  getAnyElementOfObject,
+  hasDuplicate,
+  isNullOrUndefined,
+  isNumber,
+  uniqueId,
+} from '../util/DataUtils';
 import {
   appendOffsetOfLegend,
   AxisPropsNeededForTicksGenerator,
@@ -337,12 +342,14 @@ export const getAxisMapByAxes = (
           if (!allowDuplicatedCategory) {
             domain = parseDomainOfCategoryAxis(childDomain, domain, child).reduce(
               (finalDomain: any, entry: any) =>
-                finalDomain.indexOf(entry) >= 0 || entry === '' || isNil(entry) ? finalDomain : [...finalDomain, entry],
+                finalDomain.indexOf(entry) >= 0 || entry === '' || isNullOrUndefined(entry)
+                  ? finalDomain
+                  : [...finalDomain, entry],
               [],
             );
           } else {
             // eliminate undefined or null or empty string
-            domain = domain.filter((entry: any) => entry !== '' && !isNil(entry));
+            domain = domain.filter((entry: any) => entry !== '' && !isNullOrUndefined(entry));
           }
         } else if (type === 'number') {
           // the field type is numerical
@@ -1113,7 +1120,7 @@ export const generateCategoricalChart = ({
         const hasDifferentStartOrEndIndex = startIndex !== dataStartIndex || endIndex !== dataEndIndex;
 
         // update configuration in children
-        const hasGlobalData = !isNil(data);
+        const hasGlobalData = !isNullOrUndefined(data);
         const newUpdateId = hasGlobalData && !hasDifferentStartOrEndIndex ? prevState.updateId : prevState.updateId + 1;
 
         return {
@@ -1338,7 +1345,7 @@ export const generateCategoricalChart = ({
         this.triggerSyncEvent(nextState);
 
         const { onMouseEnter } = this.props;
-        if (isFunction(onMouseEnter)) {
+        if (typeof onMouseEnter === 'function') {
           onMouseEnter(nextState, e);
         }
       }
@@ -1352,7 +1359,7 @@ export const generateCategoricalChart = ({
       this.triggerSyncEvent(nextState);
 
       const { onMouseMove } = this.props;
-      if (isFunction(onMouseMove)) {
+      if (typeof onMouseMove === 'function') {
         onMouseMove(nextState, e);
       }
     };
@@ -1409,7 +1416,7 @@ export const generateCategoricalChart = ({
       this.triggerSyncEvent(nextState);
 
       const { onMouseLeave } = this.props;
-      if (isFunction(onMouseLeave)) {
+      if (typeof onMouseLeave === 'function') {
         onMouseLeave(nextState, e);
       }
     };
@@ -1418,7 +1425,7 @@ export const generateCategoricalChart = ({
       const eventName = getReactEventByType(e);
 
       const event = get(this.props, `${eventName}`);
-      if (eventName && isFunction(event)) {
+      if (eventName && typeof event === 'function') {
         let mouse;
         if (/.*touch.*/i.test(eventName)) {
           mouse = this.getMouseInfo((e as React.TouchEvent).changedTouches[0]);
@@ -1439,7 +1446,7 @@ export const generateCategoricalChart = ({
         this.triggerSyncEvent(nextState);
 
         const { onClick } = this.props;
-        if (isFunction(onClick)) {
+        if (typeof onClick === 'function') {
           onClick(nextState, e);
         }
       }
@@ -1448,7 +1455,7 @@ export const generateCategoricalChart = ({
     handleMouseDown = (e: React.MouseEvent | React.Touch) => {
       const { onMouseDown } = this.props;
 
-      if (isFunction(onMouseDown)) {
+      if (typeof onMouseDown === 'function') {
         const nextState: CategoricalChartState = this.getMouseInfo(e);
         onMouseDown(nextState, e);
       }
@@ -1457,7 +1464,7 @@ export const generateCategoricalChart = ({
     handleMouseUp = (e: React.MouseEvent | React.Touch) => {
       const { onMouseUp } = this.props;
 
-      if (isFunction(onMouseUp)) {
+      if (typeof onMouseUp === 'function') {
         const nextState: CategoricalChartState = this.getMouseInfo(e);
         onMouseUp(nextState, e);
       }

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -26,7 +26,7 @@ import {
   findEntryInArray,
   getAnyElementOfObject,
   hasDuplicate,
-  isNullOrUndefined,
+  isNullish,
   isNumber,
   uniqueId,
 } from '../util/DataUtils';
@@ -342,14 +342,14 @@ export const getAxisMapByAxes = (
           if (!allowDuplicatedCategory) {
             domain = parseDomainOfCategoryAxis(childDomain, domain, child).reduce(
               (finalDomain: any, entry: any) =>
-                finalDomain.indexOf(entry) >= 0 || entry === '' || isNullOrUndefined(entry)
+                finalDomain.indexOf(entry) >= 0 || entry === '' || isNullish(entry)
                   ? finalDomain
                   : [...finalDomain, entry],
               [],
             );
           } else {
             // eliminate undefined or null or empty string
-            domain = domain.filter((entry: any) => entry !== '' && !isNullOrUndefined(entry));
+            domain = domain.filter((entry: any) => entry !== '' && !isNullish(entry));
           }
         } else if (type === 'number') {
           // the field type is numerical
@@ -1120,7 +1120,7 @@ export const generateCategoricalChart = ({
         const hasDifferentStartOrEndIndex = startIndex !== dataStartIndex || endIndex !== dataEndIndex;
 
         // update configuration in children
-        const hasGlobalData = !isNullOrUndefined(data);
+        const hasGlobalData = !isNullish(data);
         const newUpdateId = hasGlobalData && !hasDifferentStartOrEndIndex ? prevState.updateId : prevState.updateId + 1;
 
         return {

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -5,7 +5,7 @@ import { Dot, Props as DotProps } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 import { useTooltipAxis } from '../context/useTooltipAxis';
 import { useTooltipContext } from '../context/tooltipContext';
-import { findEntryInArray, isNullOrUndefined } from '../util/DataUtils';
+import { findEntryInArray, isNullish } from '../util/DataUtils';
 
 export interface PointType {
   readonly x: number;
@@ -88,7 +88,7 @@ export function ActivePoints({ points, mainColor, activeDot, itemDataKey }: Acti
     activePoint = points?.[activeTooltipIndex];
   }
 
-  if (isNullOrUndefined(activePoint)) {
+  if (isNullish(activePoint)) {
     return null;
   }
 

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -1,13 +1,11 @@
 import React, { cloneElement, isValidElement } from 'react';
-import isFunction from 'lodash/isFunction';
-import isNil from 'lodash/isNil';
 import { ActiveDotType, adaptEventHandlers, DataKey } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { Dot, Props as DotProps } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 import { useTooltipAxis } from '../context/useTooltipAxis';
 import { useTooltipContext } from '../context/tooltipContext';
-import { findEntryInArray } from '../util/DataUtils';
+import { findEntryInArray, isNullOrUndefined } from '../util/DataUtils';
 
 export interface PointType {
   readonly x: number;
@@ -54,7 +52,7 @@ const renderActivePoint = ({
   if (isValidElement(activeDot)) {
     // @ts-expect-error element cloning does not have types
     dot = cloneElement(activeDot, dotProps);
-  } else if (isFunction(activeDot)) {
+  } else if (typeof activeDot === 'function') {
     dot = activeDot(dotProps);
   } else {
     dot = <Dot {...dotProps} />;
@@ -90,7 +88,7 @@ export function ActivePoints({ points, mainColor, activeDot, itemDataKey }: Acti
     activePoint = points?.[activeTooltipIndex];
   }
 
-  if (isNil(activePoint)) {
+  if (isNullOrUndefined(activePoint)) {
     return null;
   }
 

--- a/src/component/Customized.tsx
+++ b/src/component/Customized.tsx
@@ -2,7 +2,6 @@
  * @fileOverview Customized
  */
 import React, { isValidElement, cloneElement, createElement, Component, FunctionComponent, ReactElement } from 'react';
-import isFunction from 'lodash/isFunction';
 
 import { Layer } from '../container/Layer';
 import { warn } from '../util/LogUtils';
@@ -20,7 +19,7 @@ export function Customized<P, C extends Comp<P>>({ component, ...props }: Props<
   let child;
   if (isValidElement(component)) {
     child = cloneElement(component, props);
-  } else if (isFunction(component)) {
+  } else if (typeof component === 'function') {
     child = createElement(component, props as any);
   } else {
     warn(false, "Customized's props `component` must be React.element or Function, but got %s.", typeof component);

--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -2,7 +2,6 @@
  * @fileOverview Default Legend Content
  */
 import React, { PureComponent, ReactNode, MouseEvent, ReactText, ReactElement } from 'react';
-import isFunction from 'lodash/isFunction';
 
 import clsx from 'clsx';
 import { warn } from '../util/LogUtils';
@@ -160,9 +159,9 @@ export class DefaultLegendContent extends PureComponent<Props> {
       }
 
       // Do not render entry.value as functions. Always require static string properties.
-      const entryValue = !isFunction(entry.value) ? entry.value : null;
+      const entryValue = typeof entry.value !== 'function' ? entry.value : null;
       warn(
-        !isFunction(entry.value),
+        typeof entry.value !== 'function',
         `The name property is also required when using a function for the dataKey of a chart's cartesian components. Ex: <Bar name="Name of my Data"/>`, // eslint-disable-line max-len
       );
 

--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -5,7 +5,7 @@
 import React, { CSSProperties, HTMLAttributes, ReactNode } from 'react';
 import sortBy from 'lodash/sortBy';
 import clsx from 'clsx';
-import { isNullOrUndefined, isNumOrStr } from '../util/DataUtils';
+import { isNullish, isNumOrStr } from '../util/DataUtils';
 import { DataKey } from '../util/types';
 
 function defaultFormatter<TValue extends ValueType>(value: TValue) {
@@ -140,7 +140,7 @@ export const DefaultTooltipContent = <TValue extends ValueType, TName extends Na
     margin: 0,
     ...labelStyle,
   };
-  const hasLabel = !isNullOrUndefined(label);
+  const hasLabel = !isNullish(label);
   let finalLabel = hasLabel ? label : '';
   const wrapperCN = clsx('recharts-default-tooltip', wrapperClassName);
   const labelCN = clsx('recharts-tooltip-label', labelClassName);

--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -4,9 +4,8 @@
 
 import React, { CSSProperties, HTMLAttributes, ReactNode } from 'react';
 import sortBy from 'lodash/sortBy';
-import isNil from 'lodash/isNil';
 import clsx from 'clsx';
-import { isNumOrStr } from '../util/DataUtils';
+import { isNullOrUndefined, isNumOrStr } from '../util/DataUtils';
 import { DataKey } from '../util/types';
 
 function defaultFormatter<TValue extends ValueType>(value: TValue) {
@@ -141,7 +140,7 @@ export const DefaultTooltipContent = <TValue extends ValueType, TName extends Na
     margin: 0,
     ...labelStyle,
   };
-  const hasLabel = !isNil(label);
+  const hasLabel = !isNullOrUndefined(label);
   let finalLabel = hasLabel ? label : '';
   const wrapperCN = clsx('recharts-default-tooltip', wrapperClassName);
   const labelCN = clsx('recharts-tooltip-label', labelClassName);

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -1,15 +1,20 @@
 import React, { cloneElement, isValidElement, ReactNode, ReactElement, createElement, SVGProps } from 'react';
-import isNil from 'lodash/isNil';
-import isFunction from 'lodash/isFunction';
-import isObject from 'lodash/isObject';
 import clsx from 'clsx';
 import { Text } from './Text';
 import { findAllByType, filterProps } from '../util/ReactUtils';
-import { isNumOrStr, isNumber, isPercent, getPercentValue, uniqueId, mathSign } from '../util/DataUtils';
+import {
+  isNumOrStr,
+  isNumber,
+  isPercent,
+  getPercentValue,
+  uniqueId,
+  mathSign,
+  isNullOrUndefined,
+} from '../util/DataUtils';
 import { polarToCartesian } from '../util/PolarUtils';
 import { ViewBox, PolarViewBox, CartesianViewBox, DataKey } from '../util/types';
 
-export type ContentType = ReactElement | ((props: Props) => ReactNode);
+export type ContentType = ReactElement | ((props: Props) => ReactNode) | Function;
 
 export type LabelPosition =
   | 'top'
@@ -66,9 +71,9 @@ export type ImplicitLabelType =
 
 const getLabel = (props: Props) => {
   const { value, formatter } = props;
-  const label = isNil(props.children) ? value : props.children;
+  const label = isNullOrUndefined(props.children) ? value : props.children;
 
-  if (isFunction(formatter)) {
+  if (typeof formatter === 'function') {
     return formatter(label);
   }
 
@@ -108,7 +113,7 @@ const renderRadialLabel = (labelProps: Props, label: ReactNode, attrs: SVGProps<
   const path = `M${startPoint.x},${startPoint.y}
     A${radius},${radius},0,1,${direction ? 0 : 1},
     ${endPoint.x},${endPoint.y}`;
-  const id = isNil(labelProps.id) ? uniqueId('recharts-radial-line-') : labelProps.id;
+  const id = isNullOrUndefined(labelProps.id) ? uniqueId('recharts-radial-line-') : labelProps.id;
 
   return (
     <text {...attrs} dominantBaseline="central" className={clsx('recharts-radial-bar-label', className)}>
@@ -354,7 +359,8 @@ const getAttrsOfCartesianLabel = (props: Props) => {
   }
 
   if (
-    isObject(position) &&
+    !!position &&
+    typeof position === 'object' &&
     (isNumber(position.x) || isPercent(position.x)) &&
     (isNumber(position.y) || isPercent(position.y))
   ) {
@@ -383,7 +389,13 @@ export function Label({ offset = 5, ...restProps }: Props) {
   const props = { offset, ...restProps };
   const { viewBox, position, value, children, content, className = '', textBreakAll } = props;
 
-  if (!viewBox || (isNil(value) && isNil(children) && !isValidElement(content) && !isFunction(content))) {
+  if (
+    !viewBox ||
+    (isNullOrUndefined(value) &&
+      isNullOrUndefined(children) &&
+      !isValidElement(content) &&
+      typeof content !== 'function')
+  ) {
     return null;
   }
 
@@ -392,7 +404,7 @@ export function Label({ offset = 5, ...restProps }: Props) {
   }
 
   let label: ReactNode;
-  if (isFunction(content)) {
+  if (typeof content === 'function') {
     label = createElement(content as any, props);
 
     if (isValidElement(label)) {
@@ -498,11 +510,11 @@ const parseLabel = (label: unknown, viewBox: ViewBox) => {
     return <Label key="label-implicit" content={label} viewBox={viewBox} />;
   }
 
-  if (isFunction(label)) {
+  if (isValidElement(label) || typeof label === 'function') {
     return <Label key="label-implicit" content={label} viewBox={viewBox} />;
   }
 
-  if (isObject(label)) {
+  if (label && typeof label === 'object') {
     return <Label viewBox={viewBox} {...label} key="label-implicit" />;
   }
 

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -2,15 +2,7 @@ import React, { cloneElement, isValidElement, ReactNode, ReactElement, createEle
 import clsx from 'clsx';
 import { Text } from './Text';
 import { findAllByType, filterProps } from '../util/ReactUtils';
-import {
-  isNumOrStr,
-  isNumber,
-  isPercent,
-  getPercentValue,
-  uniqueId,
-  mathSign,
-  isNullOrUndefined,
-} from '../util/DataUtils';
+import { isNumOrStr, isNumber, isPercent, getPercentValue, uniqueId, mathSign, isNullish } from '../util/DataUtils';
 import { polarToCartesian } from '../util/PolarUtils';
 import { ViewBox, PolarViewBox, CartesianViewBox, DataKey } from '../util/types';
 
@@ -71,7 +63,7 @@ export type ImplicitLabelType =
 
 const getLabel = (props: Props) => {
   const { value, formatter } = props;
-  const label = isNullOrUndefined(props.children) ? value : props.children;
+  const label = isNullish(props.children) ? value : props.children;
 
   if (typeof formatter === 'function') {
     return formatter(label);
@@ -113,7 +105,7 @@ const renderRadialLabel = (labelProps: Props, label: ReactNode, attrs: SVGProps<
   const path = `M${startPoint.x},${startPoint.y}
     A${radius},${radius},0,1,${direction ? 0 : 1},
     ${endPoint.x},${endPoint.y}`;
-  const id = isNullOrUndefined(labelProps.id) ? uniqueId('recharts-radial-line-') : labelProps.id;
+  const id = isNullish(labelProps.id) ? uniqueId('recharts-radial-line-') : labelProps.id;
 
   return (
     <text {...attrs} dominantBaseline="central" className={clsx('recharts-radial-bar-label', className)}>
@@ -391,10 +383,7 @@ export function Label({ offset = 5, ...restProps }: Props) {
 
   if (
     !viewBox ||
-    (isNullOrUndefined(value) &&
-      isNullOrUndefined(children) &&
-      !isValidElement(content) &&
-      typeof content !== 'function')
+    (isNullish(value) && isNullish(children) && !isValidElement(content) && typeof content !== 'function')
   ) {
     return null;
   }
@@ -510,7 +499,7 @@ const parseLabel = (label: unknown, viewBox: ViewBox) => {
     return <Label key="label-implicit" content={label} viewBox={viewBox} />;
   }
 
-  if (isValidElement(label) || typeof label === 'function') {
+  if (typeof label === 'function') {
     return <Label key="label-implicit" content={label} viewBox={viewBox} />;
   }
 

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -72,7 +72,7 @@ const getLabel = (props: Props) => {
   return label;
 };
 
-const isLabelContentAFunction = (content: unknown): content is (props: Props) => React.ReactNode => {
+export const isLabelContentAFunction = (content: unknown): content is (props: Props) => React.ReactNode => {
   return content && typeof content === 'function';
 };
 

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -6,7 +6,7 @@ import { isNumOrStr, isNumber, isPercent, getPercentValue, uniqueId, mathSign, i
 import { polarToCartesian } from '../util/PolarUtils';
 import { ViewBox, PolarViewBox, CartesianViewBox, DataKey } from '../util/types';
 
-export type ContentType = ReactElement | ((props: Props) => ReactNode) | Function;
+export type ContentType = ReactElement | ((props: Props) => ReactNode);
 
 export type LabelPosition =
   | 'top'
@@ -70,6 +70,10 @@ const getLabel = (props: Props) => {
   }
 
   return label;
+};
+
+const isLabelContentAFunction = (content: unknown): content is (props: Props) => React.ReactNode => {
+  return content && typeof content === 'function';
 };
 
 const getDeltaAngle = (startAngle: number, endAngle: number) => {
@@ -499,7 +503,7 @@ const parseLabel = (label: unknown, viewBox: ViewBox) => {
     return <Label key="label-implicit" content={label} viewBox={viewBox} />;
   }
 
-  if (typeof label === 'function') {
+  if (isLabelContentAFunction(label)) {
     return <Label key="label-implicit" content={label} viewBox={viewBox} />;
   }
 

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -6,7 +6,7 @@ import { Layer } from '../container/Layer';
 import { findAllByType, filterProps } from '../util/ReactUtils';
 import { getValueByDataKey } from '../util/ChartUtils';
 import { DataKey, ViewBox } from '../util/types';
-import { isNullOrUndefined } from '../util/DataUtils';
+import { isNullish } from '../util/DataUtils';
 
 interface Data {
   value?: number | string | Array<number | string>;
@@ -49,10 +49,10 @@ export function LabelList<T extends Data>({ valueAccessor = defaultAccessor, ...
   return (
     <Layer className="recharts-label-list">
       {data.map((entry, index) => {
-        const value = isNullOrUndefined(dataKey)
+        const value = isNullish(dataKey)
           ? valueAccessor(entry, index)
           : (getValueByDataKey(entry && entry.payload, dataKey) as string | number);
-        const idProps = isNullOrUndefined(id) ? {} : { id: `${id}-${index}` };
+        const idProps = isNullish(id) ? {} : { id: `${id}-${index}` };
 
         return (
           <Label
@@ -62,7 +62,7 @@ export function LabelList<T extends Data>({ valueAccessor = defaultAccessor, ...
             parentViewBox={entry.parentViewBox}
             value={value}
             textBreakAll={textBreakAll}
-            viewBox={Label.parseViewBox(isNullOrUndefined(clockWise) ? entry : { ...entry, clockWise })}
+            viewBox={Label.parseViewBox(isNullish(clockWise) ? entry : { ...entry, clockWise })}
             key={`label-${index}`} // eslint-disable-line react/no-array-index-key
             index={index}
           />

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -1,7 +1,7 @@
 import React, { cloneElement, ReactElement, ReactNode, SVGProps } from 'react';
 import last from 'lodash/last';
 
-import { Label, ContentType, Props as LabelProps, LabelPosition } from './Label';
+import { Label, ContentType, Props as LabelProps, LabelPosition, isLabelContentAFunction } from './Label';
 import { Layer } from '../container/Layer';
 import { findAllByType, filterProps } from '../util/ReactUtils';
 import { getValueByDataKey } from '../util/ChartUtils';
@@ -83,7 +83,7 @@ function parseLabelList<T extends Data>(label: unknown, data: ReadonlyArray<T>) 
     return <LabelList key="labelList-implicit" data={data} />;
   }
 
-  if (React.isValidElement(label) || typeof label === 'function') {
+  if (React.isValidElement(label) || isLabelContentAFunction(label)) {
     return <LabelList key="labelList-implicit" data={data} content={label} />;
   }
 

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -1,7 +1,4 @@
 import React, { cloneElement, ReactElement, ReactNode, SVGProps } from 'react';
-import isNil from 'lodash/isNil';
-import isObject from 'lodash/isObject';
-import isFunction from 'lodash/isFunction';
 import last from 'lodash/last';
 
 import { Label, ContentType, Props as LabelProps, LabelPosition } from './Label';
@@ -9,6 +6,7 @@ import { Layer } from '../container/Layer';
 import { findAllByType, filterProps } from '../util/ReactUtils';
 import { getValueByDataKey } from '../util/ChartUtils';
 import { DataKey, ViewBox } from '../util/types';
+import { isNullOrUndefined } from '../util/DataUtils';
 
 interface Data {
   value?: number | string | Array<number | string>;
@@ -51,10 +49,10 @@ export function LabelList<T extends Data>({ valueAccessor = defaultAccessor, ...
   return (
     <Layer className="recharts-label-list">
       {data.map((entry, index) => {
-        const value = isNil(dataKey)
+        const value = isNullOrUndefined(dataKey)
           ? valueAccessor(entry, index)
           : (getValueByDataKey(entry && entry.payload, dataKey) as string | number);
-        const idProps = isNil(id) ? {} : { id: `${id}-${index}` };
+        const idProps = isNullOrUndefined(id) ? {} : { id: `${id}-${index}` };
 
         return (
           <Label
@@ -64,7 +62,7 @@ export function LabelList<T extends Data>({ valueAccessor = defaultAccessor, ...
             parentViewBox={entry.parentViewBox}
             value={value}
             textBreakAll={textBreakAll}
-            viewBox={Label.parseViewBox(isNil(clockWise) ? entry : { ...entry, clockWise })}
+            viewBox={Label.parseViewBox(isNullOrUndefined(clockWise) ? entry : { ...entry, clockWise })}
             key={`label-${index}`} // eslint-disable-line react/no-array-index-key
             index={index}
           />
@@ -85,11 +83,11 @@ function parseLabelList<T extends Data>(label: unknown, data: ReadonlyArray<T>) 
     return <LabelList key="labelList-implicit" data={data} />;
   }
 
-  if (React.isValidElement(label) || isFunction(label)) {
+  if (React.isValidElement(label) || typeof label === 'function') {
     return <LabelList key="labelList-implicit" data={data} content={label} />;
   }
 
-  if (isObject(label)) {
+  if (typeof label === 'object') {
     return <LabelList data={data} {...label} key="labelList-implicit" />;
   }
 

--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties, SVGProps, useMemo } from 'react';
 
 import clsx from 'clsx';
-import { isNullOrUndefined, isNumber, isNumOrStr } from '../util/DataUtils';
+import { isNullish, isNumber, isNumOrStr } from '../util/DataUtils';
 import { Global } from '../util/Global';
 import { filterProps } from '../util/ReactUtils';
 import { getStringSize } from '../util/DOMUtils';
@@ -24,7 +24,7 @@ type CalculateWordWidthsParam = Pick<Props, 'children' | 'breakAll' | 'style'>;
 const calculateWordWidths = ({ children, breakAll, style }: CalculateWordWidthsParam): CalculatedWordWidths => {
   try {
     let words: string[] = [];
-    if (!isNullOrUndefined(children)) {
+    if (!isNullish(children)) {
       if (breakAll) {
         words = children.toString().split('');
       } else {
@@ -160,7 +160,7 @@ const calculateWordsByLines = (
 };
 
 const getWordsWithoutCalculate = (children: React.ReactNode): Array<Words> => {
-  const words = !isNullOrUndefined(children) ? children.toString().split(BREAKING_SPACES) : [];
+  const words = !isNullish(children) ? children.toString().split(BREAKING_SPACES) : [];
   return [{ words }];
 };
 

--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -1,8 +1,7 @@
 import React, { CSSProperties, SVGProps, useMemo } from 'react';
 
-import isNil from 'lodash/isNil';
 import clsx from 'clsx';
-import { isNumber, isNumOrStr } from '../util/DataUtils';
+import { isNullOrUndefined, isNumber, isNumOrStr } from '../util/DataUtils';
 import { Global } from '../util/Global';
 import { filterProps } from '../util/ReactUtils';
 import { getStringSize } from '../util/DOMUtils';
@@ -25,7 +24,7 @@ type CalculateWordWidthsParam = Pick<Props, 'children' | 'breakAll' | 'style'>;
 const calculateWordWidths = ({ children, breakAll, style }: CalculateWordWidthsParam): CalculatedWordWidths => {
   try {
     let words: string[] = [];
-    if (!isNil(children)) {
+    if (!isNullOrUndefined(children)) {
       if (breakAll) {
         words = children.toString().split('');
       } else {
@@ -161,7 +160,7 @@ const calculateWordsByLines = (
 };
 
 const getWordsWithoutCalculate = (children: React.ReactNode): Array<Words> => {
-  const words = !isNil(children) ? children.toString().split(BREAKING_SPACES) : [];
+  const words = !isNullOrUndefined(children) ? children.toString().split(BREAKING_SPACES) : [];
   return [{ words }];
 };
 

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -3,7 +3,6 @@ import React, { PureComponent, ReactElement, ReactNode, SVGProps, useMemo } from
 import Animate from 'react-smooth';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
-import isFunction from 'lodash/isFunction';
 
 import clsx from 'clsx';
 import { ResolvedPieSettings, selectPieLegend, selectPieSectors } from '../state/selectors/pieSelectors';
@@ -386,7 +385,7 @@ const renderLabelLineItem = (option: PieLabelLine, props: any) => {
   if (React.isValidElement(option)) {
     return React.cloneElement(option, props);
   }
-  if (isFunction(option)) {
+  if (typeof option === 'function') {
     return option(props);
   }
 
@@ -399,7 +398,7 @@ const renderLabelItem = (option: PieLabel, props: any, value: any) => {
     return React.cloneElement(option, props);
   }
   let label = value;
-  if (isFunction(option)) {
+  if (typeof option === 'function') {
     label = option(props);
     if (React.isValidElement(label)) {
       return label;
@@ -408,7 +407,7 @@ const renderLabelItem = (option: PieLabel, props: any, value: any) => {
 
   const className = clsx(
     'recharts-pie-label-text',
-    typeof option !== 'boolean' && !isFunction(option) ? option.className : '',
+    typeof option !== 'boolean' && typeof option !== 'function' ? option.className : '',
   );
   return (
     <Text {...props} alignmentBaseline="middle" className={className}>
@@ -565,7 +564,7 @@ export class PieWithState extends PureComponent<InternalProps, State> {
       isAnimationFinished: true,
     });
 
-    if (isFunction(onAnimationEnd)) {
+    if (typeof onAnimationEnd === 'function') {
       onAnimationEnd();
     }
   };
@@ -577,7 +576,7 @@ export class PieWithState extends PureComponent<InternalProps, State> {
       isAnimationFinished: false,
     });
 
-    if (isFunction(onAnimationStart)) {
+    if (typeof onAnimationStart === 'function') {
       onAnimationStart();
     }
   };

--- a/src/polar/PolarAngleAxis.tsx
+++ b/src/polar/PolarAngleAxis.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent, PureComponent, ReactElement, SVGProps, useEffect } from 'react';
-import isFunction from 'lodash/isFunction';
 import clsx from 'clsx';
 import { Layer } from '../container/Layer';
 import { Dot } from '../shape/Dot';
@@ -148,7 +147,7 @@ const TickItemText = ({ tick, allAxisProps, tickProps, value }: TickItemProps): 
   if (React.isValidElement(tick)) {
     return React.cloneElement(tick, tickProps);
   }
-  if (isFunction(tick)) {
+  if (typeof tick === 'function') {
     return tick(allAxisProps);
   }
   return (

--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent, PureComponent, ReactElement, useEffect } from 'react';
 import maxBy from 'lodash/maxBy';
 import minBy from 'lodash/minBy';
-import isFunction from 'lodash/isFunction';
 import clsx from 'clsx';
 import { Text } from '../component/Text';
 import { Label } from '../component/Label';
@@ -130,7 +129,7 @@ const renderTickItem = (option: Props['tick'], tickProps: any, value: string | n
 
   if (React.isValidElement(option)) {
     tickItem = React.cloneElement(option, tickProps);
-  } else if (isFunction(option)) {
+  } else if (typeof option === 'function') {
     tickItem = option(tickProps);
   } else {
     tickItem = (

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -1,14 +1,12 @@
 // eslint-disable-next-line max-classes-per-file
 import React, { PureComponent, ReactElement, MouseEvent, SVGProps } from 'react';
 import Animate from 'react-smooth';
-import isNil from 'lodash/isNil';
 import last from 'lodash/last';
 import first from 'lodash/first';
 import isEqual from 'lodash/isEqual';
-import isFunction from 'lodash/isFunction';
 
 import clsx from 'clsx';
-import { interpolateNumber } from '../util/DataUtils';
+import { interpolateNumber, isNullOrUndefined } from '../util/DataUtils';
 import { Global } from '../util/Global';
 import { polarToCartesian } from '../util/PolarUtils';
 import { getTooltipNameProp, getValueByDataKey, RechartsScale } from '../util/ChartUtils';
@@ -148,7 +146,7 @@ function renderDotItem(option: RadarDot, props: DotProps) {
   if (React.isValidElement(option)) {
     // @ts-expect-error typescript is unhappy with cloned props type
     dotItem = React.cloneElement(option, props);
-  } else if (isFunction(option)) {
+  } else if (typeof option === 'function') {
     dotItem = option(props);
   } else {
     dotItem = (
@@ -182,7 +180,7 @@ export function computeRadarPoints({
     const value = getValueByDataKey(entry, dataKey);
     const angle = angleAxis.scale(name) + angleBandSize;
     const pointValue = Array.isArray(value) ? last(value) : value;
-    const radius = isNil(pointValue) ? undefined : radiusAxis.scale(pointValue);
+    const radius = isNullOrUndefined(pointValue) ? undefined : radiusAxis.scale(pointValue);
 
     if (Array.isArray(value) && value.length >= 2) {
       isRange = true;
@@ -207,7 +205,7 @@ export function computeRadarPoints({
     points.forEach(point => {
       if (Array.isArray(point.value)) {
         const baseValue = first(point.value);
-        const radius = isNil(baseValue) ? undefined : radiusAxis.scale(baseValue);
+        const radius = isNullOrUndefined(baseValue) ? undefined : radiusAxis.scale(baseValue);
 
         baseLinePoints.push({
           ...point,
@@ -260,7 +258,7 @@ class RadarWithState extends PureComponent<Props, State> {
     const { onAnimationEnd } = this.props;
     this.setState({ isAnimationFinished: true });
 
-    if (isFunction(onAnimationEnd)) {
+    if (typeof onAnimationEnd === 'function') {
       onAnimationEnd();
     }
   };
@@ -270,7 +268,7 @@ class RadarWithState extends PureComponent<Props, State> {
 
     this.setState({ isAnimationFinished: false });
 
-    if (isFunction(onAnimationStart)) {
+    if (typeof onAnimationStart === 'function') {
       onAnimationStart();
     }
   };
@@ -321,7 +319,7 @@ class RadarWithState extends PureComponent<Props, State> {
     let radar;
     if (React.isValidElement(shape)) {
       radar = React.cloneElement(shape, { ...this.props, points } as any);
-    } else if (isFunction(shape)) {
+    } else if (typeof shape === 'function') {
       radar = shape({ ...this.props, points });
     } else {
       radar = (

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -6,7 +6,7 @@ import first from 'lodash/first';
 import isEqual from 'lodash/isEqual';
 
 import clsx from 'clsx';
-import { interpolateNumber, isNullOrUndefined } from '../util/DataUtils';
+import { interpolateNumber, isNullish } from '../util/DataUtils';
 import { Global } from '../util/Global';
 import { polarToCartesian } from '../util/PolarUtils';
 import { getTooltipNameProp, getValueByDataKey, RechartsScale } from '../util/ChartUtils';
@@ -180,7 +180,7 @@ export function computeRadarPoints({
     const value = getValueByDataKey(entry, dataKey);
     const angle = angleAxis.scale(name) + angleBandSize;
     const pointValue = Array.isArray(value) ? last(value) : value;
-    const radius = isNullOrUndefined(pointValue) ? undefined : radiusAxis.scale(pointValue);
+    const radius = isNullish(pointValue) ? undefined : radiusAxis.scale(pointValue);
 
     if (Array.isArray(value) && value.length >= 2) {
       isRange = true;
@@ -205,7 +205,7 @@ export function computeRadarPoints({
     points.forEach(point => {
       if (Array.isArray(point.value)) {
         const baseValue = first(point.value);
-        const radius = isNullOrUndefined(baseValue) ? undefined : radiusAxis.scale(baseValue);
+        const radius = isNullish(baseValue) ? undefined : radiusAxis.scale(baseValue);
 
         baseLinePoints.push({
           ...point,

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -3,7 +3,6 @@ import React, { PureComponent, ReactElement } from 'react';
 import clsx from 'clsx';
 import Animate from 'react-smooth';
 import isEqual from 'lodash/isEqual';
-import isFunction from 'lodash/isFunction';
 
 import { Series } from 'victory-vendor/d3-shape';
 import { parseCornerRadius, RadialBarSector, RadialBarSectorProps } from '../util/RadialBarUtils';
@@ -210,7 +209,7 @@ class RadialBarWithState extends PureComponent<RadialBarProps, State> {
     const { onAnimationEnd } = this.props;
     this.setState({ isAnimationFinished: true });
 
-    if (isFunction(onAnimationEnd)) {
+    if (typeof onAnimationEnd === 'function') {
       onAnimationEnd();
     }
   };
@@ -220,7 +219,7 @@ class RadialBarWithState extends PureComponent<RadialBarProps, State> {
 
     this.setState({ isAnimationFinished: false });
 
-    if (isFunction(onAnimationStart)) {
+    if (typeof onAnimationStart === 'function') {
       onAnimationStart();
     }
   };

--- a/src/shape/Curve.tsx
+++ b/src/shape/Curve.tsx
@@ -20,13 +20,11 @@ import {
   curveStepAfter,
   curveStepBefore,
 } from 'victory-vendor/d3-shape';
-import upperFirst from 'lodash/upperFirst';
-import isFunction from 'lodash/isFunction';
 
 import clsx from 'clsx';
 import { LayoutType, PresentationAttributesWithProps, adaptEventHandlers } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
-import { isNumber } from '../util/DataUtils';
+import { isNumber, upperFirst } from '../util/DataUtils';
 
 interface CurveFactories {
   [index: string]: CurveFactory;
@@ -76,7 +74,7 @@ const getX = (p: Point) => p.x;
 const getY = (p: Point) => p.y;
 
 const getCurveFactory = (type: CurveType, layout: LayoutType) => {
-  if (isFunction(type)) {
+  if (typeof type === 'function') {
     return type;
   }
 

--- a/src/shape/Symbols.tsx
+++ b/src/shape/Symbols.tsx
@@ -80,7 +80,7 @@ export interface InnerSymbolsProp {
 export type SymbolsProps = SVGProps<SVGPathElement> & InnerSymbolsProp;
 
 const registerSymbol = (key: string, factory: D3SymbolType) => {
-  symbolFactories[`symbol${key.substring(0, 1).toUpperCase() + key.substring(1)}`] = factory;
+  symbolFactories[`symbol${upperFirst(key)}`] = factory;
 };
 
 export const Symbols = ({ type = 'circle', size = 64, sizeType = 'area', ...rest }: SymbolsProps) => {

--- a/src/shape/Symbols.tsx
+++ b/src/shape/Symbols.tsx
@@ -2,7 +2,6 @@
  * @fileOverview Curve
  */
 import React, { SVGProps } from 'react';
-import upperFirst from 'lodash/upperFirst';
 
 import {
   symbol as shapeSymbol,
@@ -18,6 +17,7 @@ import {
 import clsx from 'clsx';
 import { SymbolType } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
+import { upperFirst } from '../util/DataUtils';
 
 type SizeType = 'area' | 'diameter';
 
@@ -80,7 +80,7 @@ export interface InnerSymbolsProp {
 export type SymbolsProps = SVGProps<SVGPathElement> & InnerSymbolsProp;
 
 const registerSymbol = (key: string, factory: D3SymbolType) => {
-  symbolFactories[`symbol${upperFirst(key)}`] = factory;
+  symbolFactories[`symbol${key.substring(0, 1).toUpperCase() + key.substring(1)}`] = factory;
 };
 
 export const Symbols = ({ type = 'circle', size = 64, sizeType = 'area', ...rest }: SymbolsProps) => {

--- a/src/state/optionsSlice.ts
+++ b/src/state/optionsSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { TooltipEventType } from '../util/types';
 import { TooltipPayloadSearcher } from './tooltipSlice';
+import { isNan } from '../util/DataUtils';
 
 /**
  * These chart options are decided internally, by Recharts,
@@ -22,7 +23,7 @@ export const arrayTooltipSearcher: TooltipPayloadSearcher = (
   strIndex: string | undefined,
 ): unknown => {
   const numIndex = Number.parseInt(strIndex, 10);
-  if (Number.isNaN(numIndex)) {
+  if (isNan(numIndex)) {
     return undefined;
   }
   return data?.[numIndex];

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -45,7 +45,7 @@ import {
   parseNumericalUserDomain,
 } from '../../util/isDomainSpecifiedByUser';
 import { AppliedChartData, ChartData, ChartDataState } from '../chartDataSlice';
-import { getPercentValue, hasDuplicate, isNumber, isNumOrStr, mathSign, upperFirst } from '../../util/DataUtils';
+import { getPercentValue, hasDuplicate, isNan, isNumber, isNumOrStr, mathSign, upperFirst } from '../../util/DataUtils';
 import { CartesianGraphicalItemSettings, ErrorBarsSettings, GraphicalItemSettings } from '../graphicalItemsSlice';
 import { isWellBehavedNumber } from '../../util/isWellBehavedNumber';
 import { getNiceTickValues, getTickValuesFixedDomain } from '../../util/scale';
@@ -443,7 +443,7 @@ export function fromMainValueToError(value: unknown): ErrorValue | undefined {
   if (Array.isArray(value)) {
     const minError = Math.min(...value);
     const maxError = Math.max(...value);
-    if (!Number.isNaN(minError) && !Number.isNaN(maxError) && Number.isFinite(minError) && Number.isFinite(maxError)) {
+    if (!isNan(minError) && !isNan(maxError) && Number.isFinite(minError) && Number.isFinite(maxError)) {
       return [minError, maxError];
     }
   }
@@ -455,7 +455,7 @@ function onlyAllowNumbers(data: ReadonlyArray<unknown>): ReadonlyArray<number> {
   return data
     .filter(v => isNumOrStr(v) || v instanceof Date)
     .map(Number)
-    .filter(n => Number.isNaN(n) === false);
+    .filter(n => isNan(n) === false);
 }
 
 /**
@@ -469,7 +469,7 @@ export function getErrorDomainByDataKey(
   appliedValue: unknown,
   relevantErrorBars: ReadonlyArray<ErrorBarsSettings>,
 ): ReadonlyArray<number> {
-  if (!relevantErrorBars || typeof appliedValue !== 'number' || Number.isNaN(appliedValue)) {
+  if (!relevantErrorBars || typeof appliedValue !== 'number' || isNan(appliedValue)) {
     return [];
   }
 
@@ -1634,7 +1634,7 @@ export const combineAxisTicks = (
       };
     });
 
-    return result.filter((row: CartesianTickItem) => !Number.isNaN(row.coordinate));
+    return result.filter((row: CartesianTickItem) => !isNan(row.coordinate));
   }
 
   // When axis is a categorical axis, but the type of axis is number or the scale of axis is not "auto"

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -45,7 +45,7 @@ import {
   parseNumericalUserDomain,
 } from '../../util/isDomainSpecifiedByUser';
 import { AppliedChartData, ChartData, ChartDataState } from '../chartDataSlice';
-import { getPercentValue, hasDuplicate, mathSign, upperFirst } from '../../util/DataUtils';
+import { getPercentValue, hasDuplicate, isNumber, isNumOrStr, mathSign, upperFirst } from '../../util/DataUtils';
 import { CartesianGraphicalItemSettings, ErrorBarsSettings, GraphicalItemSettings } from '../graphicalItemsSlice';
 import { isWellBehavedNumber } from '../../util/isWellBehavedNumber';
 import { getNiceTickValues, getTickValuesFixedDomain } from '../../util/scale';
@@ -436,7 +436,7 @@ export type AppliedChartDataWithErrorDomain = {
 export type ErrorValue = [number, number];
 
 export function fromMainValueToError(value: unknown): ErrorValue | undefined {
-  if (typeof value === 'number' && !Number.isNaN(value) && Number.isFinite(value)) {
+  if (isNumber(value) && Number.isFinite(value)) {
     return [value, value];
   }
 
@@ -453,7 +453,7 @@ export function fromMainValueToError(value: unknown): ErrorValue | undefined {
 
 function onlyAllowNumbers(data: ReadonlyArray<unknown>): ReadonlyArray<number> {
   return data
-    .filter(v => typeof v === 'number' || typeof v === 'string' || v instanceof Date)
+    .filter(v => isNumOrStr(v) || v instanceof Date)
     .map(Number)
     .filter(n => Number.isNaN(n) === false);
 }
@@ -611,7 +611,7 @@ export function getDefaultDomainByAxisType(axisType: 'number' | string) {
 
 function onlyAllowNumbersAndStringsAndDates(item: { value: unknown }): string | number | Date {
   const { value } = item;
-  if ((typeof value === 'number' && !Number.isNaN(value)) || typeof value === 'string' || value instanceof Date) {
+  if (isNumOrStr(value) || value instanceof Date) {
     return value;
   }
   return undefined;

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -1,9 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 import range from 'lodash/range';
 import { Series } from 'victory-vendor/d3-shape';
-import isNan from 'lodash/isNaN';
 import * as d3Scales from 'victory-vendor/d3-scale';
-import upperFirst from 'lodash/upperFirst';
 import { selectChartLayout } from '../../context/chartLayoutContext';
 import {
   checkDomainOfScale,
@@ -47,7 +45,7 @@ import {
   parseNumericalUserDomain,
 } from '../../util/isDomainSpecifiedByUser';
 import { AppliedChartData, ChartData, ChartDataState } from '../chartDataSlice';
-import { getPercentValue, hasDuplicate, mathSign } from '../../util/DataUtils';
+import { getPercentValue, hasDuplicate, mathSign, upperFirst } from '../../util/DataUtils';
 import { CartesianGraphicalItemSettings, ErrorBarsSettings, GraphicalItemSettings } from '../graphicalItemsSlice';
 import { isWellBehavedNumber } from '../../util/isWellBehavedNumber';
 import { getNiceTickValues, getTickValuesFixedDomain } from '../../util/scale';
@@ -1636,7 +1634,7 @@ export const combineAxisTicks = (
       };
     });
 
-    return result.filter((row: CartesianTickItem) => !isNan(row.coordinate));
+    return result.filter((row: CartesianTickItem) => !Number.isNaN(row.coordinate));
   }
 
   // When axis is a categorical axis, but the type of axis is number or the scale of axis is not "auto"

--- a/src/state/selectors/barSelectors.ts
+++ b/src/state/selectors/barSelectors.ts
@@ -12,7 +12,7 @@ import {
   StackGroup,
 } from './axisSelectors';
 import { AxisId } from '../cartesianAxisSlice';
-import { getPercentValue, isNullOrUndefined } from '../../util/DataUtils';
+import { getPercentValue, isNullish } from '../../util/DataUtils';
 import { CartesianGraphicalItemSettings } from '../graphicalItemsSlice';
 import { BarPositionPosition, getBandSizeOfAxis, StackId } from '../../util/ChartUtils';
 import { DataKey, LayoutType, TickItem } from '../../util/types';
@@ -72,7 +72,7 @@ const getBarSize = (
 ): number | undefined => {
   const barSize: string | number | undefined = selfSize ?? globalSize;
 
-  return isNullOrUndefined(barSize) ? undefined : getPercentValue(barSize, totalSize, 0);
+  return isNullish(barSize) ? undefined : getPercentValue(barSize, totalSize, 0);
 };
 
 export const selectAllVisibleBars: (
@@ -203,7 +203,7 @@ export const selectBarBandSize: (
   const layout = selectChartLayout(state);
   const globalMaxBarSize: number | undefined = selectRootMaxBarSize(state);
   const { maxBarSize: childMaxBarSize } = barSettings;
-  const maxBarSize: number = isNullOrUndefined(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
+  const maxBarSize: number = isNullish(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
   let axis: BaseAxisWithScale, ticks: ReadonlyArray<TickItem>;
   if (layout === 'horizontal') {
     axis = selectAxisWithScale(state, 'xAxis', xAxisId, isPanorama);
@@ -344,7 +344,7 @@ export const combineAllBarPositions = (
   bandSize: number,
   childMaxBarSize: number | undefined,
 ): ReadonlyArray<BarWithPosition> | undefined => {
-  const maxBarSize: number = isNullOrUndefined(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
+  const maxBarSize: number = isNullish(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
 
   let allBarPositions = getBarPositions(
     barGap,

--- a/src/state/selectors/barSelectors.ts
+++ b/src/state/selectors/barSelectors.ts
@@ -1,5 +1,4 @@
 import { createSelector } from '@reduxjs/toolkit';
-import isNil from 'lodash/isNil';
 import { ReactElement } from 'react';
 import { Series } from 'victory-vendor/d3-shape';
 import { RechartsRootState } from '../store';
@@ -13,7 +12,7 @@ import {
   StackGroup,
 } from './axisSelectors';
 import { AxisId } from '../cartesianAxisSlice';
-import { getPercentValue } from '../../util/DataUtils';
+import { getPercentValue, isNullOrUndefined } from '../../util/DataUtils';
 import { CartesianGraphicalItemSettings } from '../graphicalItemsSlice';
 import { BarPositionPosition, getBandSizeOfAxis, StackId } from '../../util/ChartUtils';
 import { DataKey, LayoutType, TickItem } from '../../util/types';
@@ -71,9 +70,9 @@ const getBarSize = (
   totalSize: number | undefined,
   selfSize: number | string | undefined,
 ): number | undefined => {
-  const barSize: string | number | undefined = isNil(selfSize) ? globalSize : selfSize;
+  const barSize: string | number | undefined = selfSize ?? globalSize;
 
-  return isNil(barSize) ? undefined : getPercentValue(barSize, totalSize, 0);
+  return isNullOrUndefined(barSize) ? undefined : getPercentValue(barSize, totalSize, 0);
 };
 
 export const selectAllVisibleBars: (
@@ -204,7 +203,7 @@ export const selectBarBandSize: (
   const layout = selectChartLayout(state);
   const globalMaxBarSize: number | undefined = selectRootMaxBarSize(state);
   const { maxBarSize: childMaxBarSize } = barSettings;
-  const maxBarSize: number = isNil(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
+  const maxBarSize: number = isNullOrUndefined(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
   let axis: BaseAxisWithScale, ticks: ReadonlyArray<TickItem>;
   if (layout === 'horizontal') {
     axis = selectAxisWithScale(state, 'xAxis', xAxisId, isPanorama);
@@ -345,7 +344,7 @@ export const combineAllBarPositions = (
   bandSize: number,
   childMaxBarSize: number | undefined,
 ): ReadonlyArray<BarWithPosition> | undefined => {
-  const maxBarSize: number = isNil(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
+  const maxBarSize: number = isNullOrUndefined(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
 
   let allBarPositions = getBarPositions(
     barGap,

--- a/src/state/selectors/radialBarSelectors.ts
+++ b/src/state/selectors/radialBarSelectors.ts
@@ -1,6 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { ReactElement } from 'react';
-import isNil from 'lodash/isNil';
 import { Series } from 'victory-vendor/d3-shape';
 import { computeRadialBarDataItems, RadialBarDataItem } from '../../polar/RadialBar';
 import { selectChartDataWithIndexes } from './dataSelectors';
@@ -39,6 +38,7 @@ import {
 import { selectStackOffsetType } from './selectors';
 import { AngleAxisSettings, RadiusAxisSettings } from '../polarAxisSlice';
 import { Payload as LegendPayload } from '../../component/DefaultLegendContent';
+import { isNullOrUndefined } from '../../util/DataUtils';
 
 export interface RadialBarSettings extends MaybeStackedGraphicalItem {
   dataKey: DataKey<any> | undefined;
@@ -248,7 +248,7 @@ export const selectPolarBarBandSize: (
     radiusAxisTicks,
     childMaxBarSize: number | undefined,
   ): number | undefined => {
-    const maxBarSize: number = isNil(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
+    const maxBarSize: number = isNullOrUndefined(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
     if (layout === 'centric') {
       return getBandSizeOfAxis(angleAxis, angleAxisTicks, true) ?? maxBarSize ?? 0;
     }

--- a/src/state/selectors/radialBarSelectors.ts
+++ b/src/state/selectors/radialBarSelectors.ts
@@ -38,7 +38,7 @@ import {
 import { selectStackOffsetType } from './selectors';
 import { AngleAxisSettings, RadiusAxisSettings } from '../polarAxisSlice';
 import { Payload as LegendPayload } from '../../component/DefaultLegendContent';
-import { isNullOrUndefined } from '../../util/DataUtils';
+import { isNullish } from '../../util/DataUtils';
 
 export interface RadialBarSettings extends MaybeStackedGraphicalItem {
   dataKey: DataKey<any> | undefined;
@@ -248,7 +248,7 @@ export const selectPolarBarBandSize: (
     radiusAxisTicks,
     childMaxBarSize: number | undefined,
   ): number | undefined => {
-    const maxBarSize: number = isNullOrUndefined(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
+    const maxBarSize: number = isNullish(childMaxBarSize) ? globalMaxBarSize : childMaxBarSize;
     if (layout === 'centric') {
       return getBandSizeOfAxis(angleAxis, angleAxisTicks, true) ?? maxBarSize ?? 0;
     }

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -34,7 +34,7 @@ import {
   TickItem,
   TooltipEventType,
 } from '../../util/types';
-import { findEntryInArray } from '../../util/DataUtils';
+import { findEntryInArray, isNan } from '../../util/DataUtils';
 import { AxisMap, AxisPropsWithExtraComputedData, TooltipTrigger } from '../../chart/types';
 import {
   selectChartLayout,
@@ -148,7 +148,7 @@ export const selectActiveLabel = createSelector(
   selectActiveIndex,
   (tooltipTicks: ReadonlyArray<TickItem>, activeIndex: TooltipIndex): string | undefined => {
     const n = Number(activeIndex);
-    if (Number.isNaN(n) || activeIndex == null) {
+    if (isNan(n) || activeIndex == null) {
       return undefined;
     }
     return n >= 0 ? tooltipTicks?.[n]?.value : undefined;

--- a/src/util/ActiveShapeUtils.tsx
+++ b/src/util/ActiveShapeUtils.tsx
@@ -1,7 +1,5 @@
 import React, { cloneElement, isValidElement, SVGProps } from 'react';
-import isFunction from 'lodash/isFunction';
 import isPlainObject from 'lodash/isPlainObject';
-import isBoolean from 'lodash/isBoolean';
 
 import { Rectangle } from '../shape/Rectangle';
 import { Trapezoid } from '../shape/Trapezoid';
@@ -87,9 +85,9 @@ export function Shape<OptionType, ExtraProps, ShapePropsType>({
 
   if (isValidElement(option)) {
     shape = cloneElement(option, { ...props, ...getPropsFromShapeOption(option) });
-  } else if (isFunction(option)) {
+  } else if (typeof option === 'function') {
     shape = option(props);
-  } else if (isPlainObject(option) && !isBoolean(option)) {
+  } else if (isPlainObject(option) && typeof option !== 'boolean') {
     const nextProps = propTransformer(option, props);
     shape = <ShapeSelector<ShapePropsType> shapeType={shapeType} elementProps={nextProps} />;
   } else {

--- a/src/util/BarUtils.tsx
+++ b/src/util/BarUtils.tsx
@@ -4,6 +4,7 @@ import { ActiveShape } from './types';
 import { Props as RectangleProps } from '../shape/Rectangle';
 import { BarProps } from '../cartesian/Bar';
 import { Shape } from './ActiveShapeUtils';
+import { isNumber } from './DataUtils';
 
 // Rectangle props is expecting x, y, height, width as numbers, name as a string, and radius as a custom type
 // When props are being spread in from a user defined component in Bar,
@@ -66,8 +67,8 @@ export type MinPointSize = number | ((value: number, index: number) => number);
 export const minPointSizeCallback =
   (minPointSize: MinPointSize, defaultValue = 0) =>
   (value: unknown, index: number): number => {
-    if (typeof minPointSize === 'number') return minPointSize;
-    const isValueNumber = typeof value === 'number';
+    if (isNumber(minPointSize)) return minPointSize;
+    const isValueNumber = isNumber(value);
     if (isValueNumber) {
       return minPointSize(value, index);
     }

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -20,7 +20,7 @@ import { ReactElement } from 'react';
 import {
   findEntryInArray,
   getAnyElementOfObject,
-  isNullOrUndefined,
+  isNullish,
   isNumber,
   isNumOrStr,
   mathSign,
@@ -54,7 +54,7 @@ import { LegendState } from '../state/legendSlice';
 import { BaseAxisWithScale } from '../state/selectors/axisSelectors';
 
 export function getValueByDataKey<T>(obj: T, dataKey: DataKey<T>, defaultValue?: any): unknown {
-  if (isNullOrUndefined(obj) || isNullOrUndefined(dataKey)) {
+  if (isNullish(obj) || isNullish(dataKey)) {
     return defaultValue;
   }
 
@@ -92,7 +92,7 @@ export function getDomainOfDataByKey<T>(
     return domain.length ? [min(domain), max(domain)] : [Infinity, -Infinity];
   }
 
-  const validateData = filterNil ? flattenData.filter(entry => !isNullOrUndefined(entry)) : flattenData;
+  const validateData = filterNil ? flattenData.filter(entry => !isNullish(entry)) : flattenData;
 
   // Supports x-axis of Date type
   return validateData.map(entry => (isNumOrStr(entry) || entry instanceof Date ? entry : ''));
@@ -275,7 +275,7 @@ export const appendOffsetOfLegend = (offset: ChartOffset, legendState: LegendSta
  * @return if true then is relevant, if false then irrelevant
  */
 export const isErrorBarRelevantForAxis = (layout?: LayoutType, axisType?: AxisType, direction?: 'x' | 'y'): boolean => {
-  if (isNullOrUndefined(axisType)) {
+  if (isNullish(axisType)) {
     return true;
   }
 
@@ -881,7 +881,7 @@ export function getCateCoordinateOfLine<T extends Record<string, unknown>>({
   if (axis.type === 'category') {
     // find coordinate of category axis by the value of category
     // @ts-expect-error why does this use direct object access instead of getValueByDataKey?
-    if (!axis.allowDuplicatedCategory && axis.dataKey && !isNullOrUndefined(entry[axis.dataKey])) {
+    if (!axis.allowDuplicatedCategory && axis.dataKey && !isNullish(entry[axis.dataKey])) {
       // @ts-expect-error why does this use direct object access instead of getValueByDataKey?
       const matchedTick = findEntryInArray(ticks, 'value', entry[axis.dataKey]);
 
@@ -893,10 +893,10 @@ export function getCateCoordinateOfLine<T extends Record<string, unknown>>({
     return ticks[index] ? ticks[index].coordinate + bandSize / 2 : null;
   }
 
-  const value = getValueByDataKey(entry, !isNullOrUndefined(dataKey) ? dataKey : axis.dataKey);
+  const value = getValueByDataKey(entry, !isNullish(dataKey) ? dataKey : axis.dataKey);
 
   // @ts-expect-error getValueByDataKey does not validate the output type
-  return !isNullOrUndefined(value) ? axis.scale(value) : null;
+  return !isNullish(value) ? axis.scale(value) : null;
 }
 
 export const getCateCoordinateOfBar = ({
@@ -919,7 +919,7 @@ export const getCateCoordinateOfBar = ({
   }
   const value = getValueByDataKey(entry, axis.dataKey, axis.scale.domain()[index]);
 
-  return !isNullOrUndefined(value) ? axis.scale(value) - bandSize / 2 + offset : null;
+  return !isNullish(value) ? axis.scale(value) - bandSize / 2 + offset : null;
 };
 
 export const getBaseValueOfBar = ({ numericAxis }: { numericAxis: BaseAxisWithScale }): number | unknown => {

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1,14 +1,9 @@
 import flatMap from 'lodash/flatMap';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
-import isFunction from 'lodash/isFunction';
-import isNan from 'lodash/isNaN';
-import isNil from 'lodash/isNil';
-import isString from 'lodash/isString';
 import max from 'lodash/max';
 import min from 'lodash/min';
 import sortBy from 'lodash/sortBy';
-import upperFirst from 'lodash/upperFirst';
 import * as d3Scales from 'victory-vendor/d3-scale';
 import {
   Series,
@@ -22,7 +17,16 @@ import {
 } from 'victory-vendor/d3-shape';
 
 import { ReactElement } from 'react';
-import { findEntryInArray, getAnyElementOfObject, isNumber, isNumOrStr, mathSign, uniqueId } from './DataUtils';
+import {
+  findEntryInArray,
+  getAnyElementOfObject,
+  isNullOrUndefined,
+  isNumber,
+  isNumOrStr,
+  mathSign,
+  uniqueId,
+  upperFirst,
+} from './DataUtils';
 import { filterProps } from './ReactUtils';
 
 import { TooltipEntrySettings, TooltipPayloadEntry } from '../state/tooltipSlice';
@@ -50,7 +54,7 @@ import { LegendState } from '../state/legendSlice';
 import { BaseAxisWithScale } from '../state/selectors/axisSelectors';
 
 export function getValueByDataKey<T>(obj: T, dataKey: DataKey<T>, defaultValue?: any): unknown {
-  if (isNil(obj) || isNil(dataKey)) {
+  if (isNullOrUndefined(obj) || isNullOrUndefined(dataKey)) {
     return defaultValue;
   }
 
@@ -58,7 +62,7 @@ export function getValueByDataKey<T>(obj: T, dataKey: DataKey<T>, defaultValue?:
     return get(obj, dataKey, defaultValue);
   }
 
-  if (isFunction(dataKey)) {
+  if (typeof dataKey === 'function') {
     return dataKey(obj);
   }
 
@@ -88,7 +92,7 @@ export function getDomainOfDataByKey<T>(
     return domain.length ? [min(domain), max(domain)] : [Infinity, -Infinity];
   }
 
-  const validateData = filterNil ? flattenData.filter(entry => !isNil(entry)) : flattenData;
+  const validateData = filterNil ? flattenData.filter(entry => !isNullOrUndefined(entry)) : flattenData;
 
   // Supports x-axis of Date type
   return validateData.map(entry => (isNumOrStr(entry) || entry instanceof Date ? entry : ''));
@@ -271,7 +275,7 @@ export const appendOffsetOfLegend = (offset: ChartOffset, legendState: LegendSta
  * @return if true then is relevant, if false then irrelevant
  */
 export const isErrorBarRelevantForAxis = (layout?: LayoutType, axisType?: AxisType, direction?: 'x' | 'y'): boolean => {
-  if (isNil(axisType)) {
+  if (isNullOrUndefined(axisType)) {
     return true;
   }
 
@@ -421,7 +425,7 @@ export const getTicksOfAxis = (
       };
     });
 
-    return result.filter((row: TickItem) => !isNan(row.coordinate));
+    return result.filter((row: TickItem) => !Number.isNaN(row.coordinate));
   }
 
   // When axis is a categorical axis, but the type of axis is number or the scale of axis is not "auto"
@@ -511,7 +515,7 @@ export const parseScale = (
     // @ts-expect-error we need to wrap the d3 scales in unified interface
     return { scale: d3Scales.scaleLinear(), realScaleType: 'linear' };
   }
-  if (isString(scale)) {
+  if (typeof scale === 'string') {
     const name = `scale${upperFirst(scale)}`;
 
     return {
@@ -521,7 +525,7 @@ export const parseScale = (
   }
 
   // @ts-expect-error we need to wrap the d3 scales in unified interface
-  return isFunction(scale)
+  return typeof scale === 'function'
     ? { scale, realScaleType: undefined }
     : { scale: d3Scales.scalePoint(), realScaleType: 'point' };
 };
@@ -602,7 +606,7 @@ export const offsetSign: OffsetAccessor = series => {
     let negative = 0;
 
     for (let i = 0; i < n; ++i) {
-      const value = isNan(series[i][j][1]) ? series[i][j][0] : series[i][j][1];
+      const value = Number.isNaN(series[i][j][1]) ? series[i][j][0] : series[i][j][1];
 
       /* eslint-disable prefer-destructuring, no-param-reassign */
       if (value >= 0) {
@@ -637,7 +641,7 @@ export const offsetPositive: OffsetAccessor = series => {
     let positive = 0;
 
     for (let i = 0; i < n; ++i) {
-      const value = isNan(series[i][j][1]) ? series[i][j][0] : series[i][j][1];
+      const value = Number.isNaN(series[i][j][1]) ? series[i][j][0] : series[i][j][1];
 
       /* eslint-disable prefer-destructuring, no-param-reassign */
       if (value >= 0) {
@@ -877,7 +881,7 @@ export function getCateCoordinateOfLine<T extends Record<string, unknown>>({
   if (axis.type === 'category') {
     // find coordinate of category axis by the value of category
     // @ts-expect-error why does this use direct object access instead of getValueByDataKey?
-    if (!axis.allowDuplicatedCategory && axis.dataKey && !isNil(entry[axis.dataKey])) {
+    if (!axis.allowDuplicatedCategory && axis.dataKey && !isNullOrUndefined(entry[axis.dataKey])) {
       // @ts-expect-error why does this use direct object access instead of getValueByDataKey?
       const matchedTick = findEntryInArray(ticks, 'value', entry[axis.dataKey]);
 
@@ -889,10 +893,10 @@ export function getCateCoordinateOfLine<T extends Record<string, unknown>>({
     return ticks[index] ? ticks[index].coordinate + bandSize / 2 : null;
   }
 
-  const value = getValueByDataKey(entry, !isNil(dataKey) ? dataKey : axis.dataKey);
+  const value = getValueByDataKey(entry, !isNullOrUndefined(dataKey) ? dataKey : axis.dataKey);
 
   // @ts-expect-error getValueByDataKey does not validate the output type
-  return !isNil(value) ? axis.scale(value) : null;
+  return !isNullOrUndefined(value) ? axis.scale(value) : null;
 }
 
 export const getCateCoordinateOfBar = ({
@@ -915,7 +919,7 @@ export const getCateCoordinateOfBar = ({
   }
   const value = getValueByDataKey(entry, axis.dataKey, axis.scale.domain()[index]);
 
-  return !isNil(value) ? axis.scale(value) - bandSize / 2 + offset : null;
+  return !isNullOrUndefined(value) ? axis.scale(value) - bandSize / 2 + offset : null;
 };
 
 export const getBaseValueOfBar = ({ numericAxis }: { numericAxis: BaseAxisWithScale }): number | unknown => {
@@ -989,7 +993,7 @@ export const parseSpecifiedDomain = (
   dataDomain: any,
   allowDataOverflow?: boolean,
 ) => {
-  if (isFunction(specifiedDomain)) {
+  if (typeof specifiedDomain === 'function') {
     return specifiedDomain(dataDomain, allowDataOverflow);
   }
 
@@ -1006,7 +1010,7 @@ export const parseSpecifiedDomain = (
     const value = +MIN_VALUE_REG.exec(specifiedDomain[0])[1];
 
     domain[0] = dataDomain[0] - value;
-  } else if (isFunction(specifiedDomain[0])) {
+  } else if (typeof specifiedDomain[0] === 'function') {
     domain[0] = specifiedDomain[0](dataDomain[0]);
   } else {
     domain[0] = dataDomain[0];
@@ -1018,7 +1022,7 @@ export const parseSpecifiedDomain = (
     const value = +MAX_VALUE_REG.exec(specifiedDomain[1])[1];
 
     domain[1] = dataDomain[1] + value;
-  } else if (isFunction(specifiedDomain[1])) {
+  } else if (typeof specifiedDomain[1] === 'function') {
     domain[1] = specifiedDomain[1](dataDomain[1]);
   } else {
     domain[1] = dataDomain[1];

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -20,6 +20,7 @@ import { ReactElement } from 'react';
 import {
   findEntryInArray,
   getAnyElementOfObject,
+  isNan,
   isNullish,
   isNumber,
   isNumOrStr,
@@ -425,7 +426,7 @@ export const getTicksOfAxis = (
       };
     });
 
-    return result.filter((row: TickItem) => !Number.isNaN(row.coordinate));
+    return result.filter((row: TickItem) => !isNan(row.coordinate));
   }
 
   // When axis is a categorical axis, but the type of axis is number or the scale of axis is not "auto"
@@ -606,7 +607,7 @@ export const offsetSign: OffsetAccessor = series => {
     let negative = 0;
 
     for (let i = 0; i < n; ++i) {
-      const value = Number.isNaN(series[i][j][1]) ? series[i][j][0] : series[i][j][1];
+      const value = isNan(series[i][j][1]) ? series[i][j][0] : series[i][j][1];
 
       /* eslint-disable prefer-destructuring, no-param-reassign */
       if (value >= 0) {
@@ -641,7 +642,7 @@ export const offsetPositive: OffsetAccessor = series => {
     let positive = 0;
 
     for (let i = 0; i < n; ++i) {
-      const value = Number.isNaN(series[i][j][1]) ? series[i][j][0] : series[i][j][1];
+      const value = isNan(series[i][j][1]) ? series[i][j][0] : series[i][j][1];
 
       /* eslint-disable prefer-destructuring, no-param-reassign */
       if (value >= 0) {

--- a/src/util/DataUtils.ts
+++ b/src/util/DataUtils.ts
@@ -1,7 +1,4 @@
-import isString from 'lodash/isString';
-import isNan from 'lodash/isNaN';
 import get from 'lodash/get';
-import lodashIsNumber from 'lodash/isNumber';
 
 export const mathSign = (value: number) => {
   if (value === 0) {
@@ -15,11 +12,13 @@ export const mathSign = (value: number) => {
 };
 
 export const isPercent = (value: string | number): value is `${number}%` =>
-  isString(value) && value.indexOf('%') === value.length - 1;
+  typeof value === 'string' && value.indexOf('%') === value.length - 1;
 
-export const isNumber = (value: unknown): value is number => lodashIsNumber(value) && !isNan(value);
+export const isNumber = (value: unknown): value is number =>
+  (typeof value === 'number' || value instanceof Number) && !Number.isNaN(value);
 
-export const isNumOrStr = (value: unknown): value is number | string => isNumber(value as number) || isString(value);
+export const isNumOrStr = (value: unknown): value is number | string =>
+  isNumber(value as number) || typeof value === 'string';
 
 let idCounter = 0;
 export const uniqueId = (prefix?: string) => {
@@ -37,7 +36,7 @@ export const uniqueId = (prefix?: string) => {
  * @return {number} value
  */
 export const getPercentValue = (percent: number | string, totalValue: number, defaultValue = 0, validate = false) => {
-  if (!isNumber(percent) && !isString(percent)) {
+  if (!isNumber(percent) && typeof percent !== 'string') {
     return defaultValue;
   }
 
@@ -50,7 +49,7 @@ export const getPercentValue = (percent: number | string, totalValue: number, de
     value = +percent;
   }
 
-  if (isNan(value)) {
+  if (Number.isNaN(value)) {
     value = defaultValue;
   }
 
@@ -158,4 +157,22 @@ export const getLinearRegression = (data: ReadonlyArray<{ cx?: number; cy?: numb
     a,
     b: (ysum - a * xsum) / len,
   };
+};
+
+/**
+ * Checks if the value is null or undefined
+ * @param {any} value The value to check
+ * @returns {boolean} true if the value is null or undefined
+ */
+export const isNullOrUndefined = (value: any): boolean => {
+  return value === null || typeof value === 'undefined';
+};
+
+/**
+ *Uppercase the first letter of a string
+ * @param {string} value The string to uppercase
+ * @returns {string} The uppercased string
+ */
+export const upperFirst = (value: string): string => {
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
 };

--- a/src/util/DataUtils.ts
+++ b/src/util/DataUtils.ts
@@ -164,7 +164,7 @@ export const getLinearRegression = (data: ReadonlyArray<{ cx?: number; cy?: numb
  * @param {any} value The value to check
  * @returns {boolean} true if the value is null or undefined
  */
-export const isNullOrUndefined = (value: any): boolean => {
+export const isNullish = (value: any): boolean => {
   return value === null || typeof value === 'undefined';
 };
 
@@ -174,5 +174,9 @@ export const isNullOrUndefined = (value: any): boolean => {
  * @returns {string} The uppercased string
  */
 export const upperFirst = (value: string): string => {
+  if (isNullish(value)) {
+    return value;
+  }
+
   return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
 };

--- a/src/util/DataUtils.ts
+++ b/src/util/DataUtils.ts
@@ -11,11 +11,16 @@ export const mathSign = (value: number) => {
   return -1;
 };
 
+export const isNan = (value: any): boolean => {
+  // eslint-disable-next-line eqeqeq
+  return typeof value == 'number' && value != +value;
+};
+
 export const isPercent = (value: string | number): value is `${number}%` =>
   typeof value === 'string' && value.indexOf('%') === value.length - 1;
 
 export const isNumber = (value: unknown): value is number =>
-  (typeof value === 'number' || value instanceof Number) && !Number.isNaN(value);
+  (typeof value === 'number' || value instanceof Number) && !isNan(value);
 
 export const isNumOrStr = (value: unknown): value is number | string =>
   isNumber(value as number) || typeof value === 'string';
@@ -49,7 +54,7 @@ export const getPercentValue = (percent: number | string, totalValue: number, de
     value = +percent;
   }
 
-  if (Number.isNaN(value)) {
+  if (isNan(value)) {
     value = defaultValue;
   }
 

--- a/src/util/PolarUtils.ts
+++ b/src/util/PolarUtils.ts
@@ -1,5 +1,5 @@
 import { ReactElement, SVGProps, isValidElement } from 'react';
-import { getPercentValue, isNullOrUndefined } from './DataUtils';
+import { getPercentValue, isNullish } from './DataUtils';
 import { parseScale, checkDomainOfScale, getTicksOfScale } from './ChartUtils';
 import { Coordinate, ChartOffset, GeometrySector, RangeObj } from './types';
 
@@ -59,7 +59,7 @@ export const formatAxisMap = (
     const { domain, reversed } = axis;
     let range;
 
-    if (isNullOrUndefined(axis.range)) {
+    if (isNullish(axis.range)) {
       if (axisType === 'angleAxis') {
         range = [startAngle, endAngle];
       } else if (axisType === 'radiusAxis') {

--- a/src/util/PolarUtils.ts
+++ b/src/util/PolarUtils.ts
@@ -1,7 +1,5 @@
-import isNil from 'lodash/isNil';
 import { ReactElement, SVGProps, isValidElement } from 'react';
-import isFunction from 'lodash/isFunction';
-import { getPercentValue } from './DataUtils';
+import { getPercentValue, isNullOrUndefined } from './DataUtils';
 import { parseScale, checkDomainOfScale, getTicksOfScale } from './ChartUtils';
 import { Coordinate, ChartOffset, GeometrySector, RangeObj } from './types';
 
@@ -61,7 +59,7 @@ export const formatAxisMap = (
     const { domain, reversed } = axis;
     let range;
 
-    if (isNil(axis.range)) {
+    if (isNullOrUndefined(axis.range)) {
       if (axisType === 'angleAxis') {
         range = [startAngle, endAngle];
       } else if (axisType === 'radiusAxis') {
@@ -188,4 +186,4 @@ export const inRangeOfSector = ({ x, y }: Coordinate, sector: GeometrySector): R
 
 export const getTickClassName = (
   tick?: SVGProps<SVGTextElement> | ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | boolean,
-) => (!isValidElement(tick) && !isFunction(tick) && typeof tick !== 'boolean' ? tick.className : '');
+) => (!isValidElement(tick) && typeof tick !== 'function' && typeof tick !== 'boolean' ? tick.className : '');

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -1,12 +1,9 @@
 import get from 'lodash/get';
-import isNil from 'lodash/isNil';
-import isFunction from 'lodash/isFunction';
-import isObject from 'lodash/isObject';
 
 import React, { Children, Component, FunctionComponent, isValidElement, ReactNode } from 'react';
 import { isFragment } from 'react-is';
 import { DotProps } from '..';
-import { isNumber } from './DataUtils';
+import { isNullOrUndefined, isNumber } from './DataUtils';
 import { shallowEqual } from './ShallowEqual';
 import { FilteredSvgElementType, FilteredElementKeyMap, SVGElementPropKeys, EventKeys, ActiveDotType } from './types';
 
@@ -76,7 +73,7 @@ export const toArray = <T extends ReactNode>(children: T | T[]): T[] => {
   }
   let result: T[] = [];
   Children.forEach(children, child => {
-    if (isNil(child)) return;
+    if (isNullOrUndefined(child)) return;
     if (isFragment(child)) {
       result = result.concat(toArray(child.props.children));
     } else {
@@ -178,7 +175,7 @@ export const isValidSpreadableProp = (
   const matchingElementTypeKeys = FilteredElementKeyMap?.[svgElementType] ?? [];
 
   return (
-    (!isFunction(property) &&
+    (typeof property !== 'function' &&
       ((svgElementType && matchingElementTypeKeys.includes(key)) || SVGElementPropKeys.includes(key))) ||
     (includeEvents && EventKeys.includes(key))
   );
@@ -199,7 +196,7 @@ export const filterProps = (
     inputProps = props.props as Record<string, any>;
   }
 
-  if (!isObject(inputProps)) {
+  if (typeof inputProps !== 'object' && typeof inputProps !== 'function') {
     return null;
   }
 
@@ -273,10 +270,10 @@ export const isChildrenEqual = (nextChildren: React.ReactElement[], prevChildren
  * @return deprecated do not use
  */
 const isSingleChildEqual = (nextChild: React.ReactElement, prevChild: React.ReactElement): boolean => {
-  if (isNil(nextChild) && isNil(prevChild)) {
+  if (isNullOrUndefined(nextChild) && isNullOrUndefined(prevChild)) {
     return true;
   }
-  if (!isNil(nextChild) && !isNil(prevChild)) {
+  if (!isNullOrUndefined(nextChild) && !isNullOrUndefined(prevChild)) {
     const { children: nextChildren, ...nextProps } = nextChild.props || {};
     const { children: prevChildren, ...prevProps } = prevChild.props || {};
 

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -3,7 +3,7 @@ import get from 'lodash/get';
 import React, { Children, Component, FunctionComponent, isValidElement, ReactNode } from 'react';
 import { isFragment } from 'react-is';
 import { DotProps } from '..';
-import { isNullOrUndefined, isNumber } from './DataUtils';
+import { isNullish, isNumber } from './DataUtils';
 import { shallowEqual } from './ShallowEqual';
 import { FilteredSvgElementType, FilteredElementKeyMap, SVGElementPropKeys, EventKeys, ActiveDotType } from './types';
 
@@ -73,7 +73,7 @@ export const toArray = <T extends ReactNode>(children: T | T[]): T[] => {
   }
   let result: T[] = [];
   Children.forEach(children, child => {
-    if (isNullOrUndefined(child)) return;
+    if (isNullish(child)) return;
     if (isFragment(child)) {
       result = result.concat(toArray(child.props.children));
     } else {
@@ -270,10 +270,10 @@ export const isChildrenEqual = (nextChildren: React.ReactElement[], prevChildren
  * @return deprecated do not use
  */
 const isSingleChildEqual = (nextChild: React.ReactElement, prevChild: React.ReactElement): boolean => {
-  if (isNullOrUndefined(nextChild) && isNullOrUndefined(prevChild)) {
+  if (isNullish(nextChild) && isNullish(prevChild)) {
     return true;
   }
-  if (!isNullOrUndefined(nextChild) && !isNullOrUndefined(prevChild)) {
+  if (!isNullish(nextChild) && !isNullish(prevChild)) {
     const { children: nextChildren, ...nextProps } = nextChild.props || {};
     const { children: prevChildren, ...prevProps } = prevChild.props || {};
 

--- a/src/util/ReduceCSSCalc.ts
+++ b/src/util/ReduceCSSCalc.ts
@@ -1,3 +1,5 @@
+import { isNan } from './DataUtils';
+
 const MULTIPLY_OR_DIVIDE_REGEX = /(-?\d+(?:\.\d+)?[a-zA-Z%]*)([*/])(-?\d+(?:\.\d+)?[a-zA-Z%]*)/;
 const ADD_OR_SUBTRACT_REGEX = /(-?\d+(?:\.\d+)?[a-zA-Z%]*)([+-])(-?\d+(?:\.\d+)?[a-zA-Z%]*)/;
 const CSS_LENGTH_UNIT_REGEX = /^px|cm|vh|vw|em|rem|%|mm|in|pt|pc|ex|ch|vmin|vmax|Q$/;
@@ -34,7 +36,7 @@ class DecimalCSS {
     this.num = num;
     this.unit = unit;
 
-    if (Number.isNaN(num)) {
+    if (isNan(num)) {
       this.unit = '';
     }
 
@@ -86,7 +88,7 @@ class DecimalCSS {
   }
 
   isNaN() {
-    return Number.isNaN(this.num);
+    return isNan(this.num);
   }
 }
 

--- a/src/util/getDomainOfErrorBars.ts
+++ b/src/util/getDomainOfErrorBars.ts
@@ -1,11 +1,11 @@
 import { ReactElement } from 'react';
-import isNil from 'lodash/isNil';
 import min from 'lodash/min';
 import max from 'lodash/max';
 import { AxisType, BaseAxisProps, CategoricalDomain, DataKey, LayoutType, NumberDomain } from './types';
 import { findAllByType } from './ReactUtils';
 import { ErrorBar } from '../cartesian/ErrorBar';
 import { getDomainOfDataByKey, getValueByDataKey, isErrorBarRelevantForAxis } from './ChartUtils';
+import { isNullOrUndefined } from './DataUtils';
 
 /**
  * @deprecated - this is using direct DOM access. Use different approach.
@@ -34,7 +34,7 @@ export const getDomainOfErrorBars = (
     return data.reduce<NumberDomain>(
       (result: NumberDomain, entry: object): NumberDomain => {
         const entryValue = getValueByDataKey(entry, dataKey);
-        if (isNil(entryValue)) return result;
+        if (isNullOrUndefined(entryValue)) return result;
 
         const mainValue = Array.isArray(entryValue) ? [min(entryValue), max(entryValue)] : [entryValue, entryValue];
         const errorDomain = keys.reduce(
@@ -75,7 +75,7 @@ export const parseErrorBarsOfAxis = (
 ): NumberDomain | null => {
   const domains = items
     .map(item => getDomainOfErrorBars(data, item, dataKey, layout, axisType))
-    .filter(entry => !isNil(entry));
+    .filter(entry => !isNullOrUndefined(entry));
 
   if (domains && domains.length) {
     return domains.reduce(

--- a/src/util/getDomainOfErrorBars.ts
+++ b/src/util/getDomainOfErrorBars.ts
@@ -5,7 +5,7 @@ import { AxisType, BaseAxisProps, CategoricalDomain, DataKey, LayoutType, Number
 import { findAllByType } from './ReactUtils';
 import { ErrorBar } from '../cartesian/ErrorBar';
 import { getDomainOfDataByKey, getValueByDataKey, isErrorBarRelevantForAxis } from './ChartUtils';
-import { isNullOrUndefined } from './DataUtils';
+import { isNullish } from './DataUtils';
 
 /**
  * @deprecated - this is using direct DOM access. Use different approach.
@@ -34,7 +34,7 @@ export const getDomainOfErrorBars = (
     return data.reduce<NumberDomain>(
       (result: NumberDomain, entry: object): NumberDomain => {
         const entryValue = getValueByDataKey(entry, dataKey);
-        if (isNullOrUndefined(entryValue)) return result;
+        if (isNullish(entryValue)) return result;
 
         const mainValue = Array.isArray(entryValue) ? [min(entryValue), max(entryValue)] : [entryValue, entryValue];
         const errorDomain = keys.reduce(
@@ -75,7 +75,7 @@ export const parseErrorBarsOfAxis = (
 ): NumberDomain | null => {
   const domains = items
     .map(item => getDomainOfErrorBars(data, item, dataKey, layout, axisType))
-    .filter(entry => !isNullOrUndefined(entry));
+    .filter(entry => !isNullish(entry));
 
   if (domains && domains.length) {
     return domains.reduce(

--- a/src/util/isDomainSpecifiedByUser.ts
+++ b/src/util/isDomainSpecifiedByUser.ts
@@ -179,7 +179,7 @@ export function parseNumericalUserDomain(
       if (dataDomain != null) {
         finalMin = Math.min(...dataDomain);
       }
-    } else if (typeof providedMin === 'number' && !Number.isNaN(providedMin)) {
+    } else if (isNumber(providedMin)) {
       finalMin = providedMin;
     } else if (typeof providedMin === 'function') {
       try {
@@ -199,7 +199,7 @@ export function parseNumericalUserDomain(
       if (dataDomain != null) {
         finalMax = Math.max(...dataDomain);
       }
-    } else if (typeof providedMax === 'number' && !Number.isNaN(providedMax)) {
+    } else if (isNumber(providedMax)) {
       finalMax = providedMax;
     } else if (typeof providedMax === 'function') {
       try {

--- a/src/util/payload/getUniqPayload.ts
+++ b/src/util/payload/getUniqPayload.ts
@@ -1,5 +1,4 @@
 import uniqBy from 'lodash/uniqBy';
-import isFunction from 'lodash/isFunction';
 
 type UniqueFunc<T> = (entry: T) => unknown;
 
@@ -17,7 +16,7 @@ export function getUniqPayload<T>(payload: Array<T>, option: UniqueOption<T>, de
     return uniqBy(payload, defaultUniqBy);
   }
 
-  if (isFunction(option)) {
+  if (typeof option === 'function') {
     return uniqBy(payload, option);
   }
 

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -23,7 +23,6 @@ import {
   WheelEvent,
   JSX,
 } from 'react';
-import isObject from 'lodash/isObject';
 import { ScaleContinuousNumeric as D3ScaleContinuousNumeric } from 'victory-vendor/d3-scale';
 import { PolarAngleAxisProps } from '../polar/PolarAngleAxis';
 import { PolarRadiusAxisProps } from '../polar/PolarRadiusAxis';
@@ -1245,7 +1244,7 @@ export const adaptEventHandlers = (
     inputProps = props.props as RecordString<any>;
   }
 
-  if (!isObject(inputProps)) {
+  if (typeof inputProps !== 'object' && typeof inputProps !== 'function') {
     return null;
   }
 
@@ -1273,7 +1272,7 @@ export const adaptEventsOfChild = (
   data: any,
   index: number,
 ): RecordString<(e?: Event) => any> | null => {
-  if (!isObject(props) || typeof props !== 'object') {
+  if (props === null || (typeof props !== 'object' && typeof props !== 'function')) {
     return null;
   }
 

--- a/test/util/DataUtils.spec.ts
+++ b/test/util/DataUtils.spec.ts
@@ -12,6 +12,7 @@ import {
   uniqueId,
   isNullish,
   upperFirst,
+  isNan,
 } from '../../src/util/DataUtils';
 
 /**
@@ -307,5 +308,31 @@ describe('upperFirst', () => {
 
   it('should return the string with the first letter uppercased', () => {
     expect(upperFirst('hello')).toBe('Hello');
+  });
+});
+
+describe('isNan', () => {
+  it('should return true when value is NaN', () => {
+    expect(isNan(NaN)).toBe(true);
+  });
+
+  it('should return false when value is undefined', () => {
+    expect(isNan(undefined)).toBe(false);
+  });
+
+  it('should return false when value is null', () => {
+    expect(isNan(null)).toBe(false);
+  });
+
+  it('should return false when value is empty string', () => {
+    expect(isNan('')).toBe(false);
+  });
+
+  it('should return false when value is "0"', () => {
+    expect(isNan('0')).toBe(false);
+  });
+
+  it('should return false when value is a number', () => {
+    expect(isNan(1)).toBe(false);
   });
 });

--- a/test/util/DataUtils.spec.ts
+++ b/test/util/DataUtils.spec.ts
@@ -10,7 +10,7 @@ import {
   getLinearRegression,
   findEntryInArray,
   uniqueId,
-  isNullOrUndefined,
+  isNullish,
   upperFirst,
 } from '../../src/util/DataUtils';
 
@@ -276,23 +276,35 @@ describe('getLinearRegression', () => {
   });
 });
 
-describe('isNullOrUndefined', () => {
+describe('isNullish', () => {
   it('should return true when value is null', () => {
-    expect(isNullOrUndefined(null)).toBe(true);
+    expect(isNullish(null)).toBe(true);
   });
 
   it('should return true when value is undefined', () => {
-    expect(isNullOrUndefined(undefined)).toBe(true);
+    expect(isNullish(undefined)).toBe(true);
   });
 
   it('should return false when value is not null or undefined', () => {
-    expect(isNullOrUndefined(0)).toBe(false);
-    expect(isNullOrUndefined('')).toBe(false);
-    expect(isNullOrUndefined('0')).toBe(false);
+    expect(isNullish(0)).toBe(false);
+    expect(isNullish('')).toBe(false);
+    expect(isNullish('0')).toBe(false);
   });
 });
 
 describe('upperFirst', () => {
+  it('should return null when value is null', () => {
+    expect(upperFirst(null)).toBe(null);
+  });
+
+  it('should return undefined when value is undefined', () => {
+    expect(upperFirst(undefined)).toBe(undefined);
+  });
+
+  it('should return empty string when value is empty string', () => {
+    expect(upperFirst('')).toBe('');
+  });
+
   it('should return the string with the first letter uppercased', () => {
     expect(upperFirst('hello')).toBe('Hello');
   });

--- a/test/util/DataUtils.spec.ts
+++ b/test/util/DataUtils.spec.ts
@@ -10,6 +10,8 @@ import {
   getLinearRegression,
   findEntryInArray,
   uniqueId,
+  isNullOrUndefined,
+  upperFirst,
 } from '../../src/util/DataUtils';
 
 /**
@@ -271,5 +273,27 @@ describe('getLinearRegression', () => {
       xmax: 0,
       xmin: 0,
     });
+  });
+});
+
+describe('isNullOrUndefined', () => {
+  it('should return true when value is null', () => {
+    expect(isNullOrUndefined(null)).toBe(true);
+  });
+
+  it('should return true when value is undefined', () => {
+    expect(isNullOrUndefined(undefined)).toBe(true);
+  });
+
+  it('should return false when value is not null or undefined', () => {
+    expect(isNullOrUndefined(0)).toBe(false);
+    expect(isNullOrUndefined('')).toBe(false);
+    expect(isNullOrUndefined('0')).toBe(false);
+  });
+});
+
+describe('upperFirst', () => {
+  it('should return the string with the first letter uppercased', () => {
+    expect(upperFirst('hello')).toBe('Hello');
   });
 });


### PR DESCRIPTION
## Description
When bundling an application, lodash seems to be taking a lot of space when using recharts. This is the first PR to replace lodash with either native functions or move to es-toolkit. 

This PR replaces any functions that could be replaced with either `typeof`, `isNullOrUndefined`, `upperFirst`, and `Number.isNaN`. In the future, there will be other PRs that replace other instances of lodash functions that are more complex.

## Related Issue

Issue: https://github.com/recharts/recharts/issues/5266

## Motivation and Context

Reduces the size of recharts bundle by removing lodash and replacing with internal functions.

## How Has This Been Tested?

All tests pass, and new tests have been written for  `isNullOrUndefined`, and `upperFirst` functions.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes