### PR TITLE
selectActiveLabel, and removing generator code

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -114,6 +114,7 @@
   "es6/state/selectors/barSelectors.js",
   "es6/state/selectors/brushSelectors.js",
   "es6/state/selectors/combiners",
+  "es6/state/selectors/combiners/combineActiveLabel.js",
   "es6/state/selectors/combiners/combineAxisRangeWithReverse.js",
   "es6/state/selectors/containerSelectors.js",
   "es6/state/selectors/dataSelectors.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -114,6 +114,7 @@
   "lib/state/selectors/barSelectors.js",
   "lib/state/selectors/brushSelectors.js",
   "lib/state/selectors/combiners",
+  "lib/state/selectors/combiners/combineActiveLabel.js",
   "lib/state/selectors/combiners/combineAxisRangeWithReverse.js",
   "lib/state/selectors/containerSelectors.js",
   "lib/state/selectors/dataSelectors.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -114,6 +114,7 @@
   "types/state/selectors/barSelectors.d.ts",
   "types/state/selectors/brushSelectors.d.ts",
   "types/state/selectors/combiners",
+  "types/state/selectors/combiners/combineActiveLabel.d.ts",
   "types/state/selectors/combiners/combineAxisRangeWithReverse.d.ts",
   "types/state/selectors/containerSelectors.d.ts",
   "types/state/selectors/dataSelectors.d.ts",

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -34,9 +34,6 @@ import {
   appendOffsetOfLegend,
   AxisPropsNeededForTicksGenerator,
   AxisStackGroups,
-  calculateActiveTickIndex,
-  calculateTooltipPos,
-  getActiveCoordinate,
   getDomainOfDataByKey,
   getDomainOfStackGroups,
   getStackGroupsByAxisId,
@@ -62,10 +59,7 @@ import {
   LayoutType,
   Margin,
   MouseInfo,
-  RangeObj,
   StackOffsetType,
-  TickItem,
-  TooltipData,
   TooltipEventType,
   XAxisMap,
   YAxisMap,
@@ -195,43 +189,6 @@ const getTooltipContent = (
       return getTooltipItem(child, payload);
     })
     .filter(Boolean);
-};
-
-/**
- * Returns tooltip data based on a mouse position (as a parameter or in state)
- * @param  state      current state
- * @param  chartData  the data defined in chart
- * @param  layout     The layout type of chart
- * @param  rangeObj   coordinates
- * @return            Tooltip data
- */
-const getTooltipData = (
-  state: CategoricalChartState,
-  chartData: any[],
-  layout: LayoutType,
-  rangeObj?: RangeObj,
-): TooltipData | null => {
-  const rangeData: RangeObj = rangeObj || { x: state.chartX, y: state.chartY };
-
-  const pos: number | undefined = calculateTooltipPos(rangeData, layout);
-  const { orderedTooltipTicks: ticks, tooltipAxis: axis, tooltipTicks } = state;
-
-  const activeIndex = calculateActiveTickIndex(pos, ticks, tooltipTicks, axis?.axisType, axis?.range);
-
-  if (activeIndex >= 0 && tooltipTicks) {
-    const activeLabel: TickItem['value'] | undefined = tooltipTicks[activeIndex] && tooltipTicks[activeIndex].value;
-    const activePayload = getTooltipContent(state, chartData, activeIndex, activeLabel);
-    const activeCoordinate = getActiveCoordinate(layout, ticks, activeIndex, rangeData);
-
-    return {
-      activeTooltipIndex: activeIndex,
-      activeLabel,
-      activePayload,
-      activeCoordinate,
-    };
-  }
-
-  return null;
 };
 
 /**
@@ -1056,7 +1013,6 @@ export const generateCategoricalChart = ({
 
         const updatesToState = {
           // Update the current tooltip data (in case it changes without mouse interaction)
-          ...getTooltipData(prevState, data, layout),
           updateId: prevState.updateId + 1,
         };
 
@@ -1189,15 +1145,6 @@ export const generateCategoricalChart = ({
         const yValue: number | null = yScale && yScale.invert ? yScale.invert(e.chartY) : null;
 
         return { ...e, xValue, yValue };
-      }
-
-      const toolTipData = getTooltipData(this.state, this.props.data, this.props.layout, rangeObj);
-
-      if (toolTipData) {
-        return {
-          ...e,
-          ...toolTipData,
-        };
       }
 
       return null;

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -4,10 +4,9 @@ import { filterProps } from '../util/ReactUtils';
 import { Dot, Props as DotProps } from '../shape/Dot';
 import { Layer } from '../container/Layer';
 import { useTooltipAxis } from '../context/useTooltipAxis';
-import { useTooltipContext } from '../context/tooltipContext';
 import { findEntryInArray, isNullish } from '../util/DataUtils';
 import { useAppSelector } from '../state/hooks';
-import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
+import { selectActiveLabel, selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 
 export interface PointType {
   readonly x: number;
@@ -73,7 +72,7 @@ type ActivePointsProps = {
 export function ActivePoints({ points, mainColor, activeDot, itemDataKey }: ActivePointsProps) {
   const tooltipAxis = useTooltipAxis();
   const activeTooltipIndex = useAppSelector(selectActiveTooltipIndex);
-  const { label: activeLabel } = useTooltipContext();
+  const activeLabel = useAppSelector(selectActiveLabel);
   if (!activeTooltipIndex) {
     return null;
   }

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -13,7 +13,6 @@ import { Global } from '../util/Global';
 import { getUniqPayload, UniqueOption } from '../util/payload/getUniqPayload';
 import { AllowInDimension, AnimationDuration, AnimationTiming, Coordinate } from '../util/types';
 import { useViewBox } from '../context/chartLayoutContext';
-import { TooltipContextValue } from '../context/tooltipContext';
 import { useAccessibilityLayer } from '../context/accessibilityContext';
 import { useGetBoundingClientRect } from '../util/useGetBoundingClientRect';
 import { Cursor, CursorDefinition } from './Cursor';
@@ -39,8 +38,9 @@ function defaultUniqBy<TValue extends ValueType, TName extends NameType>(entry: 
   return entry.dataKey;
 }
 
-type TooltipContentProps<TValue extends ValueType, TName extends NameType> = TooltipProps<TValue, TName> &
-  Pick<TooltipContextValue, 'label' | 'payload' | 'coordinate' | 'active'> & { accessibilityLayer: boolean };
+type TooltipContentProps<TValue extends ValueType, TName extends NameType> = TooltipProps<TValue, TName> & {
+  accessibilityLayer: boolean;
+};
 
 function renderContent<TValue extends ValueType, TName extends NameType>(
   content: ContentType<TValue, TName>,

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -11,7 +11,7 @@ import { TooltipBoundingBox } from './TooltipBoundingBox';
 
 import { Global } from '../util/Global';
 import { getUniqPayload, UniqueOption } from '../util/payload/getUniqPayload';
-import { AllowInDimension, AnimationDuration, AnimationTiming, Coordinate } from '../util/types';
+import { AllowInDimension, AnimationDuration, AnimationTiming, ChartCoordinate, Coordinate } from '../util/types';
 import { useViewBox } from '../context/chartLayoutContext';
 import { useAccessibilityLayer } from '../context/accessibilityContext';
 import { useGetBoundingClientRect } from '../util/useGetBoundingClientRect';
@@ -39,6 +39,10 @@ function defaultUniqBy<TValue extends ValueType, TName extends NameType>(entry: 
 }
 
 type TooltipContentProps<TValue extends ValueType, TName extends NameType> = TooltipProps<TValue, TName> & {
+  label: string;
+  payload: any[];
+  coordinate: ChartCoordinate;
+  active: boolean;
   accessibilityLayer: boolean;
 };
 

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -2,7 +2,6 @@ import React, { createContext, ReactNode, useContext, useEffect } from 'react';
 import { CartesianViewBox, ChartOffset, LayoutType, Margin, Size } from '../util/types';
 import type { CategoricalChartState } from '../chart/types';
 import { LegendPayloadProvider } from './legendPayloadContext';
-import { TooltipContextProvider, TooltipContextValue } from './tooltipContext';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { RechartsRootState } from '../state/store';
 import { setChartSize, setLayout, setMargin } from '../state/layoutSlice';
@@ -36,7 +35,7 @@ export type ChartLayoutContextProviderProps = {
  */
 export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProps) => {
   const {
-    state: { activeLabel, activePayload, isTooltipActive, activeCoordinate, updateId, activeTooltipIndex },
+    state: { updateId },
     clipPathId,
     children,
     width,
@@ -44,14 +43,6 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
     margin,
     layout,
   } = props;
-
-  const tooltipContextValue: TooltipContextValue = {
-    label: activeLabel,
-    payload: activePayload,
-    coordinate: activeCoordinate,
-    active: isTooltipActive,
-    index: activeTooltipIndex,
-  };
 
   const dispatch = useAppDispatch();
 
@@ -85,9 +76,7 @@ export const ChartLayoutContextProvider = (props: ChartLayoutContextProviderProp
     <UpdateIdContext.Provider value={updateId}>
       <MarginContext.Provider value={margin}>
         <LegendPayloadProvider>
-          <ClipPathIdContext.Provider value={clipPathId}>
-            <TooltipContextProvider value={tooltipContextValue}>{children}</TooltipContextProvider>
-          </ClipPathIdContext.Provider>
+          <ClipPathIdContext.Provider value={clipPathId}>{children}</ClipPathIdContext.Provider>
         </LegendPayloadProvider>
       </MarginContext.Provider>
     </UpdateIdContext.Provider>

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -1,46 +1,7 @@
 import React, { createContext, useContext } from 'react';
-import { ChartCoordinate, Coordinate, DataKey } from '../util/types';
+import { Coordinate, DataKey } from '../util/types';
 import { useAppDispatch } from '../state/hooks';
 import { mouseLeaveItem, setActiveClickItemIndex, setActiveMouseOverItemIndex } from '../state/tooltipSlice';
-
-export type TooltipContextValue = {
-  label: string;
-  payload: any[];
-  coordinate: ChartCoordinate;
-  active: boolean;
-  index: number;
-};
-
-export const doNotDisplayTooltip: TooltipContextValue = {
-  label: '',
-  payload: [],
-  coordinate: { x: 0, y: 0 },
-  active: false,
-  index: -1,
-};
-
-const TooltipContext = createContext<TooltipContextValue>(doNotDisplayTooltip);
-
-/**
- * @deprecated do not use; instead prefer actions from tooltipSlice
- *
- * This depends on state set from generateCategoricalChart.
- */
-export const TooltipContextProvider = TooltipContext.Provider;
-
-/**
- * @deprecated this is depending on generateCategoricalChart state, do not use.
- *
- * Instead, use:
- * - selectActiveIndex for index
- * - selectActiveCoordinate for coordinate
- * - selectActiveLabel for label
- * - selectTooltipPayload for payload
- * - selectIsTooltipActive for active
- *
- * @returns deprecated, do not use
- */
-export const useTooltipContext = () => useContext(TooltipContext);
 
 export type TooltipPayloadType = any[];
 

--- a/src/state/selectors/combiners/combineActiveLabel.ts
+++ b/src/state/selectors/combiners/combineActiveLabel.ts
@@ -1,0 +1,14 @@
+import { TickItem } from '../../../util/types';
+import { TooltipIndex } from '../../tooltipSlice';
+import { isNan } from '../../../util/DataUtils';
+
+export const combineActiveLabel = (
+  tooltipTicks: ReadonlyArray<TickItem>,
+  activeIndex: TooltipIndex,
+): string | undefined => {
+  const n = Number(activeIndex);
+  if (isNan(n) || activeIndex == null) {
+    return undefined;
+  }
+  return n >= 0 ? tooltipTicks?.[n]?.value : undefined;
+};

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -36,7 +36,7 @@ import {
   TickItem,
   TooltipEventType,
 } from '../../util/types';
-import { findEntryInArray, isNan } from '../../util/DataUtils';
+import { findEntryInArray } from '../../util/DataUtils';
 import { TooltipTrigger } from '../../chart/types';
 import { ChartPointer } from '../../chart/generateCategoricalChart';
 import { selectChartDataWithIndexes } from './dataSelectors';
@@ -46,6 +46,7 @@ import { selectChartName } from './rootPropsSelectors';
 import { selectChartLayout } from '../../context/chartLayoutContext';
 import { selectChartOffset } from './selectChartOffset';
 import { selectChartHeight, selectChartWidth } from './containerSelectors';
+import { combineActiveLabel } from './combiners/combineActiveLabel';
 
 export const useChartName = (): string => {
   return useAppSelector(selectChartName);
@@ -284,17 +285,7 @@ export const selectActiveLabel: (
   tooltipEventType: TooltipEventType,
   trigger: TooltipTrigger,
   defaultIndex: number | undefined,
-) => string | undefined = createSelector(
-  selectTooltipAxisTicks,
-  selectActiveIndex,
-  (tooltipTicks: ReadonlyArray<TickItem>, activeIndex: TooltipIndex): string | undefined => {
-    const n = Number(activeIndex);
-    if (isNan(n) || activeIndex == null) {
-      return undefined;
-    }
-    return n >= 0 ? tooltipTicks?.[n]?.value : undefined;
-  },
-);
+) => string | undefined = createSelector(selectTooltipAxisTicks, selectActiveIndex, combineActiveLabel);
 
 function selectFinalData(dataDefinedOnItem: unknown, dataDefinedOnChart: ReadonlyArray<unknown>) {
   /*

--- a/src/state/selectors/tooltipSelectors.ts
+++ b/src/state/selectors/tooltipSelectors.ts
@@ -55,6 +55,8 @@ import {
   selectValidateTooltipEventTypes,
 } from './selectTooltipEventType';
 
+import { combineActiveLabel } from './combiners/combineActiveLabel';
+
 export const selectTooltipAxisType = (state: RechartsRootState): XorYType => {
   const layout = selectChartLayout(state);
 
@@ -364,4 +366,9 @@ export const selectActiveTooltipIndex: (state: RechartsRootState) => TooltipInde
     }
     return undefined;
   },
+);
+
+export const selectActiveLabel: (state: RechartsRootState) => string | undefined = createSelector(
+  [selectTooltipAxisTicks, selectActiveTooltipIndex],
+  combineActiveLabel,
 );

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -18,7 +18,6 @@ import {
 
 import { ReactElement } from 'react';
 import { findEntryInArray, isNan, isNullish, isNumber, isNumOrStr, mathSign, uniqueId, upperFirst } from './DataUtils';
-import { filterProps } from './ReactUtils';
 
 import { TooltipEntrySettings, TooltipPayloadEntry } from '../state/tooltipSlice';
 import { getNiceTickValues, getTickValuesFixedDomain } from './scale';
@@ -1072,46 +1071,6 @@ export const parseDomainOfCategoryAxis = <T>(
   }
 
   return specifiedDomain;
-};
-
-/**
- * @deprecated instead use {@link getTooltipEntry}
- * @param graphicalItem do not use
- * @param payload do not use
- * @return do not use
- */
-export const getTooltipItem = (
-  graphicalItem: {
-    type: { displayName: string };
-    props: {
-      stroke: string;
-      fill: string;
-      dataKey: DataKey<any>;
-      name: string;
-      unit: string;
-      formatter: any;
-      tooltipType: any;
-      chartType: any;
-      hide: boolean;
-    };
-  },
-  payload: any,
-) => {
-  const { dataKey, name, unit, formatter, tooltipType, chartType, hide } = graphicalItem.props;
-
-  return {
-    ...filterProps(graphicalItem, false),
-    dataKey,
-    unit,
-    formatter,
-    name: name || dataKey,
-    color: getMainColorOfGraphicItem(graphicalItem),
-    value: getValueByDataKey(payload, dataKey),
-    type: tooltipType,
-    payload,
-    chartType,
-    hide,
-  };
 };
 
 export function getTooltipEntry({

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -175,38 +175,6 @@ export const calculateActiveTickIndex = (
   return index;
 };
 
-/**
- * @deprecated render child components as children instead of reading DOM elements and passing them around
- * Get the main color of each graphic item
- * @param  {ReactElement} item A graphic item
- * @return {String}            Color
- */
-export const getMainColorOfGraphicItem = (item: {
-  type: { displayName: string };
-  props: { stroke: string; fill: string };
-}) => {
-  const {
-    type: { displayName },
-  } = item as any; // TODO: check if displayName is valid.
-  const { stroke, fill } = item.props;
-  let result;
-
-  switch (displayName) {
-    case 'Line':
-      result = stroke;
-      break;
-    case 'Area':
-    case 'Radar':
-      result = stroke && stroke !== 'none' ? stroke : fill;
-      break;
-    default:
-      result = fill;
-      break;
-  }
-
-  return result;
-};
-
 export type BarPositionPosition = {
   /**
    * Offset is returned always from zero position.

--- a/test/component/Tooltip/ActiveDot.spec.tsx
+++ b/test/component/Tooltip/ActiveDot.spec.tsx
@@ -109,7 +109,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, areaChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(2);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 161,
@@ -225,7 +225,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, lineChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(2);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 161,
@@ -341,7 +341,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, composedChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(2);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 161,
@@ -456,7 +456,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, radarChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 203.42950722399726,

--- a/test/component/Tooltip/ActiveDot.spec.tsx
+++ b/test/component/Tooltip/ActiveDot.spec.tsx
@@ -109,7 +109,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, areaChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 161,
@@ -225,7 +225,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, lineChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 161,
@@ -341,7 +341,7 @@ describe('ActiveDot', () => {
       expect(spy).toHaveBeenCalledTimes(0);
       expect(container.querySelector('.recharts-active-dot')).not.toBeInTheDocument();
       const tooltipTrigger = showTooltip(container, composedChartMouseHoverTooltipSelector, debug);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(container.querySelector('.recharts-active-dot')).toBeVisible();
       expect(spy).toHaveBeenCalledWith({
         cx: 161,

--- a/test/state/selectors/selectActiveTooltipIndex.spec.tsx
+++ b/test/state/selectors/selectActiveTooltipIndex.spec.tsx
@@ -170,10 +170,10 @@ describe('selectActiveTooltipIndex', () => {
           expect(spy).toHaveBeenCalledTimes(1);
           fireEvent.click(trigger, { clientX: 200, clientY: 200 });
           expect(spy).toHaveBeenLastCalledWith('3');
-          expect(spy).toHaveBeenCalledTimes(3);
+          expect(spy).toHaveBeenCalledTimes(2);
           fireEvent.click(trigger, { clientX: 200, clientY: 200 });
           expect(spy).toHaveBeenLastCalledWith('3');
-          expect(spy).toHaveBeenCalledTimes(3);
+          expect(spy).toHaveBeenCalledTimes(2);
         });
 
         it('should return undefined after mouse hover', () => {
@@ -207,10 +207,10 @@ describe('selectActiveTooltipIndex', () => {
           expect(spy).toHaveBeenCalledTimes(3);
           fireEvent.click(trigger, { clientX: 200, clientY: 200 });
           expect(spy).toHaveBeenLastCalledWith('3');
-          expect(spy).toHaveBeenCalledTimes(5);
+          expect(spy).toHaveBeenCalledTimes(4);
           fireEvent.click(trigger, { clientX: 200, clientY: 200 });
           expect(spy).toHaveBeenLastCalledWith('3');
-          expect(spy).toHaveBeenCalledTimes(5);
+          expect(spy).toHaveBeenCalledTimes(4);
         });
 
         it('should ignore mouse hover events', () => {


### PR DESCRIPTION
## Description

`selectActiveLabel` was the last remaining usage of tooltip generator data, so I removed it all.

## Related Issue

https://github.com/recharts/recharts/issues/4549