### PR TITLE
selectActiveTooltipIndex to replace tooltip generator in graphical items

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -134,6 +134,7 @@
   "es6/state/selectors/selectActivePropsFromMousePointer.js",
   "es6/state/selectors/selectAllAxes.js",
   "es6/state/selectors/selectChartOffset.js",
+  "es6/state/selectors/selectTooltipEventType.js",
   "es6/state/selectors/selectors.js",
   "es6/state/selectors/tooltipSelectors.js",
   "es6/state/store.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -134,6 +134,7 @@
   "lib/state/selectors/selectActivePropsFromMousePointer.js",
   "lib/state/selectors/selectAllAxes.js",
   "lib/state/selectors/selectChartOffset.js",
+  "lib/state/selectors/selectTooltipEventType.js",
   "lib/state/selectors/selectors.js",
   "lib/state/selectors/tooltipSelectors.js",
   "lib/state/store.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -134,6 +134,7 @@
   "types/state/selectors/selectActivePropsFromMousePointer.d.ts",
   "types/state/selectors/selectAllAxes.d.ts",
   "types/state/selectors/selectChartOffset.d.ts",
+  "types/state/selectors/selectTooltipEventType.d.ts",
   "types/state/selectors/selectors.d.ts",
   "types/state/selectors/tooltipSelectors.d.ts",
   "types/state/store.d.ts",

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -43,7 +43,6 @@ import {
   useMouseClickItemDispatch,
   useMouseEnterItemDispatch,
   useMouseLeaveItemDispatch,
-  useTooltipContext,
 } from '../context/tooltipContext';
 import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
@@ -55,6 +54,7 @@ import { BarSettings, selectBarRectangles } from '../state/selectors/barSelector
 import { BaseAxisWithScale } from '../state/selectors/axisSelectors';
 import { useAppSelector } from '../state/hooks';
 import { useIsPanorama } from '../context/PanoramaContext';
+import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 
 export interface BarRectangleItem extends RectangleProps {
   value?: number | [number, number];
@@ -207,7 +207,7 @@ type BarBackgroundProps = {
 };
 
 function BarBackground(props: BarBackgroundProps) {
-  const { index: activeIndex } = useTooltipContext();
+  const activeIndex = useAppSelector(selectActiveTooltipIndex);
 
   const { data, dataKey, background: backgroundFromProps, onAnimationStart, onAnimationEnd, allOtherBarProps } = props;
 
@@ -245,7 +245,7 @@ function BarBackground(props: BarBackgroundProps) {
 
         const barRectangleProps: BarRectangleProps = {
           option: backgroundFromProps,
-          isActive: i === activeIndex,
+          isActive: String(i) === activeIndex,
           ...rest,
           // @ts-expect-error BarRectangle props do not accept `fill` property.
           fill: '#eee',
@@ -279,7 +279,7 @@ function BarRectangles(props: BarRectanglesProps) {
   const baseProps = filterProps(rest, false);
   const { data, shape, dataKey, activeBar } = props;
 
-  const { index: activeIndex, active: isTooltipActive } = useTooltipContext();
+  const activeIndex = useAppSelector(selectActiveTooltipIndex);
   const {
     onMouseEnter: onMouseEnterFromProps,
     onClick: onItemClickFromProps,
@@ -298,7 +298,7 @@ function BarRectangles(props: BarRectanglesProps) {
   return (
     <>
       {data.map((entry: BarRectangleItem, i: number) => {
-        const isActive = isTooltipActive && activeBar && i === activeIndex;
+        const isActive = activeBar && String(i) === activeIndex;
         const option = isActive ? activeBar : shape;
         const barRectangleProps = {
           ...baseProps,

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -35,7 +35,6 @@ import {
   useMouseClickItemDispatch,
   useMouseEnterItemDispatch,
   useMouseLeaveItemDispatch,
-  useTooltipContext,
 } from '../context/tooltipContext';
 import { TooltipPayload, TooltipPayloadConfiguration, TooltipPayloadEntry } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
@@ -47,6 +46,7 @@ import { useAppSelector } from '../state/hooks';
 import { BaseAxisWithScale, ZAxisWithScale } from '../state/selectors/axisSelectors';
 import { UpdateId, useUpdateId } from '../context/chartLayoutContext';
 import { useIsPanorama } from '../context/PanoramaContext';
+import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 
 interface ScatterPointNode {
   x?: number | string;
@@ -175,7 +175,7 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
   const { shape, activeShape } = allOtherScatterProps;
   const baseProps = filterProps(allOtherScatterProps, false);
 
-  const { index: activeIndex, active: isTooltipActive } = useTooltipContext();
+  const activeIndex = useAppSelector(selectActiveTooltipIndex);
   const {
     onMouseEnter: onMouseEnterFromProps,
     onClick: onItemClickFromProps,
@@ -190,7 +190,7 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
   return (
     <>
       {points.map((entry, i) => {
-        const isActive = isTooltipActive && activeShape && activeIndex === i;
+        const isActive = activeShape && activeIndex === String(i);
         const option = isActive ? activeShape : shape;
         const symbolProps = { key: `symbol-${i}`, ...baseProps, ...entry };
 

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -939,7 +939,12 @@ export const generateCategoricalChart = ({
       const { defaultIndex } = tooltipElem.props;
 
       // Protect against runtime errors
-      if (typeof defaultIndex !== 'number' || defaultIndex < 0 || defaultIndex > this.state.tooltipTicks.length - 1) {
+      if (
+        typeof defaultIndex !== 'number' ||
+        defaultIndex < 0 ||
+        this.state.tooltipTicks == null ||
+        defaultIndex > this.state.tooltipTicks.length - 1
+      ) {
         return;
       }
 

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -6,6 +6,8 @@ import { Layer } from '../container/Layer';
 import { useTooltipAxis } from '../context/useTooltipAxis';
 import { useTooltipContext } from '../context/tooltipContext';
 import { findEntryInArray, isNullish } from '../util/DataUtils';
+import { useAppSelector } from '../state/hooks';
+import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 
 export interface PointType {
   readonly x: number;
@@ -70,8 +72,9 @@ type ActivePointsProps = {
 
 export function ActivePoints({ points, mainColor, activeDot, itemDataKey }: ActivePointsProps) {
   const tooltipAxis = useTooltipAxis();
-  const { active, index: activeTooltipIndex, label: activeLabel } = useTooltipContext();
-  if (!active) {
+  const activeTooltipIndex = useAppSelector(selectActiveTooltipIndex);
+  const { label: activeLabel } = useTooltipContext();
+  if (!activeTooltipIndex) {
     return null;
   }
 
@@ -85,7 +88,7 @@ export function ActivePoints({ points, mainColor, activeDot, itemDataKey }: Acti
         : `payload.${tooltipAxisDataKey}`;
     activePoint = findEntryInArray(points, specifiedKey, activeLabel);
   } else {
-    activePoint = points?.[activeTooltipIndex];
+    activePoint = points?.[Number(activeTooltipIndex)];
   }
 
   if (isNullish(activePoint)) {
@@ -94,7 +97,7 @@ export function ActivePoints({ points, mainColor, activeDot, itemDataKey }: Acti
 
   return renderActivePoint({
     point: activePoint,
-    childIndex: activeTooltipIndex,
+    childIndex: Number(activeTooltipIndex),
     mainColor,
     dataKey: itemDataKey,
     activeDot,

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -22,13 +22,13 @@ import {
   selectActiveLabel,
   selectIsTooltipActive,
   selectTooltipPayload,
-  useTooltipEventType,
 } from '../state/selectors/selectors';
 import { useCursorPortal, useTooltipPortal } from '../context/tooltipPortalContext';
 import { TooltipTrigger } from '../chart/types';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { setTooltipSettingsState, TooltipPayload } from '../state/tooltipSlice';
 import { AxisId } from '../state/cartesianAxisSlice';
+import { useTooltipEventType } from '../state/selectors/selectTooltipEventType';
 
 export type ContentType<TValue extends ValueType, TName extends NameType> =
   | ReactElement

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -139,8 +139,16 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    dispatch(setTooltipSettingsState({ shared, trigger, axisId, active: activeFromProps }));
-  }, [dispatch, shared, trigger, axisId, activeFromProps]);
+    dispatch(
+      setTooltipSettingsState({
+        shared,
+        trigger,
+        axisId,
+        active: activeFromProps,
+        defaultIndex: typeof defaultIndex === 'number' ? String(defaultIndex) : defaultIndex,
+      }),
+    );
+  }, [dispatch, shared, trigger, axisId, activeFromProps, defaultIndex]);
 
   const viewBox = useViewBox();
   const accessibilityLayer = useAccessibilityLayer();

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -39,11 +39,11 @@ import {
   useMouseClickItemDispatch,
   useMouseEnterItemDispatch,
   useMouseLeaveItemDispatch,
-  useTooltipContext,
 } from '../context/tooltipContext';
 import { TooltipPayload, TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 import { UpdateId, useUpdateId } from '../context/chartLayoutContext';
+import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 
 interface PieDef {
   /** The abscissa of pole in polar coordinate  */
@@ -281,7 +281,7 @@ function getTooltipEntrySettings(props: InternalProps): TooltipPayloadConfigurat
 function PieSectors(props: PieSectorsProps) {
   const { sectors, sectorRefs, activeShape, blendStroke, inactiveShape: inactiveShapeProp, allOtherPieProps } = props;
 
-  const { index: activeIndex, active: isTooltipActive } = useTooltipContext();
+  const activeIndex = useAppSelector(selectActiveTooltipIndex);
   const {
     onMouseEnter: onMouseEnterFromProps,
     onClick: onItemClickFromProps,
@@ -295,8 +295,8 @@ function PieSectors(props: PieSectorsProps) {
 
   return sectors.map((entry, i) => {
     if (entry?.startAngle === 0 && entry?.endAngle === 0 && sectors.length !== 1) return null;
-    const isSectorActive = isTooltipActive && activeShape && i === activeIndex;
-    const inactiveShape = activeIndex === -1 ? null : inactiveShapeProp;
+    const isSectorActive = activeShape && String(i) === activeIndex;
+    const inactiveShape = activeIndex ? inactiveShapeProp : null;
     const sectorOptions = isSectorActive ? activeShape : inactiveShape;
     const sectorProps = {
       ...entry,

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -37,7 +37,6 @@ import {
   useMouseClickItemDispatch,
   useMouseEnterItemDispatch,
   useMouseLeaveItemDispatch,
-  useTooltipContext,
 } from '../context/tooltipContext';
 import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
@@ -47,6 +46,7 @@ import { BaseAxisWithScale } from '../state/selectors/axisSelectors';
 import { ChartData } from '../state/chartDataSlice';
 import { RadialBarSettings, selectLegendPayload, selectRadialBarSectors } from '../state/selectors/radialBarSelectors';
 import { useAppSelector } from '../state/hooks';
+import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 
 export type RadialBarDataItem = SectorProps & {
   value?: any;
@@ -66,7 +66,7 @@ function RadialBarSectors(props: RadialBarSectorsProps) {
   const { shape, activeShape, cornerRadius, ...others } = allOtherRadialBarProps;
   const baseProps = filterProps(others, false);
 
-  const { index: activeIndex, active: isTooltipActive } = useTooltipContext();
+  const activeIndex = useAppSelector(selectActiveTooltipIndex);
   const {
     onMouseEnter: onMouseEnterFromProps,
     onClick: onItemClickFromProps,
@@ -81,7 +81,7 @@ function RadialBarSectors(props: RadialBarSectorsProps) {
   return (
     <>
       {sectors.map((entry, i) => {
-        const isActive = isTooltipActive && activeShape && i === activeIndex;
+        const isActive = activeShape && activeIndex === String(i);
         // @ts-expect-error the types need a bit of attention
         const onMouseEnter = onMouseEnterFromContext(entry, i);
         // @ts-expect-error the types need a bit of attention

--- a/src/state/mouseEventsMiddleware.ts
+++ b/src/state/mouseEventsMiddleware.ts
@@ -1,9 +1,9 @@
 import { createAction, createListenerMiddleware, ListenerEffectAPI, PayloadAction } from '@reduxjs/toolkit';
 import { AppDispatch, RechartsRootState } from './store';
-import { selectTooltipEventType } from './selectors/selectors';
 import { MousePointer } from '../chart/generateCategoricalChart';
 import { mouseLeaveChart, setMouseClickAxisIndex, setMouseOverAxisIndex } from './tooltipSlice';
 import { selectActivePropsFromMousePointer } from './selectors/selectActivePropsFromMousePointer';
+import { selectTooltipEventType } from './selectors/selectTooltipEventType';
 
 export const mouseClickAction = createAction<MousePointer>('mouseClick');
 

--- a/src/state/selectors/selectTooltipEventType.ts
+++ b/src/state/selectors/selectTooltipEventType.ts
@@ -1,0 +1,30 @@
+import { RechartsRootState } from '../store';
+import { TooltipEventType } from '../../util/types';
+import { useAppSelector } from '../hooks';
+
+export const selectDefaultTooltipEventType = (state: RechartsRootState): TooltipEventType =>
+  state.options.defaultTooltipEventType;
+export const selectValidateTooltipEventTypes = (state: RechartsRootState): ReadonlyArray<TooltipEventType> =>
+  state.options.validateTooltipEventTypes;
+
+export function combineTooltipEventType(
+  shared: boolean,
+  defaultTooltipEventType: TooltipEventType,
+  validateTooltipEventTypes: ReadonlyArray<TooltipEventType>,
+): TooltipEventType {
+  if (shared == null) {
+    return defaultTooltipEventType;
+  }
+  const eventType = shared ? 'axis' : 'item';
+  return validateTooltipEventTypes.includes(eventType) ? eventType : defaultTooltipEventType;
+}
+
+export function selectTooltipEventType(state: RechartsRootState, shared: boolean | undefined): TooltipEventType {
+  const defaultTooltipEventType = selectDefaultTooltipEventType(state);
+  const validateTooltipEventTypes = selectValidateTooltipEventTypes(state);
+  return combineTooltipEventType(shared, defaultTooltipEventType, validateTooltipEventTypes);
+}
+
+export function useTooltipEventType(shared: boolean | undefined): TooltipEventType {
+  return useAppSelector(state => selectTooltipEventType(state, shared));
+}

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -96,7 +96,7 @@ function getSliced<T>(
   return arr;
 }
 
-export const selectTooltipState = (state: RechartsRootState) => state.tooltip;
+export const selectTooltipState = (state: RechartsRootState): TooltipState => state.tooltip;
 
 export const selectTooltipSettings = (state: RechartsRootState): TooltipSettingsState => state.tooltip.settings;
 

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -49,9 +49,6 @@ export const useChartName = (): string => {
   return useAppSelector(selectChartName);
 };
 
-const selectDefaultTooltipEventType = (state: RechartsRootState) => state.options.defaultTooltipEventType;
-const selectValidateTooltipEventTypes = (state: RechartsRootState) => state.options.validateTooltipEventTypes;
-
 const pickTooltipEventType = (_state: RechartsRootState, tooltipEventType: TooltipEventType): TooltipEventType =>
   tooltipEventType;
 
@@ -67,20 +64,6 @@ const pickDefaultIndex = (
   _trigger: TooltipTrigger,
   defaultIndex?: number | undefined,
 ): number | undefined => defaultIndex;
-
-export function selectTooltipEventType(state: RechartsRootState, shared: boolean | undefined): TooltipEventType {
-  const defaultTooltipEventType = selectDefaultTooltipEventType(state);
-  const validateTooltipEventTypes = selectValidateTooltipEventTypes(state);
-  if (shared == null) {
-    return defaultTooltipEventType;
-  }
-  const eventType = shared ? 'axis' : 'item';
-  return validateTooltipEventTypes.includes(eventType) ? eventType : defaultTooltipEventType;
-}
-
-export function useTooltipEventType(shared: boolean | undefined): TooltipEventType {
-  return useAppSelector(state => selectTooltipEventType(state, shared));
-}
 
 function getSliced<T>(
   arr: unknown | ReadonlyArray<T>,

--- a/src/state/selectors/tooltipSelectors.ts
+++ b/src/state/selectors/tooltipSelectors.ts
@@ -39,7 +39,7 @@ import {
 import { selectChartLayout } from '../../context/chartLayoutContext';
 import { AxisId } from '../cartesianAxisSlice';
 import { isCategoricalAxis, RechartsScale, StackId } from '../../util/ChartUtils';
-import { AxisDomain, CategoricalDomain, LayoutType, NumberDomain, TickItem } from '../../util/types';
+import { AxisDomain, CategoricalDomain, LayoutType, NumberDomain, TickItem, TooltipEventType } from '../../util/types';
 import { AppliedChartData, ChartData } from '../chartDataSlice';
 import { selectChartDataWithIndexes } from './dataSelectors';
 import { GraphicalItemSettings } from '../graphicalItemsSlice';
@@ -48,6 +48,12 @@ import { selectChartName, selectStackOffsetType } from './rootPropsSelectors';
 import { mathSign } from '../../util/DataUtils';
 import { combineAxisRangeWithReverse } from './combiners/combineAxisRangeWithReverse';
 import { TooltipIndex, TooltipState } from '../tooltipSlice';
+
+import {
+  combineTooltipEventType,
+  selectDefaultTooltipEventType,
+  selectValidateTooltipEventTypes,
+} from './selectTooltipEventType';
 
 export const selectTooltipAxisType = (state: RechartsRootState): XorYType => {
   const layout = selectChartLayout(state);
@@ -308,16 +314,26 @@ export const selectTooltipAxisTicks = createSelector(
 );
 
 export const selectActiveTooltipIndex: (state: RechartsRootState) => TooltipIndex | undefined = createSelector(
-  [(state: RechartsRootState) => state.tooltip],
-  (tooltipState: TooltipState): TooltipIndex | undefined => {
+  [(state: RechartsRootState) => state.tooltip, selectDefaultTooltipEventType, selectValidateTooltipEventTypes],
+  (
+    tooltipState: TooltipState,
+    defaultTooltipEventType: TooltipEventType,
+    validateTooltipEventType: ReadonlyArray<TooltipEventType>,
+  ): TooltipIndex | undefined => {
     const { settings } = tooltipState;
+
+    const tooltipEventType = combineTooltipEventType(
+      settings.shared,
+      defaultTooltipEventType,
+      validateTooltipEventType,
+    );
 
     if (tooltipState.syncInteraction.active && tooltipState.syncInteraction.activeAxisIndex != null) {
       // Synchronised events always override other events
       return tooltipState.syncInteraction.activeAxisIndex;
     }
     if (settings.trigger === 'click') {
-      if (settings.shared) {
+      if (tooltipEventType === 'axis') {
         if (tooltipState.axisInteraction.activeClickAxisIndex != null) {
           if (tooltipState.axisInteraction.activeClick) {
             return tooltipState.axisInteraction.activeClickAxisIndex;
@@ -330,7 +346,7 @@ export const selectActiveTooltipIndex: (state: RechartsRootState) => TooltipInde
         }
         return undefined;
       }
-    } else if (settings.shared) {
+    } else if (tooltipEventType === 'axis') {
       if (tooltipState.axisInteraction.activeMouseOverAxisIndex != null) {
         if (tooltipState.axisInteraction.activeHover) {
           return tooltipState.axisInteraction.activeMouseOverAxisIndex;

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -83,8 +83,14 @@ export type TooltipSettingsState = {
    * It means "active after user interaction has ended".
    * By default, the tooltip is only active while the user is hovering over the chart.
    * With `active=true`, the tooltip will remain visible after mouse leave event.
+   *
+   * If you want to see the "active before user interaction" settings, see `defaultIndex`.
    */
   active: boolean;
+  /**
+   * If you want to set the tooltip to be active before user interaction, you can set this property.
+   */
+  defaultIndex: TooltipIndex | undefined;
 };
 
 /**
@@ -228,6 +234,7 @@ export const initialState: TooltipState = {
     trigger: 'hover',
     axisId: 0,
     active: false,
+    defaultIndex: undefined,
   },
 };
 

--- a/storybook/stories/API/chart/RadialBarChart.stories.tsx
+++ b/storybook/stories/API/chart/RadialBarChart.stories.tsx
@@ -19,7 +19,7 @@ export const Simple: StoryObj = {
     return (
       <RadialBarChart {...args}>
         <RadialBar dataKey="uv" activeShape={{ fill: 'red' }} />
-        <Tooltip />
+        <Tooltip defaultIndex={3} />
         <RechartsHookInspector rechartsInspectorEnabled={context.rechartsInspectorEnabled} />
       </RadialBarChart>
     );

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -45,7 +45,7 @@ import {
 } from '../component/Tooltip/tooltipTestHelpers';
 import { scatterChartMouseHoverTooltipSelector } from '../component/Tooltip/tooltipMouseHoverSelectors';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
-import { TooltipPayloadConfiguration } from '../../src/state/tooltipSlice';
+import { TooltipPayloadConfiguration, TooltipState } from '../../src/state/tooltipSlice';
 
 describe('ScatterChart of three dimension data', () => {
   const data01 = [
@@ -1591,7 +1591,7 @@ describe('Tooltip integration', () => {
 
     it('should select tooltip state', () => {
       const { spy } = renderTestCase(selectTooltipState);
-      expect(spy).toHaveBeenLastCalledWith({
+      const expected: TooltipState = {
         axisInteraction: {
           activeClick: false,
           activeClickAxisDataKey: undefined,
@@ -1617,6 +1617,7 @@ describe('Tooltip integration', () => {
           axisId: 0,
           shared: undefined,
           trigger: 'hover',
+          defaultIndex: '1',
         },
         syncInteraction: {
           active: false,
@@ -1836,7 +1837,8 @@ describe('Tooltip integration', () => {
             },
           },
         ],
-      });
+      };
+      expect(spy).toHaveBeenLastCalledWith(expected);
     });
 
     it('should select tooltip payload configurations', () => {

--- a/test/component/Tooltip/ActiveDot.spec.tsx
+++ b/test/component/Tooltip/ActiveDot.spec.tsx
@@ -109,7 +109,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, areaChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 161,
@@ -225,7 +225,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, lineChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 161,
@@ -341,7 +341,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, composedChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 161,
@@ -456,7 +456,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, radarChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 203.42950722399726,

--- a/test/component/Tooltip/Tooltip.state.spec.tsx
+++ b/test/component/Tooltip/Tooltip.state.spec.tsx
@@ -1,21 +1,68 @@
 import React from 'react';
 import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
 import { LineChart, Tooltip } from '../../../src';
+import { TooltipSettingsState } from '../../../src/state/tooltipSlice';
 
 describe('Tooltip state integration', () => {
-  const renderTestCase = createSelectorTestCase(({ children }) => (
-    <LineChart width={1} height={1}>
-      <Tooltip shared trigger="click" axisId="my-axis-id" />
-      {children}
-    </LineChart>
-  ));
+  describe('with explicit settings', () => {
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <LineChart width={1} height={1}>
+        <Tooltip shared trigger="click" axisId="my-axis-id" active defaultIndex={4} />
+        {children}
+      </LineChart>
+    ));
 
-  test('Tooltip should publish its settings to Redux store', () => {
-    const { spy } = renderTestCase(state => state.tooltip.settings);
-    expect(spy).toHaveBeenLastCalledWith({
-      axisId: 'my-axis-id',
-      shared: true,
-      trigger: 'click',
+    test('should publish its settings to Redux store', () => {
+      const { spy } = renderTestCase(state => state.tooltip.settings);
+      const expected: TooltipSettingsState = {
+        axisId: 'my-axis-id',
+        shared: true,
+        trigger: 'click',
+        active: true,
+        defaultIndex: '4',
+      };
+      expect(spy).toHaveBeenLastCalledWith(expected);
+    });
+  });
+
+  describe('with default settings', () => {
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <LineChart width={1} height={1}>
+        <Tooltip />
+        {children}
+      </LineChart>
+    ));
+
+    test('should publish its settings to Redux store', () => {
+      const { spy } = renderTestCase(state => state.tooltip.settings);
+      const expected: TooltipSettingsState = {
+        active: undefined,
+        axisId: 0,
+        defaultIndex: undefined,
+        shared: undefined,
+        trigger: 'hover',
+      };
+      expect(spy).toHaveBeenLastCalledWith(expected);
+    });
+  });
+
+  describe('with implicit settings', () => {
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <LineChart width={1} height={1}>
+        {children}
+      </LineChart>
+    ));
+
+    test('should read initial settings from Redux store', () => {
+      const { spy } = renderTestCase(state => state.tooltip.settings);
+      const expected: TooltipSettingsState = {
+        active: false,
+        axisId: 0,
+        defaultIndex: undefined,
+        shared: false,
+        trigger: 'hover',
+      };
+      expect(spy).toHaveBeenLastCalledWith(expected);
     });
   });
 });

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -78,6 +78,7 @@ import {
 } from '../../../src/state/selectors/selectors';
 import { expectScale } from '../../helper/expectScale';
 import { selectChartLayout } from '../../../src/context/chartLayoutContext';
+import { TooltipState } from '../../../src/state/tooltipSlice';
 
 type TooltipVisibilityTestCase = {
   // For identifying which test is running
@@ -591,16 +592,8 @@ describe('Tooltip visibility', () => {
 
     describe('defaultIndex prop', () => {
       it('should show tooltip from the beginning if defaultIndex is set to a valid value', context => {
-        if (name === 'RadialBarChart') {
-          /*
-           * RadialBarChart throws an error when called with defaultIndex!
-           * Error: Uncaught [TypeError: Cannot read properties of undefined (reading 'coordinate')]
-           * at CategoricalChartWrapper.displayDefaultTooltip
-           */
-          // IntelliJ (incorrectly) reports this as test failure - but CLI says it's skipped. Since CLI is the source of truth I leave this here.
-          context.skip();
-        }
         if (name === 'FunnelChart') {
+          // IntelliJ (incorrectly) reports the context.skip() as test failure - but CLI says it's skipped. Since CLI is the source of truth I leave this here.
           // FunnelChart throws an error when called with defaultIndex
           context.skip();
         }
@@ -891,7 +884,7 @@ describe('Tooltip visibility', () => {
     it('should select tooltip state before & after hover', () => {
       const { container, spy } = renderTestCase(selectTooltipState);
 
-      expect(spy).toHaveBeenLastCalledWith({
+      const expected: TooltipState = {
         axisInteraction: {
           activeClick: false,
           activeClickAxisDataKey: undefined,
@@ -922,6 +915,8 @@ describe('Tooltip visibility', () => {
           axisId: 0,
           shared: undefined,
           trigger: 'hover',
+          active: undefined,
+          defaultIndex: undefined,
         },
         tooltipItemPayloads: [
           {
@@ -938,9 +933,11 @@ describe('Tooltip visibility', () => {
               type: undefined,
               unit: '',
             },
+            positions: undefined,
           },
         ],
-      });
+      };
+      expect(spy).toHaveBeenLastCalledWith(expected);
 
       showTooltip(container, RadarChartTestCase.mouseHoverSelector);
 

--- a/test/state/selectors/selectActiveTooltipIndex.spec.tsx
+++ b/test/state/selectors/selectActiveTooltipIndex.spec.tsx
@@ -7,6 +7,7 @@ import { PageData } from '../../_data';
 import { selectActiveTooltipIndex } from '../../../src/state/selectors/tooltipSelectors';
 import { showTooltip } from '../../component/Tooltip/tooltipTestHelpers';
 import { assertNotNull } from '../../helper/assertNotNull';
+import { radialBarChartMouseHoverTooltipSelector } from '../../component/Tooltip/tooltipMouseHoverSelectors';
 
 describe('selectActiveTooltipIndex', () => {
   describe('in RadialChart', () => {
@@ -27,7 +28,7 @@ describe('selectActiveTooltipIndex', () => {
       it('should return index after mouse hover, and undefined again after mouse leave', () => {
         const { container, spy } = renderTestCase(selectActiveTooltipIndex);
         const trigger = showTooltip(container, '.recharts-radial-bar-sector');
-        expect(spy).toHaveBeenLastCalledWith('0');
+        expect(spy).toHaveBeenLastCalledWith('3');
         fireEvent.mouseLeave(trigger);
         expect(spy).toHaveBeenLastCalledWith(undefined);
       });
@@ -48,20 +49,20 @@ describe('selectActiveTooltipIndex', () => {
       const renderTestCase = createSelectorTestCase(({ children }) => (
         <RadialBarChart width={300} height={300} data={PageData}>
           <RadialBar dataKey="uv" isAnimationActive={false} />
-          <Tooltip defaultIndex={3} />
+          <Tooltip defaultIndex={0} />
           {children}
         </RadialBarChart>
       ));
 
       it('should return the default index before any interaction', () => {
         const { spy } = renderTestCase(selectActiveTooltipIndex);
-        expect(spy).toHaveBeenLastCalledWith('3');
+        expect(spy).toHaveBeenLastCalledWith('0');
       });
 
       it('should return mouse hover index after mouse hover, and undefined again after mouse leave', () => {
         const { container, spy } = renderTestCase(selectActiveTooltipIndex);
-        const trigger = showTooltip(container, '.recharts-radial-bar-sector');
-        expect(spy).toHaveBeenLastCalledWith('0');
+        const trigger = showTooltip(container, radialBarChartMouseHoverTooltipSelector);
+        expect(spy).toHaveBeenLastCalledWith('3');
         fireEvent.mouseLeave(trigger);
         expect(spy).toHaveBeenLastCalledWith(undefined);
       });
@@ -70,10 +71,10 @@ describe('selectActiveTooltipIndex', () => {
         const { container, spy } = renderTestCase(selectActiveTooltipIndex);
         const trigger = container.querySelector('.recharts-radial-bar-sector');
         assertNotNull(trigger);
-        expect(spy).toHaveBeenLastCalledWith('3');
+        expect(spy).toHaveBeenLastCalledWith('0');
         expect(spy).toHaveBeenCalledTimes(3);
         fireEvent.click(trigger);
-        expect(spy).toHaveBeenLastCalledWith('3');
+        expect(spy).toHaveBeenLastCalledWith('0');
         expect(spy).toHaveBeenCalledTimes(3);
       });
     });
@@ -161,18 +162,18 @@ describe('selectActiveTooltipIndex', () => {
           expect(spy).toHaveBeenLastCalledWith(undefined);
         });
 
-        it('should return index after clicking on a sector, and continue returning that index after clicking again', () => {
+        it('should return index after clicking on a chart, and continue returning that index after clicking again', () => {
           const { container, spy } = renderTestCase(selectActiveTooltipIndex);
-          const trigger = container.querySelector('.recharts-radial-bar-sector');
+          const trigger = container.querySelector(radialBarChartMouseHoverTooltipSelector);
           assertNotNull(trigger);
           expect(spy).toHaveBeenLastCalledWith(undefined);
           expect(spy).toHaveBeenCalledTimes(1);
-          fireEvent.click(trigger);
-          expect(spy).toHaveBeenLastCalledWith('0');
-          expect(spy).toHaveBeenCalledTimes(2);
-          fireEvent.click(trigger);
-          expect(spy).toHaveBeenLastCalledWith('0');
-          expect(spy).toHaveBeenCalledTimes(2);
+          fireEvent.click(trigger, { clientX: 200, clientY: 200 });
+          expect(spy).toHaveBeenLastCalledWith('3');
+          expect(spy).toHaveBeenCalledTimes(3);
+          fireEvent.click(trigger, { clientX: 200, clientY: 200 });
+          expect(spy).toHaveBeenLastCalledWith('3');
+          expect(spy).toHaveBeenCalledTimes(3);
         });
 
         it('should return undefined after mouse hover', () => {
@@ -188,36 +189,36 @@ describe('selectActiveTooltipIndex', () => {
         const renderTestCase = createSelectorTestCase(({ children }) => (
           <RadialBarChart width={300} height={300} data={PageData}>
             <RadialBar dataKey="uv" isAnimationActive={false} />
-            <Tooltip trigger="click" defaultIndex={3} />
+            <Tooltip trigger="click" defaultIndex={1} />
             {children}
           </RadialBarChart>
         ));
 
         it('should return the default index before any interaction', () => {
           const { spy } = renderTestCase(selectActiveTooltipIndex);
-          expect(spy).toHaveBeenLastCalledWith('3');
+          expect(spy).toHaveBeenLastCalledWith('1');
         });
 
-        it('should return mouse hover index after clicking on a sector, and continue returning that index after clicking again', () => {
+        it('should return mouse hover index after clicking on the chart, and continue returning that index after clicking again', () => {
           const { container, spy } = renderTestCase(selectActiveTooltipIndex);
-          const trigger = container.querySelector('.recharts-radial-bar-sector');
+          const trigger = container.querySelector(radialBarChartMouseHoverTooltipSelector);
           assertNotNull(trigger);
-          expect(spy).toHaveBeenLastCalledWith('3');
+          expect(spy).toHaveBeenLastCalledWith('1');
           expect(spy).toHaveBeenCalledTimes(3);
-          fireEvent.click(trigger);
-          expect(spy).toHaveBeenLastCalledWith('0');
-          expect(spy).toHaveBeenCalledTimes(4);
-          fireEvent.click(trigger);
-          expect(spy).toHaveBeenLastCalledWith('0');
-          expect(spy).toHaveBeenCalledTimes(4);
+          fireEvent.click(trigger, { clientX: 200, clientY: 200 });
+          expect(spy).toHaveBeenLastCalledWith('3');
+          expect(spy).toHaveBeenCalledTimes(5);
+          fireEvent.click(trigger, { clientX: 200, clientY: 200 });
+          expect(spy).toHaveBeenLastCalledWith('3');
+          expect(spy).toHaveBeenCalledTimes(5);
         });
 
         it('should ignore mouse hover events', () => {
           const { container, spy } = renderTestCase(selectActiveTooltipIndex);
-          const trigger = showTooltip(container, '.recharts-radial-bar-sector');
-          expect(spy).toHaveBeenLastCalledWith('3');
+          const trigger = showTooltip(container, radialBarChartMouseHoverTooltipSelector);
+          expect(spy).toHaveBeenLastCalledWith('1');
           fireEvent.mouseLeave(trigger);
-          expect(spy).toHaveBeenLastCalledWith('3');
+          expect(spy).toHaveBeenLastCalledWith('1');
         });
       });
     });

--- a/test/state/selectors/selectActiveTooltipIndex.spec.tsx
+++ b/test/state/selectors/selectActiveTooltipIndex.spec.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
+import { RadialBar, RadialBarChart, Tooltip } from '../../../src';
+import { PageData } from '../../_data';
+import { selectActiveTooltipIndex } from '../../../src/state/selectors/tooltipSelectors';
+import { showTooltip } from '../../component/Tooltip/tooltipTestHelpers';
+import { assertNotNull } from '../../helper/assertNotNull';
+
+describe('selectActiveTooltipIndex', () => {
+  describe('in RadialChart', () => {
+    describe('with default Tooltip', () => {
+      const renderTestCase = createSelectorTestCase(({ children }) => (
+        <RadialBarChart width={300} height={300} data={PageData}>
+          <RadialBar dataKey="uv" isAnimationActive={false} />
+          <Tooltip />
+          {children}
+        </RadialBarChart>
+      ));
+
+      it('should return undefined before any interaction', () => {
+        const { spy } = renderTestCase(selectActiveTooltipIndex);
+        expect(spy).toHaveBeenLastCalledWith(undefined);
+      });
+
+      it('should return index after mouse hover, and undefined again after mouse leave', () => {
+        const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+        const trigger = showTooltip(container, '.recharts-radial-bar-sector');
+        expect(spy).toHaveBeenLastCalledWith('0');
+        fireEvent.mouseLeave(trigger);
+        expect(spy).toHaveBeenLastCalledWith(undefined);
+      });
+
+      it('should return undefined after clicking on a sector', () => {
+        const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+        const trigger = container.querySelector('.recharts-radial-bar-sector');
+        assertNotNull(trigger);
+        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expect(spy).toHaveBeenCalledTimes(1);
+        fireEvent.click(trigger);
+        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('with defaultIndex=number', () => {
+      const renderTestCase = createSelectorTestCase(({ children }) => (
+        <RadialBarChart width={300} height={300} data={PageData}>
+          <RadialBar dataKey="uv" isAnimationActive={false} />
+          <Tooltip defaultIndex={3} />
+          {children}
+        </RadialBarChart>
+      ));
+
+      it('should return the default index before any interaction', () => {
+        const { spy } = renderTestCase(selectActiveTooltipIndex);
+        expect(spy).toHaveBeenLastCalledWith('3');
+      });
+
+      it('should return mouse hover index after mouse hover, and undefined again after mouse leave', () => {
+        const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+        const trigger = showTooltip(container, '.recharts-radial-bar-sector');
+        expect(spy).toHaveBeenLastCalledWith('0');
+        fireEvent.mouseLeave(trigger);
+        expect(spy).toHaveBeenLastCalledWith(undefined);
+      });
+
+      it('should return the default index after clicking on a sector', () => {
+        const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+        const trigger = container.querySelector('.recharts-radial-bar-sector');
+        assertNotNull(trigger);
+        expect(spy).toHaveBeenLastCalledWith('3');
+        expect(spy).toHaveBeenCalledTimes(3);
+        fireEvent.click(trigger);
+        expect(spy).toHaveBeenLastCalledWith('3');
+        expect(spy).toHaveBeenCalledTimes(3);
+      });
+    });
+
+    describe('with shared=false', () => {
+      const renderTestCase = createSelectorTestCase(({ children }) => (
+        <RadialBarChart width={300} height={300} data={PageData}>
+          <RadialBar dataKey="uv" isAnimationActive={false} />
+          <Tooltip shared={false} />
+          {children}
+        </RadialBarChart>
+      ));
+
+      it('should return undefined before any interaction', () => {
+        const { spy } = renderTestCase(selectActiveTooltipIndex);
+        expect(spy).toHaveBeenLastCalledWith(undefined);
+      });
+
+      it('should return index after mouse hover, and undefined again after mouse leave', () => {
+        const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+        const trigger = showTooltip(container, '.recharts-radial-bar-sector');
+        expect(spy).toHaveBeenLastCalledWith('0');
+        fireEvent.mouseLeave(trigger);
+        expect(spy).toHaveBeenLastCalledWith(undefined);
+      });
+
+      it('should return undefined after clicking on a sector', () => {
+        const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+        const trigger = container.querySelector('.recharts-radial-bar-sector');
+        assertNotNull(trigger);
+        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expect(spy).toHaveBeenCalledTimes(1);
+        fireEvent.click(trigger);
+        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('with shared=false and defaultIndex=number', () => {
+      const renderTestCase = createSelectorTestCase(({ children }) => (
+        <RadialBarChart width={300} height={300} data={PageData}>
+          <RadialBar dataKey="uv" isAnimationActive={false} />
+          <Tooltip shared={false} defaultIndex={3} />
+          {children}
+        </RadialBarChart>
+      ));
+
+      it('should return the default index before any interaction', () => {
+        const { spy } = renderTestCase(selectActiveTooltipIndex);
+        expect(spy).toHaveBeenLastCalledWith('3');
+      });
+
+      it('should return mouse hover index after mouse hover, and undefined again after mouse leave', () => {
+        const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+        const trigger = showTooltip(container, '.recharts-radial-bar-sector');
+        expect(spy).toHaveBeenLastCalledWith('0');
+        fireEvent.mouseLeave(trigger);
+        expect(spy).toHaveBeenLastCalledWith(undefined);
+      });
+
+      it('should return the default index after clicking on a sector', () => {
+        const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+        const trigger = container.querySelector('.recharts-radial-bar-sector');
+        assertNotNull(trigger);
+        expect(spy).toHaveBeenLastCalledWith('3');
+        expect(spy).toHaveBeenCalledTimes(3);
+        fireEvent.click(trigger);
+        expect(spy).toHaveBeenLastCalledWith('3');
+        expect(spy).toHaveBeenCalledTimes(3);
+      });
+    });
+
+    describe('with trigger=click', () => {
+      describe('without defaultIndex', () => {
+        const renderTestCase = createSelectorTestCase(({ children }) => (
+          <RadialBarChart width={300} height={300} data={PageData}>
+            <RadialBar dataKey="uv" isAnimationActive={false} />
+            <Tooltip trigger="click" />
+            {children}
+          </RadialBarChart>
+        ));
+
+        it('should return undefined before any interaction', () => {
+          const { spy } = renderTestCase(selectActiveTooltipIndex);
+          expect(spy).toHaveBeenLastCalledWith(undefined);
+        });
+
+        it('should return index after clicking on a sector, and continue returning that index after clicking again', () => {
+          const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+          const trigger = container.querySelector('.recharts-radial-bar-sector');
+          assertNotNull(trigger);
+          expect(spy).toHaveBeenLastCalledWith(undefined);
+          expect(spy).toHaveBeenCalledTimes(1);
+          fireEvent.click(trigger);
+          expect(spy).toHaveBeenLastCalledWith('0');
+          expect(spy).toHaveBeenCalledTimes(2);
+          fireEvent.click(trigger);
+          expect(spy).toHaveBeenLastCalledWith('0');
+          expect(spy).toHaveBeenCalledTimes(2);
+        });
+
+        it('should return undefined after mouse hover', () => {
+          const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+          const trigger = showTooltip(container, '.recharts-radial-bar-sector');
+          expect(spy).toHaveBeenLastCalledWith(undefined);
+          fireEvent.mouseLeave(trigger);
+          expect(spy).toHaveBeenLastCalledWith(undefined);
+        });
+      });
+
+      describe('with defaultIndex=number', () => {
+        const renderTestCase = createSelectorTestCase(({ children }) => (
+          <RadialBarChart width={300} height={300} data={PageData}>
+            <RadialBar dataKey="uv" isAnimationActive={false} />
+            <Tooltip trigger="click" defaultIndex={3} />
+            {children}
+          </RadialBarChart>
+        ));
+
+        it('should return the default index before any interaction', () => {
+          const { spy } = renderTestCase(selectActiveTooltipIndex);
+          expect(spy).toHaveBeenLastCalledWith('3');
+        });
+
+        it('should return mouse hover index after clicking on a sector, and continue returning that index after clicking again', () => {
+          const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+          const trigger = container.querySelector('.recharts-radial-bar-sector');
+          assertNotNull(trigger);
+          expect(spy).toHaveBeenLastCalledWith('3');
+          expect(spy).toHaveBeenCalledTimes(3);
+          fireEvent.click(trigger);
+          expect(spy).toHaveBeenLastCalledWith('0');
+          expect(spy).toHaveBeenCalledTimes(4);
+          fireEvent.click(trigger);
+          expect(spy).toHaveBeenLastCalledWith('0');
+          expect(spy).toHaveBeenCalledTimes(4);
+        });
+
+        it('should ignore mouse hover events', () => {
+          const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+          const trigger = showTooltip(container, '.recharts-radial-bar-sector');
+          expect(spy).toHaveBeenLastCalledWith('3');
+          fireEvent.mouseLeave(trigger);
+          expect(spy).toHaveBeenLastCalledWith('3');
+        });
+      });
+    });
+  });
+});

--- a/test/state/selectors/selectors.spec.tsx
+++ b/test/state/selectors/selectors.spec.tsx
@@ -10,7 +10,6 @@ import {
   selectTooltipPayload,
   selectTooltipPayloadConfigurations,
   selectTooltipState,
-  useTooltipEventType,
 } from '../../../src/state/selectors/selectors';
 import { createRechartsStore, RechartsRootState } from '../../../src/state/store';
 import { RechartsStoreProvider } from '../../../src/state/RechartsStoreProvider';
@@ -49,6 +48,7 @@ import {
   useAppSelectorWithStableTest,
 } from '../../helper/selectorTestHelpers';
 import { selectActivePropsFromMousePointer } from '../../../src/state/selectors/selectActivePropsFromMousePointer';
+import { useTooltipEventType } from '../../../src/state/selectors/selectTooltipEventType';
 
 const exampleTooltipPayloadConfiguration1: TooltipPayloadConfiguration = {
   settings: {


### PR DESCRIPTION
## Description

Removing another usage of tooltip generator state

## Related Issue

https://github.com/recharts/recharts/issues/4549