### PR TITLE
Fix tooltip coordinate reset onMouseLeave

### DIFF
--- a/src/state/selectors/combiners/combineTooltipInteractionState.ts
+++ b/src/state/selectors/combiners/combineTooltipInteractionState.ts
@@ -61,5 +61,8 @@ export const combineTooltipInteractionState = (
     };
   }
 
-  return noInteraction;
+  return {
+    ...noInteraction,
+    coordinate: appropriateMouseInteraction.coordinate,
+  };
 };

--- a/test/chart/chartEvents.spec.tsx
+++ b/test/chart/chartEvents.spec.tsx
@@ -212,7 +212,10 @@ describe('chart wrapper event data', () => {
       });
       fireEvent.mouseLeave(container.querySelector('.recharts-wrapper'));
       expectLastCalledWithData(spies.onMouseLeave, {
-        activeCoordinate: undefined,
+        activeCoordinate: {
+          x: 37.5,
+          y: 20,
+        },
         activeDataKey: undefined,
         activeIndex: null,
         activeLabel: undefined,

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -1490,7 +1490,7 @@ describe('Tooltip payload', () => {
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
 
       showTooltipOnCoordinate(
         container,
@@ -1618,7 +1618,7 @@ describe('Tooltip payload', () => {
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
 
       showTooltipOnCoordinate(
         container,
@@ -1630,7 +1630,7 @@ describe('Tooltip payload', () => {
         activeIndex: '3',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -1502,7 +1502,7 @@ describe('Tooltip payload', () => {
         activeIndex: '1',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
     });
 
     it('should select active coordinate', () => {

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -1322,7 +1322,7 @@ describe('Tooltip visibility', () => {
           activeIndex: null,
           isActive: false,
         });
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
 
         showTooltip(container, composedChartMouseHoverTooltipSelector);
 
@@ -1330,7 +1330,7 @@ describe('Tooltip visibility', () => {
           activeIndex: '0',
           isActive: true,
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(4);
       });
 
       it('should render tooltip payload for hidden items', () => {

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -785,7 +785,7 @@ describe('Tooltip visibility', () => {
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
 
       showTooltipOnCoordinate(
         container,
@@ -797,7 +797,7 @@ describe('Tooltip visibility', () => {
         activeIndex: '3',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -1322,7 +1322,7 @@ describe('Tooltip visibility', () => {
           activeIndex: null,
           isActive: false,
         });
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledTimes(2);
 
         showTooltip(container, composedChartMouseHoverTooltipSelector);
 
@@ -1330,7 +1330,7 @@ describe('Tooltip visibility', () => {
           activeIndex: '0',
           isActive: true,
         });
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should render tooltip payload for hidden items', () => {

--- a/test/state/selectors/selectIsTooltipActive.spec.tsx
+++ b/test/state/selectors/selectIsTooltipActive.spec.tsx
@@ -34,21 +34,21 @@ describe('selectIsTooltipActive', () => {
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
 
       showTooltip(container, barChartMouseHoverTooltipSelector);
       expect(spy).toHaveBeenLastCalledWith({
         activeIndex: '1',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
 
       hideTooltip(container, barChartMouseHoverTooltipSelector);
       expect(spy).toHaveBeenLastCalledWith({
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -118,21 +118,21 @@ describe('selectIsTooltipActive', () => {
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
 
       showTooltip(container, scatterChartMouseHoverTooltipSelector);
       expect(spy).toHaveBeenLastCalledWith({
         activeIndex: '0',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
 
       hideTooltip(container, scatterChartMouseHoverTooltipSelector);
       expect(spy).toHaveBeenLastCalledWith({
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -202,21 +202,21 @@ describe('selectIsTooltipActive', () => {
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
 
       showTooltip(container, barChartMouseHoverTooltipSelector);
       expect(spy).toHaveBeenLastCalledWith({
         activeIndex: '1',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
 
       hideTooltip(container, barChartMouseHoverTooltipSelector);
       expect(spy).toHaveBeenLastCalledWith({
         activeIndex: '1',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/test/state/selectors/selectIsTooltipActive.spec.tsx
+++ b/test/state/selectors/selectIsTooltipActive.spec.tsx
@@ -118,21 +118,21 @@ describe('selectIsTooltipActive', () => {
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
 
       showTooltip(container, scatterChartMouseHoverTooltipSelector);
       expect(spy).toHaveBeenLastCalledWith({
         activeIndex: '0',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(4);
 
       hideTooltip(container, scatterChartMouseHoverTooltipSelector);
       expect(spy).toHaveBeenLastCalledWith({
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(4);
+      expect(spy).toHaveBeenCalledTimes(5);
     });
   });
 

--- a/test/state/selectors/selectors.spec.tsx
+++ b/test/state/selectors/selectors.spec.tsx
@@ -583,7 +583,7 @@ describe('selectActiveCoordinate', () => {
 
     store.dispatch(mouseLeaveChart());
 
-    expect(selectActiveCoordinate(store.getState(), 'axis', 'hover', undefined)).toBe(undefined);
+    expect(selectActiveCoordinate(store.getState(), 'axis', 'hover', undefined)).toEqual({ x: 100, y: 150 });
     // the selector stops returning the coordinates but they should still be present in store for the next animation
     expect(store.getState().tooltip.axisInteraction.hover.coordinate).toEqual(expected);
   });
@@ -627,11 +627,14 @@ describe('selectActiveCoordinate', () => {
 
     expect(selectActiveCoordinate(store.getState(), 'item', 'hover', undefined)).toBe(expected);
 
-    // neither of these reset the coordinates but the selector stops returning them
+    // neither of these reset the coordinates and the selector does NOT stop returning them
     store.dispatch(mouseLeaveItem());
     store.dispatch(mouseLeaveChart());
 
-    expect(selectActiveCoordinate(store.getState(), 'item', 'hover', undefined)).toBe(undefined);
+    expect(selectActiveCoordinate(store.getState(), 'item', 'hover', undefined)).toEqual({
+      x: 100,
+      y: 150,
+    });
     // the selector stops returning the coordinates but they should still be present in store for the next animation
     expect(store.getState().tooltip.itemInteraction.hover.coordinate).toBe(expected);
   });

--- a/test/synchronisation/useChartSynchronisation.spec.tsx
+++ b/test/synchronisation/useChartSynchronisation.spec.tsx
@@ -73,7 +73,10 @@ describe('useTooltipChartSynchronisation', () => {
         'my-sync-id',
         setSyncInteraction({
           active: false,
-          coordinate: undefined,
+          coordinate: {
+            x: 202.5,
+            y: 200,
+          },
           dataKey: undefined,
           index: null,
           label: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix tooltip coordinate reset.

This affects non-item charts too but I think for the better. Instead of always flying in from 0,0 after chart leave we now always come from the last known coordinate

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5487

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fixes some buggy behavior in charts, especially those with `item` type or `shared={false}`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm test`, update tests

Before https://63da8268a0da9970db6992aa-yujhlvsjyn.chromatic.com/?path=/story/examples-barchart--stacked

After https://63da8268a0da9970db6992aa-ynarlpziva.chromatic.com/?path=/story/examples-barchart--stacked


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
