### PR TITLE
fix(default-legend-content): add aria-label to legend icons

### DIFF
--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -166,6 +166,7 @@ export class DefaultLegendContent extends PureComponent<Props> {
       );
 
       const color = entry.inactive ? inactiveColor : entry.color;
+      const finalValue = finalFormatter ? finalFormatter(entryValue, entry, i) : entryValue;
 
       return (
         <li
@@ -175,11 +176,17 @@ export class DefaultLegendContent extends PureComponent<Props> {
           key={`legend-item-${i}`}
           {...adaptEventsOfChild(this.props, entry, i)}
         >
-          <Surface width={iconSize} height={iconSize} viewBox={viewBox} style={svgStyle}>
+          <Surface
+            width={iconSize}
+            height={iconSize}
+            viewBox={viewBox}
+            style={svgStyle}
+            aria-label={`${finalValue} legend icon`}
+          >
             {this.renderIcon(entry, iconType)}
           </Surface>
           <span className="recharts-legend-item-text" style={{ color }}>
-            {finalFormatter ? finalFormatter(entryValue, entry, i) : entryValue}
+            {finalValue}
           </span>
         </li>
       );

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -609,6 +609,7 @@ describe('<Legend />', () => {
         const surface = legendItem.getElementsByClassName('recharts-surface')[0];
         expect(surface.getAttribute('height')).toBe('14');
         expect(surface.getAttribute('width')).toBe('14');
+        expect(surface.getAttribute('aria-label')).toBe('My Line Data legend icon');
       });
 
       test(`Renders '' if sibling's dataKey is a function and name is not provided`, () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
add an aria label to make accessibility scanners behave

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5412

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
accessibility

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
assert this label is there, scanner no longer calls this an issue

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
