### PR TITLE
Render cursor in JSX order, instead of a portal

### DIFF
--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -12,7 +12,7 @@ import { validateWidthHeight, findChildByType, filterProps } from '../util/React
 import { getValueByDataKey } from '../util/ChartUtils';
 import { Margin, DataKey, SankeyLink, SankeyNode } from '../util/types';
 import { ReportChartMargin, ReportChartSize } from '../context/chartLayoutContext';
-import { CursorPortalContext, TooltipPortalContext } from '../context/tooltipPortalContext';
+import { TooltipPortalContext } from '../context/tooltipPortalContext';
 import { RechartsWrapper } from './RechartsWrapper';
 import { RechartsStoreProvider } from '../state/RechartsStoreProvider';
 import { useAppDispatch } from '../state/hooks';
@@ -497,7 +497,6 @@ interface State {
   prevNodePadding?: number;
   prevSort?: boolean;
 
-  cursorPortal?: SVGElement | null;
   tooltipPortal?: HTMLElement | null;
 }
 
@@ -977,61 +976,51 @@ export class Sankey extends PureComponent<Props, State> {
         <SetComputedData computedData={{ links: modifiedLinks, nodes: modifiedNodes }} />
         <ReportChartSize width={width} height={height} />
         <ReportChartMargin margin={defaultSankeyMargin} />
-        <CursorPortalContext.Provider value={this.state.cursorPortal}>
-          <TooltipPortalContext.Provider value={this.state.tooltipPortal}>
-            <RechartsWrapper
-              className={className}
-              style={style}
-              width={width}
-              height={height}
-              ref={(node: HTMLDivElement) => {
-                if (this.state.tooltipPortal == null) {
-                  this.setState({ tooltipPortal: node });
-                }
-              }}
-              onMouseEnter={undefined}
-              onMouseLeave={undefined}
-              onClick={undefined}
-              onMouseMove={undefined}
-              onMouseDown={undefined}
-              onMouseUp={undefined}
-              onContextMenu={undefined}
-              onDoubleClick={undefined}
-              onTouchStart={undefined}
-              onTouchMove={undefined}
-              onTouchEnd={undefined}
-            >
-              <Surface {...attrs} width={width} height={height}>
-                <g
-                  className="recharts-cursor-portal"
-                  ref={(node: SVGElement) => {
-                    if (this.state.cursorPortal == null) {
-                      this.setState({ cursorPortal: node });
-                    }
-                  }}
-                />
-                {children}
-                <AllSankeyLinkElements
-                  links={links}
-                  modifiedLinks={modifiedLinks}
-                  linkContent={this.props.link}
-                  dataKey={this.props.dataKey}
-                  onMouseEnter={(linkProps: LinkProps, e: MouseEvent) => this.handleMouseEnter(linkProps, 'link', e)}
-                  onMouseLeave={(linkProps: LinkProps, e: MouseEvent) => this.handleMouseLeave(linkProps, 'link', e)}
-                  onClick={(linkProps: LinkProps, e: MouseEvent) => this.handleClick(linkProps, 'link', e)}
-                />
-                <AllNodeElements
-                  modifiedNodes={modifiedNodes}
-                  nodeContent={this.props.node}
-                  dataKey={this.props.dataKey}
-                  onMouseEnter={(nodeProps: NodeProps, e: MouseEvent) => this.handleMouseEnter(nodeProps, 'node', e)}
-                  onMouseLeave={(nodeProps: NodeProps, e: MouseEvent) => this.handleMouseLeave(nodeProps, 'node', e)}
-                  onClick={(nodeProps: NodeProps, e: MouseEvent) => this.handleClick(nodeProps, 'node', e)}
-                />
-              </Surface>
-            </RechartsWrapper>
-          </TooltipPortalContext.Provider>
-        </CursorPortalContext.Provider>
+        <TooltipPortalContext.Provider value={this.state.tooltipPortal}>
+          <RechartsWrapper
+            className={className}
+            style={style}
+            width={width}
+            height={height}
+            ref={(node: HTMLDivElement) => {
+              if (this.state.tooltipPortal == null) {
+                this.setState({ tooltipPortal: node });
+              }
+            }}
+            onMouseEnter={undefined}
+            onMouseLeave={undefined}
+            onClick={undefined}
+            onMouseMove={undefined}
+            onMouseDown={undefined}
+            onMouseUp={undefined}
+            onContextMenu={undefined}
+            onDoubleClick={undefined}
+            onTouchStart={undefined}
+            onTouchMove={undefined}
+            onTouchEnd={undefined}
+          >
+            <Surface {...attrs} width={width} height={height}>
+              {children}
+              <AllSankeyLinkElements
+                links={links}
+                modifiedLinks={modifiedLinks}
+                linkContent={this.props.link}
+                dataKey={this.props.dataKey}
+                onMouseEnter={(linkProps: LinkProps, e: MouseEvent) => this.handleMouseEnter(linkProps, 'link', e)}
+                onMouseLeave={(linkProps: LinkProps, e: MouseEvent) => this.handleMouseLeave(linkProps, 'link', e)}
+                onClick={(linkProps: LinkProps, e: MouseEvent) => this.handleClick(linkProps, 'link', e)}
+              />
+              <AllNodeElements
+                modifiedNodes={modifiedNodes}
+                nodeContent={this.props.node}
+                dataKey={this.props.dataKey}
+                onMouseEnter={(nodeProps: NodeProps, e: MouseEvent) => this.handleMouseEnter(nodeProps, 'node', e)}
+                onMouseLeave={(nodeProps: NodeProps, e: MouseEvent) => this.handleMouseLeave(nodeProps, 'node', e)}
+                onClick={(nodeProps: NodeProps, e: MouseEvent) => this.handleClick(nodeProps, 'node', e)}
+              />
+            </Surface>
+          </RechartsWrapper>
+        </TooltipPortalContext.Provider>
       </RechartsStoreProvider>
     );
   }

--- a/src/chart/SunburstChart.tsx
+++ b/src/chart/SunburstChart.tsx
@@ -8,7 +8,7 @@ import { Sector } from '../shape/Sector';
 import { Text } from '../component/Text';
 import { polarToCartesian } from '../util/PolarUtils';
 import { ReportChartMargin, ReportChartSize } from '../context/chartLayoutContext';
-import { CursorPortalContext, TooltipPortalContext } from '../context/tooltipPortalContext';
+import { TooltipPortalContext } from '../context/tooltipPortalContext';
 import { RechartsWrapper } from './RechartsWrapper';
 import {
   mouseLeaveItem,
@@ -209,7 +209,6 @@ const SunburstChartImpl = ({
   const positions: SunburstPositionMap = new Map<string, ChartCoordinate>([]);
 
   const [tooltipPortal, setTooltipPortal] = useState<HTMLElement | null>(null);
-  const [cursorPortal, setCursorPortal] = useState<SVGElement | null>(null);
   // event handlers
   function handleMouseEnter(node: SunburstData, e: React.MouseEvent) {
     if (onMouseEnter) onMouseEnter(node, e);
@@ -303,49 +302,39 @@ const SunburstChartImpl = ({
 
   const layerClass = clsx('recharts-sunburst', className);
   return (
-    <CursorPortalContext.Provider value={cursorPortal}>
-      <TooltipPortalContext.Provider value={tooltipPortal}>
-        <RechartsWrapper
-          className={className}
-          width={width}
-          // Sunburst doesn't support `style` property, why?
-          height={height}
-          ref={(node: HTMLDivElement) => {
-            if (tooltipPortal == null && node != null) {
-              setTooltipPortal(node);
-            }
-          }}
-          onMouseEnter={undefined}
-          onMouseLeave={undefined}
-          onClick={undefined}
-          onMouseMove={undefined}
-          onMouseDown={undefined}
-          onMouseUp={undefined}
-          onContextMenu={undefined}
-          onDoubleClick={undefined}
-          onTouchStart={undefined}
-          onTouchMove={undefined}
-          onTouchEnd={undefined}
-        >
-          <Surface width={width} height={height}>
-            <g
-              className="recharts-cursor-portal"
-              ref={(node: SVGElement) => {
-                if (cursorPortal == null && node != null) {
-                  setCursorPortal(node);
-                }
-              }}
-            />
-            <Layer className={layerClass}>{sectors}</Layer>
-            <SetTooltipEntrySettings
-              fn={getTooltipEntrySettings}
-              args={{ dataKey, data, stroke, fill, nameKey, positions }}
-            />
-            {children}
-          </Surface>
-        </RechartsWrapper>
-      </TooltipPortalContext.Provider>
-    </CursorPortalContext.Provider>
+    <TooltipPortalContext.Provider value={tooltipPortal}>
+      <RechartsWrapper
+        className={className}
+        width={width}
+        // Sunburst doesn't support `style` property, why?
+        height={height}
+        ref={(node: HTMLDivElement) => {
+          if (tooltipPortal == null && node != null) {
+            setTooltipPortal(node);
+          }
+        }}
+        onMouseEnter={undefined}
+        onMouseLeave={undefined}
+        onClick={undefined}
+        onMouseMove={undefined}
+        onMouseDown={undefined}
+        onMouseUp={undefined}
+        onContextMenu={undefined}
+        onDoubleClick={undefined}
+        onTouchStart={undefined}
+        onTouchMove={undefined}
+        onTouchEnd={undefined}
+      >
+        <Surface width={width} height={height}>
+          <Layer className={layerClass}>{sectors}</Layer>
+          <SetTooltipEntrySettings
+            fn={getTooltipEntrySettings}
+            args={{ dataKey, data, stroke, fill, nameKey, positions }}
+          />
+          {children}
+        </Surface>
+      </RechartsWrapper>
+    </TooltipPortalContext.Provider>
   );
 };
 

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -16,7 +16,7 @@ import { Global } from '../util/Global';
 import { findChildByType, validateWidthHeight, filterProps } from '../util/ReactUtils';
 import { AnimationDuration, AnimationTiming, DataKey, Margin } from '../util/types';
 import { ReportChartMargin, ReportChartSize } from '../context/chartLayoutContext';
-import { CursorPortalContext, TooltipPortalContext } from '../context/tooltipPortalContext';
+import { TooltipPortalContext } from '../context/tooltipPortalContext';
 import { RechartsWrapper } from './RechartsWrapper';
 import {
   TooltipIndex,
@@ -362,7 +362,6 @@ interface State {
 
   prevAspectRatio?: number;
 
-  cursorPortal?: SVGElement | null;
   tooltipPortal?: HTMLElement | null;
 }
 
@@ -873,50 +872,40 @@ export class Treemap extends PureComponent<Props, State> {
       <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={this.props.className ?? 'Treemap'}>
         <ReportChartSize width={this.props.width} height={this.props.height} />
         <ReportChartMargin margin={defaultTreemapMargin} />
-        <CursorPortalContext.Provider value={this.state.cursorPortal}>
-          <TooltipPortalContext.Provider value={this.state.tooltipPortal}>
-            <SetTooltipEntrySettings
-              fn={getTooltipEntrySettings}
-              args={{ props: this.props, currentRoot: this.state.currentRoot }}
-            />
-            <RechartsWrapper
-              className={className}
-              style={style}
-              width={width}
-              height={height}
-              ref={(node: HTMLDivElement) => {
-                if (this.state.tooltipPortal == null) {
-                  this.setState({ tooltipPortal: node });
-                }
-              }}
-              onMouseEnter={undefined}
-              onMouseLeave={undefined}
-              onClick={undefined}
-              onMouseMove={undefined}
-              onMouseDown={undefined}
-              onMouseUp={undefined}
-              onContextMenu={undefined}
-              onDoubleClick={undefined}
-              onTouchStart={undefined}
-              onTouchMove={undefined}
-              onTouchEnd={undefined}
-            >
-              <Surface {...attrs} width={width} height={type === 'nest' ? height - 30 : height}>
-                <g
-                  className="recharts-cursor-portal"
-                  ref={(node: SVGElement) => {
-                    if (this.state.cursorPortal == null) {
-                      this.setState({ cursorPortal: node });
-                    }
-                  }}
-                />
-                {this.renderAllNodes()}
-                {children}
-              </Surface>
-              {type === 'nest' && this.renderNestIndex()}
-            </RechartsWrapper>
-          </TooltipPortalContext.Provider>
-        </CursorPortalContext.Provider>
+        <TooltipPortalContext.Provider value={this.state.tooltipPortal}>
+          <SetTooltipEntrySettings
+            fn={getTooltipEntrySettings}
+            args={{ props: this.props, currentRoot: this.state.currentRoot }}
+          />
+          <RechartsWrapper
+            className={className}
+            style={style}
+            width={width}
+            height={height}
+            ref={(node: HTMLDivElement) => {
+              if (this.state.tooltipPortal == null) {
+                this.setState({ tooltipPortal: node });
+              }
+            }}
+            onMouseEnter={undefined}
+            onMouseLeave={undefined}
+            onClick={undefined}
+            onMouseMove={undefined}
+            onMouseDown={undefined}
+            onMouseUp={undefined}
+            onContextMenu={undefined}
+            onDoubleClick={undefined}
+            onTouchStart={undefined}
+            onTouchMove={undefined}
+            onTouchEnd={undefined}
+          >
+            <Surface {...attrs} width={width} height={type === 'nest' ? height - 30 : height}>
+              {this.renderAllNodes()}
+              {children}
+            </Surface>
+            {type === 'nest' && this.renderNestIndex()}
+          </RechartsWrapper>
+        </TooltipPortalContext.Provider>
       </RechartsStoreProvider>
     );
   }

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -12,7 +12,7 @@ import { ChartDataContextProvider } from '../context/chartDataContext';
 import { ClipPath } from '../container/ClipPath';
 import { ChartOptions } from '../state/optionsSlice';
 import { RechartsStoreProvider } from '../state/RechartsStoreProvider';
-import { CursorPortalContext, TooltipPortalContext } from '../context/tooltipPortalContext';
+import { TooltipPortalContext } from '../context/tooltipPortalContext';
 import { RechartsWrapper } from './RechartsWrapper';
 import { ReportChartProps } from '../state/ReportChartProps';
 import { PolarChartOptions } from '../state/polarOptionsSlice';
@@ -216,60 +216,50 @@ export const generateCategoricalChart = ({
       return (
         <>
           <ChartDataContextProvider chartData={this.props.data} />
-          <CursorPortalContext.Provider value={this.state.cursorPortal}>
-            <TooltipPortalContext.Provider value={this.state.tooltipPortal}>
-              <LegendPortalContext.Provider value={this.state.legendPortal}>
-                <ChartLayoutContextProvider updateId={this.state.updateId} clipPathId={this.clipPathId}>
-                  <RechartsWrapper
-                    className={className}
-                    style={style}
+          <TooltipPortalContext.Provider value={this.state.tooltipPortal}>
+            <LegendPortalContext.Provider value={this.state.legendPortal}>
+              <ChartLayoutContextProvider updateId={this.state.updateId} clipPathId={this.clipPathId}>
+                <RechartsWrapper
+                  className={className}
+                  style={style}
+                  width={width}
+                  height={height}
+                  ref={(node: HTMLDivElement) => {
+                    this.container = node;
+                    if (this.state.tooltipPortal == null) {
+                      this.setState({ tooltipPortal: node });
+                    }
+                    if (this.state.legendPortal == null) {
+                      this.setState({ legendPortal: node });
+                    }
+                  }}
+                  onClick={this.props.onClick}
+                  onMouseLeave={this.props.onMouseLeave}
+                  onMouseEnter={this.props.onMouseEnter}
+                  onMouseMove={this.props.onMouseMove}
+                  onMouseDown={this.props.onMouseDown}
+                  onMouseUp={this.props.onMouseUp}
+                  onContextMenu={this.props.onContextMenu}
+                  onDoubleClick={this.props.onDoubleClick}
+                  onTouchStart={this.props.onTouchStart}
+                  onTouchMove={this.props.onTouchMove}
+                  onTouchEnd={this.props.onTouchEnd}
+                >
+                  <Surface
+                    {...attrs}
                     width={width}
                     height={height}
-                    ref={(node: HTMLDivElement) => {
-                      this.container = node;
-                      if (this.state.tooltipPortal == null) {
-                        this.setState({ tooltipPortal: node });
-                      }
-                      if (this.state.legendPortal == null) {
-                        this.setState({ legendPortal: node });
-                      }
-                    }}
-                    onClick={this.props.onClick}
-                    onMouseLeave={this.props.onMouseLeave}
-                    onMouseEnter={this.props.onMouseEnter}
-                    onMouseMove={this.props.onMouseMove}
-                    onMouseDown={this.props.onMouseDown}
-                    onMouseUp={this.props.onMouseUp}
-                    onContextMenu={this.props.onContextMenu}
-                    onDoubleClick={this.props.onDoubleClick}
-                    onTouchStart={this.props.onTouchStart}
-                    onTouchMove={this.props.onTouchMove}
-                    onTouchEnd={this.props.onTouchEnd}
+                    title={title}
+                    desc={desc}
+                    style={FULL_WIDTH_AND_HEIGHT}
                   >
-                    <Surface
-                      {...attrs}
-                      width={width}
-                      height={height}
-                      title={title}
-                      desc={desc}
-                      style={FULL_WIDTH_AND_HEIGHT}
-                    >
-                      <ClipPath clipPathId={this.clipPathId} />
-                      <g
-                        className="recharts-cursor-portal"
-                        ref={(node: SVGElement) => {
-                          if (this.state.cursorPortal == null) {
-                            this.setState({ cursorPortal: node });
-                          }
-                        }}
-                      />
-                      {children}
-                    </Surface>
-                  </RechartsWrapper>
-                </ChartLayoutContextProvider>
-              </LegendPortalContext.Provider>
-            </TooltipPortalContext.Provider>
-          </CursorPortalContext.Provider>
+                    <ClipPath clipPathId={this.clipPathId} />
+                    {children}
+                  </Surface>
+                </RechartsWrapper>
+              </ChartLayoutContextProvider>
+            </LegendPortalContext.Provider>
+          </TooltipPortalContext.Provider>
         </>
       );
     }

--- a/src/chart/types.ts
+++ b/src/chart/types.ts
@@ -15,7 +15,6 @@ export interface CategoricalChartState {
   prevChildren?: any;
 
   tooltipPortal?: HTMLElement | null;
-  cursorPortal?: SVGElement | null;
   legendPortal?: HTMLElement | null;
 }
 

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -22,7 +22,7 @@ import {
   selectIsTooltipActive,
   selectTooltipPayload,
 } from '../state/selectors/selectors';
-import { useCursorPortal, useTooltipPortal } from '../context/tooltipPortalContext';
+import { useTooltipPortal } from '../context/tooltipPortalContext';
 import { TooltipTrigger } from '../chart/types';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { setTooltipSettingsState, TooltipPayload } from '../state/tooltipSlice';
@@ -191,8 +191,7 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
   useTooltipChartSynchronisation(tooltipEventType, trigger, coordinate, finalLabel, activeIndex, finalIsActive);
 
   const tooltipPortal = portalFromProps ?? tooltipPortalFromContext;
-  const cursorPortal = useCursorPortal();
-  if (tooltipPortal == null || cursorPortal == null) {
+  if (tooltipPortal == null) {
     return null;
   }
 
@@ -245,18 +244,15 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
     <>
       {/* Tooltip the HTML element renders through a React portal so that it escapes clipping, and it renders on top of everything else */}
       {createPortal(tooltipElement, tooltipPortal)}
-      {/* Cursor is an SVG element and renders in another portal, so that it renders _below_ the graphical elements */}
-      {finalIsActive &&
-        createPortal(
-          <Cursor
-            cursor={cursor}
-            tooltipEventType={tooltipEventType}
-            coordinate={coordinate}
-            payload={payload}
-            index={activeIndex}
-          />,
-          cursorPortal,
-        )}
+      {finalIsActive && (
+        <Cursor
+          cursor={cursor}
+          tooltipEventType={tooltipEventType}
+          coordinate={coordinate}
+          payload={payload}
+          index={activeIndex}
+        />
+      )}
     </>
   );
 }

--- a/src/context/tooltipPortalContext.tsx
+++ b/src/context/tooltipPortalContext.tsx
@@ -1,7 +1,5 @@
 import { createContext, useContext } from 'react';
 
 export const TooltipPortalContext = createContext<HTMLElement | null>(null);
-export const CursorPortalContext = createContext<SVGElement | null>(null);
 
 export const useTooltipPortal = (): HTMLElement | null => useContext(TooltipPortalContext);
-export const useCursorPortal = (): SVGElement | null => useContext(CursorPortalContext);

--- a/storybook/stories/Examples/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart.stories.tsx
@@ -37,9 +37,9 @@ export const Simple = {
           <XAxis dataKey="name" />
           <YAxis />
           <Legend />
+          <Tooltip cursor={{ stroke: 'gold', strokeWidth: 2 }} defaultIndex={3} />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
-          <Tooltip />
           <RechartsHookInspector rechartsInspectorEnabled={context.rechartsInspectorEnabled} />
         </LineChart>
       </ResponsiveContainer>


### PR DESCRIPTION
## Description

Allow the position of `<Tooltip />` element to decide on the z-index of the cursor

Visual diff: https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=2002

## Related Issue

This doesn't completely fix https://github.com/recharts/recharts/issues/5582 but it should somewhat improve the situation