### PR TITLE
Fix x y axis ref

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "recharts",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "recharts",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recharts",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "React charts",
   "main": "lib/index.js",
   "module": "es6/index.js",

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -14,7 +14,7 @@ interface XAxisProps extends BaseAxisProps {
   xAxisId?: string | number;
   /** The width of axis which is usually calculated internally */
   width?: number;
-  /** The height of axis, which need to be setted by user */
+  /** The height of axis, which need to be set by the user */
   height?: number;
   mirror?: boolean;
   // The orientation of axis
@@ -33,7 +33,7 @@ interface XAxisProps extends BaseAxisProps {
   tickMargin?: number;
 }
 
-export type Props = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>, 'scale'> & XAxisProps;
+export type Props = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>, 'scale' | 'ref'> & XAxisProps;
 
 function XAxisImpl({ xAxisId }: Props) {
   const width = useChartWidth();

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -16,7 +16,7 @@ interface YAxisProps extends BaseAxisProps {
    * Ticks must be numbers when the axis is the type of number
    */
   ticks?: (string | number)[];
-  /** The width of axis, which need to be setted by user */
+  /** The width of axis, which need to be set by the user */
   width?: number;
   /** The height of axis which is usually calculated in Chart */
   height?: number;
@@ -33,7 +33,7 @@ interface YAxisProps extends BaseAxisProps {
   tickMargin?: number;
 }
 
-export type Props = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>, 'scale'> & YAxisProps;
+export type Props = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>, 'scale' | 'ref'> & YAxisProps;
 
 const YAxisImpl = ({ yAxisId }: Props) => {
   const width = useChartWidth();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

`ref` needs removed from X and Y axis Props.

Upon adding `PresentationAttributesAdaptChildEvent` it also added `ref` from `SVGProps` to types

This might be a breaking change for anyone who has started using `ref` since 2.13.0, but the addition was unintentional

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5294

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm test` `npm run build`

test that `ref` is no longer there

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
