### PR TITLE
Use use-sync-external-store shim, also add scripts for testing react16 and react19 installations

### DIFF
--- a/scripts/install-react-16.sh
+++ b/scripts/install-react-16.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Useful for testing the package with React 16
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+npm install
+npm install --no-save react@16.14 react-dom@16.14 @testing-library/react@12.x.x

--- a/scripts/install-react-19.sh
+++ b/scripts/install-react-19.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Useful for testing the package with React 16
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+npm install
+# --force because of the myriad storybook packages depending on each other as peers and always failing to resolve
+npm install --no-save --force react@19.0.0 react-dom@19.0.0 react-is@19.0.0

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector';
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 import { useContext } from 'react';
 import { type AppDispatch, type RechartsRootState } from './store';
 


### PR DESCRIPTION
## Description

Turns out that `import from 'use-sync-external-store'` will only work on React18+ and to get backwards compatibility (which I thought was the only point of existence of this package but I digress) we need to `import from 'use-sync-external-store/shim'`.

Also I added two scripts so that I can more easily get a React@16 and React@19 setup going.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/5472 and React 16 compatibility