### PR TITLE
Allow using custom Redux components as children inside Recharts

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -86,6 +86,7 @@
   "es6/shape/Symbols.js",
   "es6/shape/Trapezoid.js",
   "es6/state",
+  "es6/state/RechartsReduxContext.js",
   "es6/state/RechartsStoreProvider.js",
   "es6/state/ReportBar.js",
   "es6/state/ReportChartProps.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -86,6 +86,7 @@
   "lib/shape/Symbols.js",
   "lib/shape/Trapezoid.js",
   "lib/state",
+  "lib/state/RechartsReduxContext.js",
   "lib/state/RechartsStoreProvider.js",
   "lib/state/ReportBar.js",
   "lib/state/ReportChartProps.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -86,6 +86,7 @@
   "types/shape/Symbols.d.ts",
   "types/shape/Trapezoid.d.ts",
   "types/state",
+  "types/state/RechartsReduxContext.d.ts",
   "types/state/RechartsStoreProvider.d.ts",
   "types/state/ReportBar.d.ts",
   "types/state/ReportChartProps.d.ts",

--- a/src/state/RechartsReduxContext.tsx
+++ b/src/state/RechartsReduxContext.tsx
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+/**
+ * We need to use our own independent Redux context because we need to avoid interfering with other people's Redux stores
+ * in case they decide to install and use Recharts in another Redux app which is likely to happen.
+ *
+ * https://react-redux.js.org/using-react-redux/accessing-store#providing-custom-context
+ */
+export const RechartsReduxContext = createContext(null);

--- a/src/state/RechartsStoreProvider.tsx
+++ b/src/state/RechartsStoreProvider.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode, useRef } from 'react';
 import { Provider } from 'react-redux';
 import { createRechartsStore, RechartsRootState } from './store';
 import { useIsPanorama } from '../context/PanoramaContext';
+import { RechartsReduxContext } from './RechartsReduxContext';
 
 type RechartsStoreProviderProps = {
   children: ReactNode;
@@ -38,5 +39,9 @@ export function RechartsStoreProvider({ preloadedState, children, reduxStoreName
   if (storeRef.current == null) {
     storeRef.current = createRechartsStore(preloadedState, reduxStoreName);
   }
-  return <Provider store={storeRef.current}>{children}</Provider>;
+  return (
+    <Provider context={RechartsReduxContext} store={storeRef.current}>
+      {children}
+    </Provider>
+  );
 }

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -1,12 +1,13 @@
-import { ReactReduxContext } from 'react-redux';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector';
 import { useContext } from 'react';
 import { type AppDispatch, type RechartsRootState } from './store';
 
+import { RechartsReduxContext } from './RechartsReduxContext';
+
 const noopDispatch: AppDispatch = (): undefined => {};
 
 export const useAppDispatch = (): AppDispatch => {
-  const context = useContext(ReactReduxContext);
+  const context = useContext(RechartsReduxContext);
   if (context) {
     return context.store.dispatch;
   }
@@ -37,7 +38,7 @@ const refEquality: EqualityFn<unknown> = (a, b) => a === b;
  * @return whatever the selector returned; or undefined when outside of Redux store
  */
 export function useAppSelector<T>(selector: (state: RechartsRootState) => T): T | undefined {
-  const context = useContext(ReactReduxContext);
+  const context = useContext(RechartsReduxContext);
 
   return useSyncExternalStoreWithSelector<RechartsRootState | undefined, T | undefined>(
     context ? context.subscription.addNestedSub : addNestedSubNoop,

--- a/test/state/hooks.spec.tsx
+++ b/test/state/hooks.spec.tsx
@@ -6,6 +6,7 @@ import { useAppDispatch, useAppSelector } from '../../src/state/hooks';
 import { createRechartsStore } from '../../src/state/store';
 import { RechartsStoreProvider } from '../../src/state/RechartsStoreProvider';
 import { setChartData } from '../../src/state/chartDataSlice';
+import { RechartsReduxContext } from '../../src/state/RechartsReduxContext';
 
 describe('useAppSelector', () => {
   it('should return undefined when used outside of Redux context', () => {
@@ -82,7 +83,7 @@ describe('useAppDispatch', () => {
     const spy = vi.fn();
     store.subscribe(spy);
     render(
-      <Provider store={store}>
+      <Provider context={RechartsReduxContext} store={store}>
         <Dispatcher />
       </Provider>,
     );

--- a/test/state/redux-nesting.spec.tsx
+++ b/test/state/redux-nesting.spec.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import { combineReducers, configureStore, createSlice } from '@reduxjs/toolkit';
+import { Provider, useSelector } from 'react-redux';
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { Line, LineChart } from '../../src';
+import { selectChartHeight } from '../../src/state/selectors/containerSelectors';
+import { useAppSelector } from '../../src/state/hooks';
+
+const exampleSlice = createSlice({
+  name: 'example',
+  initialState: {
+    value: 0,
+  },
+  reducers: {
+    increment: state => {
+      state.value += 1;
+    },
+    reset: state => {
+      state.value = 0;
+    },
+  },
+});
+
+const exampleStore = configureStore({
+  reducer: combineReducers({ counter: exampleSlice.reducer }),
+});
+
+type ExampleState = ReturnType<typeof exampleStore.getState>;
+
+const Counter = () => {
+  const count = useSelector((state: ExampleState) => state.counter.value);
+  return <div>Current count is: {count}</div>;
+};
+
+describe('when a Recharts chart is used in another Redux app as a neighbour', () => {
+  beforeEach(() => {
+    exampleStore.dispatch(exampleSlice.actions.reset());
+  });
+
+  const App = ({ spy }: { spy?: (arg: number) => unknown }) => {
+    const Comp = (): null => {
+      const chartHeight = useAppSelector(selectChartHeight);
+      spy?.(chartHeight);
+      return null;
+    };
+    return (
+      <Provider store={exampleStore}>
+        <LineChart width={200} height={100}>
+          <Line dataKey="value" />
+          <Comp />
+        </LineChart>
+        {/* My custom app with custom state, next to Recharts chart, looks straightforward */}
+        <Counter />
+      </Provider>
+    );
+  };
+
+  it('should allow selecting data from recharts store', () => {
+    const spy = vi.fn();
+    render(<App spy={spy} />);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenLastCalledWith(100);
+  });
+
+  it('should allow selecting data from the parent app store', () => {
+    const { container } = render(<App />);
+    expect(exampleStore.getState()).toEqual({ counter: { value: 0 } });
+    expect(container).toHaveTextContent('Current count is: 0');
+
+    act(() => {
+      exampleStore.dispatch(exampleSlice.actions.increment());
+    });
+
+    expect(exampleStore.getState()).toEqual({ counter: { value: 1 } });
+    expect(container).toHaveTextContent('Current count is: 1');
+  });
+});
+
+describe('when a Recharts chart is used in another Redux app as a parent', () => {
+  beforeEach(() => {
+    exampleStore.dispatch(exampleSlice.actions.reset());
+  });
+
+  const App = ({ spy }: { spy?: (arg: number) => unknown }) => {
+    const Comp = (): null => {
+      const chartHeight = useAppSelector(selectChartHeight);
+      spy?.(chartHeight);
+      return null;
+    };
+    return (
+      <Provider store={exampleStore}>
+        <LineChart width={200} height={100}>
+          <Line dataKey="value" />
+          <Comp />
+          {/*
+           * So here I have my custom app with custom state, _inside_ the Recharts chart.
+           * This should work too! Recharts should work independently of the internal state solution.
+           * If we want people to have access to the internal state then we export that as hooks
+           * so that we allow switching to another state management solution if needed.
+           */}
+          <Counter />
+        </LineChart>
+      </Provider>
+    );
+  };
+
+  it('should allow selecting data from recharts store', () => {
+    const spy = vi.fn();
+    render(<App spy={spy} />);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenLastCalledWith(100);
+  });
+
+  it('should allow selecting data from the parent app store', () => {
+    const { container } = render(<App />);
+    expect(exampleStore.getState()).toEqual({ counter: { value: 0 } });
+    expect(container).toHaveTextContent('Current count is: 0');
+
+    act(() => {
+      exampleStore.dispatch(exampleSlice.actions.increment());
+    });
+
+    expect(exampleStore.getState()).toEqual({ counter: { value: 1 } });
+    expect(container).toHaveTextContent('Current count is: 1');
+  });
+});


### PR DESCRIPTION
## Description

alpha-1 was failing in my pet project app because I used my own selectors inside the `<Tooltip component={Here} />`. This PR fixes that.

## Related Issue

I forgot to create an issue for this one. alpha-2 I suppose.