### PR TITLE
Clamp the active tooltip index to be within the current data length

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -116,6 +116,7 @@
   "es6/state/selectors/brushSelectors.js",
   "es6/state/selectors/combiners",
   "es6/state/selectors/combiners/combineActiveLabel.js",
+  "es6/state/selectors/combiners/combineActiveTooltipIndex.js",
   "es6/state/selectors/combiners/combineAxisRangeWithReverse.js",
   "es6/state/selectors/combiners/combineTooltipInteractionState.js",
   "es6/state/selectors/containerSelectors.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -116,6 +116,7 @@
   "lib/state/selectors/brushSelectors.js",
   "lib/state/selectors/combiners",
   "lib/state/selectors/combiners/combineActiveLabel.js",
+  "lib/state/selectors/combiners/combineActiveTooltipIndex.js",
   "lib/state/selectors/combiners/combineAxisRangeWithReverse.js",
   "lib/state/selectors/combiners/combineTooltipInteractionState.js",
   "lib/state/selectors/containerSelectors.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -116,6 +116,7 @@
   "types/state/selectors/brushSelectors.d.ts",
   "types/state/selectors/combiners",
   "types/state/selectors/combiners/combineActiveLabel.d.ts",
+  "types/state/selectors/combiners/combineActiveTooltipIndex.d.ts",
   "types/state/selectors/combiners/combineAxisRangeWithReverse.d.ts",
   "types/state/selectors/combiners/combineTooltipInteractionState.d.ts",
   "types/state/selectors/containerSelectors.d.ts",

--- a/src/state/keyboardEventsMiddleware.ts
+++ b/src/state/keyboardEventsMiddleware.ts
@@ -1,9 +1,10 @@
 import { createAction, createListenerMiddleware, ListenerEffectAPI } from '@reduxjs/toolkit';
 import { setKeyboardInteraction } from './tooltipSlice';
 import { AppDispatch, RechartsRootState } from './store';
-import { selectTooltipAxisTicks } from './selectors/tooltipSelectors';
+import { selectTooltipAxisTicks, selectTooltipDisplayedData } from './selectors/tooltipSelectors';
 import { selectCoordinateForDefaultIndex } from './selectors/selectors';
 import { selectChartDirection } from './selectors/axisSelectors';
+import { combineActiveTooltipIndex } from './selectors/combiners/combineActiveTooltipIndex';
 
 export const keyDownAction = createAction<KeyboardEvent['key']>('keyDown');
 export const focusAction = createAction('focus');
@@ -27,7 +28,10 @@ keyboardEventsMiddleware.startListening({
       return;
     }
 
-    const currentIndex = Number(keyboardInteraction.index);
+    // TODO this is lacking index for charts that do not support numeric indexes
+    const currentIndex: number = Number(
+      combineActiveTooltipIndex(keyboardInteraction, selectTooltipDisplayedData(state)),
+    );
     const tooltipTicks = selectTooltipAxisTicks(state);
     if (key === 'Enter') {
       const coordinate = selectCoordinateForDefaultIndex(state, 'axis', 'hover', String(keyboardInteraction.index));

--- a/src/state/selectors/combiners/combineActiveTooltipIndex.ts
+++ b/src/state/selectors/combiners/combineActiveTooltipIndex.ts
@@ -1,0 +1,33 @@
+import { TooltipIndex, TooltipInteractionState } from '../../tooltipSlice';
+import { ChartData } from '../../chartDataSlice';
+import { isWellBehavedNumber } from '../../../util/isWellBehavedNumber';
+
+export const combineActiveTooltipIndex = (
+  tooltipInteraction: TooltipInteractionState,
+  chartData: ChartData,
+): TooltipIndex | null => {
+  const desiredIndex: TooltipIndex = tooltipInteraction?.index;
+  if (desiredIndex == null) {
+    return null;
+  }
+
+  const indexAsNumber = Number(desiredIndex);
+  if (!isWellBehavedNumber(indexAsNumber)) {
+    // this is for charts like Sankey and Treemap that do not support numerical indexes. We need a proper solution for this before we can start supporting keyboard events on these charts.
+    return desiredIndex;
+  }
+
+  /*
+   * Zero is a trivial limit for single-dimensional charts like Line and Area,
+   * but this also needs a support for multidimensional charts like Sankey and Treemap! TODO
+   */
+  const lowerLimit = 0;
+  let upperLimit: number = +Infinity;
+
+  if (chartData.length > 0) {
+    upperLimit = chartData.length - 1;
+  }
+
+  // now let's clamp the desiredIndex between the limits
+  return String(Math.max(lowerLimit, Math.min(indexAsNumber, upperLimit)));
+};

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -38,7 +38,7 @@ import { findEntryInArray } from '../../util/DataUtils';
 import { TooltipTrigger } from '../../chart/types';
 import { ChartPointer } from '../../chart/generateCategoricalChart';
 import { selectChartDataWithIndexes } from './dataSelectors';
-import { selectTooltipAxis, selectTooltipAxisTicks } from './tooltipSelectors';
+import { selectTooltipAxis, selectTooltipAxisTicks, selectTooltipDisplayedData } from './tooltipSelectors';
 import { AxisRange } from './axisSelectors';
 import { selectChartName } from './rootPropsSelectors';
 import { selectChartLayout } from '../../context/chartLayoutContext';
@@ -46,6 +46,7 @@ import { selectChartOffset } from './selectChartOffset';
 import { selectChartHeight, selectChartWidth } from './containerSelectors';
 import { combineActiveLabel } from './combiners/combineActiveLabel';
 import { combineTooltipInteractionState } from './combiners/combineTooltipInteractionState';
+import { combineActiveTooltipIndex } from './combiners/combineActiveTooltipIndex';
 
 export const useChartName = (): string => {
   return useAppSelector(selectChartName);
@@ -102,9 +103,9 @@ export const selectActiveIndex: (
   tooltipEventType: TooltipEventType,
   trigger: TooltipTrigger,
   defaultIndex: TooltipIndex | undefined,
-) => TooltipIndex | undefined = createSelector(
-  [selectTooltipInteractionState],
-  (tooltipInteraction: TooltipInteractionState | undefined) => tooltipInteraction?.index,
+) => TooltipIndex | null = createSelector(
+  [selectTooltipInteractionState, selectTooltipDisplayedData],
+  combineActiveTooltipIndex,
 );
 
 export const selectTooltipDataKey = (

--- a/src/state/selectors/tooltipSelectors.ts
+++ b/src/state/selectors/tooltipSelectors.ts
@@ -68,6 +68,7 @@ import { combineActiveLabel } from './combiners/combineActiveLabel';
 import { selectTooltipSettings } from './selectTooltipSettings';
 
 import { combineTooltipInteractionState } from './combiners/combineTooltipInteractionState';
+import { combineActiveTooltipIndex } from './combiners/combineActiveTooltipIndex';
 
 export const selectTooltipAxisType = (state: RechartsRootState): XorYType => {
   const layout = selectChartLayout(state);
@@ -349,9 +350,9 @@ const selectTooltipInteractionState: (state: RechartsRootState) => TooltipIntera
   combineTooltipInteractionState,
 );
 
-export const selectActiveTooltipIndex: (state: RechartsRootState) => TooltipIndex | undefined = createSelector(
-  [selectTooltipInteractionState],
-  (tooltipInteraction: TooltipInteractionState): TooltipIndex | undefined => tooltipInteraction?.index,
+export const selectActiveTooltipIndex: (state: RechartsRootState) => TooltipIndex | null = createSelector(
+  [selectTooltipInteractionState, selectTooltipDisplayedData],
+  combineActiveTooltipIndex,
 );
 
 export const selectActiveLabel: (state: RechartsRootState) => string | undefined = createSelector(

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -643,14 +643,10 @@ describe('Tooltip visibility', () => {
         expect(tooltip).not.toBeVisible();
       });
 
-      it('should ignore invalid defaultIndex value', context => {
-        if (name === 'FunnelChart') {
-          // FunnelChart throws an error when called with defaultIndex
-          context.skip();
-        }
+      it('should ignore invalid defaultIndex value', () => {
         const { container } = render(
           <Wrapper>
-            <Tooltip defaultIndex={20} />
+            <Tooltip defaultIndex={NaN} />
           </Wrapper>,
         );
 
@@ -659,9 +655,27 @@ describe('Tooltip visibility', () => {
         expect(tooltip).not.toBeVisible();
       });
 
-      it('should not fail when defaultIndex is data.length', context => {
+      it('should show the last item when defaultIndex is same or larger than the data.length', context => {
         if (name === 'FunnelChart') {
           // FunnelChart throws an error when called with defaultIndex
+          context.skip();
+        }
+        if (name === 'Sankey') {
+          /*
+           * Sankey chart does not support numeric tooltip indexes
+           */
+          context.skip();
+        }
+        if (name === 'Treemap') {
+          /*
+           * Treemap chart does not support numeric tooltip indexes
+           */
+          context.skip();
+        }
+        if (name === 'SunburstChart') {
+          /*
+           * SunburstChart does not support numeric tooltip indexes
+           */
           context.skip();
         }
         const { container } = render(
@@ -672,7 +686,7 @@ describe('Tooltip visibility', () => {
 
         const tooltip = getTooltip(container);
         expect(tooltip).toBeInTheDocument();
-        expect(tooltip).not.toBeVisible();
+        expect(tooltip).toBeVisible();
       });
     });
   });

--- a/test/helper/clickOn.ts
+++ b/test/helper/clickOn.ts
@@ -1,0 +1,11 @@
+import { fireEvent } from '@testing-library/react';
+import { assertNotNull } from './assertNotNull';
+
+export function clickOn(selector: string): (container: HTMLElement) => void {
+  return function clickOnElement(container: HTMLElement): void {
+    assertNotNull(container);
+    const target = container.querySelector(selector);
+    assertNotNull(target);
+    fireEvent.click(target);
+  };
+}


### PR DESCRIPTION
## Description

If the data array changes while keyboard interaction is active then the tooltip index should also update with it.

This also affects the defaultIndex so I updated those tests too.
