### PR TITLE
Polar graphical items no longer render their legend in cartesian charts

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -43,7 +43,7 @@ import { TooltipPayload, TooltipPayloadConfiguration } from '../state/tooltipSli
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 import { UpdateId, useUpdateId } from '../context/chartLayoutContext';
 import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
-import { SetLegendPayload } from '../state/SetLegendPayload';
+import { SetPolarLegendPayload } from '../state/SetLegendPayload';
 
 interface PieDef {
   /** The abscissa of pole in polar coordinate  */
@@ -245,7 +245,7 @@ function SetPiePayloadLegend(props: Props) {
   );
 
   const legendPayload = useAppSelector(state => selectPieLegend(state, pieSettings, cells));
-  return <SetLegendPayload legendPayload={legendPayload} />;
+  return <SetPolarLegendPayload legendPayload={legendPayload} />;
 }
 
 type PieSectorsProps = {

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -24,7 +24,7 @@ import { PolarGraphicalItemContext } from '../context/PolarGraphicalItemContext'
 import { selectRadarPoints } from '../state/selectors/radarSelectors';
 import { useAppSelector } from '../state/hooks';
 import { useIsPanorama } from '../context/PanoramaContext';
-import { SetLegendPayload } from '../state/SetLegendPayload';
+import { SetPolarLegendPayload } from '../state/SetLegendPayload';
 
 interface RadarPoint {
   x: number;
@@ -460,7 +460,7 @@ export class Radar extends PureComponent<Props> {
           barSize={undefined}
           type="radar"
         />
-        <SetLegendPayload legendPayload={computeLegendPayloadFromRadarSectors(this.props)} />
+        <SetPolarLegendPayload legendPayload={computeLegendPayloadFromRadarSectors(this.props)} />
         <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
         <RadarImpl {...this.props} />
       </>

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -50,7 +50,7 @@ import {
 } from '../state/selectors/radialBarSelectors';
 import { useAppSelector } from '../state/hooks';
 import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
-import { SetLegendPayload } from '../state/SetLegendPayload';
+import { SetPolarLegendPayload } from '../state/SetLegendPayload';
 
 export type RadialBarDataItem = SectorProps & {
   value?: any;
@@ -160,7 +160,7 @@ interface State {
 
 function SetRadialBarPayloadLegend(props: RadialBarProps) {
   const legendPayload = useAppSelector(state => selectRadialBarLegendPayload(state, props.legendType));
-  return <SetLegendPayload legendPayload={legendPayload} />;
+  return <SetPolarLegendPayload legendPayload={legendPayload} />;
 }
 
 function getTooltipEntrySettings(props: RadialBarProps): TooltipPayloadConfiguration {

--- a/src/state/SetLegendPayload.ts
+++ b/src/state/SetLegendPayload.ts
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
 import { LegendPayload } from '../component/DefaultLegendContent';
-import { useAppDispatch } from './hooks';
+import { useAppDispatch, useAppSelector } from './hooks';
 import { addLegendPayload, removeLegendPayload } from './legendSlice';
 import { useIsPanorama } from '../context/PanoramaContext';
+import { selectChartLayout } from '../context/chartLayoutContext';
 
 const noop = () => {};
 
@@ -18,5 +19,20 @@ export function SetLegendPayload({ legendPayload }: { legendPayload: ReadonlyArr
       dispatch(removeLegendPayload(legendPayload));
     };
   }, [dispatch, isPanorama, legendPayload]);
+  return null;
+}
+
+export function SetPolarLegendPayload({ legendPayload }: { legendPayload: ReadonlyArray<LegendPayload> }): null {
+  const dispatch = useAppDispatch();
+  const layout = useAppSelector(selectChartLayout);
+  useEffect(() => {
+    if (layout !== 'centric' && layout !== 'radial') {
+      return noop;
+    }
+    dispatch(addLegendPayload(legendPayload));
+    return () => {
+      dispatch(removeLegendPayload(legendPayload));
+    };
+  }, [dispatch, legendPayload]);
   return null;
 }

--- a/src/state/selectors/radialBarSelectors.ts
+++ b/src/state/selectors/radialBarSelectors.ts
@@ -372,14 +372,22 @@ export const selectRadialBarSectors: (
     bandSize: number | undefined,
     layout: LayoutType,
     baseValue: number | unknown,
-    { cx, cy, startAngle, endAngle }: PolarViewBox,
+    polarViewBox: PolarViewBox,
     cells: ReadonlyArray<ReactElement> | undefined,
     pos: BarPositionPosition | undefined,
     stackedData: Series<Record<number, number>, DataKey<any>> | undefined,
   ) => {
-    if (radiusAxis == null || angleAxis == null || chartData == null || bandSize == null || pos == null) {
+    if (
+      radiusAxis == null ||
+      angleAxis == null ||
+      chartData == null ||
+      bandSize == null ||
+      pos == null ||
+      (layout !== 'centric' && layout !== 'radial')
+    ) {
       return undefined;
     }
+    const { cx, cy, startAngle, endAngle } = polarViewBox;
     const displayedData = chartData.slice(dataStartIndex, dataEndIndex + 1);
     const numericAxis = layout === 'centric' ? radiusAxis : angleAxis;
     const stackedDomain: ReadonlyArray<unknown> | null = stackedData ? numericAxis.scale.domain() : null;

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -2175,20 +2175,16 @@ describe('<Legend />', () => {
       expect.soft(queryByText('bad but invisible')).not.toBeInTheDocument();
     });
 
-    // this throws an error - we should probably fix that so that it does nothing instead of throwing?
-    it.fails('should not render legend of unsupported graphical element', () => {
-      // ComposedChart now renders Pie Legend - we should probably fix that?
+    it('should not render legend of unsupported graphical element', () => {
       const { container } = render(
         <ComposedChart width={500} height={500} data={categoricalData}>
           <Legend />
           <Pie dataKey="pie datakey" />
           <Radar dataKey="radar datakey" />
           <RadialBar dataKey="radialbar datakey" />
-          {/* Scatter is not supported according to the website, but it still renders its Legend payload, interesting */}
-          {/* <Scatter dataKey="scatter datakey" /> */}
         </ComposedChart>,
       );
-      expectLegendLabels(container, []);
+      expectLegendLabels(container, null);
     });
 
     it('should render legend of Scatter even though it is not a supported graphical element inside ComposedChart', () => {


### PR DESCRIPTION
## Description

I am not sure why would anyone want to do this in the first place but this test was failing so it's no longer failing.
