### PR TITLE
Add Tooltip data positions to redux store

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -167,6 +167,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
   const { dataKey, data, stroke, strokeWidth, fill, name, hide, unit } = props;
   return {
     dataDefinedOnItem: data,
+    positions: undefined,
     settings: {
       stroke,
       strokeWidth,

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -181,6 +181,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
   const { dataKey, stroke, strokeWidth, fill, name, hide, unit } = props;
   return {
     dataDefinedOnItem: undefined,
+    positions: undefined,
     settings: {
       stroke,
       strokeWidth,

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -155,6 +155,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
   const { dataKey, data, stroke, strokeWidth, fill, name, hide, unit } = props;
   return {
     dataDefinedOnItem: data,
+    positions: undefined,
     settings: {
       stroke,
       strokeWidth,

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -19,6 +19,7 @@ import {
   adaptEventsOfChild,
   AnimationDuration,
   AnimationTiming,
+  Coordinate,
   DataKey,
   LegendType,
   PresentationAttributesAdaptChildEvent,
@@ -60,6 +61,7 @@ export interface ScatterPointItem {
   node?: ScatterPointNode;
   payload?: any;
   tooltipPayload?: TooltipPayload;
+  tooltipPosition: Coordinate;
 }
 
 export type ScatterCustomizedShape = ActiveShape<ScatterPointItem, SVGPathElement & InnerSymbolsProp> | SymbolType;
@@ -229,6 +231,7 @@ function getTooltipEntrySettings(props: InputRequiredToComputeTooltipEntrySettin
   const { dataKey, points, stroke, strokeWidth, fill, name, hide, tooltipType } = props;
   return {
     dataDefinedOnItem: points?.map((p: ScatterPointItem) => p.tooltipPayload),
+    positions: points?.map((p: ScatterPointItem) => p.tooltipPosition),
     settings: {
       stroke,
       strokeWidth,

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -388,6 +388,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
   const { dataKey, nameKey, stroke, strokeWidth, fill, name, data } = props;
   return {
     dataDefinedOnItem: data,
+    positions: undefined,
     settings: {
       stroke,
       strokeWidth,

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -490,6 +490,7 @@ function getTooltipEntrySettings({
   const { dataKey, nameKey, stroke, fill } = props;
   return {
     dataDefinedOnItem: currentRoot,
+    positions: undefined, // TODO I think Treemap has the capability of computing positions and supporting defaultIndex? Except it doesn't yet
     settings: {
       stroke,
       strokeWidth: undefined,

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -262,6 +262,7 @@ function getTooltipEntrySettings(props: InternalProps): TooltipPayloadConfigurat
   const { dataKey, nameKey, sectors, stroke, strokeWidth, fill, name, hide, tooltipType } = props;
   return {
     dataDefinedOnItem: sectors?.map((p: PieSectorDataItem) => p.tooltipPayload),
+    positions: sectors?.map((p: PieSectorDataItem) => p.tooltipPosition),
     settings: {
       stroke,
       strokeWidth,

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -125,6 +125,7 @@ function getTooltipEntrySettings(props: Props): TooltipPayloadConfiguration {
      * So, undefined it is.
      */
     dataDefinedOnItem: undefined,
+    positions: undefined,
     settings: {
       stroke,
       strokeWidth,

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -168,6 +168,7 @@ function getTooltipEntrySettings(props: RadialBarProps): TooltipPayloadConfigura
   const { dataKey, data, stroke, strokeWidth, name, hide, fill, tooltipType } = props;
   return {
     dataDefinedOnItem: data,
+    positions: undefined,
     settings: {
       stroke,
       strokeWidth,

--- a/src/state/selectors/funnelSelectors.ts
+++ b/src/state/selectors/funnelSelectors.ts
@@ -13,7 +13,7 @@ type FunnelComposedData = {
   data: any[];
 };
 
-type ResolvedFunnelSettings = {
+export type ResolvedFunnelSettings = {
   dataKey: DataKey<any>;
   data: any[];
   nameKey: DataKey<any>;
@@ -25,7 +25,10 @@ type ResolvedFunnelSettings = {
   presentationProps: Record<string, any>;
 };
 
-const pickFunnelSettings = (_state: RechartsRootState, funnelSettings: ResolvedFunnelSettings) => funnelSettings;
+const pickFunnelSettings = (
+  _state: RechartsRootState,
+  funnelSettings: ResolvedFunnelSettings,
+): ResolvedFunnelSettings => funnelSettings;
 
 export const selectFunnelTrapezoids: (
   state: RechartsRootState,

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -1,7 +1,8 @@
 import { createSlice, current, PayloadAction } from '@reduxjs/toolkit';
+import { castDraft } from 'immer';
 import { TooltipTrigger } from '../chart/types';
 import type { NameType, Payload, ValueType } from '../component/DefaultTooltipContent';
-import { ChartCoordinate, DataKey } from '../util/types';
+import { ChartCoordinate, Coordinate, DataKey } from '../util/types';
 import { AxisId } from './cartesianAxisSlice';
 import { SynchronisedTooltipAction } from '../synchronisation/SynchronisedAction';
 
@@ -58,6 +59,14 @@ export type TooltipPayloadConfiguration = {
    * data + activeIndex, pass it to the TooltipPayloadSearcher, and render the result in a Tooltip.
    */
   dataDefinedOnItem: unknown;
+  /**
+   * Opportunity for the graphical item to define its own Tooltip coordinates
+   * instead of relying on the axes.
+   *
+   * If undefined, then Recharts will use mouse interaction coordinates, or the axis coordinates,
+   * with some defaults (like, top/left of the chart).
+   */
+  positions: Record<TooltipIndex, Coordinate> | ReadonlyArray<Coordinate> | undefined;
 };
 
 export type ActiveTooltipProps = {
@@ -227,10 +236,10 @@ const tooltipSlice = createSlice({
   initialState,
   reducers: {
     addTooltipEntrySettings(state, action: PayloadAction<TooltipPayloadConfiguration>) {
-      state.tooltipItemPayloads.push(action.payload);
+      state.tooltipItemPayloads.push(castDraft(action.payload));
     },
     removeTooltipEntrySettings(state, action: PayloadAction<TooltipPayloadConfiguration>) {
-      const index = current(state).tooltipItemPayloads.indexOf(action.payload);
+      const index = current(state).tooltipItemPayloads.indexOf(castDraft(action.payload));
       if (index > -1) {
         state.tooltipItemPayloads.splice(index, 1);
       }

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -44,6 +44,7 @@ import {
 } from '../component/Tooltip/tooltipTestHelpers';
 import { scatterChartMouseHoverTooltipSelector } from '../component/Tooltip/tooltipMouseHoverSelectors';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
+import { TooltipPayloadConfiguration } from '../../src/state/tooltipSlice';
 
 describe('ScatterChart of three dimension data', () => {
   const data01 = [
@@ -1593,8 +1594,34 @@ describe('Tooltip integration', () => {
 
     it('should select tooltip data', () => {
       const { spy } = renderTestCase(state => selectTooltipPayloadConfigurations(state, 'item', 'hover', 0));
-      expect(spy).toHaveBeenLastCalledWith([
+      const expected: ReadonlyArray<TooltipPayloadConfiguration> = [
         {
+          positions: [
+            {
+              x: 67.5,
+              y: 50.6,
+            },
+            {
+              x: 72.5,
+              y: 37.598,
+            },
+            {
+              x: 77.5,
+              y: 56.611999999999995,
+            },
+            {
+              x: 82.5,
+              y: 6.200000000000001,
+            },
+            {
+              x: 87.5,
+              y: 41.552,
+            },
+            {
+              x: 92.5,
+              y: 36.2,
+            },
+          ],
           dataDefinedOnItem: [
             [
               {
@@ -1778,7 +1805,8 @@ describe('Tooltip integration', () => {
             unit: '',
           },
         },
-      ]);
+      ];
+      expect(spy).toHaveBeenLastCalledWith(expected);
     });
   });
 });

--- a/test/state/selectors/selectors.spec.tsx
+++ b/test/state/selectors/selectors.spec.tsx
@@ -84,6 +84,7 @@ const exampleTooltipPayloadConfiguration1: TooltipPayloadConfiguration = {
       },
     ],
   ],
+  positions: undefined,
 };
 
 const exampleTooltipPayloadConfiguration2: TooltipPayloadConfiguration = {
@@ -120,6 +121,7 @@ const exampleTooltipPayloadConfiguration2: TooltipPayloadConfiguration = {
       },
     ],
   ],
+  positions: undefined,
 };
 
 type TestCaseTooltipCombination = { tooltipEventType: TooltipEventType; trigger: TooltipTrigger };
@@ -250,6 +252,7 @@ describe('selectTooltipPayload', () => {
   it('should return settings and data from axis hover, if activeIndex is set for the item', () => {
     const store = createRechartsStore(preloadedState);
     const tooltipSettings1: TooltipPayloadConfiguration = {
+      positions: undefined,
       settings: undefined,
       dataDefinedOnItem: undefined,
     };
@@ -260,6 +263,7 @@ describe('selectTooltipPayload', () => {
       value: undefined,
     };
     const tooltipSettings2: TooltipPayloadConfiguration = {
+      positions: undefined,
       settings: {
         stroke: 'red',
         fill: 'green',
@@ -296,6 +300,7 @@ describe('selectTooltipPayload', () => {
   it('should return settings and data if defaultIndex is provided', () => {
     const store = createRechartsStore(preloadedState);
     const tooltipSettings1: TooltipPayloadConfiguration = {
+      positions: undefined,
       settings: undefined,
       dataDefinedOnItem: undefined,
     };
@@ -306,6 +311,7 @@ describe('selectTooltipPayload', () => {
       value: undefined,
     };
     const tooltipSettings2: TooltipPayloadConfiguration = {
+      positions: undefined,
       settings: {
         stroke: 'red',
         fill: 'green',
@@ -337,6 +343,7 @@ describe('selectTooltipPayload', () => {
   it('should fill in chartData, if it is not defined on the item for item hover', () => {
     const store = createRechartsStore(preloadedState);
     const tooltipSettings: TooltipPayloadConfiguration = {
+      positions: undefined,
       settings: {
         stroke: 'red',
         fill: 'green',
@@ -373,6 +380,7 @@ describe('selectTooltipPayload', () => {
   it('should return sliced data if set by Brush for item hover', () => {
     const store = createRechartsStore(preloadedState);
     const tooltipSettings: TooltipPayloadConfiguration = {
+      positions: undefined,
       settings: {
         stroke: 'red',
         fill: 'green',
@@ -455,6 +463,7 @@ describe('selectTooltipPayload', () => {
     const tooltipPayloadConfiguration: TooltipPayloadConfiguration = {
       settings: { nameKey: undefined },
       dataDefinedOnItem: [],
+      positions: undefined,
     };
     const chartDataState: ChartDataState = initialChartDataState;
     const tooltipAxis: BaseAxisProps = {

--- a/test/util/FunnelUtils.spec.tsx
+++ b/test/util/FunnelUtils.spec.tsx
@@ -1,22 +1,28 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { typeGuardTrapezoidProps, FunnelTrapezoid } from '../../src/util/FunnelUtils';
+import { Coordinate } from '../../src/util/types';
+import { FunnelTrapezoidItem } from '../../src/cartesian/Funnel';
+import { Props as TrapezoidProps } from '../../src/shape/Trapezoid';
 
 describe('funnelUtils', () => {
+  const mockTooltipPosition: Coordinate = { x: 10, y: 10 };
   const mockOptions = {
     x: 10,
     y: 10,
     height: 100,
   };
-  const mockProps = {
+  const mockProps: FunnelTrapezoidItem = {
     x: 11,
     y: 11,
     isActive: false,
+    tooltipPosition: undefined,
   };
   it('typeGuardTrapezoidProps returns object from options + props', () => {
-    const mockRes = {
+    const mockRes: TrapezoidProps = {
       x: mockProps.x,
       y: mockProps.y,
+      // @ts-expect-error the types do not match what the function is doing
       isActive: mockProps.isActive,
       height: mockOptions.height,
     };
@@ -27,7 +33,7 @@ describe('funnelUtils', () => {
   it('<FunnelTrapezoid /> returns a trapezoid shape with no options', () => {
     const { container } = render(
       <svg width={100} height={100}>
-        <FunnelTrapezoid option={{}} {...mockProps} isActive={Boolean(true)} />
+        <FunnelTrapezoid tooltipPosition={mockTooltipPosition} option={{}} {...mockProps} isActive={Boolean(true)} />
       </svg>,
     );
     expect(container.querySelector('g')).toHaveClass('recharts-active-shape');
@@ -36,6 +42,7 @@ describe('funnelUtils', () => {
     const { container } = render(
       <svg width={100} height={100}>
         <FunnelTrapezoid
+          tooltipPosition={mockTooltipPosition}
           option={{ x: 10, y: 10 }}
           {...{
             isActive: true,


### PR DESCRIPTION
## Description

We don't use this information yet - in the next PR I will include it in selectors. This will allow us to remove the coordinate dependency on generator.

## Related Issue

https://github.com/recharts/recharts/issues/4549