### PR TITLE
Make Tooltip a function component

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, PureComponent, ReactElement, ReactNode, useEffect } from 'react';
+import React, { CSSProperties, ReactElement, ReactNode, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import {
   DefaultTooltipContent,
@@ -119,7 +119,38 @@ export type TooltipProps<TValue extends ValueType, TName extends NameType> = Omi
 
 const emptyPayload: TooltipPayload = [];
 
-function TooltipInternal<TValue extends ValueType, TName extends NameType>(props: TooltipProps<TValue, TName>) {
+const defaultTooltipProps: Partial<TooltipProps<any, any>> = {
+  allowEscapeViewBox: { x: false, y: false },
+  animationDuration: 400,
+  animationEasing: 'ease',
+  axisId: 0,
+  contentStyle: {},
+  cursor: true,
+  filterNull: true,
+  isAnimationActive: !Global.isSsr,
+  itemSorter: 'name',
+  itemStyle: {},
+  labelStyle: {},
+  offset: 10,
+  reverseDirection: { x: false, y: false },
+  separator: ' : ',
+  trigger: 'hover',
+  useTranslate3d: false,
+  wrapperStyle: {},
+};
+
+function resolveDefaultProps<T extends Record<string, any>>(realProps: T, defaultProps: Partial<T>): T {
+  const resolvedProps: T = { ...realProps };
+  return (Object.keys(defaultProps) as (keyof T)[]).reduce((acc: T, key: keyof T): T => {
+    if (acc[key] === undefined) {
+      acc[key] = defaultProps[key];
+    }
+    return acc;
+  }, resolvedProps);
+}
+
+export function Tooltip<TValue extends ValueType, TName extends NameType>(outsideProps: TooltipProps<TValue, TName>) {
+  const props = resolveDefaultProps(outsideProps, defaultTooltipProps);
   const {
     active: activeFromProps,
     allowEscapeViewBox,
@@ -255,35 +286,4 @@ function TooltipInternal<TValue extends ValueType, TName extends NameType>(props
       )}
     </>
   );
-}
-
-export class Tooltip<TValue extends ValueType, TName extends NameType> extends PureComponent<
-  TooltipProps<TValue, TName>
-> {
-  static displayName = 'Tooltip';
-
-  static defaultProps = {
-    allowEscapeViewBox: { x: false, y: false },
-    animationDuration: 400,
-    animationEasing: 'ease',
-    axisId: 0,
-    contentStyle: {},
-    coordinate: { x: 0, y: 0 },
-    cursor: true,
-    filterNull: true,
-    isAnimationActive: !Global.isSsr,
-    itemSorter: 'name',
-    itemStyle: {},
-    labelStyle: {},
-    offset: 10,
-    reverseDirection: { x: false, y: false },
-    separator: ' : ',
-    trigger: 'hover',
-    useTranslate3d: false,
-    wrapperStyle: {},
-  };
-
-  render() {
-    return <TooltipInternal {...this.props} />;
-  }
 }

--- a/storybook/storybook-addon-recharts/preview.tsx
+++ b/storybook/storybook-addon-recharts/preview.tsx
@@ -3,7 +3,6 @@ import { withRechartsHookInspector } from './withRechartsHookInspector';
 import { PARAM_ENABLED_KEY } from './constants';
 
 const preview: ProjectAnnotations<Renderer> = {
-  // @ts-expect-error storybook types are unhappy about the decorator, can't figure out why
   decorators: [withRechartsHookInspector],
   initialGlobals: {
     [PARAM_ENABLED_KEY]: false,


### PR DESCRIPTION
## Description

I am trying to debug the React 19 typescript failure and I can't figure out why. The error says that the `shouldComponentUpdate` signature doesn't match. But we don't even use `shouldComponentUpdate`.

One of the errors is coming from Tooltip. Maybe if I switch it to functional component it will help? If this works then I will switch the other components too.

I still can't reproduce the error anywhere outside of recharts-integ.
