### PR TITLE
refactor: remove the blendStroke prop, prefer stroke=none

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -102,8 +102,6 @@ interface InternalPieProps extends PieDef {
   className?: string;
   dataKey: DataKey<any>;
   nameKey?: DataKey<any>;
-  /** Match each sector's stroke color to it's fill color */
-  blendStroke?: boolean;
   /** The minimum angle for no-zero element */
   minAngle?: number;
   legendType?: LegendType;
@@ -136,8 +134,6 @@ interface PieProps extends PieDef {
   className?: string;
   dataKey: DataKey<any>;
   nameKey?: DataKey<any>;
-  /** Match each sector's stroke color to it's fill color */
-  blendStroke?: boolean;
   /** The minimum angle for no-zero element */
   minAngle?: number;
   legendType?: LegendType;
@@ -251,7 +247,6 @@ function SetPiePayloadLegend(props: Props) {
 type PieSectorsProps = {
   sectors: Readonly<PieSectorDataItem[]>;
   activeShape: ActiveShape<Readonly<PieSectorDataItem>>;
-  blendStroke: boolean;
   inactiveShape: ActiveShape<Readonly<PieSectorDataItem>>;
   allOtherPieProps: Props;
   sectorRefs: SVGGElement[];
@@ -278,7 +273,7 @@ function getTooltipEntrySettings(props: InternalProps): TooltipPayloadConfigurat
 }
 
 function PieSectors(props: PieSectorsProps) {
-  const { sectors, sectorRefs, activeShape, blendStroke, inactiveShape: inactiveShapeProp, allOtherPieProps } = props;
+  const { sectors, sectorRefs, activeShape, inactiveShape: inactiveShapeProp, allOtherPieProps } = props;
 
   const activeIndex = useAppSelector(selectActiveTooltipIndex);
   const {
@@ -299,7 +294,7 @@ function PieSectors(props: PieSectorsProps) {
     const sectorOptions = isSectorActive ? activeShape : inactiveShape;
     const sectorProps = {
       ...entry,
-      stroke: blendStroke ? entry.fill : entry.stroke,
+      stroke: entry.stroke,
       tabIndex: -1,
     };
 
@@ -629,12 +624,11 @@ export class PieWithState extends PureComponent<InternalProps, State> {
   }
 
   renderSectorsStatically(sectors: Readonly<PieSectorDataItem[]>) {
-    const { activeShape, blendStroke, inactiveShape: inactiveShapeProp } = this.props;
+    const { activeShape, inactiveShape: inactiveShapeProp } = this.props;
     return (
       <PieSectors
         sectors={sectors}
         activeShape={activeShape}
-        blendStroke={blendStroke}
         inactiveShape={inactiveShapeProp}
         allOtherPieProps={this.props}
         sectorRefs={this.sectorRefs}
@@ -793,7 +787,6 @@ const defaultPieProps: Partial<Props> = {
   animationDuration: 1500,
   animationEasing: 'ease',
   nameKey: 'name',
-  blendStroke: false,
   rootTabIndex: 0,
 };
 

--- a/storybook/stories/Examples/Pie/PieWithCells.stories.tsx
+++ b/storybook/stories/Examples/Pie/PieWithCells.stories.tsx
@@ -22,7 +22,7 @@ export const PieWithCells = {
         <PieChart width={400} height={400}>
           <Pie dataKey="percent" {...args}>
             {data.map(d => (
-              <Cell key={`d-${d.value}`} fill={d.color} stroke="black" />
+              <Cell key={`d-${d.value}`} fill={d.color} stroke="none" />
             ))}
           </Pie>
           <Legend />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Since we're releasing 3.0, ripping off some breaking change band-aids.

- Remove `blendStroke` prop which was undocumented

See linked issue, but this prop causes some weird offsets with `stroke`. Instead of using, which sets `stroke`=`fill` to match the two just set `stroke="none"`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/4385

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
simplify the API, remove a deprecated prop

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `npm test`
- test in storybook that `stroke="none"` does the exact thing as `blendStroke` except for better

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
