### PR TITLE
fix: missing dependency in `useEffect` in `SetPolarLegendPayload`

### DIFF
--- a/src/state/SetLegendPayload.ts
+++ b/src/state/SetLegendPayload.ts
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
-import { LegendPayload } from '../component/DefaultLegendContent';
-import { useAppDispatch, useAppSelector } from './hooks';
-import { addLegendPayload, removeLegendPayload } from './legendSlice';
+import type { LegendPayload } from '../component/DefaultLegendContent';
 import { useIsPanorama } from '../context/PanoramaContext';
 import { selectChartLayout } from '../context/chartLayoutContext';
+import { useAppDispatch, useAppSelector } from './hooks';
+import { addLegendPayload, removeLegendPayload } from './legendSlice';
 
 const noop = () => {};
 

--- a/src/state/SetLegendPayload.ts
+++ b/src/state/SetLegendPayload.ts
@@ -33,6 +33,6 @@ export function SetPolarLegendPayload({ legendPayload }: { legendPayload: Readon
     return () => {
       dispatch(removeLegendPayload(legendPayload));
     };
-  }, [dispatch, legendPayload]);
+  }, [dispatch, layout, legendPayload]);
   return null;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds a missing dependency to the `useEffect` in `SetPolarLegendPayload`.

<!--- Describe your changes in detail -->

## Related Issue

Fixes #5550

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

git pre-push hook

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes