### PR TITLE
Replace lodash isEqual with dequal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@reduxjs/toolkit": "1.x.x || 2.x.x",
         "clsx": "^2.1.1",
         "decimal.js-light": "^2.5.1",
+        "dequal": "^2.0.3",
         "eventemitter3": "^5.0.1",
         "immer": "^10.1.1",
         "lodash": "^4.17.21",
@@ -10515,7 +10516,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@reduxjs/toolkit": "1.x.x || 2.x.x",
     "clsx": "^2.1.1",
     "decimal.js-light": "^2.5.1",
+    "dequal": "^2.0.3",
     "eventemitter3": "^5.0.1",
     "immer": "^10.1.1",
     "lodash": "^4.17.21",

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -3,7 +3,7 @@ import React, { PureComponent } from 'react';
 import clsx from 'clsx';
 import Animate from 'react-smooth';
 import max from 'lodash/max';
-import isEqual from 'lodash/isEqual';
+import { dequal } from 'dequal';
 import { Curve, CurveType, Point as CurvePoint, Props as CurveProps } from '../shape/Curve';
 import { Dot } from '../shape/Dot';
 import { Layer } from '../container/Layer';
@@ -471,7 +471,7 @@ class AreaWithState extends PureComponent<InternalProps, State> {
       isAnimationActive &&
       points &&
       points.length &&
-      ((!prevPoints && totalLength > 0) || !isEqual(prevPoints, points) || !isEqual(prevBaseLine, baseLine))
+      ((!prevPoints && totalLength > 0) || !dequal(prevPoints, points) || !dequal(prevBaseLine, baseLine))
     ) {
       return this.renderAreaWithAnimation(needClip, clipPathId);
     }

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -5,8 +5,8 @@
 import React, { Key, PureComponent, ReactElement } from 'react';
 import clsx from 'clsx';
 import Animate from 'react-smooth';
-import isEqual from 'lodash/isEqual';
 import { Series } from 'victory-vendor/d3-shape';
+import { dequal } from 'dequal';
 import { Props as RectangleProps } from '../shape/Rectangle';
 import { Layer } from '../container/Layer';
 import { ErrorBarDataItem, ErrorBarDataPointFormatter, SetErrorBarPreferredDirection } from './ErrorBar';
@@ -491,7 +491,7 @@ class BarWithState extends PureComponent<InternalProps, State> {
     const { data, isAnimationActive } = this.props;
     const { prevData } = this.state;
 
-    if (isAnimationActive && data && data.length && (!prevData || !isEqual(prevData, data))) {
+    if (isAnimationActive && data && data.length && (!prevData || !dequal(prevData, data))) {
       return this.renderRectanglesWithAnimation();
     }
 

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -2,9 +2,9 @@
 import React, { PureComponent, useMemo } from 'react';
 import Animate from 'react-smooth';
 import omit from 'lodash/omit';
-import isEqual from 'lodash/isEqual';
 
 import clsx from 'clsx';
+import { dequal } from 'dequal';
 import { selectActiveIndex } from '../state/selectors/selectors';
 import { useAppSelector } from '../state/hooks';
 import { Layer } from '../container/Layer';
@@ -326,7 +326,7 @@ export class FunnelWithState extends PureComponent<InternalProps, State> {
       isAnimationActive &&
       trapezoids &&
       trapezoids.length &&
-      (!prevTrapezoids || !isEqual(prevTrapezoids, trapezoids))
+      (!prevTrapezoids || !dequal(prevTrapezoids, trapezoids))
     ) {
       return this.renderTrapezoidsWithAnimation();
     }

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -1,9 +1,9 @@
 // eslint-disable-next-line max-classes-per-file
 import React, { Component, PureComponent } from 'react';
 import Animate from 'react-smooth';
-import isEqual from 'lodash/isEqual';
 
 import clsx from 'clsx';
+import { dequal } from 'dequal';
 import { Curve, CurveType, Point as CurvePoint, Props as CurveProps } from '../shape/Curve';
 import { Dot } from '../shape/Dot';
 import { Layer } from '../container/Layer';
@@ -446,7 +446,7 @@ class LineWithState extends Component<InternalProps, State> {
       isAnimationActive &&
       points &&
       points.length &&
-      ((!prevPoints && totalLength > 0) || !isEqual(prevPoints, points))
+      ((!prevPoints && totalLength > 0) || !dequal(prevPoints, points))
     ) {
       return this.renderCurveWithAnimation(needClip, clipPathId);
     }

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -2,8 +2,8 @@
 import React, { Component, PureComponent, ReactElement, useMemo } from 'react';
 import Animate from 'react-smooth';
 
-import isEqual from 'lodash/isEqual';
 import clsx from 'clsx';
+import { dequal } from 'dequal';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelListType, LabelList } from '../component/LabelList';
 import { filterProps, findAllByType } from '../util/ReactUtils';
@@ -490,7 +490,7 @@ class ScatterWithState extends PureComponent<InternalProps, State> {
     const { points, isAnimationActive } = this.props;
     const { prevPoints } = this.state;
 
-    if (isAnimationActive && points && points.length && (!prevPoints || !isEqual(prevPoints, points))) {
+    if (isAnimationActive && points && points.length && (!prevPoints || !dequal(prevPoints, points))) {
       return this.renderSymbolsWithAnimation();
     }
 

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -2,9 +2,9 @@
 import React, { PureComponent, ReactElement, ReactNode, SVGProps, useMemo } from 'react';
 import Animate from 'react-smooth';
 import get from 'lodash/get';
-import isEqual from 'lodash/isEqual';
 
 import clsx from 'clsx';
+import { dequal } from 'dequal';
 import { ResolvedPieSettings, selectPieLegend, selectPieSectors } from '../state/selectors/pieSelectors';
 import { useAppSelector } from '../state/hooks';
 import { SetPolarGraphicalItem } from '../state/SetGraphicalItem';
@@ -687,7 +687,7 @@ export class PieWithState extends PureComponent<InternalProps, State> {
     const { sectors, isAnimationActive } = this.props;
     const { prevSectors } = this.state;
 
-    if (isAnimationActive && sectors && sectors.length && (!prevSectors || !isEqual(prevSectors, sectors))) {
+    if (isAnimationActive && sectors && sectors.length && (!prevSectors || !dequal(prevSectors, sectors))) {
       return this.renderSectorsWithAnimation();
     }
     return this.renderSectorsStatically(sectors);

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -3,9 +3,9 @@ import React, { PureComponent, ReactElement, MouseEvent, SVGProps } from 'react'
 import Animate from 'react-smooth';
 import last from 'lodash/last';
 import first from 'lodash/first';
-import isEqual from 'lodash/isEqual';
 
 import clsx from 'clsx';
+import { dequal } from 'dequal';
 import { interpolateNumber, isNullish } from '../util/DataUtils';
 import { Global } from '../util/Global';
 import { polarToCartesian } from '../util/PolarUtils';
@@ -391,7 +391,7 @@ class RadarWithState extends PureComponent<Props, State> {
     const { points, isAnimationActive, isRange } = this.props;
     const { prevPoints } = this.state;
 
-    if (isAnimationActive && points && points.length && !isRange && (!prevPoints || !isEqual(prevPoints, points))) {
+    if (isAnimationActive && points && points.length && !isRange && (!prevPoints || !dequal(prevPoints, points))) {
       return this.renderPolygonWithAnimation();
     }
 

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -2,9 +2,9 @@
 import React, { PureComponent, ReactElement } from 'react';
 import clsx from 'clsx';
 import Animate from 'react-smooth';
-import isEqual from 'lodash/isEqual';
 
 import { Series } from 'victory-vendor/d3-shape';
+import { dequal } from 'dequal';
 import { parseCornerRadius, RadialBarSector, RadialBarSectorProps } from '../util/RadialBarUtils';
 import { Props as SectorProps } from '../shape/Sector';
 import { Layer } from '../container/Layer';
@@ -275,7 +275,7 @@ class RadialBarWithState extends PureComponent<RadialBarProps, State> {
     const { data, isAnimationActive } = this.props;
     const { prevData } = this.state;
 
-    if (isAnimationActive && data && data.length && (!prevData || !isEqual(prevData, data))) {
+    if (isAnimationActive && data && data.length && (!prevData || !dequal(prevData, data))) {
       return this.renderSectorsWithAnimation();
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

`dequal` is an order of magnitude faster than `_.isEqual` while being much smaller (500B gzipped vs almost 5KB gzipped). 

## Description

<!--- Describe your changes in detail -->

All instances of `_.isEqual` are replaced with `dequal`.

## Related Issue
#5266
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Reducing the bundle size while improving the performance of recharts.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

All existing tests pass, since the functionality is the same.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
