### PR TITLE
Also omits onDragEnd from default drag event

### DIFF
--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -65,7 +65,7 @@ interface BrushProps {
   alwaysShowText?: boolean;
 }
 
-export type Props = Omit<SVGProps<SVGElement>, 'onChange'> & BrushProps;
+export type Props = Omit<SVGProps<SVGElement>, 'onChange' | 'onDragEnd'> & BrushProps;
 
 type PropertiesFromContext = {
   x: number;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Omits onDragEnd from default drag event. Otherwise, the event callback has the union of both callback definitions as the argument. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
