### PR TITLE
Put the defaultIndex coordinate in the middle-ish of the chart

### DIFF
--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -43,7 +43,7 @@ import { AxisRange } from './axisSelectors';
 import { selectChartName } from './rootPropsSelectors';
 import { selectChartLayout } from '../../context/chartLayoutContext';
 import { selectChartOffset } from './selectChartOffset';
-import { selectChartHeight } from './containerSelectors';
+import { selectChartHeight, selectChartWidth } from './containerSelectors';
 
 export const useChartName = (): string => {
   return useAppSelector(selectChartName);
@@ -182,6 +182,7 @@ const selectCoordinateForDefaultIndex: (
   defaultIndex: number | undefined,
 ) => ChartCoordinate | undefined = createSelector(
   [
+    selectChartWidth,
     selectChartHeight,
     selectChartLayout,
     selectChartOffset,
@@ -191,6 +192,7 @@ const selectCoordinateForDefaultIndex: (
     selectTooltipPayloadSearcher,
   ],
   (
+    width: number,
     height: number,
     layout: LayoutType,
     offset: ChartOffset | undefined,
@@ -219,13 +221,13 @@ const selectCoordinateForDefaultIndex: (
       case 'horizontal': {
         return {
           x: tick.coordinate,
-          y: offset.top,
+          y: (offset.top + height) / 2,
         };
       }
       default: {
         // This logic is not super sound - it conflates vertical, radial, centric layouts into just one. TODO improve!
         return {
-          x: (offset.top + height) / 2,
+          x: (offset.left + width) / 2,
           y: tick.coordinate,
         };
       }


### PR DESCRIPTION
## Description

Similar to what the generator used to do but a little bit better: https://github.com/recharts/recharts/pull/5367/files#diff-aa1b4fbed632e1bdab786e0521346d3a1a2386c633f22f5778d4bcbc47581a65

Generator for example ignored vertical layout completely, now at least we use width instead of height for vertical layouts X-coordinate.

We can still iterate on the exact positioning but this is pretty close I think.

Visual diff: https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=1803

## Related Issue

https://github.com/recharts/recharts/issues/4549