### PR TITLE
Fix tooltip coordinate in Bar with shared=false

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -29,6 +29,7 @@ import {
   AnimationDuration,
   AnimationTiming,
   ChartOffset,
+  Coordinate,
   DataKey,
   LegendType,
   PresentationAttributesAdaptChildEvent,
@@ -65,6 +66,7 @@ export interface BarRectangleItem extends RectangleProps {
     width?: number;
     height?: number;
   };
+  tooltipPosition: Coordinate;
 }
 
 export interface BarProps {
@@ -230,7 +232,7 @@ function BarBackground(props: BarBackgroundProps) {
   return (
     <>
       {data.map((entry: BarRectangleItem, i: number) => {
-        const { value, background: backgroundFromDataEntry, ...rest } = entry;
+        const { value, background: backgroundFromDataEntry, tooltipPosition, ...rest } = entry;
 
         if (!backgroundFromDataEntry) {
           return null;
@@ -643,7 +645,7 @@ export function computeBarRectangles({
   const stackedDomain: ReadonlyArray<number> = stackedData ? numericAxis.scale.domain() : null;
   const baseValue = getBaseValueOfBar({ numericAxis });
 
-  return displayedData.map((entry, index) => {
+  return displayedData.map((entry, index): BarRectangleItem => {
     let value, x, y, width, height, background;
 
     if (stackedData) {
@@ -710,6 +712,7 @@ export function computeBarRectangles({
       value: stackedData ? value : value[1],
       payload: entry,
       background,
+      tooltipPosition: { x: x + width / 2, y: y + height / 2 },
       ...(cells && cells[index] && cells[index].props),
     };
   });

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -2035,6 +2035,10 @@ describe('<BarChart />', () => {
           topWhisker: 200,
         },
         size: 150,
+        tooltipPosition: {
+          x: 120,
+          y: 55,
+        },
         topBox: 200,
         topWhisker: 200,
         value: [450, 650],
@@ -2064,6 +2068,10 @@ describe('<BarChart />', () => {
           topWhisker: 100,
         },
         size: 250,
+        tooltipPosition: {
+          x: 230,
+          y: 15,
+        },
         topBox: 100,
         topWhisker: 100,
         value: [700, 800],
@@ -2093,6 +2101,10 @@ describe('<BarChart />', () => {
           topWhisker: 200,
         },
         size: 350,
+        tooltipPosition: {
+          x: 340,
+          y: 25,
+        },
         topBox: 200,
         topWhisker: 200,
         value: [600, 800],


### PR DESCRIPTION
## Description

I missed this scenario sometime when moving over the Tooltip positions to Redux. Fixed now

<img width="496" alt="image" src="https://github.com/user-attachments/assets/a442101b-4671-474e-828a-3a7267ba409d" />

## Related Issue

Fixes https://github.com/recharts/recharts/issues/5399