### PR TITLE
feat: allow index wraparound for keyboard control

### DIFF
--- a/src/state/keyboardEventsMiddleware.ts
+++ b/src/state/keyboardEventsMiddleware.ts
@@ -49,9 +49,11 @@ keyboardEventsMiddleware.startListening({
     const direction = selectChartDirection(state);
     const directionMultiplier = direction === 'left-to-right' ? 1 : -1;
     const movement = key === 'ArrowRight' ? 1 : -1;
-    const nextIndex = currentIndex + movement * directionMultiplier;
-    if (nextIndex >= tooltipTicks.length || nextIndex < 0) {
-      return;
+    let nextIndex = currentIndex + movement * directionMultiplier;
+    if (nextIndex >= tooltipTicks.length) {
+      nextIndex = 0;
+    } else if (nextIndex < 0) {
+      nextIndex = tooltipTicks.length;
     }
     const coordinate = selectCoordinateForDefaultIndex(state, 'axis', 'hover', String(nextIndex));
 

--- a/test/chart/AccessibilityLayer.spec.tsx
+++ b/test/chart/AccessibilityLayer.spec.tsx
@@ -147,39 +147,39 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
       const cursor = container.querySelector('.recharts-tooltip-cursor');
       expect(cursor).not.toBeNull();
 
-      // Ignore left arrow when you're already at the left
+      // Wrap around when already at the left
       arrowLeft(svg);
       const cursorPathA = cursor.getAttribute('d');
 
-      // Respect right arrow when there's something to the right
+      // Wrap back around tot he start when just wrapped to the end
       arrowRight(svg);
-      expect(tooltip).toHaveTextContent('Page B');
+      expect(tooltip).toHaveTextContent('Page A');
       const cursorPathB = cursor.getAttribute('d');
 
-      expect(cursorPathA).not.toEqual(cursorPathB);
+      expect(cursorPathA).toEqual(cursorPathB);
+
+      // Page B
+      arrowRight(svg);
 
       // Page C
       arrowRight(svg);
 
-      // Page D
       arrowRight(svg);
-
-      arrowRight(svg);
-      expect(tooltip).toHaveTextContent('Page E');
+      expect(tooltip).toHaveTextContent('Page D');
 
       // Ignore right arrow when you're already at the right
       arrowRight(svg);
-      expect(tooltip).toHaveTextContent('Page F');
+      expect(tooltip).toHaveTextContent('Page E');
 
       // Respect left arrow when there's something to the left
       arrowLeft(svg);
-      expect(tooltip).toHaveTextContent('Page E');
+      expect(tooltip).toHaveTextContent('Page D');
 
       // Chart ignores non-arrow keys
       fireEvent.keyDown(svg, {
         key: 'a',
       });
-      expect(tooltip).toHaveTextContent('Page E');
+      expect(tooltip).toHaveTextContent('Page D');
 
       // Keyboard controls no longer spoof mouse events!
       expect(mockMouseMovements).toHaveBeenCalledTimes(0);
@@ -214,36 +214,36 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
       act(() => svg.focus());
       expect(tooltip).toHaveTextContent('Page A');
 
-      // Ignore right arrow when you're already at the right
+      // Wrap around when at the right
       arrowRight(svg);
-      expect(tooltip).toHaveTextContent('Page A');
+      expect(tooltip).toHaveTextContent('Page F');
 
       // Respect left arrow when there's something to the left
       arrowLeft(svg);
-      expect(tooltip).toHaveTextContent('Page B');
+      expect(tooltip).toHaveTextContent('Page A');
+
+      // Page B
+      arrowLeft(svg);
 
       // Page C
       arrowLeft(svg);
 
-      // Page D
       arrowLeft(svg);
-
-      arrowLeft(svg);
-      expect(tooltip).toHaveTextContent('Page E');
+      expect(tooltip).toHaveTextContent('Page D');
 
       // Ignore left arrow when you're already at the left
       arrowLeft(svg);
-      expect(tooltip).toHaveTextContent('Page F');
+      expect(tooltip).toHaveTextContent('Page E');
 
       // Respect right arrow when there's something to the right
       arrowRight(svg);
-      expect(tooltip).toHaveTextContent('Page E');
+      expect(tooltip).toHaveTextContent('Page D');
 
       // Chart ignores non-arrow keys
       fireEvent.keyDown(svg, {
         key: 'a',
       });
-      expect(tooltip).toHaveTextContent('Page E');
+      expect(tooltip).toHaveTextContent('Page D');
       expect(mockMouseMovements).toHaveBeenCalledTimes(0);
     });
 
@@ -342,9 +342,9 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
         arrowRight(svg);
         expectTooltipPayload(container, 'Page E', ['uv : 278']);
 
-        // The chart only goes from A - E, so we shouldn't be able to go right any further.
+        // The chart only goes from A - E, but we will wrap around to the start
         arrowRight(svg);
-        expectTooltipPayload(container, 'Page E', ['uv : 278']);
+        expectTooltipPayload(container, 'Page A', ['uv : 400']);
       });
     });
 
@@ -395,9 +395,9 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
       act(() => svg.focus());
       expect(tooltip).toHaveTextContent('Page A');
 
-      // Ignore left arrow when you're already at the left
+      // Wrap around when you're already at the left most point
       arrowLeft(svg);
-      expect(tooltip).toHaveTextContent('Page A');
+      expect(tooltip).toHaveTextContent('Page F');
     });
 
     const BugExample = () => {
@@ -749,7 +749,7 @@ describe('AreaChart horizontal', () => {
     expectTooltipPayload(container, 'Page B', ['uv : 300']);
   });
 
-  test('should stay on the first index after pressing left', () => {
+  test('should wrap around to the end after pressing left', () => {
     const { container } = renderTestCase();
 
     expectTooltipNotVisible(container);
@@ -760,10 +760,10 @@ describe('AreaChart horizontal', () => {
     expectTooltipPayload(container, 'Page A', ['uv : 400']);
 
     arrowLeft(svg);
-    expectTooltipPayload(container, 'Page A', ['uv : 400']);
+    expectTooltipPayload(container, 'Page F', ['uv : 189']);
   });
 
-  test('after it arrives at the end of the available data and then press arrow right again, it will continue showing the last item', () => {
+  test('after it arrives at the end of the available data and then press arrow right again, it will wrap around to show the first item again', () => {
     const { container } = renderTestCase();
 
     expectTooltipNotVisible(container);
@@ -789,7 +789,7 @@ describe('AreaChart horizontal', () => {
     expectTooltipPayload(container, 'Page F', ['uv : 189']);
 
     arrowRight(svg);
-    expectTooltipPayload(container, 'Page F', ['uv : 189']);
+    expectTooltipPayload(container, 'Page A', ['uv : 400']);
   });
 });
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

allow wrap around in accessibilityLayer/keyboard navigation. Polar charts (and all charts) should wrap back to 0 when the end of the chart is reached. For polar charts this enables pie to navigate "normally" as the last index is in the position that I would generally consider 2nd

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

- anticipate issues reported for accessibilityLayer in polar charts

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

https://github.com/user-attachments/assets/5db77cce-9feb-4bc1-bfbe-0a27d13d5705

https://github.com/recharts/recharts/pull/5543 interferes with this right now but it will be removed in that PR


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
