### PR TITLE
chore: update react-smooth version to support React 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.21",
         "react-is": "^18.3.1",
-        "react-smooth": "^4.0.0",
+        "react-smooth": "^4.0.4",
         "recharts-scale": "^0.4.4",
         "tiny-invariant": "^1.3.1",
         "victory-vendor": "^36.6.8"
@@ -21156,17 +21156,18 @@
       "dev": true
     },
     "node_modules/react-smooth": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.0.tgz",
-      "integrity": "sha512-2NMXOBY1uVUQx1jBeENGA497HK20y6CPGYL1ZnJLeoQ8rrc3UfmOM82sRxtzpcoCkUMy4CS0RGylfuVhuFjBgg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
       "dependencies": {
         "fast-equals": "^5.0.1",
         "prop-types": "^15.8.1",
         "react-transition-group": "^4.4.5"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eventemitter3": "^4.0.1",
     "lodash": "^4.17.21",
     "react-is": "^18.3.1",
-    "react-smooth": "^4.0.0",
+    "react-smooth": "^4.0.4",
     "recharts-scale": "^0.4.4",
     "tiny-invariant": "^1.3.1",
     "victory-vendor": "^36.6.8"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I've updated the react-smooth to 4.0.4 that supports React 19.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

When installing recharts, the package manager warns that react-smooth does not support React 19. This commit updates react-smooth to the latest version.

## How Has This Been Tested?

By reinstalling the packages.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
