### PR TITLE
#5458 Keep Tooltip within viewBox for negative offsets

### DIFF
--- a/src/util/tooltip/translate.ts
+++ b/src/util/tooltip/translate.ts
@@ -55,8 +55,9 @@ export function getTooltipTranslateXY({
     return position[key];
   }
 
-  const negative = coordinate[key] - tooltipDimension - offsetTopLeft;
+  const negative = coordinate[key] - tooltipDimension - (offsetTopLeft > 0 ? offsetTopLeft : 0);
   const positive = coordinate[key] + offsetTopLeft;
+
   if (allowEscapeViewBox[key]) {
     return reverseDirection[key] ? negative : positive;
   }

--- a/storybook/stories/Examples/Tooltip.stories.tsx
+++ b/storybook/stories/Examples/Tooltip.stories.tsx
@@ -512,3 +512,23 @@ export const RechartsTooltipBug5542Repro = {
     data: pageData,
   },
 };
+
+export const TooltipWithNegativeOffset = {
+  render: () => {
+    return (
+      <ResponsiveContainer width="100%" height={400}>
+        <ComposedChart data={pageData}>
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Line dataKey="uv" />
+          <Tooltip
+            offset={-50}
+            wrapperStyle={{
+              width: 100,
+            }}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    );
+  },
+};

--- a/test/util/tooltip/translate.spec.ts
+++ b/test/util/tooltip/translate.spec.ts
@@ -57,6 +57,21 @@ describe.each(dimensions)('getTooltipTranslateXY dimension %s', dimension => {
       expect(result).toBe(132);
     });
 
+    it('should return number outside of viewBox even when offsetTopLeft is negative', () => {
+      const result = getTooltipTranslateXY({
+        allowEscapeViewBox: { [dimension]: true },
+        coordinate: { [dimension]: 900 },
+        key: dimension,
+        offsetTopLeft: -35,
+        position: {},
+        reverseDirection: { [dimension]: false },
+        tooltipDimension: 70,
+        viewBox: { [dimension]: 65 },
+        viewBoxDimension: 800,
+      });
+      expect(result).toBe(865);
+    });
+
     it('should return Y even outside of viewBox when reversed', () => {
       const result = getTooltipTranslateXY({
         allowEscapeViewBox: { y: true },
@@ -143,7 +158,7 @@ describe.each(dimensions)('getTooltipTranslateXY dimension %s', dimension => {
     it('should try to fit translate inside the viewBox', () => {
       const result = getTooltipTranslateXY({
         allowEscapeViewBox: { [dimension]: false },
-        coordinate: { [dimension]: 150 },
+        coordinate: { [dimension]: 900 },
         key: dimension,
         offsetTopLeft: -35,
         position: {},
@@ -152,7 +167,7 @@ describe.each(dimensions)('getTooltipTranslateXY dimension %s', dimension => {
         viewBox: { [dimension]: 65 },
         viewBoxDimension: 800,
       });
-      expect(result).toBe(115);
+      expect(result).toBe(830);
     });
   });
 });

--- a/test/util/tooltip/translate.spec.ts
+++ b/test/util/tooltip/translate.spec.ts
@@ -138,6 +138,23 @@ describe.each(dimensions)('getTooltipTranslateXY dimension %s', dimension => {
       expect(result).toBe(172);
     });
   });
+
+  describe('when tooltip has negative offset', () => {
+    it('should try to fit translate inside the viewBox', () => {
+      const result = getTooltipTranslateXY({
+        allowEscapeViewBox: { [dimension]: false },
+        coordinate: { [dimension]: 150 },
+        key: dimension,
+        offsetTopLeft: -35,
+        position: {},
+        reverseDirection: { [dimension]: false },
+        tooltipDimension: 70,
+        viewBox: { [dimension]: 65 },
+        viewBoxDimension: 800,
+      });
+      expect(result).toBe(115);
+    });
+  });
 });
 
 describe('getTranslateTransform', () => {


### PR DESCRIPTION
## Description

When setting the `offset` prop on the Tooltip to a negative number, the Tooltip would escape the viewBox area even when `allowEscapeViewBox` was false. Solution is to ignore a negative offset when calculating the value for `negative`. 

## Related Issue

#5458 

## Motivation and Context

Using a negative offset prop on the Tooltip to center it and having a chart that extends all the way to the edges of the container, parts of the Tooltip would run outside of the positive ends of the container. 

## How Has This Been Tested?

Tested in the storybook for Tooltip, see new story named "Tooltip with negative offset". 
This change does not affect other areas of the code.

## Screenshots (if appropriate):

**Before**
<img width="314" alt="Bildschirmfoto 2025-02-13 um 16 18 09" src="https://github.com/user-attachments/assets/4e4fe11d-c1dd-4582-ad7e-ab1edf758875" />

**After**
<img width="258" alt="Bildschirmfoto 2025-02-13 um 16 17 55" src="https://github.com/user-attachments/assets/08c0b8dd-44f1-4558-a37f-75f5d3a3c83a" />

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
