### PR TITLE
Add tests for Tooltip.itemSorter, allow `dataKey` and `value` as inputs

### DIFF
--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -53,7 +53,7 @@ export interface Props<TValue extends ValueType, TName extends NameType> {
   labelFormatter?: (label: any, payload: ReadonlyArray<Payload<TValue, TName>>) => ReactNode;
   label?: any;
   payload?: ReadonlyArray<Payload<TValue, TName>>;
-  itemSorter?: (item: Payload<TValue, TName>) => number | string;
+  itemSorter?: 'dataKey' | 'value' | ((item: Payload<TValue, TName>) => number | string);
   accessibilityLayer: boolean;
 }
 

--- a/test/component/Tooltip/itemSorter.spec.tsx
+++ b/test/component/Tooltip/itemSorter.spec.tsx
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { Selector } from '@reduxjs/toolkit';
+import { Area, Bar, ComposedChart, Line, Scatter, Tooltip, TooltipProps, XAxis, YAxis } from '../../../src';
+import { PageData } from '../../_data';
+import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
+import { RechartsRootState } from '../../../src/state/store';
+import { expectTooltipPayload, showTooltip } from './tooltipTestHelpers';
+import { composedChartMouseHoverTooltipSelector } from './tooltipMouseHoverSelectors';
+import { selectTooltipPayload } from '../../../src/state/selectors/selectors';
+import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
+
+describe('itemSorter', () => {
+  beforeEach(() => {
+    mockGetBoundingClientRect({ width: 100, height: 100 });
+  });
+
+  function renderTestCase<T>(
+    itemSorter: TooltipProps<number, string>['itemSorter'],
+    selector?: Selector<RechartsRootState, T, never>,
+  ) {
+    return createSelectorTestCase(({ children }) => (
+      <ComposedChart width={300} height={300} data={PageData}>
+        <Area dataKey="uv" />
+        <Bar dataKey="pv" />
+        <Line dataKey="amt" />
+        <Scatter dataKey="uv" />
+        <YAxis dataKey="pv" />
+        <XAxis dataKey="name" />
+        <Tooltip itemSorter={itemSorter} />
+        {children}
+      </ComposedChart>
+    ))(selector);
+  }
+
+  describe('when itemSorter is undefined', () => {
+    it('should render payload in arbitrary order', () => {
+      const { container } = renderTestCase(undefined);
+      showTooltip(container, composedChartMouseHoverTooltipSelector);
+      expectTooltipPayload(container, 'Page D', ['uv : 200', 'pv : 9800', 'amt : 2400', 'name : Page D', 'pv : 9800']);
+    });
+
+    it('should select payload in arbitrary order', () => {
+      const { spy } = renderTestCase(undefined, state => selectTooltipPayload(state, 'axis', 'hover', '0'));
+      expect(spy).toHaveBeenLastCalledWith([
+        {
+          color: '#3182bd',
+          dataKey: 'uv',
+          fill: '#3182bd',
+          hide: false,
+          name: 'uv',
+          nameKey: undefined,
+          payload: {
+            amt: 2400,
+            name: 'Page A',
+            pv: 2400,
+            uv: 400,
+          },
+          stroke: '#3182bd',
+          strokeWidth: undefined,
+          type: undefined,
+          unit: undefined,
+          value: 400,
+        },
+        {
+          color: undefined,
+          dataKey: 'pv',
+          fill: undefined,
+          hide: false,
+          name: 'pv',
+          nameKey: undefined,
+          payload: {
+            amt: 2400,
+            name: 'Page A',
+            pv: 2400,
+            uv: 400,
+          },
+          stroke: undefined,
+          strokeWidth: undefined,
+          type: undefined,
+          unit: undefined,
+          value: 2400,
+        },
+        {
+          color: '#3182bd',
+          dataKey: 'amt',
+          fill: '#fff',
+          hide: false,
+          name: 'amt',
+          nameKey: undefined,
+          payload: {
+            amt: 2400,
+            name: 'Page A',
+            pv: 2400,
+            uv: 400,
+          },
+          stroke: '#3182bd',
+          strokeWidth: 1,
+          type: undefined,
+          unit: undefined,
+          value: 2400,
+        },
+        {
+          color: undefined,
+          dataKey: 'name',
+          fill: undefined,
+          hide: false,
+          name: 'name',
+          nameKey: undefined,
+          payload: {
+            amt: 2400,
+            name: 'Page A',
+            pv: 2400,
+            uv: 400,
+          },
+          stroke: undefined,
+          strokeWidth: undefined,
+          type: undefined,
+          unit: '',
+          value: 'Page A',
+        },
+        {
+          color: undefined,
+          dataKey: 'pv',
+          fill: undefined,
+          hide: false,
+          name: 'pv',
+          nameKey: undefined,
+          payload: {
+            amt: 2400,
+            name: 'Page A',
+            pv: 2400,
+            uv: 400,
+          },
+          stroke: undefined,
+          strokeWidth: undefined,
+          type: undefined,
+          unit: '',
+          value: 2400,
+        },
+      ]);
+      expect(spy).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('when itemSorter=`dataKey`', () => {
+    it('should render sorted payload', () => {
+      const { container } = renderTestCase('dataKey');
+      showTooltip(container, composedChartMouseHoverTooltipSelector);
+      expectTooltipPayload(container, 'Page D', ['amt : 2400', 'name : Page D', 'pv : 9800', 'pv : 9800', 'uv : 200']);
+    });
+  });
+
+  describe('when itemSorter=`value`', () => {
+    it('should render sorted payload', () => {
+      const { container } = renderTestCase('value');
+      showTooltip(container, composedChartMouseHoverTooltipSelector);
+      expectTooltipPayload(container, 'Page D', ['uv : 200', 'amt : 2400', 'pv : 9800', 'name : Page D', 'pv : 9800']);
+    });
+  });
+
+  describe('when itemSorter is a function', () => {
+    it('should render sorted payload', () => {
+      const { container } = renderTestCase(item => item.value);
+      showTooltip(container, composedChartMouseHoverTooltipSelector);
+      expectTooltipPayload(container, 'Page D', ['uv : 200', 'amt : 2400', 'pv : 9800', 'name : Page D', 'pv : 9800']);
+    });
+
+    it('should call the function once for every payload item, and pass the item as an argument', () => {
+      const spy = vi.fn();
+      const { container } = renderTestCase(spy);
+      expect(spy).toHaveBeenCalledTimes(0);
+      showTooltip(container, composedChartMouseHoverTooltipSelector);
+      expect(spy).toHaveBeenCalledTimes(5);
+      expect(spy).toHaveBeenNthCalledWith(1, {
+        color: '#3182bd',
+        dataKey: 'uv',
+        fill: '#3182bd',
+        hide: false,
+        name: 'uv',
+        nameKey: undefined,
+        payload: {
+          amt: 2400,
+          name: 'Page D',
+          pv: 9800,
+          uv: 200,
+        },
+        stroke: '#3182bd',
+        strokeWidth: undefined,
+        type: undefined,
+        unit: undefined,
+        value: 200,
+      });
+      expect(spy).toHaveBeenNthCalledWith(2, {
+        color: undefined,
+        dataKey: 'pv',
+        fill: undefined,
+        hide: false,
+        name: 'pv',
+        nameKey: undefined,
+        payload: {
+          amt: 2400,
+          name: 'Page D',
+          pv: 9800,
+          uv: 200,
+        },
+        stroke: undefined,
+        strokeWidth: undefined,
+        type: undefined,
+        unit: undefined,
+        value: 9800,
+      });
+      expect(spy).toHaveBeenNthCalledWith(3, {
+        color: '#3182bd',
+        dataKey: 'amt',
+        fill: '#fff',
+        hide: false,
+        name: 'amt',
+        nameKey: undefined,
+        payload: {
+          amt: 2400,
+          name: 'Page D',
+          pv: 9800,
+          uv: 200,
+        },
+        stroke: '#3182bd',
+        strokeWidth: 1,
+        type: undefined,
+        unit: undefined,
+        value: 2400,
+      });
+      expect(spy).toHaveBeenNthCalledWith(4, {
+        color: undefined,
+        dataKey: 'name',
+        fill: undefined,
+        hide: false,
+        name: 'name',
+        nameKey: undefined,
+        payload: {
+          amt: 2400,
+          name: 'Page D',
+          pv: 9800,
+          uv: 200,
+        },
+        stroke: undefined,
+        strokeWidth: undefined,
+        type: undefined,
+        unit: '',
+        value: 'Page D',
+      });
+      expect(spy).toHaveBeenNthCalledWith(5, {
+        color: undefined,
+        dataKey: 'pv',
+        fill: undefined,
+        hide: false,
+        name: 'pv',
+        nameKey: undefined,
+        payload: {
+          amt: 2400,
+          name: 'Page D',
+          pv: 9800,
+          uv: 200,
+        },
+        stroke: undefined,
+        strokeWidth: undefined,
+        type: undefined,
+        unit: '',
+        value: 9800,
+      });
+    });
+  });
+});

--- a/test/component/Tooltip/tooltipTestHelpers.tsx
+++ b/test/component/Tooltip/tooltipTestHelpers.tsx
@@ -22,6 +22,11 @@ const defaultCoordinates: MouseCoordinate = { clientX: 200, clientY: 200 };
 /**
  * Test helper that will simulate a mouse over event on a given element which should trigger the tooltip to show.
  *
+ * Whenever you're trying to use this function, remember to mock the bounding rect call too, otherwise the jsdom environment
+ * will never recognize the mouse event as a chart event. Example:
+ *
+ * mockGetBoundingClientRect({ width: 100, height: 100 });
+ *
  * @param container Element rendered in the test
  * @param selector Tooltip reacts to different triggers based on props, this is the selector that will be used to find the trigger element. If undefined then uses the container element itself.
  * @param coordinates X, Y coordinate of the mouse event
@@ -48,6 +53,11 @@ export function showTooltipOnCoordinate(
 /**
  * Test helper that will simulate a mouse over event on a given element which should trigger the tooltip to show.
  * This function will use default coordinates of 200, 200.
+ *
+ * Whenever you're trying to use this function, remember to mock the bounding rect call too, otherwise the jsdom environment
+ * will never recognize the mouse event as a chart event. Example:
+ *
+ * mockGetBoundingClientRect({ width: 100, height: 100 });
  *
  * @param container Element rendered in the test
  * @param selector Tooltip reacts to different triggers based on props, this is the selector that will be used to find the trigger element. If undefined then uses the container element itself.


### PR DESCRIPTION
## Description

Testing the existing behavior

## Related Issue

https://github.com/recharts/recharts/issues/4547