### PR TITLE
Export type TooltipContentProps

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -38,7 +38,7 @@ function defaultUniqBy<TValue extends ValueType, TName extends NameType>(entry: 
   return entry.dataKey;
 }
 
-type TooltipContentProps<TValue extends ValueType, TName extends NameType> = TooltipProps<TValue, TName> & {
+export type TooltipContentProps<TValue extends ValueType, TName extends NameType> = TooltipProps<TValue, TName> & {
   label: string;
   payload: any[];
   coordinate: ChartCoordinate;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export type { Props as LegendProps } from './component/Legend';
 export { DefaultLegendContent } from './component/DefaultLegendContent';
 export type { Props as DefaultLegendContentProps } from './component/DefaultLegendContent';
 export { Tooltip } from './component/Tooltip';
-export type { TooltipProps } from './component/Tooltip';
+export type { TooltipProps, TooltipContentProps } from './component/Tooltip';
 export { DefaultTooltipContent } from './component/DefaultTooltipContent';
 export type { Props as DefaultTooltipContentProps } from './component/DefaultTooltipContent';
 export { ResponsiveContainer } from './component/ResponsiveContainer';


### PR DESCRIPTION
## Description

I need to use this type because now it's different from `TooltipProps`.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/5405