### PR TITLE
Remove container from state

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -186,4 +186,5 @@
   "es6/util/tooltip/translate.js",
   "es6/util/types.js",
   "es6/util/useElementOffset.js",
+  "es6/util/useReportScale.js",
 ]

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -186,4 +186,5 @@
   "lib/util/tooltip/translate.js",
   "lib/util/types.js",
   "lib/util/useElementOffset.js",
+  "lib/util/useReportScale.js",
 ]

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -186,4 +186,5 @@
   "types/util/tooltip/translate.d.ts",
   "types/util/types.d.ts",
   "types/util/useElementOffset.d.ts",
+  "types/util/useReportScale.d.ts",
 ]

--- a/src/chart/RechartsWrapper.tsx
+++ b/src/chart/RechartsWrapper.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties, DOMAttributes, forwardRef, ReactNode, Ref, useEffect } from 'react';
 import clsx from 'clsx';
 import { mouseLeaveChart } from '../state/tooltipSlice';
-import { setContainer, setOffset } from '../state/layoutSlice';
+import { setOffset } from '../state/layoutSlice';
 import { useAppDispatch } from '../state/hooks';
 import { mouseClickAction, mouseMoveAction } from '../state/mouseEventsMiddleware';
 import { useSynchronisedEventsFromOtherCharts } from '../synchronisation/useChartSynchronisation';
@@ -39,7 +39,6 @@ export const RechartsWrapper = forwardRef(
     const setScaleRef = useReportScale();
 
     const innerRef = (node: HTMLDivElement | null) => {
-      dispatch(setContainer(node));
       setLastOffset(node);
       setScaleRef(node);
       if (typeof ref === 'function') {

--- a/src/chart/RechartsWrapper.tsx
+++ b/src/chart/RechartsWrapper.tsx
@@ -7,6 +7,7 @@ import { mouseClickAction, mouseMoveAction } from '../state/mouseEventsMiddlewar
 import { useSynchronisedEventsFromOtherCharts } from '../synchronisation/useChartSynchronisation';
 import { focusAction, keyDownAction } from '../state/keyboardEventsMiddleware';
 import { useElementOffset } from '../util/useElementOffset';
+import { useReportScale } from '../util/useReportScale';
 
 export type RechartsWrapperProps = {
   children: ReactNode;
@@ -35,12 +36,15 @@ export const RechartsWrapper = forwardRef(
 
     const setLastOffset = useReportChartOffset();
 
+    const setScaleRef = useReportScale();
+
     const innerRef = (node: HTMLDivElement | null) => {
       dispatch(setContainer(node));
+      setLastOffset(node);
+      setScaleRef(node);
       if (typeof ref === 'function') {
         ref(node);
       }
-      setLastOffset(node);
     };
     const myOnClick = (e: React.MouseEvent<HTMLDivElement>) => {
       dispatch(mouseClickAction(e));

--- a/src/state/layoutSlice.ts
+++ b/src/state/layoutSlice.ts
@@ -28,6 +28,11 @@ type ChartLayoutState = {
   height: number;
   margin: Margin;
   offset: ElementOffset;
+  /**
+   * How much is the chart zoomed in.
+   * Used for scaling the mouse coordinates to the chart coordinates.
+   */
+  scale: number;
 };
 
 const initialState: ChartLayoutState = {
@@ -37,6 +42,7 @@ const initialState: ChartLayoutState = {
   height: 0,
   margin: { top: 5, right: 5, bottom: 5, left: 5 },
   offset: { top: 0, left: 0, width: 0, height: 0 },
+  scale: 1,
 };
 
 const chartLayoutSlice = createSlice({
@@ -59,9 +65,12 @@ const chartLayoutSlice = createSlice({
     setOffset(state, action: PayloadAction<ElementOffset>) {
       state.offset = action.payload;
     },
+    setScale(state, action: PayloadAction<number>) {
+      state.scale = action.payload;
+    },
   },
 });
 
-export const { setMargin, setLayout, setContainer, setChartSize, setOffset } = chartLayoutSlice.actions;
+export const { setMargin, setLayout, setContainer, setChartSize, setOffset, setScale } = chartLayoutSlice.actions;
 
 export const chartLayoutReducer = chartLayoutSlice.reducer;

--- a/src/state/layoutSlice.ts
+++ b/src/state/layoutSlice.ts
@@ -1,29 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { castDraft } from 'immer';
 import { LayoutType, Margin, Size } from '../util/types';
 import { ElementOffset } from '../util/useElementOffset';
 
-/**
- * This is a subset of DOMRect returned by getBoundingClientRect().
- * We don't use the straight `DOMRect` type for two reasons:
- *
- * 1. We don't use all the properties from it, and
- * 2. DOMRect type has `toJSON` method that I am too lazy to mock everywhere and also is not serializable, so I don't want to store it in Redux state.
- */
-export type RechartsDOMRect = {
-  width: number;
-  height: number;
-  top: number;
-  left: number;
-};
-
-export interface RechartsHTMLContainer {
-  getBoundingClientRect: () => RechartsDOMRect;
-}
-
 type ChartLayoutState = {
   layoutType: LayoutType;
-  container: RechartsHTMLContainer | null;
   width: number;
   height: number;
   margin: Margin;
@@ -37,7 +17,6 @@ type ChartLayoutState = {
 
 const initialState: ChartLayoutState = {
   layoutType: 'horizontal',
-  container: null,
   width: 0,
   height: 0,
   margin: { top: 5, right: 5, bottom: 5, left: 5 },
@@ -51,9 +30,6 @@ const chartLayoutSlice = createSlice({
   reducers: {
     setLayout(state, action: PayloadAction<LayoutType>) {
       state.layoutType = action.payload;
-    },
-    setContainer(state, action: PayloadAction<RechartsHTMLContainer | null>) {
-      state.container = castDraft(action.payload);
     },
     setChartSize(state, action: PayloadAction<Size>) {
       state.width = action.payload.width;
@@ -71,6 +47,6 @@ const chartLayoutSlice = createSlice({
   },
 });
 
-export const { setMargin, setLayout, setContainer, setChartSize, setOffset, setScale } = chartLayoutSlice.actions;
+export const { setMargin, setLayout, setChartSize, setOffset, setScale } = chartLayoutSlice.actions;
 
 export const chartLayoutReducer = chartLayoutSlice.reducer;

--- a/src/state/selectors/containerSelectors.ts
+++ b/src/state/selectors/containerSelectors.ts
@@ -1,30 +1,8 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { RechartsRootState } from '../store';
-import { RechartsDOMRect, RechartsHTMLContainer } from '../layoutSlice';
 import { ChartPointer, MousePointer } from '../../chart/generateCategoricalChart';
 import { Margin } from '../../util/types';
 import { ElementOffset } from '../../util/useElementOffset';
-
-const selectRootContainer = (state: RechartsRootState): RechartsHTMLContainer | undefined => state.layout.container;
-
-/**
- * This selector is not stable, and it is important that it is not stable
- * - because browser will return different instances of getBoundingClientRect() even if the element is the same.
- *
- * This results in Reselect showing this error:
- * An input selector returned a different result when passed same arguments.
- * This means your output selector will likely run more frequently than intended
- *
- * Which is correct and unfortunate but good enough for now.
- * The fix is to listen for resize events in the container element,
- * and store only the resulting DOMRect instead of the whole container in Redux store.
- *
- * @param state RechartsRootState
- * @return DOMRect
- */
-export const selectRootContainerDomRect: (state: RechartsRootState) => RechartsDOMRect | undefined = (
-  state: RechartsRootState,
-) => selectRootContainer(state)?.getBoundingClientRect();
 
 export const selectContainerOffset: (state: RechartsRootState) => ElementOffset | undefined = (
   state: RechartsRootState,
@@ -50,16 +28,5 @@ export const selectChartCoordinates: (state: RechartsRootState, event: MousePoin
   );
 
 export const selectContainerScale: (state: RechartsRootState) => number = state => state.layout.scale;
-
-// export const selectContainerScale: (state: RechartsRootState) => number | undefined = createSelector(
-//   selectContainerOffset,
-//   selectRootContainerDomRect,
-//   (offset: ElementOffset | undefined, rect: DOMRect | undefined): number => {
-//     if (!rect?.width || !offset?.width) {
-//       return 1;
-//     }
-//     return rect.width / offset.width;
-//   },
-// );
 
 export const selectMargin = (state: RechartsRootState): Margin | undefined => state.layout.margin;

--- a/src/state/selectors/containerSelectors.ts
+++ b/src/state/selectors/containerSelectors.ts
@@ -49,15 +49,17 @@ export const selectChartCoordinates: (state: RechartsRootState, event: MousePoin
     },
   );
 
-export const selectContainerScale: (state: RechartsRootState) => number | undefined = createSelector(
-  selectContainerOffset,
-  selectRootContainerDomRect,
-  (offset: ElementOffset | undefined, rect: DOMRect | undefined): number => {
-    if (!rect?.width || !offset?.width) {
-      return 1;
-    }
-    return rect.width / offset.width;
-  },
-);
+export const selectContainerScale: (state: RechartsRootState) => number = state => state.layout.scale;
+
+// export const selectContainerScale: (state: RechartsRootState) => number | undefined = createSelector(
+//   selectContainerOffset,
+//   selectRootContainerDomRect,
+//   (offset: ElementOffset | undefined, rect: DOMRect | undefined): number => {
+//     if (!rect?.width || !offset?.width) {
+//       return 1;
+//     }
+//     return rect.width / offset.width;
+//   },
+// );
 
 export const selectMargin = (state: RechartsRootState): Margin | undefined => state.layout.margin;

--- a/src/util/useReportScale.ts
+++ b/src/util/useReportScale.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { useAppDispatch, useAppSelector } from '../state/hooks';
+import { selectContainerScale } from '../state/selectors/containerSelectors';
+import { setScale } from '../state/layoutSlice';
+import { isWellBehavedNumber } from './isWellBehavedNumber';
+
+export function useReportScale() {
+  const dispatch = useAppDispatch();
+  const [ref, setRef] = useState<HTMLElement | null>(null);
+  const scale = useAppSelector(selectContainerScale);
+  useEffect(() => {
+    if (ref == null) {
+      return;
+    }
+    const rect = ref.getBoundingClientRect();
+    const newScale = rect.width / ref.offsetWidth;
+    if (isWellBehavedNumber(newScale) && newScale !== scale) {
+      dispatch(setScale(newScale));
+    }
+  }, [ref, dispatch, scale]);
+  return setRef;
+}

--- a/storybook/stories/Examples/ChartLayout.stories.tsx
+++ b/storybook/stories/Examples/ChartLayout.stories.tsx
@@ -158,12 +158,13 @@ function Crosshair({ x, y }: { x: number; y: number }) {
 function CrosshairWrapper() {
   const [mousePosition, setMousePosition] = useState<null | { pageX: number; pageY: number }>(null);
   const offset: ElementOffset | undefined = useAppSelector(selectContainerOffset);
+  const scale: number = useAppSelector(selectContainerScale);
   if (offset == null) {
     return null;
   }
 
   const onMouseMove = (event: React.MouseEvent) => {
-    setMousePosition({ pageX: event.pageX, pageY: event.pageY });
+    setMousePosition({ pageX: event.pageX / scale, pageY: event.pageY / scale });
   };
   const onMouseLeave = () => {
     setMousePosition(null);

--- a/storybook/stories/Examples/ChartLayout.stories.tsx
+++ b/storybook/stories/Examples/ChartLayout.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { ComposedChart, ResponsiveContainer } from '../../../src';
 import { useChartHeight, useChartWidth } from '../../../src/context/chartLayoutContext';
-import { selectContainerOffset } from '../../../src/state/selectors/containerSelectors';
+import { selectContainerOffset, selectContainerScale } from '../../../src/state/selectors/containerSelectors';
 import { useAppSelector } from '../../../src/state/hooks';
 import { ElementOffset } from '../../../src/util/useElementOffset';
 
@@ -179,6 +179,19 @@ function CrosshairWrapper() {
   );
 }
 
+function ShowScale() {
+  const width = useChartWidth();
+  const height = useChartHeight();
+  const scale = useAppSelector(selectContainerScale);
+  return (
+    <svg width="100%" height="100%" style={{ position: 'absolute', top: 0, left: 0 }}>
+      <text x={width * 0.9} y={height * 0.9} textAnchor="end" dominantBaseline="hanging" stroke="black">
+        {`scale: ${scale}`}
+      </text>
+    </svg>
+  );
+}
+
 export default {
   component: ComposedChart,
   docs: {
@@ -203,6 +216,7 @@ export const WithResponsiveContainer = {
           {createPortal(<OffsetDimensions />, document.getElementById('storybook-root'))}
           <ChartSizeDimensions />
           <CrosshairWrapper />
+          <ShowScale />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -220,6 +234,7 @@ export const WithStaticDimensions = {
         {createPortal(<OffsetDimensions />, document.getElementById('storybook-root'))}
         <ChartSizeDimensions />
         <CrosshairWrapper />
+        <ShowScale />
       </ComposedChart>
     );
   },

--- a/test/cartesian/Bar.spec.tsx
+++ b/test/cartesian/Bar.spec.tsx
@@ -924,7 +924,7 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
             <Bar isAnimationActive={false} label={spy} dataKey="value" />
           </ChartElement>,
         );
-        expect(spy).toHaveBeenCalledTimes(2 * data.length);
+        expect(spy).toHaveBeenCalledTimes(data.length);
         expect(spy).toBeCalledWith(
           {
             content: spy,

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -1689,7 +1689,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3400]);
-      expect(axisDomainSpy).toHaveBeenCalledTimes(3);
+      expect(axisDomainSpy).toHaveBeenCalledTimes(2);
       rerender(
         <BarChart data={dataWithError} width={500} height={500}>
           <YAxis dataKey="uv" />
@@ -1802,7 +1802,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3600]);
-      expect(axisDomainSpy).toHaveBeenCalledTimes(8);
+      expect(axisDomainSpy).toHaveBeenCalledTimes(5);
     });
 
     it('should extend YAxis domain when data is defined on the graphical item', () => {
@@ -1849,7 +1849,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3400]);
-      expect(axisDomainSpy).toHaveBeenCalledTimes(3);
+      expect(axisDomainSpy).toHaveBeenCalledTimes(2);
 
       rerender(
         <LineChart width={500} height={500}>
@@ -1963,7 +1963,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 3600]);
-      expect(axisDomainSpy).toHaveBeenCalledTimes(8);
+      expect(axisDomainSpy).toHaveBeenCalledTimes(5);
     });
 
     it('should extend XAxis domain', () => {
@@ -2011,7 +2011,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(xAxisDomainSpy).toHaveBeenLastCalledWith([0, 3400]);
-      expect(xAxisDomainSpy).toHaveBeenCalledTimes(3);
+      expect(xAxisDomainSpy).toHaveBeenCalledTimes(2);
       expectBars(container, [
         {
           d: 'M 65,16.5 h 252.94117647058823 v 92 h -252.94117647058823 Z',
@@ -2159,7 +2159,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(xAxisDomainSpy).toHaveBeenLastCalledWith([0, 3600]);
-      expect(xAxisDomainSpy).toHaveBeenCalledTimes(8);
+      expect(xAxisDomainSpy).toHaveBeenCalledTimes(5);
       expectBars(container, [
         {
           d: 'M 65,16.5 h 238.8888888888889 v 92 h -238.8888888888889 Z',
@@ -2240,7 +2240,7 @@ describe('<ErrorBar />', () => {
         },
       ]);
       expect(xAxisSpy).toHaveBeenLastCalledWith([0, 3400]);
-      expect(xAxisSpy).toHaveBeenCalledTimes(3);
+      expect(xAxisSpy).toHaveBeenCalledTimes(2);
 
       rerender(
         <LineChart width={500} height={500}>

--- a/test/cartesian/Line.spec.tsx
+++ b/test/cartesian/Line.spec.tsx
@@ -120,7 +120,7 @@ describe('<Line />', () => {
         direction: 'y',
       },
     ]);
-    expect(spy).toHaveBeenCalledTimes(5);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 
   it('should report its ErrorBars to state in vertical chart', () => {
@@ -145,7 +145,7 @@ describe('<Line />', () => {
         direction: 'x',
       },
     ]);
-    expect(spy).toHaveBeenCalledTimes(5);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 
   describe('Tooltip integration', () => {
@@ -178,7 +178,7 @@ describe('<Line />', () => {
           value: 50,
         },
       ]);
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/test/cartesian/ReferenceArea.spec.tsx
+++ b/test/cartesian/ReferenceArea.spec.tsx
@@ -478,7 +478,7 @@ describe('<ReferenceArea />', () => {
           <ReferenceArea x1="201106" x2="201110" fill="#666" shape={spy} radius={10} strokeWidth={3} />
         </BarChart>,
       );
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith({
         clipPath: undefined,
         fill: '#666',
@@ -588,7 +588,7 @@ describe('<ReferenceArea />', () => {
           yAxisId: 0,
         },
       ]);
-      expect(areaSpy).toHaveBeenCalledTimes(3);
+      expect(areaSpy).toHaveBeenCalledTimes(2);
 
       rerender(
         <BarChart width={200} height={200} data={data}>
@@ -600,7 +600,7 @@ describe('<ReferenceArea />', () => {
       );
 
       expect(areaSpy).toHaveBeenLastCalledWith([]);
-      expect(areaSpy).toHaveBeenCalledTimes(6);
+      expect(areaSpy).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/test/cartesian/ReferenceDot.spec.tsx
+++ b/test/cartesian/ReferenceDot.spec.tsx
@@ -371,7 +371,7 @@ describe('<ReferenceDot />', () => {
           ifOverflow: 'extendDomain',
         },
       ]);
-      expect(dotSpy).toHaveBeenCalledTimes(3);
+      expect(dotSpy).toHaveBeenCalledTimes(2);
 
       rerender(
         <LineChart width={100} height={100}>
@@ -382,7 +382,7 @@ describe('<ReferenceDot />', () => {
       );
 
       expect(dotSpy).toHaveBeenLastCalledWith([]);
-      expect(dotSpy).toHaveBeenCalledTimes(6);
+      expect(dotSpy).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
+++ b/test/cartesian/ReferenceLine/ReferenceLine.spec.tsx
@@ -360,7 +360,7 @@ describe('<ReferenceLine />', () => {
         <ReferenceLine y={20} ifOverflow="visible" shape={spy} viewBox={viewBox} />
       </BarChart>,
     );
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith({
       clipPath: undefined,
       fill: 'none',
@@ -528,7 +528,7 @@ describe('<ReferenceLine />', () => {
           yAxisId: 0,
         },
       ]);
-      expect(lineSpy).toHaveBeenCalledTimes(3);
+      expect(lineSpy).toHaveBeenCalledTimes(2);
 
       rerender(
         <BarChart width={1100} height={250}>
@@ -539,7 +539,7 @@ describe('<ReferenceLine />', () => {
       );
 
       expect(lineSpy).toHaveBeenLastCalledWith([]);
-      expect(lineSpy).toHaveBeenCalledTimes(6);
+      expect(lineSpy).toHaveBeenCalledTimes(4);
     });
   });
 

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -527,7 +527,7 @@ describe('<XAxis />', () => {
     );
 
     expect(barBandSizeSpy).toHaveBeenLastCalledWith(28.16326530612244);
-    expect(barBandSizeSpy).toHaveBeenCalledTimes(3);
+    expect(barBandSizeSpy).toHaveBeenCalledTimes(2);
 
     expect(offsetSpy).toHaveBeenLastCalledWith({
       brushBottom: 35,
@@ -538,10 +538,10 @@ describe('<XAxis />', () => {
       width: 230,
       height: 260,
     });
-    expect(offsetSpy).toHaveBeenCalledTimes(3);
+    expect(offsetSpy).toHaveBeenCalledTimes(2);
 
     expect(yAxisRangeSpy).toHaveBeenLastCalledWith([265, 5]);
-    expect(yAxisRangeSpy).toHaveBeenCalledTimes(3);
+    expect(yAxisRangeSpy).toHaveBeenCalledTimes(2);
 
     expect(barTicksSpy).toHaveBeenLastCalledWith([
       {
@@ -581,7 +581,7 @@ describe('<XAxis />', () => {
         value: 110,
       },
     ]);
-    expect(barTicksSpy).toHaveBeenCalledTimes(3);
+    expect(barTicksSpy).toHaveBeenCalledTimes(2);
 
     expectBars(container, [
       {
@@ -1313,7 +1313,7 @@ describe('<XAxis />', () => {
         stackId: undefined,
       },
     ]);
-    expect(barSizeListSpy).toHaveBeenCalledTimes(3);
+    expect(barSizeListSpy).toHaveBeenCalledTimes(2);
 
     expect(yAxisTicksSpy).toHaveBeenLastCalledWith([
       {
@@ -1342,10 +1342,10 @@ describe('<XAxis />', () => {
         value: 200,
       },
     ]);
-    expect(yAxisTicksSpy).toHaveBeenCalledTimes(3);
+    expect(yAxisTicksSpy).toHaveBeenCalledTimes(2);
 
     expect(barBandSizeSpy).toHaveBeenLastCalledWith(0);
-    expect(barBandSizeSpy).toHaveBeenCalledTimes(3);
+    expect(barBandSizeSpy).toHaveBeenCalledTimes(2);
 
     expect(barPositionsSpy).toHaveBeenLastCalledWith([
       {
@@ -1357,7 +1357,7 @@ describe('<XAxis />', () => {
         stackId: undefined,
       },
     ]);
-    expect(barPositionsSpy).toHaveBeenCalledTimes(3);
+    expect(barPositionsSpy).toHaveBeenCalledTimes(2);
 
     expect(chartDataSpy).toHaveBeenLastCalledWith({
       chartData: [
@@ -1370,7 +1370,7 @@ describe('<XAxis />', () => {
       dataEndIndex: 0,
       dataStartIndex: 0,
     });
-    expect(chartDataSpy).toHaveBeenCalledTimes(3);
+    expect(chartDataSpy).toHaveBeenCalledTimes(2);
 
     expectBars(container, [
       {
@@ -1958,7 +1958,7 @@ describe('<XAxis />', () => {
         </BarChart>,
       );
       expect(container.querySelector('.xAxis')).toBeVisible();
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(2);
       const expectedSettings: XAxisSettings = {
         angle: 13,
         minTickGap: 9,
@@ -4774,7 +4774,7 @@ describe('<XAxis />', () => {
       expect(itemDataSpy).toHaveBeenLastCalledWith([]);
       expect(itemDataSpy).toHaveBeenCalledTimes(3);
       expect(displayedDataSpy).toHaveBeenLastCalledWith(pageData);
-      expect(axisDomainSpy).toHaveBeenCalledTimes(4);
+      expect(axisDomainSpy).toHaveBeenCalledTimes(3);
       expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 2520]);
     });
   });

--- a/test/cartesian/YAxis.spec.tsx
+++ b/test/cartesian/YAxis.spec.tsx
@@ -930,7 +930,7 @@ describe('<YAxis />', () => {
         </BarChart>,
       );
       expect(container.querySelector('.yAxis')).toBeVisible();
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(2);
       const expectedSettings: YAxisSettings = {
         angle: 17,
         minTickGap: 8,

--- a/test/chart/AreaChart.spec.tsx
+++ b/test/chart/AreaChart.spec.tsx
@@ -244,7 +244,7 @@ describe('AreaChart', () => {
         value: 'Page G',
       },
     ]);
-    expect(xAxisTicksSpy).toHaveBeenCalledTimes(3);
+    expect(xAxisTicksSpy).toHaveBeenCalledTimes(2);
 
     // For some reason this assertion always fails but never shows what's the difference.
     // expect(areaSpy).toHaveBeenLastCalledWith({

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -294,7 +294,7 @@ describe('<BarChart />', () => {
         zAxisId: 0,
       };
       expect(barSpy).toHaveBeenLastCalledWith([expectedBar]);
-      expect(barSpy).toHaveBeenCalledTimes(3);
+      expect(barSpy).toHaveBeenCalledTimes(2);
 
       expect(sizeListSpy).toHaveBeenLastCalledWith([
         {
@@ -303,7 +303,7 @@ describe('<BarChart />', () => {
           stackId: undefined,
         },
       ]);
-      expect(sizeListSpy).toHaveBeenCalledTimes(3);
+      expect(sizeListSpy).toHaveBeenCalledTimes(2);
 
       expectBars(container, [
         {
@@ -1007,7 +1007,7 @@ describe('<BarChart />', () => {
           },
         ];
         expect(allCartesianGraphicalItemsSpy).toHaveBeenLastCalledWith(expectedItems);
-        expect(allCartesianGraphicalItemsSpy).toHaveBeenCalledTimes(3);
+        expect(allCartesianGraphicalItemsSpy).toHaveBeenCalledTimes(2);
 
         expect(axisOneBarsSpy).toHaveBeenLastCalledWith([
           {
@@ -1024,7 +1024,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
         ]);
-        expect(axisOneBarsSpy).toHaveBeenCalledTimes(3);
+        expect(axisOneBarsSpy).toHaveBeenCalledTimes(2);
         expect(axisTwoBarsSpy).toHaveBeenLastCalledWith([
           {
             isPanorama: false,
@@ -1040,7 +1040,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
         ]);
-        expect(axisTwoBarsSpy).toHaveBeenCalledTimes(3);
+        expect(axisTwoBarsSpy).toHaveBeenCalledTimes(2);
 
         expectBars(container, [
           {
@@ -1191,7 +1191,7 @@ describe('<BarChart />', () => {
           },
         ];
         expect(allCartesianGraphicalItemsSpy).toHaveBeenLastCalledWith(expectedItems);
-        expect(allCartesianGraphicalItemsSpy).toHaveBeenCalledTimes(3);
+        expect(allCartesianGraphicalItemsSpy).toHaveBeenCalledTimes(2);
 
         expect(axisLeftBarsSpy).toHaveBeenLastCalledWith([
           {
@@ -1221,7 +1221,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
         ]);
-        expect(axisLeftBarsSpy).toHaveBeenCalledTimes(3);
+        expect(axisLeftBarsSpy).toHaveBeenCalledTimes(2);
 
         expect(axisRightBarsSpy).toHaveBeenLastCalledWith([
           {
@@ -1251,7 +1251,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
         ]);
-        expect(axisRightBarsSpy).toHaveBeenCalledTimes(3);
+        expect(axisRightBarsSpy).toHaveBeenCalledTimes(2);
 
         expect(barSizeListLeftSpy).toHaveBeenLastCalledWith([
           {
@@ -1265,7 +1265,7 @@ describe('<BarChart />', () => {
             stackId: undefined,
           },
         ]);
-        expect(barSizeListLeftSpy).toHaveBeenCalledTimes(3);
+        expect(barSizeListLeftSpy).toHaveBeenCalledTimes(2);
 
         expect(barSizeListRightSpy).toHaveBeenLastCalledWith([
           {
@@ -1279,7 +1279,7 @@ describe('<BarChart />', () => {
             stackId: undefined,
           },
         ]);
-        expect(barSizeListRightSpy).toHaveBeenCalledTimes(3);
+        expect(barSizeListRightSpy).toHaveBeenCalledTimes(2);
 
         expect(barPositionsLeftSpy).toHaveBeenLastCalledWith([
           {
@@ -1299,7 +1299,7 @@ describe('<BarChart />', () => {
             stackId: undefined,
           },
         ]);
-        expect(barPositionsLeftSpy).toHaveBeenCalledTimes(3);
+        expect(barPositionsLeftSpy).toHaveBeenCalledTimes(2);
 
         expect(barPositionsRightSpy).toHaveBeenLastCalledWith([
           {
@@ -1319,7 +1319,7 @@ describe('<BarChart />', () => {
             stackId: undefined,
           },
         ]);
-        expect(barPositionsRightSpy).toHaveBeenCalledTimes(3);
+        expect(barPositionsRightSpy).toHaveBeenCalledTimes(2);
 
         expectBars(container, [
           {
@@ -1446,7 +1446,7 @@ describe('<BarChart />', () => {
           },
         ];
         expect(allCartesianGraphicalItemsSpy).toHaveBeenLastCalledWith(expectedItems);
-        expect(allCartesianGraphicalItemsSpy).toHaveBeenCalledTimes(3);
+        expect(allCartesianGraphicalItemsSpy).toHaveBeenCalledTimes(2);
 
         expect(axisOneBarsSpy).toHaveBeenLastCalledWith([
           {
@@ -1476,7 +1476,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
         ]);
-        expect(axisOneBarsSpy).toHaveBeenCalledTimes(3);
+        expect(axisOneBarsSpy).toHaveBeenCalledTimes(2);
 
         expect(axisTwoBarsSpy).toHaveBeenLastCalledWith([
           {
@@ -1506,7 +1506,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
         ]);
-        expect(axisTwoBarsSpy).toHaveBeenCalledTimes(3);
+        expect(axisTwoBarsSpy).toHaveBeenCalledTimes(2);
 
         expectBars(container, [
           {
@@ -1657,7 +1657,7 @@ describe('<BarChart />', () => {
           },
         ];
         expect(allCartesianGraphicalItemsSpy).toHaveBeenLastCalledWith(expectedItems);
-        expect(allCartesianGraphicalItemsSpy).toHaveBeenCalledTimes(3);
+        expect(allCartesianGraphicalItemsSpy).toHaveBeenCalledTimes(2);
 
         expect(axisLeftBarsSpy).toHaveBeenLastCalledWith([
           {
@@ -1674,7 +1674,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
         ]);
-        expect(axisLeftBarsSpy).toHaveBeenCalledTimes(3);
+        expect(axisLeftBarsSpy).toHaveBeenCalledTimes(2);
 
         expect(axisRightBarsSpy).toHaveBeenLastCalledWith([
           {
@@ -1691,7 +1691,7 @@ describe('<BarChart />', () => {
             zAxisId: 0,
           },
         ]);
-        expect(axisRightBarsSpy).toHaveBeenCalledTimes(3);
+        expect(axisRightBarsSpy).toHaveBeenCalledTimes(2);
 
         expect(barSizeListLeftSpy).toHaveBeenLastCalledWith([
           {
@@ -1700,7 +1700,7 @@ describe('<BarChart />', () => {
             stackId: undefined,
           },
         ]);
-        expect(barSizeListLeftSpy).toHaveBeenCalledTimes(3);
+        expect(barSizeListLeftSpy).toHaveBeenCalledTimes(2);
 
         expect(barSizeListRightSpy).toHaveBeenLastCalledWith([
           {
@@ -1709,7 +1709,7 @@ describe('<BarChart />', () => {
             stackId: undefined,
           },
         ]);
-        expect(barSizeListRightSpy).toHaveBeenCalledTimes(3);
+        expect(barSizeListRightSpy).toHaveBeenCalledTimes(2);
 
         expect(barPositionsLeftSpy).toHaveBeenLastCalledWith([
           {
@@ -1721,7 +1721,7 @@ describe('<BarChart />', () => {
             stackId: undefined,
           },
         ]);
-        expect(barPositionsLeftSpy).toHaveBeenCalledTimes(3);
+        expect(barPositionsLeftSpy).toHaveBeenCalledTimes(2);
 
         expect(barPositionsRightSpy).toHaveBeenLastCalledWith([
           {
@@ -1733,7 +1733,7 @@ describe('<BarChart />', () => {
             stackId: undefined,
           },
         ]);
-        expect(barPositionsRightSpy).toHaveBeenCalledTimes(3);
+        expect(barPositionsRightSpy).toHaveBeenCalledTimes(2);
 
         expectBars(container, [
           {
@@ -1844,7 +1844,7 @@ describe('<BarChart />', () => {
           stackId: undefined,
         },
       ]);
-      expect(barPositionsSpy).toHaveBeenCalledTimes(4);
+      expect(barPositionsSpy).toHaveBeenCalledTimes(3);
 
       expectBars(container, [
         {

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -815,7 +815,7 @@ describe('<LineChart />', () => {
           value: undefined,
         },
       ]);
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -1060,7 +1060,7 @@ describe('<Legend />', () => {
       expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(1);
 
       expect(yAxisRangeSpy).toHaveBeenLastCalledWith([485, 5]);
-      expect(yAxisRangeSpy).toHaveBeenCalledTimes(5);
+      expect(yAxisRangeSpy).toHaveBeenCalledTimes(4);
 
       expectBars(container, [
         {
@@ -1123,7 +1123,7 @@ describe('<Legend />', () => {
       expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(0);
 
       expect(yAxisRangeSpy).toHaveBeenLastCalledWith([495, 5]);
-      expect(yAxisRangeSpy).toHaveBeenCalledTimes(8);
+      expect(yAxisRangeSpy).toHaveBeenCalledTimes(6);
 
       expectBars(container, [
         {
@@ -1663,7 +1663,7 @@ describe('<Legend />', () => {
             spy(offset);
           },
         )();
-        expect(spy).toHaveBeenCalledTimes(5);
+        expect(spy).toHaveBeenCalledTimes(4);
         expect(spy).toHaveBeenLastCalledWith({
           brushBottom: 5,
           top: 5,
@@ -1692,7 +1692,7 @@ describe('<Legend />', () => {
             spy(offset);
           },
         )();
-        expect(spy).toHaveBeenCalledTimes(5);
+        expect(spy).toHaveBeenCalledTimes(3);
         expect(spy).toHaveBeenLastCalledWith({
           brushBottom: 5,
           top: 5,
@@ -1721,7 +1721,7 @@ describe('<Legend />', () => {
             spy(offset);
           },
         )();
-        expect(spy).toHaveBeenCalledTimes(5);
+        expect(spy).toHaveBeenCalledTimes(4);
         expect(spy).toHaveBeenLastCalledWith({
           brushBottom: 5,
           top: 5,
@@ -1750,7 +1750,7 @@ describe('<Legend />', () => {
             spy(offset);
           },
         )();
-        expect(spy).toHaveBeenCalledTimes(5);
+        expect(spy).toHaveBeenCalledTimes(4);
         expect(spy).toHaveBeenLastCalledWith({
           brushBottom: 5,
           top: 5,
@@ -3517,7 +3517,7 @@ describe('<Legend />', () => {
         },
       };
       expect(legendSpy).toHaveBeenLastCalledWith(expectedAfterFirstRender);
-      expect(legendSpy).toHaveBeenCalledTimes(4);
+      expect(legendSpy).toHaveBeenCalledTimes(3);
 
       rerender(
         <BarChart width={500} height={500} data={numericalData}>
@@ -3538,7 +3538,7 @@ describe('<Legend />', () => {
         },
       };
       expect(legendSpy).toHaveBeenLastCalledWith(expectedAfterSecondRender);
-      expect(legendSpy).toHaveBeenCalledTimes(7);
+      expect(legendSpy).toHaveBeenCalledTimes(5);
     });
   });
 });

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -1385,7 +1385,7 @@ describe('Tooltip payload', () => {
           },
         },
       ]);
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(2);
     });
 
     it('should select Tooltip payload after mouse hover', () => {

--- a/test/context/chartLayoutContext.spec.tsx
+++ b/test/context/chartLayoutContext.spec.tsx
@@ -446,7 +446,7 @@ describe('useOffset', () => {
       height: 120,
       width: 40,
     });
-    expect(offsetSpy).toHaveBeenCalledTimes(3);
+    expect(offsetSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should include explicit brush height in bottom property', () => {
@@ -470,7 +470,7 @@ describe('useOffset', () => {
       height: 147,
       width: 240,
     });
-    expect(offsetSpy).toHaveBeenCalledTimes(3);
+    expect(offsetSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should include default width of YAxis', () => {
@@ -495,7 +495,7 @@ describe('useOffset', () => {
       top: 10,
       width: 120,
     });
-    expect(offsetSpy).toHaveBeenCalledTimes(3);
+    expect(offsetSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should include explicit width of YAxis', () => {
@@ -520,7 +520,7 @@ describe('useOffset', () => {
       top: 10,
       width: 178,
     });
-    expect(offsetSpy).toHaveBeenCalledTimes(3);
+    expect(offsetSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should exclude hidden YAxis dimensions', () => {
@@ -545,7 +545,7 @@ describe('useOffset', () => {
       top: 10,
       width: 240,
     });
-    expect(offsetSpy).toHaveBeenCalledTimes(3);
+    expect(offsetSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should include default height of XAxis', () => {

--- a/test/polar/PolarAngleAxis.spec.tsx
+++ b/test/polar/PolarAngleAxis.spec.tsx
@@ -134,7 +134,7 @@ describe('<PolarAngleAxis />', () => {
           type: 'category',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select polar items', () => {
@@ -151,19 +151,19 @@ describe('<PolarAngleAxis />', () => {
             radiusAxisId: 0,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([420, 460, 999, 500, 864, 650, 765, 365]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([90, -270]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
@@ -175,7 +175,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select scale', () => {
         const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
         expectScale(spy, { domain: [420, 460, 999, 500, 864, 650, 765, 365], range: [90, -270] });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select ticks', () => {
@@ -230,7 +230,7 @@ describe('<PolarAngleAxis />', () => {
             value: 365,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select nice ticks', () => {
@@ -251,7 +251,7 @@ describe('<PolarAngleAxis />', () => {
           { value: 765 },
           { value: 365 },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should render axis ticks', () => {
@@ -383,7 +383,7 @@ describe('<PolarAngleAxis />', () => {
           type: 'category',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select polar items', () => {
@@ -400,19 +400,19 @@ describe('<PolarAngleAxis />', () => {
             radiusAxisId: 0,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([90, -270]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
@@ -423,7 +423,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select scale', () => {
         const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
         expectScale(spy, { domain: [0, 1, 2, 3, 4, 5, 6, 7], range: [90, -270] });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select applied data', () => {
@@ -438,7 +438,7 @@ describe('<PolarAngleAxis />', () => {
           { value: 765 },
           { value: 365 },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should render ticks', () => {
@@ -586,7 +586,7 @@ describe('<PolarAngleAxis />', () => {
             radiusAxisId: 0,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select applied values', () => {
@@ -606,13 +606,13 @@ describe('<PolarAngleAxis />', () => {
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([90, -270]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
@@ -623,7 +623,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select scale', () => {
         const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
         expectScale(spy, { domain: [0, 1, 2, 3, 4, 5, 6, 7], range: [90, -270] });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should not render ticks', () => {
@@ -672,7 +672,7 @@ describe('<PolarAngleAxis />', () => {
           type: 'number',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select polar items', () => {
@@ -689,31 +689,31 @@ describe('<PolarAngleAxis />', () => {
             radiusAxisId: 0,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 360]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([90, -270]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith('linear');
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select scale', () => {
         const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
         expectScale(spy, { domain: [0, 360], range: [90, -270] });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select ticks', () => {
@@ -744,7 +744,7 @@ describe('<PolarAngleAxis />', () => {
             value: 270,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select nice ticks', () => {
@@ -756,7 +756,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select applied data', () => {
         const { spy } = renderTestCase(state => selectPolarAppliedValues(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([{ value: 0 }, { value: 90 }, { value: 180 }, { value: 270 }]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should render axis ticks', () => {
@@ -2337,7 +2337,7 @@ describe('<PolarAngleAxis />', () => {
         </RadarChart>,
       );
       expect(angleAxisSpy).toHaveBeenLastCalledWith(implicitAngleAxis);
-      expect(angleAxisSpy).toHaveBeenCalledTimes(5);
+      expect(angleAxisSpy).toHaveBeenCalledTimes(4);
     });
 
     it('should select angle axis settings', () => {
@@ -2407,16 +2407,16 @@ describe('<PolarAngleAxis />', () => {
         unit: undefined,
       };
       expect(axisSettingsSpy).toHaveBeenLastCalledWith(expectedSettings);
-      expect(axisSettingsSpy).toHaveBeenCalledTimes(3);
+      expect(axisSettingsSpy).toHaveBeenCalledTimes(2);
 
       expect(angleAxisRangeSpy).toHaveBeenLastCalledWith([-270, 90]);
-      expect(angleAxisRangeSpy).toHaveBeenCalledTimes(3);
+      expect(angleAxisRangeSpy).toHaveBeenCalledTimes(2);
 
       expect(angleAxisDomainSpy).toHaveBeenLastCalledWith([420, 460, 999, 500, 864, 650, 765, 365]);
-      expect(angleAxisDomainSpy).toHaveBeenCalledTimes(3);
+      expect(angleAxisDomainSpy).toHaveBeenCalledTimes(2);
 
       expect(angleAxisScaleSpy).toHaveBeenLastCalledWith(expect.any(Function));
-      expect(angleAxisScaleSpy).toHaveBeenCalledTimes(3);
+      expect(angleAxisScaleSpy).toHaveBeenCalledTimes(2);
 
       expectScale(angleAxisScaleSpy, { domain: [420, 365], range: [-270, 90] });
 
@@ -2472,10 +2472,10 @@ describe('<PolarAngleAxis />', () => {
           value: 10,
         },
       ]);
-      expect(angleAxisTicksSpy).toHaveBeenCalledTimes(3);
+      expect(angleAxisTicksSpy).toHaveBeenCalledTimes(2);
 
       expect(angleAxisNiceTicksSpy).toHaveBeenLastCalledWith(undefined);
-      expect(angleAxisNiceTicksSpy).toHaveBeenCalledTimes(3);
+      expect(angleAxisNiceTicksSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/test/polar/PolarRadiusAxis.spec.tsx
+++ b/test/polar/PolarRadiusAxis.spec.tsx
@@ -99,13 +99,13 @@ describe('<PolarRadiusAxis />', () => {
           type: 'number',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 999]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
@@ -117,7 +117,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 1000]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select range', () => {
@@ -132,7 +132,7 @@ describe('<PolarRadiusAxis />', () => {
           domain: [0, 1000],
           range: [0, 196],
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should render ticks', () => {
@@ -216,7 +216,7 @@ describe('<PolarRadiusAxis />', () => {
           type: 'category',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select domain', () => {
@@ -231,13 +231,13 @@ describe('<PolarRadiusAxis />', () => {
           'iPhone 6s',
           'iPhone 5se',
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith('band');
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select domain with nice ticks', () => {
@@ -252,7 +252,7 @@ describe('<PolarRadiusAxis />', () => {
           'iPhone 6s',
           'iPhone 5se',
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should render ticks', () => {
@@ -349,13 +349,13 @@ describe('<PolarRadiusAxis />', () => {
           type: 'number',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 999]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
@@ -367,7 +367,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 1000]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select range', () => {
@@ -382,7 +382,7 @@ describe('<PolarRadiusAxis />', () => {
           domain: [0, 1000],
           range: [0, 196],
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should render ticks', () => {
@@ -446,7 +446,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 999]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
@@ -458,7 +458,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 1000]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select range', () => {
@@ -473,7 +473,7 @@ describe('<PolarRadiusAxis />', () => {
           domain: [0, 1000],
           range: [0, 196],
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should not render ticks', () => {
@@ -1008,13 +1008,13 @@ describe('<PolarRadiusAxis />', () => {
           type: 'number',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 400]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
@@ -1026,7 +1026,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 400]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select range', () => {
@@ -1041,7 +1041,7 @@ describe('<PolarRadiusAxis />', () => {
           domain: [0, 400],
           range: [0, 196],
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should render ticks', () => {
@@ -1127,7 +1127,7 @@ describe('<PolarRadiusAxis />', () => {
         </RadarChart>,
       );
       expect(radiusAxisSpy).toHaveBeenLastCalledWith(implicitRadiusAxis);
-      expect(radiusAxisSpy).toHaveBeenCalledTimes(5);
+      expect(radiusAxisSpy).toHaveBeenCalledTimes(4);
     });
 
     it('should select radius axis settings', () => {
@@ -1182,13 +1182,13 @@ describe('<PolarRadiusAxis />', () => {
         unit: undefined,
       };
       expect(radiusAxisSpy).toHaveBeenLastCalledWith(expectedAxis);
-      expect(radiusAxisSpy).toHaveBeenCalledTimes(3);
+      expect(radiusAxisSpy).toHaveBeenCalledTimes(2);
 
       expect(radiusAxisRangeSpy).toHaveBeenLastCalledWith([76, 0]);
-      expect(radiusAxisRangeSpy).toHaveBeenCalledTimes(3);
+      expect(radiusAxisRangeSpy).toHaveBeenCalledTimes(2);
 
       expect(radiusAxisDomainSpy).toHaveBeenLastCalledWith([420, 460, 999, 500, 864, 650, 765, 365]);
-      expect(radiusAxisDomainSpy).toHaveBeenCalledTimes(3);
+      expect(radiusAxisDomainSpy).toHaveBeenCalledTimes(2);
     });
 
     it('should select numerical radius axis domain', () => {
@@ -1210,10 +1210,10 @@ describe('<PolarRadiusAxis />', () => {
       );
 
       expect(radiusAxisDomainSpy).toHaveBeenLastCalledWith([0, 999]);
-      expect(radiusAxisDomainSpy).toHaveBeenCalledTimes(3);
+      expect(radiusAxisDomainSpy).toHaveBeenCalledTimes(2);
 
       expect(realScaleTypeSpy).toHaveBeenLastCalledWith('linear');
-      expect(realScaleTypeSpy).toHaveBeenCalledTimes(3);
+      expect(realScaleTypeSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/test/polar/Radar.spec.tsx
+++ b/test/polar/Radar.spec.tsx
@@ -144,7 +144,7 @@ describe('<Radar />', () => {
         radiusAxisId: 0,
       };
       expect(polarItemsSpy).toHaveBeenLastCalledWith([expectedPolarItemsSettings]);
-      expect(polarItemsSpy).toHaveBeenCalledTimes(3);
+      expect(polarItemsSpy).toHaveBeenCalledTimes(2);
 
       rerender(
         <RadarChart width={100} height={100} data={exampleRadarData}>
@@ -153,7 +153,7 @@ describe('<Radar />', () => {
       );
 
       expect(polarItemsSpy).toHaveBeenLastCalledWith([]);
-      expect(polarItemsSpy).toHaveBeenCalledTimes(6);
+      expect(polarItemsSpy).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/test/polar/RadialBar.spec.tsx
+++ b/test/polar/RadialBar.spec.tsx
@@ -1053,7 +1053,7 @@ describe('<RadialBar />', () => {
       );
 
       expect(polarItemsSpy).toHaveBeenLastCalledWith([]);
-      expect(polarItemsSpy).toHaveBeenCalledTimes(6);
+      expect(polarItemsSpy).toHaveBeenCalledTimes(5);
     });
   });
 });

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -92,7 +92,7 @@ describe('selectAxisScale', () => {
       </BarChart>,
     );
     expect(container.querySelector('.xAxis')).toBeVisible();
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
     expect(spy).toHaveBeenCalledWith(expect.any(Function));
   });
 
@@ -111,7 +111,7 @@ describe('selectAxisScale', () => {
       </BarChart>,
     );
     expect(container.querySelector('.xAxis')).toBeVisible();
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
     expect(spy).toHaveBeenLastCalledWith(expect.any(Function));
   });
 
@@ -318,11 +318,11 @@ describe('selectAxisDomain', () => {
       </LineChart>,
     );
     expect(axisDomainSpy).toHaveBeenLastCalledWith([481, 672, 721, 446, 598, 774, 687, 762, 439, 569]);
-    expect(axisDomainSpy).toHaveBeenCalledTimes(3);
+    expect(axisDomainSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should be stable', () => {
-    expect.assertions(3);
+    expect.assertions(2);
     const Comp = (): null => {
       const isPanorama = useIsPanorama();
       const result1 = useAppSelector(state => selectAxisDomain(state, 'xAxis', defaultAxisId, isPanorama));
@@ -392,12 +392,12 @@ describe('selectAxisDomain', () => {
     expect(domainRightSpy).toHaveBeenLastCalledWith([0, 1520]);
     expect(domainRightIncludingNiceTicksSpy).toHaveBeenLastCalledWith([0, 1600]);
     expect(scaleRightSpy).toHaveBeenLastCalledWith([0, 1600]);
-    expect(domainLeftSpy).toHaveBeenCalledTimes(4);
-    expect(domainLeftIncludingNiceTicksSpy).toHaveBeenCalledTimes(4);
-    expect(scaleLeftSpy).toHaveBeenCalledTimes(4);
-    expect(domainRightSpy).toHaveBeenCalledTimes(4);
-    expect(domainRightIncludingNiceTicksSpy).toHaveBeenCalledTimes(4);
-    expect(scaleRightSpy).toHaveBeenCalledTimes(4);
+    expect(domainLeftSpy).toHaveBeenCalledTimes(3);
+    expect(domainLeftIncludingNiceTicksSpy).toHaveBeenCalledTimes(3);
+    expect(scaleLeftSpy).toHaveBeenCalledTimes(3);
+    expect(domainRightSpy).toHaveBeenCalledTimes(3);
+    expect(domainRightIncludingNiceTicksSpy).toHaveBeenCalledTimes(3);
+    expect(scaleRightSpy).toHaveBeenCalledTimes(3);
   });
 
   it('should return nothing for graphical items that do not have any explicit data prop on them', () => {
@@ -1633,7 +1633,7 @@ describe('selectCartesianGraphicalItemsData', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith([]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should return all data defined on graphical items', () => {
@@ -1661,7 +1661,7 @@ describe('selectCartesianGraphicalItemsData', () => {
       // the arrayContaining is there because it ignores elements order.
       expect.arrayContaining([7, 8, 9, 70, 80, 90, 1, 2, 3, 10, 20, 30, 4, 5, 6, 40, 50, 60]),
     );
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should return nothing for graphical items that do not have any explicit data prop on them', () => {
@@ -1875,7 +1875,7 @@ describe('selectDisplayedData', () => {
         z: 1305,
       },
     ]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should be stable', () => {
@@ -1978,7 +1978,7 @@ describe('selectDisplayedData', () => {
         z: 1305,
       },
     ]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should return data defined in all graphical items based on the input dataKey, and default axis ID', () => {
@@ -2011,7 +2011,7 @@ describe('selectDisplayedData', () => {
       { value: 293 },
       { value: 244 },
     ]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should return data defined in graphical items with matching axis ID', () => {
@@ -2100,12 +2100,12 @@ describe('selectDisplayedData', () => {
     ]);
     expect(axisDomainSpy1).toHaveBeenLastCalledWith([280, 294, 239, 293, 244]);
     expect(axisDomainSpy2).toHaveBeenLastCalledWith([481, 672, 721, 446, 598]);
-    expect(axisDomainSpy1).toHaveBeenCalledTimes(3);
-    expect(axisDomainSpy2).toHaveBeenCalledTimes(3);
+    expect(axisDomainSpy1).toHaveBeenCalledTimes(2);
+    expect(axisDomainSpy2).toHaveBeenCalledTimes(2);
     expect(displayedDataSpy1).toHaveBeenLastCalledWith(data2);
     expect(displayedDataSpy2).toHaveBeenLastCalledWith(data1);
-    expect(displayedDataSpy1).toHaveBeenCalledTimes(3);
-    expect(displayedDataSpy2).toHaveBeenCalledTimes(3);
+    expect(displayedDataSpy1).toHaveBeenCalledTimes(2);
+    expect(displayedDataSpy2).toHaveBeenCalledTimes(2);
   });
 
   it('should gather data from all graphical items that match the axis ID', () => {
@@ -2123,7 +2123,7 @@ describe('selectDisplayedData', () => {
       </LineChart>,
     );
     expect(displayedDataSpy).toHaveBeenLastCalledWith(mockData);
-    expect(displayedDataSpy).toHaveBeenCalledTimes(3);
+    expect(displayedDataSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should return data defined in the chart root', () => {
@@ -2172,7 +2172,7 @@ describe('selectDisplayedData', () => {
         z: 1184,
       },
     ]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should return data defined in the chart root regardless of the axis ID match', () => {
@@ -2223,7 +2223,7 @@ describe('selectDisplayedData', () => {
         z: 1184,
       },
     ]);
-    expect(displayedDataSpy).toHaveBeenCalledTimes(3);
+    expect(displayedDataSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should slice chart root data by dataStartIndex and dataEndIndex', () => {
@@ -2267,7 +2267,7 @@ describe('selectDisplayedData', () => {
         z: 1184,
       },
     ]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -2313,7 +2313,7 @@ describe('selectAllAppliedValues', () => {
       </LineChart>,
     );
     expect(spy).toHaveBeenLastCalledWith([]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should return all data defined in all graphical items based on the input dataKey, and default axis ID', () => {
@@ -2342,7 +2342,7 @@ describe('selectAllAppliedValues', () => {
       { value: 20 },
       { value: 30 },
     ]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should return data defined in the chart root', () => {
@@ -2369,7 +2369,7 @@ describe('selectAllAppliedValues', () => {
       { value: 140 },
       { value: 131 },
     ]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should return values as full input objects if the axis ID does not match anything in the data', () => {
@@ -2430,7 +2430,7 @@ describe('selectAllAppliedValues', () => {
         },
       },
     ]);
-    expect(displayedDataSpy).toHaveBeenCalledTimes(3);
+    expect(displayedDataSpy).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -2454,7 +2454,7 @@ describe('selectErrorBarsSettings', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith([]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 
   it('should return empty array if there is no axis with matching ID', () => {
@@ -2478,8 +2478,8 @@ describe('selectErrorBarsSettings', () => {
     // There are ErrorBars but they are specified for another XAxis
     expect(xAxisSpy).toHaveBeenLastCalledWith([]);
     expect(yAxisSpy).toHaveBeenLastCalledWith([]);
-    expect(xAxisSpy).toHaveBeenCalledTimes(3);
-    expect(yAxisSpy).toHaveBeenCalledTimes(3);
+    expect(xAxisSpy).toHaveBeenCalledTimes(2);
+    expect(yAxisSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should return bars settings if present in BarChart', () => {
@@ -2512,8 +2512,8 @@ describe('selectErrorBarsSettings', () => {
         direction: 'y',
       },
     ]);
-    expect(xAxisSpy).toHaveBeenCalledTimes(5);
-    expect(yAxisSpy).toHaveBeenCalledTimes(5);
+    expect(xAxisSpy).toHaveBeenCalledTimes(3);
+    expect(yAxisSpy).toHaveBeenCalledTimes(3);
   });
 
   it('should return bars settings if present in LineChart', () => {
@@ -2547,8 +2547,8 @@ describe('selectErrorBarsSettings', () => {
         direction: 'y',
       },
     ]);
-    expect(xAxisSpy).toHaveBeenCalledTimes(5);
-    expect(yAxisSpy).toHaveBeenCalledTimes(5);
+    expect(xAxisSpy).toHaveBeenCalledTimes(3);
+    expect(yAxisSpy).toHaveBeenCalledTimes(3);
   });
 
   it('should return bars settings if present in vertical LineChart', () => {
@@ -2582,8 +2582,8 @@ describe('selectErrorBarsSettings', () => {
         direction: 'y',
       },
     ]);
-    expect(xAxisSpy).toHaveBeenCalledTimes(5);
-    expect(yAxisSpy).toHaveBeenCalledTimes(5);
+    expect(xAxisSpy).toHaveBeenCalledTimes(3);
+    expect(yAxisSpy).toHaveBeenCalledTimes(3);
   });
 
   it('should return bars settings if present in ScatterChart', () => {
@@ -2814,7 +2814,7 @@ describe('selectNiceTicks', () => {
       </LineChart>,
     );
     expect(niceTicksSpy).toHaveBeenLastCalledWith(expectedTicks);
-    expect(niceTicksSpy).toHaveBeenCalledTimes(3);
+    expect(niceTicksSpy).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -2973,7 +2973,7 @@ describe('selectStackGroups', () => {
     //     ],
     //   },
     // });
-    expect(stackGroupsSpy).toHaveBeenCalledTimes(3);
+    expect(stackGroupsSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should return empty object for Bars without stackId', () => {
@@ -2992,6 +2992,6 @@ describe('selectStackGroups', () => {
       </BarChart>,
     );
     expect(stackGroupsSpy).toHaveBeenLastCalledWith({});
-    expect(stackGroupsSpy).toHaveBeenCalledTimes(3);
+    expect(stackGroupsSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/test/state/selectors/brushSelectors.spec.tsx
+++ b/test/state/selectors/brushSelectors.spec.tsx
@@ -24,6 +24,6 @@ describe('selectBrushHeight', () => {
       </BarChart>,
     );
     expect(heightSpy).toHaveBeenLastCalledWith(7);
-    expect(heightSpy).toHaveBeenCalledTimes(3);
+    expect(heightSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/test/state/selectors/legendSelectors.spec.tsx
+++ b/test/state/selectors/legendSelectors.spec.tsx
@@ -51,6 +51,6 @@ describe('selectLegendState', () => {
       },
     };
     expect(legendSettingsSpy).toHaveBeenLastCalledWith(expected);
-    expect(legendSettingsSpy).toHaveBeenCalledTimes(4);
+    expect(legendSettingsSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/test/state/selectors/radarSelectors.spec.tsx
+++ b/test/state/selectors/radarSelectors.spec.tsx
@@ -162,7 +162,7 @@ describe('selectRadarPoints', () => {
         },
       ],
     });
-    expect(radarPointsSpy).toHaveBeenCalledTimes(3);
+    expect(radarPointsSpy).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/test/state/selectors/rootPropsSelectors.spec.tsx
+++ b/test/state/selectors/rootPropsSelectors.spec.tsx
@@ -49,7 +49,7 @@ describe('selectRootMaxBarSize', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith(10);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
 
     rerender(
       <BarChart width={100} height={100} maxBarSize={20}>
@@ -59,7 +59,7 @@ describe('selectRootMaxBarSize', () => {
     );
 
     expect(spy).toHaveBeenLastCalledWith(20);
-    expect(spy).toHaveBeenCalledTimes(6);
+    expect(spy).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -95,7 +95,7 @@ describe('selectBarGap', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith(10);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
 
     rerender(
       <BarChart width={100} height={100} barGap={20}>
@@ -104,7 +104,7 @@ describe('selectBarGap', () => {
     );
 
     expect(spy).toHaveBeenLastCalledWith(20);
-    expect(spy).toHaveBeenCalledTimes(5);
+    expect(spy).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -155,7 +155,7 @@ describe('selectBarCategoryGap', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith(10);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
 
     rerender(
       <BarChart width={100} height={100} barCategoryGap={20}>
@@ -164,7 +164,7 @@ describe('selectBarCategoryGap', () => {
     );
 
     expect(spy).toHaveBeenLastCalledWith(20);
-    expect(spy).toHaveBeenCalledTimes(5);
+    expect(spy).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -200,7 +200,7 @@ describe('selectRootBarSize', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith(10);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
 
     rerender(
       <BarChart width={100} height={100} barSize={20}>
@@ -209,7 +209,7 @@ describe('selectRootBarSize', () => {
     );
 
     expect(spy).toHaveBeenLastCalledWith(20);
-    expect(spy).toHaveBeenCalledTimes(5);
+    expect(spy).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -232,7 +232,7 @@ describe('selectSyncMethod', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith('value');
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
 
     const fn = () => 1;
 
@@ -243,6 +243,6 @@ describe('selectSyncMethod', () => {
     );
 
     expect(spy).toHaveBeenLastCalledWith(fn);
-    expect(spy).toHaveBeenCalledTimes(6);
+    expect(spy).toHaveBeenCalledTimes(4);
   });
 });

--- a/test/state/selectors/selectIsTooltipActive.spec.tsx
+++ b/test/state/selectors/selectIsTooltipActive.spec.tsx
@@ -75,21 +75,21 @@ describe('selectIsTooltipActive', () => {
         activeIndex: '0',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(2);
 
       showTooltip(container, barChartMouseHoverTooltipSelector);
       expect(spy).toHaveBeenLastCalledWith({
         activeIndex: '1',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(4);
+      expect(spy).toHaveBeenCalledTimes(3);
 
       hideTooltip(container, barChartMouseHoverTooltipSelector);
       expect(spy).toHaveBeenLastCalledWith({
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(5);
+      expect(spy).toHaveBeenCalledTimes(4);
     });
   });
 

--- a/test/util/isWellBehavedNumber.spec.ts
+++ b/test/util/isWellBehavedNumber.spec.ts
@@ -3,24 +3,26 @@ import { isWellBehavedNumber } from '../../src/util/isWellBehavedNumber';
 
 describe('isWellBehavedNumber', () => {
   it.each([
-    [null, false],
-    [undefined, false],
-    ['a', false],
-    ['1', false],
-    [NaN, false],
-    [Symbol('a'), false],
-    [[], false],
-    [{}, false],
-    [() => {}, false],
-    [new Date(), false],
-    [new Map(), false],
-    [new Set(), false],
-    [Infinity, false],
-    [-Infinity, false],
-    [-0, true],
-    [3, true],
-    [-3, true],
-  ])('should return %s when the input is %s', (value, expected) => {
+    [false, null],
+    [false, undefined],
+    [false, 'a'],
+    [false, '1'],
+    [false, NaN],
+    [false, Symbol('a')],
+    [false, []],
+    [false, {}],
+    [false, () => {}],
+    [false, new Date()],
+    [false, new Map()],
+    [false, new Set()],
+    [false, Infinity],
+    [false, -Infinity],
+    [true, -0],
+    [true, 3],
+    [true, -3],
+    [true, -3.1],
+    [true, 0.1],
+  ])('should return %s when the input is %s', (expected, value) => {
     expect(isWellBehavedNumber(value)).toBe(expected);
   });
 });


### PR DESCRIPTION
## Description

Let's stop storing the HTML container in the state.

I have elaborated on the reasons in https://github.com/recharts/recharts/pull/5419

## Related Issue

https://github.com/recharts/recharts/pull/5408