### PR TITLE
Use getBoundingClientRect() instead of offsetLeft + offsetTop

### DIFF
--- a/src/util/useElementOffset.ts
+++ b/src/util/useElementOffset.ts
@@ -41,7 +41,7 @@ export type SetElementOffset = (node: HTMLElement | null) => void;
 /**
  * Use this to listen to element layout changes.
  *
- * Very useful for reading actual sizes of DOM elements.
+ * Very useful for reading actual sizes of DOM elements relative to the viewport.
  *
  * @param extraDependencies use this to trigger new DOM dimensions read when any of these change. Good for things like payload and label, that will re-render something down in the children array, but you want to read the layout box of a parent.
  * @returns [lastElementOffset, updateElementOffset] most recent value, and setter. Pass the setter to a DOM element ref like this: `<div ref={updateElementOffset}>`
@@ -51,11 +51,12 @@ export function useElementOffset(extraDependencies: ReadonlyArray<unknown> = [])
   const updateBoundingBox = useCallback(
     (node: HTMLDivElement | null) => {
       if (node != null) {
+        const rect = node.getBoundingClientRect();
         const box: ElementOffset = {
-          height: node.offsetHeight,
-          left: node.offsetLeft,
-          top: node.offsetTop,
-          width: node.offsetWidth,
+          height: rect.height,
+          left: rect.left,
+          top: rect.top,
+          width: rect.width,
         };
         if (
           Math.abs(box.height - lastBoundingBox.height) > EPS ||

--- a/storybook/stories/Examples/ChartLayout.stories.tsx
+++ b/storybook/stories/Examples/ChartLayout.stories.tsx
@@ -172,7 +172,7 @@ function CrosshairWrapper() {
   return (
     <svg width="100%" height="100%" onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
       {/* transparent rect is here so that there is something for the mouse events to react to. empty SVG does not fire any mouse events */}
-      <rect x={0} y={0} width={500} height={500} fill="transparent" />
+      <rect x={0} y={0} width="100%" height="100%" fill="transparent" />
       {mousePosition != null && (
         <Crosshair x={Math.round(mousePosition.pageX - offset.left)} y={Math.round(mousePosition.pageY - offset.top)} />
       )}
@@ -237,6 +237,51 @@ export const WithStaticDimensions = {
         <CrosshairWrapper />
         <ShowScale />
       </ComposedChart>
+    );
+  },
+  args: {
+    width: 500,
+    height: 500,
+  },
+};
+
+/**
+ * https://github.com/recharts/recharts/issues/5477
+ */
+export const WithAbsolutePositionAndFlexboxParents = {
+  render: (args: Record<string, any>) => {
+    return (
+      <div style={{ display: 'flex', height: '100vh' }}>
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: '#003459',
+            position: 'relative',
+          }}
+          className="spacer-top"
+        >
+          <div
+            style={{
+              position: 'absolute',
+              height: '100%',
+              width: '100%',
+              top: '100px',
+              background: '#00A7E1',
+            }}
+            className="spacer-left"
+          >
+            <ComposedChart {...args}>
+              {createPortal(<OffsetDimensions />, document.getElementById('storybook-root'))}
+              <ChartSizeDimensions />
+              <CrosshairWrapper />
+              <ShowScale />
+            </ComposedChart>
+          </div>
+        </div>
+      </div>
     );
   },
   args: {


### PR DESCRIPTION
## Description

because that better matches mouse event coordinates when the chart is wrapped in a flexbox and position: absolute parents.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/5477