### PR TITLE
calculateActiveTickIndex only accepts the arguments it actually uses instead of the whole large axis object

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -219,7 +219,7 @@ const getTooltipData = (
   const pos: number | undefined = calculateTooltipPos(rangeData, layout);
   const { orderedTooltipTicks: ticks, tooltipAxis: axis, tooltipTicks } = state;
 
-  const activeIndex = calculateActiveTickIndex(pos, ticks, tooltipTicks, axis);
+  const activeIndex = calculateActiveTickIndex(pos, ticks, tooltipTicks, axis?.axisType, axis?.range);
 
   if (activeIndex >= 0 && tooltipTicks) {
     const activeLabel: TickItem['value'] | undefined = tooltipTicks[activeIndex] && tooltipTicks[activeIndex].value;

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -347,7 +347,13 @@ export const combineActiveProps = (
   }
   const pos: number | undefined = calculateTooltipPos(rangeObj, layout);
 
-  const activeIndex = calculateActiveTickIndex(pos, orderedTooltipTicks, tooltipTicks, tooltipAxis);
+  const activeIndex = calculateActiveTickIndex(
+    pos,
+    orderedTooltipTicks,
+    tooltipTicks,
+    tooltipAxis.axisType,
+    tooltipAxis.range,
+  );
 
   const activeCoordinate = getActiveCoordinate(layout, tooltipTicks, activeIndex, rangeObj);
 

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -49,10 +49,10 @@ import {
   TickItem,
 } from './types';
 import { ValueType } from '../component/DefaultTooltipContent';
-import { AxisMap, AxisObj, AxisPropsWithExtraComputedData } from '../chart/types';
+import { AxisMap, AxisObj } from '../chart/types';
 import { inRangeOfSector, polarToCartesian } from './PolarUtils';
 import { LegendState } from '../state/legendSlice';
-import { BaseAxisWithScale } from '../state/selectors/axisSelectors';
+import { AxisRange, BaseAxisWithScale } from '../state/selectors/axisSelectors';
 
 export function getValueByDataKey<T>(obj: T, dataKey: DataKey<T>, defaultValue?: any): unknown {
   if (isNullish(obj) || isNullish(dataKey)) {
@@ -109,8 +109,9 @@ export const calculateActiveTickIndex = (
    */
   coordinate: number,
   ticks: ReadonlyArray<TickItem>,
-  unsortedTicks?: ReadonlyArray<TickItem>,
-  axis?: AxisPropsWithExtraComputedData,
+  unsortedTicks: ReadonlyArray<TickItem> | undefined,
+  axisType: AxisType | undefined,
+  range: AxisRange | undefined,
 ): number => {
   let index = -1;
   const len = ticks?.length ?? 0;
@@ -120,8 +121,7 @@ export const calculateActiveTickIndex = (
     return 0;
   }
 
-  if (axis && axis.axisType === 'angleAxis' && Math.abs(Math.abs(axis.range[1] - axis.range[0]) - 360) <= 1e-6) {
-    const { range } = axis;
+  if (axisType === 'angleAxis' && range != null && Math.abs(Math.abs(range[1] - range[0]) - 360) <= 1e-6) {
     // ticks are distributed in a circle
     for (let i = 0; i < len; i++) {
       const before = i > 0 ? unsortedTicks[i - 1].coordinate : unsortedTicks[len - 1].coordinate;

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -49,7 +49,7 @@ import {
   TickItem,
 } from './types';
 import { ValueType } from '../component/DefaultTooltipContent';
-import { AxisMap, AxisObj } from '../chart/types';
+import { AxisMap } from '../chart/types';
 import { inRangeOfSector, polarToCartesian } from './PolarUtils';
 import { LegendState } from '../state/legendSlice';
 import { AxisRange, BaseAxisWithScale } from '../state/selectors/axisSelectors';
@@ -216,15 +216,6 @@ export const getMainColorOfGraphicItem = (item: {
   }
 
   return result;
-};
-
-/**
- * @deprecated do not use - depends on passing around DOM elements
- */
-export type BarSetup = {
-  barSize: number | string;
-  stackList: ReadonlyArray<ReactElement>;
-  item: ReactElement;
 };
 
 export type BarPositionPosition = {
@@ -1181,22 +1172,6 @@ export const isAxisLTR = (axisMap: { [key: string]: Reversible }) => {
   // If there are any cases of reversed=true, then the chart is right-to-left (returning false).
   // Otherwise, the chart is left-to-right (returning true)
   return !axes.some(({ reversed }) => reversed);
-};
-
-// eslint-disable-next-line valid-jsdoc
-/**
- * @deprecated do not use, depends (indirectly) on DOM access. Instead, use {@link selectCartesianAxisSize}
- * Determine the size of the axis, used for calculation of relative bar sizes
- */
-export const getCartesianAxisSize = (axisObj: AxisObj, axisName: 'xAxis' | 'yAxis' | 'angleAxis' | 'radiusAxis') => {
-  if (axisName === 'xAxis') {
-    return axisObj[axisName].width;
-  }
-  if (axisName === 'yAxis') {
-    return axisObj[axisName].height;
-  }
-  // This is only supported for Bar charts (i.e. charts with cartesian axes), so we should never get here
-  return undefined;
 };
 
 export function inRange(

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -30,6 +30,7 @@ import type { Props as DotProps } from '../shape/Dot';
 import { TooltipPayloadSearcher } from '../state/tooltipSlice';
 import { XAxisWithExtraData, YAxisWithExtraData } from '../chart/types';
 import { RechartsScale } from './ChartUtils';
+import { AxisRange } from '../state/selectors/axisSelectors';
 
 /**
  * Determines how values are stacked:
@@ -1164,7 +1165,7 @@ export interface BaseAxisProps {
   name?: string;
   /** The unit of data displayed in the axis */
   unit?: string;
-  range?: Array<number>;
+  range?: AxisRange;
   /** axis react component */
   AxisComp?: any;
   /** Needed to allow usage of the label prop on the X and Y axis */

--- a/test/util/ChartUtils.spec.tsx
+++ b/test/util/ChartUtils.spec.tsx
@@ -389,15 +389,15 @@ describe('calculateActiveTickIndex', () => {
     { coordinate: 15, index: 3 },
   ];
   it('calculateActiveTickIndex(12, ticks) should return 1', () => {
-    expect(calculateActiveTickIndex(12, ticks)).toBe(1);
+    expect(calculateActiveTickIndex(12, ticks, [], 'radiusAxis', [0, 100])).toBe(1);
   });
 
   it('calculateActiveTickIndex(-1, ticks) should return 0', () => {
-    expect(calculateActiveTickIndex(-1, ticks)).toBe(0);
+    expect(calculateActiveTickIndex(-1, ticks, [], 'radiusAxis', [0, 100])).toBe(0);
   });
 
   it('calculateActiveTickIndex(16, ticks) should return 3', () => {
-    expect(calculateActiveTickIndex(16, ticks)).toBe(3);
+    expect(calculateActiveTickIndex(16, ticks, [], 'radiusAxis', [0, 100])).toBe(3);
   });
 });
 


### PR DESCRIPTION
## Description

This will make it easier to reuse in selectors later.

## Related Issue

https://github.com/recharts/recharts/issues/4549