### PR TITLE
Do not return categoricalDomain if dataKey is undefined

### DIFF
--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -632,7 +632,7 @@ const computeNumericalDomain = (
   return [Math.min(...onlyNumbers), Math.max(...onlyNumbers)];
 };
 
-const computeCategoricalDomain = (
+const computeDomainOfTypeCategory = (
   allDataSquished: AppliedChartData,
   axisSettings: BaseCartesianAxis,
   isCategorical: boolean,
@@ -861,7 +861,7 @@ export const combineAxisDomain = (
   }
 
   if (type === 'category') {
-    return computeCategoricalDomain(allAppliedValues, axisSettings, isCategorical);
+    return computeDomainOfTypeCategory(allAppliedValues, axisSettings, isCategorical);
   }
 
   if (stackOffsetType === 'expand') {
@@ -1526,7 +1526,7 @@ export const combineCategoricalDomain = (
   axis: AxisWithTicksSettings,
   axisType: XorYType,
 ): ReadonlyArray<unknown> | undefined => {
-  if (axis == null) {
+  if (axis == null || axis.dataKey == null) {
     return undefined;
   }
   const { type, scale } = axis;
@@ -1536,6 +1536,7 @@ export const combineCategoricalDomain = (
   }
   return undefined;
 };
+
 export const selectCategoricalDomain = createSelector(
   selectChartLayout,
   selectAllAppliedValues,

--- a/test/polar/PolarRadiusAxis.spec.tsx
+++ b/test/polar/PolarRadiusAxis.spec.tsx
@@ -842,10 +842,47 @@ describe('<PolarRadiusAxis />', () => {
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
-      it('should not render ticks', () => {
+      it('should render ticks', () => {
         const { container } = renderTestCase();
 
-        expectRadiusAxisTicks(container, []);
+        expectRadiusAxisTicks(container, [
+          {
+            textContent: '0',
+            transform: 'rotate(90, 250, 250)',
+            x: '250',
+            y: '250',
+          },
+          {
+            textContent: '1',
+            transform: 'rotate(90, 282.6666666666667, 250)',
+            x: '282.6666666666667',
+            y: '250',
+          },
+          {
+            textContent: '2',
+            transform: 'rotate(90, 315.3333333333333, 250)',
+            x: '315.3333333333333',
+            y: '250',
+          },
+          {
+            textContent: '3',
+            transform: 'rotate(90, 348, 250)',
+            x: '348',
+            y: '250',
+          },
+          {
+            textContent: '4',
+            transform: 'rotate(90, 380.66666666666663, 250)',
+            x: '380.66666666666663',
+            y: '250',
+          },
+          {
+            textContent: '5',
+            transform: 'rotate(90, 413.3333333333333, 250)',
+            x: '413.3333333333333',
+            y: '250',
+          },
+        ]);
       });
 
       it('should not render label', () => {


### PR DESCRIPTION
## Description

Made this change to better match what the generator is doing. There is a small visual diff, for the better I think: https://www.chromatic.com/test?appId=63da8268a0da9970db6992aa&id=6753d460c9cfa1f0559d5ad0

Also renamed the other `xCategoricalDomain` to better distinguish which is which. I think we need a better name here though.

## Related Issue

https://github.com/recharts/recharts/issues/4549