### PR TITLE
Legend types: remove unused id from Payload

### DIFF
--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -24,7 +24,6 @@ export type Formatter = (value: any, entry: LegendPayload, index: number) => Rea
 
 export interface LegendPayload {
   value: any;
-  id?: string;
   type?: LegendType;
   color?: string;
   payload?: {
@@ -44,15 +43,16 @@ interface InternalProps {
   layout?: LayoutType;
   align?: HorizontalAlignmentType;
   verticalAlign?: VerticalAlignmentType;
-  /**
-   * @deprecated Legend.payload prop is not doing anything. Legend is set from data on other graphical elements like Bar, Line, and Area.
-   */
-  payload?: ReadonlyArray<LegendPayload>;
   inactiveColor?: string;
   formatter?: Formatter;
   onMouseEnter?: (data: LegendPayload, index: number, event: MouseEvent) => void;
   onMouseLeave?: (data: LegendPayload, index: number, event: MouseEvent) => void;
   onClick?: (data: LegendPayload, index: number, event: MouseEvent) => void;
+  /**
+   * DefaultLegendContent.payload is omitted from Legend props.
+   * A custom payload can be passed here if desired or it can be passed from the Legend "content" callback.
+   */
+  payload?: ReadonlyArray<LegendPayload>;
 }
 
 export type Props = InternalProps & Omit<PresentationAttributesAdaptChildEvent<any, ReactElement>, keyof InternalProps>;

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -86,7 +86,7 @@ function getDefaultPosition(
   return { ...hPos, ...vPos };
 }
 
-export type Props = DefaultProps & {
+export type Props = Omit<DefaultProps, 'payload'> & {
   wrapperStyle?: CSSProperties;
   width?: number;
   height?: number;

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -361,6 +361,7 @@ describe('<Legend />', () => {
 
   describe('outside of chart context', () => {
     it('should ignore payload prop', () => {
+      // @ts-expect-error payload is now omitted from Legend types
       const { container } = render(<Legend width={500} height={30} payload={categoricalData} />);
 
       expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(0);
@@ -378,6 +379,7 @@ describe('<Legend />', () => {
         return (
           <>
             <LegendPortalContext.Provider value={portalRef}>
+              {/* @ts-expect-error payload is now omitted from Legend types */}
               <Legend width={500} height={30} payload={categoricalData} content={<CustomizedLegend />} />,
             </LegendPortalContext.Provider>
             <div


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- remove unused `id` type from `LegendPayload`
- `Omit` `payload` prop from `Legend` props. It doesn't do anything so rip off the band aid before 3.0. Can still be sent to `DefaultLegendContent` as a valid prop.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5508

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- remove a useless type while we're making breaking changes

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- see TS ignores in tests
- https://codesandbox.io/p/sandbox/simple-line-chart-forked-q5hpsg
  - `id` never ever gets populated unless you add it yourself (which you can do with any property). So remove it

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
