### PR TITLE
Fix Tooltip on ScatterChart with allowDuplicateCategory=false

### DIFF
--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -186,12 +186,13 @@ function selectFinalData(dataDefinedOnItem: unknown, dataDefinedOnChart: Readonl
 }
 
 export const combineTooltipPayload = (
-  tooltipItemPayloads: ReadonlyArray<TooltipPayloadConfiguration>,
+  tooltipPayloadConfigurations: ReadonlyArray<TooltipPayloadConfiguration>,
   activeIndex: TooltipIndex,
   chartDataState: ChartDataState,
   tooltipAxis: BaseAxisProps | undefined,
   activeLabel: string | undefined,
   tooltipPayloadSearcher: TooltipPayloadSearcher | undefined,
+  tooltipEventType: TooltipEventType,
 ): TooltipPayload | undefined => {
   if (activeIndex == null || tooltipPayloadSearcher == null) {
     return undefined;
@@ -200,7 +201,7 @@ export const combineTooltipPayload = (
 
   const init: Array<TooltipPayloadEntry> = [];
 
-  return tooltipItemPayloads.reduce((agg, { dataDefinedOnItem, settings }): Array<TooltipPayloadEntry> => {
+  return tooltipPayloadConfigurations.reduce((agg, { dataDefinedOnItem, settings }): Array<TooltipPayloadEntry> => {
     const finalData = selectFinalData(dataDefinedOnItem, chartData);
 
     const sliced = getSliced(finalData, dataStartIndex, dataEndIndex);
@@ -209,7 +210,12 @@ export const combineTooltipPayload = (
     // BaseAxisProps does not support nameKey but it could!
     const finalNameKey: DataKey<any> | undefined = settings?.nameKey; // ?? tooltipAxis?.nameKey;
     let tooltipPayload: unknown;
-    if (tooltipAxis?.dataKey && !tooltipAxis?.allowDuplicatedCategory && Array.isArray(sliced)) {
+    if (
+      tooltipAxis?.dataKey &&
+      !tooltipAxis?.allowDuplicatedCategory &&
+      Array.isArray(sliced) &&
+      tooltipEventType === 'axis'
+    ) {
       tooltipPayload = findEntryInArray(sliced, tooltipAxis.dataKey, activeLabel);
     } else {
       tooltipPayload = tooltipPayloadSearcher(sliced, activeIndex, computedData, finalNameKey);
@@ -268,6 +274,7 @@ export const selectTooltipPayload: (
     selectTooltipAxis,
     selectActiveLabel,
     selectTooltipPayloadSearcher,
+    pickTooltipEventType,
   ],
   combineTooltipPayload,
 );

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -214,6 +214,16 @@ export const combineTooltipPayload = (
       tooltipAxis?.dataKey &&
       !tooltipAxis?.allowDuplicatedCategory &&
       Array.isArray(sliced) &&
+      /*
+       * If the tooltipEventType is 'axis', we should search for the dataKey in the sliced data
+       * because thanks to allowDuplicatedCategory=false, the order of elements in the array
+       * no longer matches the order of elements in the original data
+       * and so we need to search by the active dataKey + label rather than by index.
+       *
+       * On the other hand the tooltipEventType 'item' should always search by index
+       * because we get the index from interacting over the individual elements
+       * which is always accurate, irrespective of the allowDuplicatedCategory setting.
+       */
       tooltipEventType === 'axis'
     ) {
       tooltipPayload = findEntryInArray(sliced, tooltipAxis.dataKey, activeLabel);

--- a/storybook/stories/Examples/ScatterChart.stories.tsx
+++ b/storybook/stories/Examples/ScatterChart.stories.tsx
@@ -575,3 +575,41 @@ export const SpurriousCorrelation: StoryObj<StorybookArgs> = {
     data: babiesAndVideosCorrelation,
   },
 };
+
+export const WithDuplicatedCategory: StoryObj<StorybookArgs> = {
+  render: (args: StorybookArgs) => {
+    const data = [
+      { x: 100, y: 100, z: 200 },
+      { x: 100, y: 200, z: 200 },
+      { x: 100, y: 300, z: 200 },
+    ];
+
+    return (
+      <ResponsiveContainer width="100%" height={400}>
+        <ScatterChart>
+          <CartesianGrid />
+          <XAxis
+            type="category"
+            allowDuplicatedCategory={Boolean(args.allowDuplicatedCategory)}
+            dataKey="x"
+            name="stature"
+            unit="cm"
+          />
+          <YAxis
+            type="category"
+            allowDuplicatedCategory={Boolean(args.allowDuplicatedCategory)}
+            dataKey="y"
+            name="weight"
+            unit="kg"
+          />
+          <Scatter activeShape={{ fill: 'red' }} name="A school" data={data} />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+          <Legend />
+        </ScatterChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    allowDuplicatedCategory: false,
+  },
+};

--- a/test/state/selectors/selectors.spec.tsx
+++ b/test/state/selectors/selectors.spec.tsx
@@ -431,6 +431,7 @@ describe('selectTooltipPayload', () => {
       tooltipAxis,
       activeLabel,
       arrayTooltipSearcher,
+      'item',
     );
     const expectedEntry1: TooltipPayloadEntry = {
       name: 'stature',
@@ -482,6 +483,7 @@ describe('selectTooltipPayload', () => {
       tooltipAxis,
       activeLabel,
       arrayTooltipSearcher,
+      'axis',
     );
     const expected: TooltipPayloadEntry = { dataKey: 'dataKeyOnAxis', payload: null, value: undefined };
     expect(actual).toEqual([expected]);


### PR DESCRIPTION
## Description

The logic in this method is getting convoluted again but it works ... for now. If it turns out to be problematic I will break it down further.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/5546

Reported in https://github.com/recharts/recharts/discussions/5545
