### PR TITLE
feat: Add the dataKey type to legend formatter props

### DIFF
--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -33,6 +33,7 @@ export type Formatter = (
       strokeDasharray: string | number;
       value?: any;
     };
+    dataKey?: DataKey<any>;
   },
   index: number,
 ) => ReactNode;


### PR DESCRIPTION

## Description

## Related Issue

#5508 

## Motivation and Context

Improve typescript support

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
