### PR TITLE
fix: add index back to Bar Rectangle key

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -345,7 +345,9 @@ function BarRectangles(props: BarRectanglesProps) {
             onMouseLeave={onMouseLeaveFromContext(entry, i)}
             // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
             onClick={onClickFromContext(entry, i)}
-            key={`rectangle-${entry?.x}-${entry?.y}-${entry?.value}`}
+            // https://github.com/recharts/recharts/issues/5415
+            // eslint-disable-next-line react/no-array-index-key
+            key={`rectangle-${entry?.x}-${entry?.y}-${entry?.value}-${i}`}
           >
             <BarRectangle {...barRectangleProps} />
           </Layer>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- remove console error for users

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5415

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- we've given up on not including indexes in keys a while ago, this is one of the remaining ones

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- tests pass, simple fix

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
