### PR TITLE
Replace ReactText with number|string

### DIFF
--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -6,7 +6,6 @@ import React, {
   Children,
   PureComponent,
   ReactElement,
-  ReactText,
   SVGAttributes,
   SVGProps,
   TouchEvent,
@@ -36,7 +35,7 @@ import { selectBrushDimensions } from '../state/selectors/brushSelectors';
 type BrushTravellerType = ReactElement<SVGElement> | ((props: TravellerProps) => ReactElement<SVGElement>);
 
 // Why is this tickFormatter different from the other TickFormatters? This one allows to return numbers too for some reason.
-type BrushTickFormatter = (value: any, index: number) => ReactText;
+type BrushTickFormatter = (value: any, index: number) => number | string;
 
 interface BrushProps {
   x?: number;
@@ -180,7 +179,7 @@ type TextOfTickProps = {
  * This one cannot be a React Component because React is not happy with it returning only string | number.
  * React wants a full React.JSX.Element but that is not compatible with Text component.
  */
-function getTextOfTick(props: TextOfTickProps): ReactText {
+function getTextOfTick(props: TextOfTickProps): number | string {
   const { index, data, tickFormatter, dataKey } = props;
   const text = getValueByDataKey(data[index], dataKey, index);
 

--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Default Legend Content
  */
-import React, { PureComponent, ReactNode, MouseEvent, ReactText, ReactElement } from 'react';
+import React, { PureComponent, ReactNode, MouseEvent, ReactElement } from 'react';
 
 import clsx from 'clsx';
 import { warn } from '../util/LogUtils';
@@ -28,7 +28,7 @@ export interface Payload {
   type?: LegendType;
   color?: string;
   payload?: {
-    strokeDasharray?: ReactText;
+    strokeDasharray?: number | string;
     value?: any;
   };
   formatter?: Formatter;


### PR DESCRIPTION
For React v19 type compatibility, see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69022. For anyone on v18 and older, this should have no effect because the two type are equivalent.

## How Has This Been Tested?

If I apply this patch manually to my local install of recharts, the corresponding tsc errors go away.

Beyond that, I'm relying on automated testing to catch any unforeseen issues.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
