### PR TITLE
Set margin properties one by one to avoid re-render warning

### DIFF
--- a/src/state/layoutSlice.ts
+++ b/src/state/layoutSlice.ts
@@ -33,7 +33,10 @@ const chartLayoutSlice = createSlice({
       state.height = action.payload.height;
     },
     setMargin(state, action: PayloadAction<Margin>) {
-      state.margin = action.payload;
+      state.margin.top = action.payload.top;
+      state.margin.right = action.payload.right;
+      state.margin.bottom = action.payload.bottom;
+      state.margin.left = action.payload.left;
     },
     setScale(state, action: PayloadAction<number>) {
       state.scale = action.payload;

--- a/storybook/stories/API/chart/AreaChart.stories.tsx
+++ b/storybook/stories/API/chart/AreaChart.stories.tsx
@@ -13,9 +13,19 @@ export default {
 
 export const Simple = {
   render: (args: Record<string, any>) => {
+    const [myState, setMyState] = React.useState(0);
     return (
       <ResponsiveContainer width="100%" height={400}>
-        <AreaChart {...args}>
+        <AreaChart
+          {...args}
+          onMouseDown={() => setMyState(myState + 1)}
+          margin={{
+            top: 0,
+            bottom: 0,
+            left: 50,
+            right: 50,
+          }}
+        >
           <Area dataKey="pv" strokeWidth={3} stroke="#2451B7" fill="#5376C4" />
           <CartesianGrid opacity={0.1} vertical={false} />
           <Tooltip />


### PR DESCRIPTION
## Description

Avoids new object instance passed around.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/5514