### PR TITLE
chore: export getNiceTickValues for 3x to replace its use in recharts-scale

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,3 +107,6 @@ export type { Props as TrapezoidProps } from './shape/Trapezoid';
 
 export { Global } from './util/Global';
 export type { LegendType } from './util/types';
+
+/** export getNiceTickValues so this can be used as a replacement for what is in recharts-scale */
+export { getNiceTickValues } from './util/scale/getNiceTickValues';

--- a/src/util/scale/getNiceTickValues.ts
+++ b/src/util/scale/getNiceTickValues.ts
@@ -160,7 +160,7 @@ export const calculateStep = (
 };
 
 /**
- * Calculate the ticks of an interval, the count of ticks will be guraranteed
+ * Calculate the ticks of an interval, the count of ticks will be guaranteed
  *
  * @param  {Number}  min, max      min: The minimum value, max: The maximum value
  * @param  {Integer} tickCount     The count of ticks


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
https://github.com/recharts/recharts/issues/5346

we have users that use `getNiceTicks` from recharts scale, we removed recharts-scale in 3.x. So Re-export it in 3.x. 

This should probably be documented eventually

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5346

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
https://github.com/recharts/recharts/issues/5346

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
