### PR TITLE
Put codecov token back - uploads on 3.x branch started failing without it

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,3 +32,4 @@ jobs:
         with:
           slug: recharts/recharts
           files: ./coverage/coverage-final.json
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description

Turns out it's still required, even if the documentation says it's not.

## Related Issue

https://github.com/recharts/recharts/pull/5380