### PR TITLE
bugfix: Prevent classname to be overwritten within cartesian axis ticks

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -259,8 +259,9 @@ export class CartesianAxis extends Component<Props, IState> {
     } else if (typeof option === 'function') {
       tickItem = option(props);
     } else {
+      const { className, ...restOfProps } = props;
       tickItem = (
-        <Text {...props} className="recharts-cartesian-axis-tick-value">
+        <Text {...restOfProps} className={`recharts-cartesian-axis-tick-value ${className}`}>
           {value}
         </Text>
       );

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -259,9 +259,14 @@ export class CartesianAxis extends Component<Props, IState> {
     } else if (typeof option === 'function') {
       tickItem = option(props);
     } else {
-      const { className, ...restOfProps } = props;
+      let className = 'recharts-cartesian-axis-tick-value';
+
+      if (typeof option !== 'boolean') {
+        className = clsx(className, option.className);
+      }
+
       tickItem = (
-        <Text {...restOfProps} className={`recharts-cartesian-axis-tick-value ${className}`}>
+        <Text {...props} className={className}>
           {value}
         </Text>
       );

--- a/test/cartesian/CartesianAxis.spec.tsx
+++ b/test/cartesian/CartesianAxis.spec.tsx
@@ -313,4 +313,24 @@ describe('<CartesianAxis />', () => {
 
     expect(container.querySelectorAll('.recharts-cartesian-axis-tick')).toHaveLength(0);
   });
+
+  it('Renders additional classname when passed via tick options', () => {
+    const { container } = render(
+      <Surface width={500} height={500}>
+        <CartesianAxis
+          orientation="bottom"
+          y={100}
+          width={400}
+          height={50}
+          viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
+          ticks={ticks}
+          tick={{ className: 'custom' }}
+          label="test"
+          scale={exampleScale}
+        />
+      </Surface>,
+    );
+
+    expect(container.querySelectorAll('.recharts-cartesian-axis-tick-value.custom')).toHaveLength(ticks.length);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding `option.className` from ticks props to `renderTickItem` alongside the `recharts-cartesian-axis-tick-value` class

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/recharts/recharts/issues/5517

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

So able to pass custom styling via classnames to tick elements

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I made this change on my local `node_modules` but have also ran this on local development within this repository

## Screenshots (if appropriate):

Made some changes to demo components locally and can see the `custom` class coming through in the output

<img width="505" alt="Screenshot 2025-01-31 at 16 38 04" src="https://github.com/user-attachments/assets/96c02a81-23bd-44ad-b127-e731f748c33b" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
