### PR TITLE
Highlight only the Bar that is active with Tooltip=shared

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -54,7 +54,7 @@ import { BarSettings, selectBarRectangles } from '../state/selectors/barSelector
 import { BaseAxisWithScale } from '../state/selectors/axisSelectors';
 import { useAppSelector } from '../state/hooks';
 import { useIsPanorama } from '../context/PanoramaContext';
-import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
+import { selectActiveTooltipDataKey, selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 
 export interface BarRectangleItem extends RectangleProps {
   value?: number | [number, number];
@@ -280,6 +280,8 @@ function BarRectangles(props: BarRectanglesProps) {
   const { data, shape, dataKey, activeBar } = props;
 
   const activeIndex = useAppSelector(selectActiveTooltipIndex);
+  const activeDataKey = useAppSelector(selectActiveTooltipDataKey);
+
   const {
     onMouseEnter: onMouseEnterFromProps,
     onClick: onItemClickFromProps,
@@ -298,7 +300,16 @@ function BarRectangles(props: BarRectanglesProps) {
   return (
     <>
       {data.map((entry: BarRectangleItem, i: number) => {
-        const isActive = activeBar && String(i) === activeIndex;
+        /*
+         * Bars support stacking, meaning that there can be multiple bars at the same x value.
+         * With Tooltip shared=false we only want to highlight the currently active Bar, not all.
+         *
+         * Also, if the tooltip is shared, we want to highlight all bars at the same x value
+         * regardless of the dataKey.
+         *
+         * With shared Tooltip, the activeDataKey is undefined.
+         */
+        const isActive = activeBar && String(i) === activeIndex && (activeDataKey == null || dataKey === activeDataKey);
         const option = isActive ? activeBar : shape;
         const barRectangleProps = {
           ...baseProps,

--- a/src/state/selectors/tooltipSelectors.ts
+++ b/src/state/selectors/tooltipSelectors.ts
@@ -39,7 +39,15 @@ import {
 import { selectChartLayout } from '../../context/chartLayoutContext';
 import { AxisId } from '../cartesianAxisSlice';
 import { isCategoricalAxis, RechartsScale, StackId } from '../../util/ChartUtils';
-import { AxisDomain, CategoricalDomain, LayoutType, NumberDomain, TickItem, TooltipEventType } from '../../util/types';
+import {
+  AxisDomain,
+  CategoricalDomain,
+  DataKey,
+  LayoutType,
+  NumberDomain,
+  TickItem,
+  TooltipEventType,
+} from '../../util/types';
 import { AppliedChartData, ChartData } from '../chartDataSlice';
 import { selectChartDataWithIndexes } from './dataSelectors';
 import { GraphicalItemSettings } from '../graphicalItemsSlice';
@@ -116,7 +124,7 @@ export const selectTooltipGraphicalItemsData = createSelector(
 /**
  * Data for tooltip always use the data with indexes set by a Brush,
  * and never accept the isPanorama flag:
- * because Tooltip never displays inside of the panorama anyway
+ * because Tooltip never displays inside the panorama anyway
  * so we don't need to worry what would happen there.
  */
 export const selectTooltipDisplayedData: (state: RechartsRootState) => ChartData = createSelector(
@@ -349,4 +357,15 @@ export const selectActiveTooltipIndex: (state: RechartsRootState) => TooltipInde
 export const selectActiveLabel: (state: RechartsRootState) => string | undefined = createSelector(
   [selectTooltipAxisTicks, selectActiveTooltipIndex],
   combineActiveLabel,
+);
+
+export const selectActiveTooltipDataKey: (state: RechartsRootState) => DataKey<any> | undefined = createSelector(
+  [selectTooltipInteractionState],
+  (tooltipInteraction: TooltipInteractionState): DataKey<any> | undefined => {
+    if (!tooltipInteraction) {
+      return undefined;
+    }
+
+    return tooltipInteraction.dataKey;
+  },
 );

--- a/storybook/stories/Examples/BarChart/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart/BarChart.stories.tsx
@@ -81,9 +81,9 @@ export const Stacked = {
           <XAxis dataKey="name" />
           <YAxis />
           <Legend />
-          <Bar dataKey="pv" stackId="a" fill="#8884d8" />
-          <Bar dataKey="uv" stackId="a" fill="#82ca9d" />
-          <Tooltip />
+          <Bar dataKey="pv" stackId="a" fill="#8884d8" activeBar={{ fill: 'gold' }} />
+          <Bar dataKey="uv" stackId="a" fill="#82ca9d" activeBar={{ fill: 'silver' }} />
+          <Tooltip shared={false} />
         </BarChart>
       </ResponsiveContainer>
     );

--- a/test/helper/expectBars.ts
+++ b/test/helper/expectBars.ts
@@ -10,10 +10,14 @@ type ExpectedBar = {
   d: string;
 };
 
+export function getAllBars(container: Element) {
+  return container.querySelectorAll('.recharts-bar .recharts-bar-rectangle');
+}
+
 export function expectBars(container: Element, expectedBars: ReadonlyArray<ExpectedBar>) {
   assertNotNull(container);
-  const allBars = container.querySelectorAll('.recharts-bar .recharts-bar-rectangle path.recharts-rectangle');
-  const actualBars = Array.from(allBars).map(bar => ({
+  const allBarPaths = container.querySelectorAll('.recharts-bar .recharts-bar-rectangle path.recharts-rectangle');
+  const actualBars = Array.from(allBarPaths).map(bar => ({
     x: bar.getAttribute('x'),
     y: bar.getAttribute('y'),
     width: bar.getAttribute('width'),
@@ -22,4 +26,18 @@ export function expectBars(container: Element, expectedBars: ReadonlyArray<Expec
     d: bar.getAttribute('d'),
   }));
   expect(actualBars).toEqual(expectedBars);
+}
+
+function getActiveChildren(bar: Element) {
+  return bar.querySelectorAll('.recharts-active-bar');
+}
+
+export function expectBarIsActive(bar: Element) {
+  const activeChildren = getActiveChildren(bar);
+  expect(activeChildren).toHaveLength(1);
+}
+
+export function expectBarIsNotActive(bar: Element) {
+  const activeChildren = getActiveChildren(bar);
+  expect(activeChildren).toHaveLength(0);
 }


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/fb51e0bc-7286-4e16-8eb8-2536ad59dd66

When looking at the storybook I have noticed a new bug in 3.x: https://github.com/recharts/recharts/issues/5399 <- this was there before this PR, I will look at that next.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/5124