### PR TITLE
Bump codecov to v5, remove token

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,8 +28,7 @@ jobs:
         run: npm run test-coverage
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           slug: recharts/recharts
           files: ./coverage/coverage-final.json
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description

https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token

https://github.com/codecov/codecov-action?tab=readme-ov-file#migration-guide
