### PR TITLE
feat: add onDoubleClick and onContextMenu events to categorical charts

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -753,6 +753,8 @@ export interface CategoricalChartProps {
   onMouseMove?: CategoricalChartFunc;
   onMouseDown?: CategoricalChartFunc;
   onMouseUp?: CategoricalChartFunc;
+  onContextMenu?: CategoricalChartFunc;
+  onDoubleClick?: CategoricalChartFunc;
   reverseStackOrder?: boolean;
   id?: string;
 
@@ -1249,11 +1251,13 @@ export const generateCategoricalChart = ({
         } else {
           tooltipEvents = {
             onMouseEnter: this.handleMouseEnter,
+            onDoubleClick: this.handleDoubleClick,
             onMouseMove: this.handleMouseMove,
             onMouseLeave: this.handleMouseLeave,
             onTouchMove: this.handleTouchMove,
             onTouchStart: this.handleTouchStart,
             onTouchEnd: this.handleTouchEnd,
+            onContextMenu: this.handleContextMenu,
           };
         }
       }
@@ -1500,6 +1504,24 @@ export const generateCategoricalChart = ({
     handleTouchEnd = (e: React.TouchEvent) => {
       if (e.changedTouches != null && e.changedTouches.length > 0) {
         this.handleMouseUp(e.changedTouches[0]);
+      }
+    };
+
+    handleDoubleClick = (e: React.MouseEvent) => {
+      const { onDoubleClick } = this.props;
+
+      if (typeof onDoubleClick === 'function') {
+        const nextState: CategoricalChartState = this.getMouseInfo(e);
+        onDoubleClick(nextState, e);
+      }
+    };
+
+    handleContextMenu = (e: React.MouseEvent) => {
+      const { onContextMenu } = this.props;
+
+      if (typeof onContextMenu === 'function') {
+        const nextState: CategoricalChartState = this.getMouseInfo(e);
+        onContextMenu(nextState, e);
       }
     };
 

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -20,6 +20,8 @@ const REACT_BROWSER_EVENT_MAP: Record<string, string> = {
   touchend: 'onTouchEnd',
   touchmove: 'onTouchMove',
   touchstart: 'onTouchStart',
+  contextmenu: 'onContextMenu',
+  dblclick: 'onDoubleClick',
 };
 
 export const SCALE_TYPES = [

--- a/test/chart/CategoricalChart.spec.tsx
+++ b/test/chart/CategoricalChart.spec.tsx
@@ -20,6 +20,7 @@ import {
   XAxis,
   YAxis,
 } from '../../src';
+import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 
 type WrapperProps = {
   onClick: () => void;
@@ -176,6 +177,10 @@ const testCases = [
 ];
 
 describe('CategoricalChart', () => {
+  beforeEach(() => {
+    mockGetBoundingClientRect({ height: 50, width: 50 });
+  });
+
   describe.each(testCases)('$name', ({ Wrapper }) => {
     test('should call corresponding callback on mouse events', () => {
       const handleClickMock = vi.fn();

--- a/test/chart/CategoricalChart.spec.tsx
+++ b/test/chart/CategoricalChart.spec.tsx
@@ -1,0 +1,203 @@
+import React, { ComponentType } from 'react';
+import { vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import {
+  Area,
+  AreaChart,
+  ComposedChart,
+  Funnel,
+  FunnelChart,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  Radar,
+  RadarChart,
+  RadialBar,
+  RadialBarChart,
+  Scatter,
+  ScatterChart,
+  XAxis,
+  YAxis,
+} from '../../src';
+
+type WrapperProps = {
+  onClick: () => void;
+  onDoubleClick: () => void;
+  onContextMenu: () => void;
+};
+
+const data = [
+  { name: 'Page A', uv: 400, pv: 2400, amt: 2400 },
+  { name: 'Page B', uv: 300, pv: 4567, amt: 2400 },
+  { name: 'Page C', uv: 300, pv: 1398, amt: 2400 },
+  { name: 'Page D', uv: 200, pv: 9800, amt: 2400 },
+  { name: 'Page E', uv: 278, pv: 3908, amt: 2400 },
+  { name: 'Page F', uv: 189, pv: 4800, amt: 2400 },
+];
+
+const funnelData1 = [
+  { value: 100, name: '展现' },
+  { value: 80, name: '点击' },
+  { value: 50, name: '访问' },
+  { value: 40, name: '咨询' },
+  { value: 26, name: '订单' },
+];
+
+const funnelData2 = [
+  { value: 60, name: '展现' },
+  { value: 50, name: '点击' },
+  { value: 30, name: '访问' },
+  { value: 20, name: '咨询' },
+  { value: 6, name: '订单' },
+];
+
+const commonChartProps = {
+  data,
+  width: 300,
+  height: 300,
+};
+
+type CategoricalChartTestCase = {
+  name: string;
+  Wrapper: ComponentType<WrapperProps>;
+};
+
+const AreaChartTestCase: CategoricalChartTestCase = {
+  name: 'AreaChart',
+  Wrapper: ({ onClick, onDoubleClick, onContextMenu }: WrapperProps) => (
+    <AreaChart {...commonChartProps} onContextMenu={onContextMenu} onClick={onClick} onDoubleClick={onDoubleClick}>
+      <Area type="monotone" dataKey="uv" stroke="#ff7300" fill="#ff7300" />
+    </AreaChart>
+  ),
+};
+
+const ComposedChartTestCase: CategoricalChartTestCase = {
+  name: 'ComposedChart',
+  Wrapper: ({ onClick, onDoubleClick, onContextMenu }: WrapperProps) => (
+    <ComposedChart {...commonChartProps} onContextMenu={onContextMenu} onClick={onClick} onDoubleClick={onDoubleClick}>
+      <Area type="monotone" dataKey="uv" stroke="#ff7300" fill="#ff7300" />
+      <Line type="monotone" dataKey="uv" stroke="#00EE00" />
+    </ComposedChart>
+  ),
+};
+
+const FunnelChartTestCase: CategoricalChartTestCase = {
+  name: 'FunnelChart',
+  Wrapper: ({ onClick, onDoubleClick, onContextMenu }: WrapperProps) => (
+    <FunnelChart {...commonChartProps} onContextMenu={onContextMenu} onClick={onClick} onDoubleClick={onDoubleClick}>
+      <Funnel dataKey="uv" data={funnelData1} />
+      <Funnel dataKey="uv" data={funnelData2} />
+    </FunnelChart>
+  ),
+};
+
+const LineChartTestCase: CategoricalChartTestCase = {
+  name: 'LineChart',
+  Wrapper: ({ onClick, onDoubleClick, onContextMenu }: WrapperProps) => (
+    <LineChart {...commonChartProps} onContextMenu={onContextMenu} onClick={onClick} onDoubleClick={onDoubleClick}>
+      <Line type="monotone" dataKey="uv" stroke="#ff7300" />
+    </LineChart>
+  ),
+};
+
+const PieChartTestCase: CategoricalChartTestCase = {
+  name: 'PieChart',
+  Wrapper: ({ onClick, onDoubleClick, onContextMenu }: WrapperProps) => (
+    <PieChart width={300} height={300} onContextMenu={onContextMenu} onClick={onClick} onDoubleClick={onDoubleClick}>
+      <Pie dataKey="uv" isAnimationActive data={data} cx={200} cy={200} outerRadius={80} fill="#ff7300" label />
+    </PieChart>
+  ),
+};
+
+const RadarChartTestCase: CategoricalChartTestCase = {
+  name: 'RadarChart',
+  Wrapper: ({ onClick, onDoubleClick, onContextMenu }: WrapperProps) => (
+    <RadarChart
+      {...commonChartProps}
+      cx={300}
+      cy={250}
+      outerRadius={150}
+      onContextMenu={onContextMenu}
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+    >
+      <Radar isAnimationActive={false} dot dataKey="uv" />
+    </RadarChart>
+  ),
+};
+
+const RadialBarChartTestCase: CategoricalChartTestCase = {
+  name: 'RadialBarChart',
+  Wrapper: ({ onClick, onDoubleClick, onContextMenu }: WrapperProps) => (
+    <RadialBarChart
+      {...commonChartProps}
+      cx={150}
+      cy={150}
+      innerRadius={20}
+      outerRadius={140}
+      barSize={10}
+      onContextMenu={onContextMenu}
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+    >
+      <RadialBar label={{ orientation: 'outer' }} background dataKey="uv" isAnimationActive={false} />
+    </RadialBarChart>
+  ),
+};
+
+const ScatterChartTestCase: CategoricalChartTestCase = {
+  name: 'ScatterChart',
+  Wrapper: ({ onClick, onDoubleClick, onContextMenu }: WrapperProps) => (
+    <ScatterChart
+      width={400}
+      height={400}
+      onContextMenu={onContextMenu}
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+    >
+      <XAxis dataKey="uv" name="stature" unit="cm" />
+      <YAxis dataKey="pv" name="weight" unit="kg" />
+      <Scatter line name="A school" data={data} fill="#ff7300" />
+    </ScatterChart>
+  ),
+};
+
+const testCases = [
+  AreaChartTestCase,
+  ComposedChartTestCase,
+  FunnelChartTestCase,
+  LineChartTestCase,
+  PieChartTestCase,
+  RadarChartTestCase,
+  RadialBarChartTestCase,
+  ScatterChartTestCase,
+];
+
+describe('CategoricalChart', () => {
+  describe.each(testCases)('$name', ({ Wrapper }) => {
+    test('should call corresponding callback on mouse events', () => {
+      const handleClickMock = vi.fn();
+      const handleDoubleClickMock = vi.fn();
+      const handleContextMenuMock = vi.fn();
+
+      const { container } = render(
+        <Wrapper
+          onClick={handleClickMock}
+          onDoubleClick={handleDoubleClickMock}
+          onContextMenu={handleContextMenuMock}
+        />,
+      );
+
+      const surface = container.querySelector('.recharts-wrapper');
+      fireEvent.click(surface);
+      fireEvent.doubleClick(surface);
+      fireEvent.contextMenu(surface);
+
+      expect(handleClickMock).toHaveBeenCalledWith(expect.any(Object), expect.any(Object));
+      expect(handleDoubleClickMock).toHaveBeenCalledWith(expect.any(Object), expect.any(Object));
+      expect(handleContextMenuMock).toHaveBeenCalledWith(expect.any(Object), expect.any(Object));
+    });
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
duplicate of https://github.com/recharts/recharts/pull/5255/files but for 3.x

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5254

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
