### PR TITLE
Fix radius axis range for tooltip

### DIFF
--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -60,7 +60,7 @@ import { selectChartOffset } from './selectChartOffset';
 import { AxisPropsForCartesianGridTicksGeneration } from '../../cartesian/CartesianGrid';
 import { BrushDimensions, selectBrushDimensions, selectBrushSettings } from './brushSelectors';
 import { selectBarCategoryGap, selectChartName, selectStackOffsetType } from './rootPropsSelectors';
-import { selectAngleAxis, selectPolarAxisRange, selectRadiusAxis } from './polarAxisSelectors';
+import { selectAngleAxis, selectAngleAxisRange, selectRadiusAxis, selectRadiusAxisRange } from './polarAxisSelectors';
 import { AngleAxisSettings, RadiusAxisSettings } from '../polarAxisSlice';
 import { pickAxisType } from './pickAxisType';
 import { pickAxisId } from './pickAxisId';
@@ -1257,8 +1257,9 @@ export const selectAxisRange = (
     case 'zAxis':
       return selectZAxisSettings(state, axisId)?.range;
     case 'angleAxis':
+      return selectAngleAxisRange(state);
     case 'radiusAxis':
-      return selectPolarAxisRange(state);
+      return selectRadiusAxisRange(state, axisId);
     default:
       return undefined;
   }

--- a/src/state/selectors/polarAxisSelectors.ts
+++ b/src/state/selectors/polarAxisSelectors.ts
@@ -132,7 +132,7 @@ export const selectOuterRadius: (state: RechartsRootState) => number | undefined
   },
 );
 
-const combinePolarAxisRange = (polarOptions: PolarChartOptions | undefined): AxisRange => {
+const combineAngleAxisRange = (polarOptions: PolarChartOptions | undefined): AxisRange => {
   if (polarOptions == null) {
     return [0, 0];
   }
@@ -140,27 +140,26 @@ const combinePolarAxisRange = (polarOptions: PolarChartOptions | undefined): Axi
   return [startAngle, endAngle];
 };
 
-export const selectPolarAxisRange: (state: RechartsRootState) => AxisRange = createSelector(
+export const selectAngleAxisRange: (state: RechartsRootState) => AxisRange = createSelector(
   [selectPolarOptions],
-  combinePolarAxisRange,
+  combineAngleAxisRange,
 );
 
 export const selectAngleAxisRangeWithReversed: (state: RechartsRootState, angleAxisId: AxisId) => AxisRange =
-  createSelector([selectAngleAxis, selectPolarAxisRange], combineAxisRangeWithReverse);
+  createSelector([selectAngleAxis, selectAngleAxisRange], combineAxisRangeWithReverse);
+
+export const selectRadiusAxisRange: (state: RechartsRootState, radiusAxisId: AxisId) => AxisRange = createSelector(
+  [selectMaxRadius, selectInnerRadius, selectOuterRadius],
+  (maxRadius, innerRadius, outerRadius) => {
+    if (maxRadius == null || innerRadius == null || outerRadius == null) {
+      return undefined;
+    }
+    return [innerRadius, outerRadius];
+  },
+);
 
 export const selectRadiusAxisRangeWithReversed: (state: RechartsRootState, radiusAxisId: AxisId) => AxisRange =
-  createSelector(
-    [selectMaxRadius, selectInnerRadius, selectOuterRadius, selectRadiusAxis],
-    (maxRadius, innerRadius, outerRadius, radiusAxis) => {
-      if (maxRadius == null || innerRadius == null || outerRadius == null) {
-        return undefined;
-      }
-      if (radiusAxis.reversed) {
-        return [outerRadius, innerRadius];
-      }
-      return [innerRadius, outerRadius];
-    },
-  );
+  createSelector([selectRadiusAxis, selectRadiusAxisRange], combineAxisRangeWithReverse);
 
 export const selectPolarViewBox: (state: RechartsRootState) => PolarViewBox = createSelector(
   [selectPolarOptions, selectInnerRadius, selectOuterRadius, selectChartWidth, selectChartHeight],

--- a/storybook/stories/API/chart/RadialBarChart.stories.tsx
+++ b/storybook/stories/API/chart/RadialBarChart.stories.tsx
@@ -1,23 +1,26 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import { Meta } from '@storybook/react';
+import { StoryContext, StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
 import { pageData, pageDataWithFillColor } from '../../data';
-import { Tooltip, RadialBar, RadialBarChart, ResponsiveContainer, Cell, Legend, RadialBarProps } from '../../../../src';
+import { Tooltip, RadialBar, RadialBarChart, ResponsiveContainer, Cell, Legend } from '../../../../src';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RadialBarChartProps } from '../props/RadialBarChartProps';
+import { RechartsHookInspector } from '../../../storybook-addon-recharts/RechartsHookInspector';
+import { StorybookArgs } from '../../../StorybookArgs';
 
 export default {
   argTypes: RadialBarChartProps,
   component: RadialBarChart,
 };
 
-export const Simple: Meta<RadialBarProps> = {
-  render: (args: Record<string, any>) => {
+export const Simple: StoryObj = {
+  render: (args: StorybookArgs, context: StoryContext) => {
     return (
       <RadialBarChart {...args}>
         <RadialBar dataKey="uv" activeShape={{ fill: 'red' }} />
         <Tooltip />
+        <RechartsHookInspector rechartsInspectorEnabled={context.rechartsInspectorEnabled} />
       </RadialBarChart>
     );
   },

--- a/storybook/storybook-addon-recharts/ArrayInspector.tsx
+++ b/storybook/storybook-addon-recharts/ArrayInspector.tsx
@@ -26,6 +26,9 @@ export function ArrayInspector({ arr }: { arr: ReadonlyArray<unknown> | undefine
   const typeofArr = typeof arr[0];
   const shouldExpandByDefault = length <= 1 || (typeofArr !== 'object' && typeofArr !== 'function');
   const [expand, setExpand] = useState(shouldExpandByDefault);
+  function copyToClipboard() {
+    navigator.clipboard.writeText(JSON.stringify(arr, null, 2));
+  }
   return (
     <>
       {expand ? (
@@ -37,6 +40,9 @@ export function ArrayInspector({ arr }: { arr: ReadonlyArray<unknown> | undefine
           Expand
         </button>
       )}{' '}
+      <button type="button" onClick={copyToClipboard}>
+        Copy to clipboard
+      </button>
       {typeofArr === 'object' ? (
         <ArrayOfObjectsInspector arr={arr} expand={expand} />
       ) : (

--- a/storybook/storybook-addon-recharts/PolarChartInspector.tsx
+++ b/storybook/storybook-addon-recharts/PolarChartInspector.tsx
@@ -2,10 +2,16 @@ import React, { CSSProperties } from 'react';
 import { useAppSelector } from '../../src/state/hooks';
 import { selectRealScaleType } from '../../src/state/selectors/axisSelectors';
 import { useChartLayout } from '../../src/context/chartLayoutContext';
-import { selectPolarAxisScale } from '../../src/state/selectors/polarScaleSelectors';
+import { selectPolarAxisScale, selectPolarAxisTicks } from '../../src/state/selectors/polarScaleSelectors';
 import { ScaleInspector } from './ScaleInspector';
 import { selectPolarAppliedValues, selectPolarDisplayedData } from '../../src/state/selectors/polarSelectors';
 import { ArrayInspector } from './ArrayInspector';
+import {
+  selectTooltipAxisRealScaleType,
+  selectTooltipAxisScale,
+  selectTooltipAxisTicks,
+  selectTooltipAxisType,
+} from '../../src/state/selectors/tooltipSelectors';
 
 // TODO come up with better styling solution, perhaps reuse a component library
 const tableStyle: CSSProperties = { border: '1px solid black', borderCollapse: 'collapse' };
@@ -20,6 +26,13 @@ export function PolarChartInspector() {
   const radiusAxisRealScaleType = useAppSelector(state => selectRealScaleType(state, 'radiusAxis', 0));
   const radiusAxisDisplayedData = useAppSelector(state => selectPolarDisplayedData(state, 'radiusAxis', 0));
   const radiusAxisAppliedValues = useAppSelector(state => selectPolarAppliedValues(state, 'radiusAxis', 0));
+  const radiusAxisTicks = useAppSelector(state => selectPolarAxisTicks(state, 'radiusAxis', 0));
+
+  const tooltipAxisType = useAppSelector(selectTooltipAxisType);
+  const tooltipAxisScale = useAppSelector(selectTooltipAxisScale);
+  const tooltipAxisRealScaleType = useAppSelector(selectTooltipAxisRealScaleType);
+  const tooltipAxisTicks = useAppSelector(selectTooltipAxisTicks);
+
   return (
     <table style={tableStyle}>
       <tbody>
@@ -61,6 +74,28 @@ export function PolarChartInspector() {
           <th style={tableStyle}>Radius axis applied values</th>
           <td style={tableStyle}>
             <ArrayInspector arr={radiusAxisAppliedValues} />
+          </td>
+        </tr>
+        <tr style={tableStyle}>
+          <th style={tableStyle}>Radius axis ticks</th>
+          <td style={tableStyle}>
+            <ArrayInspector arr={radiusAxisTicks} />
+          </td>
+        </tr>
+        <tr style={tableStyle}>
+          <th style={tableStyle}>Tooltip axis type</th>
+          <td style={tableStyle}>{tooltipAxisType}</td>
+        </tr>
+        <tr style={tableStyle}>
+          <th style={tableStyle}>Tooltip axis scale</th>
+          <td style={tableStyle}>
+            <ScaleInspector scale={tooltipAxisScale} realScaleType={tooltipAxisRealScaleType} />
+          </td>
+        </tr>
+        <tr style={tableStyle}>
+          <th style={tableStyle}>Tooltip axis ticks</th>
+          <td style={tableStyle}>
+            <ArrayInspector arr={tooltipAxisTicks} />
           </td>
         </tr>
       </tbody>

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -339,7 +339,7 @@ const RadialBarChartTestCase: TooltipPayloadTestCase = {
   mouseHoverSelector: radialBarChartMouseHoverTooltipSelector,
   // I cannot figure out how to make RadialBar display anything else other than the index
   expectedTooltipTitle: '4',
-  expectedTooltipContent: ['uv : 300', 'My custom name : 1398', 'amt : 2400'],
+  expectedTooltipContent: ['uv : 200', 'My custom name : 9800', 'amt : 2400'],
 };
 
 const SankeyNodeHoverTestCase: TooltipPayloadTestCase = {
@@ -1764,7 +1764,7 @@ describe('Tooltip payload', () => {
         showTooltip(container, radialBarChartMouseHoverTooltipSelector, debug);
 
         const expectedTooltipTitle = '4';
-        const expectedTooltipContent = ['uv : 300', 'My custom name : 1398', 'amt : 2400'];
+        const expectedTooltipContent = ['uv : 200', 'My custom name : 9800', 'amt : 2400'];
         expectTooltipPayload(container, expectedTooltipTitle, expectedTooltipContent);
       });
 

--- a/test/component/Tooltip/Tooltip.sync.spec.tsx
+++ b/test/component/Tooltip/Tooltip.sync.spec.tsx
@@ -185,7 +185,7 @@ const RadialBarChartTestCase: TooltipSyncTestCase = {
     </RadialBarChart>
   ),
   mouseHoverSelector: radialBarChartMouseHoverTooltipSelector,
-  tooltipContent: { chartOne: { name: 'Mike', value: '300' }, chartTwo: { name: 'Mike', value: '4567' } },
+  tooltipContent: { chartOne: { name: 'Mike', value: '278' }, chartTwo: { name: 'Mike', value: '4567' } },
 };
 
 // TODO: fix synchronization in Pie, Scatter, Funnel. These currently accept syncId as a prop but do not work.

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -252,7 +252,7 @@ const RadialBarChartTestCase: TooltipVisibilityTestCase = {
     </RadialBarChart>
   ),
   mouseHoverSelector: radialBarChartMouseHoverTooltipSelector,
-  expectedTransform: 'transform: translate(225.1471862576143px, 225.1471862576143px);',
+  expectedTransform: 'transform: translate(198.74853309331652px, 198.7485330933165px);',
 };
 
 const SankeyTestCase: TooltipVisibilityTestCase = {
@@ -1110,14 +1110,14 @@ describe('Tooltip visibility', () => {
 
     it('should select tooltip axis range', () => {
       const { spy } = renderTestCase(selectTooltipAxisRangeWithReverse);
-      expect(spy).toHaveBeenLastCalledWith([0, 360]);
+      expect(spy).toHaveBeenLastCalledWith([0, 236]);
     });
 
     it('should select tooltip axis scale', () => {
       const { spy } = renderTestCase(selectTooltipAxisScale);
       expectScale(spy, {
         domain: [0, 1, 2, 3, 4, 5],
-        range: [0, 360],
+        range: [0, 236],
       });
     });
 
@@ -1136,31 +1136,31 @@ describe('Tooltip visibility', () => {
           value: 0,
         },
         {
-          coordinate: 60,
+          coordinate: 39.333333333333336,
           index: 1,
           offset: 0,
           value: 1,
         },
         {
-          coordinate: 120,
+          coordinate: 78.66666666666667,
           index: 2,
           offset: 0,
           value: 2,
         },
         {
-          coordinate: 180,
+          coordinate: 118,
           index: 3,
           offset: 0,
           value: 3,
         },
         {
-          coordinate: 240,
+          coordinate: 157.33333333333334,
           index: 4,
           offset: 0,
           value: 4,
         },
         {
-          coordinate: 300,
+          coordinate: 196.66666666666669,
           index: 5,
           offset: 0,
           value: 5,

--- a/test/polar/PolarRadiusAxis.spec.tsx
+++ b/test/polar/PolarRadiusAxis.spec.tsx
@@ -122,7 +122,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 196]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -372,7 +372,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 196]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -830,7 +830,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 196]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -944,7 +944,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 196]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -1031,7 +1031,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 196]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {


### PR DESCRIPTION
## Description

There was a bug where the selectors were assuming that angle axis and radius axis have the same range, so that's now fixed.

The tooltip active area is now better than before but not 100% perfect, I suspect the tooltip axis and radial axis are computing barBandSize differently or something. I will look into it next.

## Related Issue

https://github.com/recharts/recharts/issues/4583