### PR TITLE
Remove Tooltip state from Sankey

### DIFF
--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -5,10 +5,9 @@ import get from 'lodash/get';
 import sumBy from 'lodash/sumBy';
 import { Surface } from '../container/Surface';
 import { Layer } from '../container/Layer';
-import { Tooltip } from '../component/Tooltip';
 import { Rectangle, Props as RectangleProps } from '../shape/Rectangle';
 import { shallowEqual } from '../util/ShallowEqual';
-import { validateWidthHeight, findChildByType, filterProps } from '../util/ReactUtils';
+import { validateWidthHeight, filterProps } from '../util/ReactUtils';
 import { getValueByDataKey } from '../util/ChartUtils';
 import { Margin, DataKey, SankeyLink, SankeyNode } from '../util/types';
 import { ReportChartMargin, ReportChartSize } from '../context/chartLayoutContext';
@@ -479,9 +478,6 @@ type Props = SVGProps<SVGElement> & SankeyProps;
 type SankeyElementType = 'node' | 'link';
 
 interface State {
-  activeElement?: NodeProps | LinkProps;
-  activeElementType?: SankeyElementType;
-  isTooltipActive: boolean;
   nodes: SankeyNode[];
   links: SankeyLink[];
   modifiedNodes: NodeProps[];
@@ -816,9 +812,6 @@ export class Sankey extends PureComponent<Props, State> {
   };
 
   state: State = {
-    activeElement: null,
-    activeElementType: null,
-    isTooltipActive: false,
     nodes: [],
     links: [],
     modifiedLinks: [],
@@ -887,76 +880,22 @@ export class Sankey extends PureComponent<Props, State> {
   }
 
   handleMouseEnter(item: NodeProps | LinkProps, type: SankeyElementType, e: MouseEvent) {
-    const { onMouseEnter, children } = this.props;
-    const tooltipItem = findChildByType([children], Tooltip);
-
-    if (tooltipItem) {
-      this.setState(
-        prev => {
-          if (tooltipItem.props.trigger === 'hover') {
-            return { ...prev, activeElement: item, activeElementType: type, isTooltipActive: true };
-          }
-          return prev;
-        },
-        () => {
-          if (onMouseEnter) {
-            onMouseEnter(item, type, e);
-          }
-        },
-      );
-    } else if (onMouseEnter) {
+    const { onMouseEnter } = this.props;
+    if (onMouseEnter) {
       onMouseEnter(item, type, e);
     }
   }
 
   handleMouseLeave(item: NodeProps | LinkProps, type: SankeyElementType, e: MouseEvent) {
-    const { onMouseLeave, children } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip);
+    const { onMouseLeave } = this.props;
 
-    if (tooltipItem) {
-      this.setState(
-        prev => {
-          if (tooltipItem.props.trigger === 'hover') {
-            return { ...prev, activeElement: undefined, activeElementType: undefined, isTooltipActive: false };
-          }
-          return prev;
-        },
-        () => {
-          if (onMouseLeave) {
-            onMouseLeave(item, type, e);
-          }
-        },
-      );
-    } else if (onMouseLeave) {
+    if (onMouseLeave) {
       onMouseLeave(item, type, e);
     }
   }
 
   handleClick(item: NodeProps | LinkProps, type: SankeyElementType, e: MouseEvent) {
-    const { onClick, children } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip);
-
-    if (tooltipItem && tooltipItem.props.trigger === 'click') {
-      if (this.state.isTooltipActive) {
-        this.setState(prev => {
-          return {
-            ...prev,
-            activeElement: undefined as NodeProps | LinkProps | undefined,
-            activeElementType: undefined as SankeyElementType | undefined,
-            isTooltipActive: false,
-          };
-        });
-      } else {
-        this.setState(prev => {
-          return {
-            ...prev,
-            activeElement: item,
-            activeElementType: type,
-            isTooltipActive: true,
-          };
-        });
-      }
-    }
+    const { onClick } = this.props;
 
     if (onClick) onClick(item, type, e);
   }

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -49,8 +49,8 @@ import {
   radarChartMouseHoverTooltipSelector,
   radialBarChartMouseHoverTooltipSelector,
   radialBarMouseHoverTooltipSelector,
-  sankeyChartMouseHoverTooltipSelector,
-  sankeyNodeChartMouseHoverTooltipSelector,
+  sankeyLinkMouseHoverTooltipSelector,
+  sankeyNodeMouseHoverTooltipSelector,
   sunburstChartMouseHoverTooltipSelector,
   treemapNodeChartMouseHoverTooltipSelector,
 } from './tooltipMouseHoverSelectors';
@@ -351,7 +351,7 @@ const SankeyNodeHoverTestCase: TooltipPayloadTestCase = {
       {children}
     </Sankey>
   ),
-  mouseHoverSelector: sankeyNodeChartMouseHoverTooltipSelector,
+  mouseHoverSelector: sankeyNodeMouseHoverTooltipSelector,
   expectedTooltipTitle: '',
   expectedTooltipContent: ['Agricultural waste : 124.729'],
 };
@@ -363,7 +363,7 @@ const SankeyLinkHoverTestCase: TooltipPayloadTestCase = {
       {children}
     </Sankey>
   ),
-  mouseHoverSelector: sankeyChartMouseHoverTooltipSelector,
+  mouseHoverSelector: sankeyLinkMouseHoverTooltipSelector,
   expectedTooltipTitle: '',
   expectedTooltipContent: ['Agricultural waste - Bio-conversion : 124.729'],
 };

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -53,7 +53,7 @@ import {
   pieChartMouseHoverTooltipSelector,
   radarChartMouseHoverTooltipSelector,
   radialBarChartMouseHoverTooltipSelector,
-  sankeyNodeChartMouseHoverTooltipSelector,
+  sankeyNodeMouseHoverTooltipSelector,
   scatterChartMouseHoverTooltipSelector,
   sunburstChartMouseHoverTooltipSelector,
   treemapNodeChartMouseHoverTooltipSelector,
@@ -265,7 +265,7 @@ const SankeyTestCase: TooltipVisibilityTestCase = {
       {children}
     </Sankey>
   ),
-  mouseHoverSelector: sankeyNodeChartMouseHoverTooltipSelector,
+  mouseHoverSelector: sankeyNodeMouseHoverTooltipSelector,
   expectedTransform: 'transform: translate(35px, 114.89236115144739px);',
 };
 

--- a/test/component/Tooltip/tooltipMouseHoverSelectors.ts
+++ b/test/component/Tooltip/tooltipMouseHoverSelectors.ts
@@ -39,11 +39,11 @@ export const radialBarChartMouseHoverTooltipSelector: MouseHoverTooltipTriggerSe
  * instead it only reacts to hovering over individual RadialBars.
  */
 export const radialBarMouseHoverTooltipSelector: MouseHoverTooltipTriggerSelector = '.recharts-radial-bar-sector';
-export const sankeyNodeChartMouseHoverTooltipSelector: MouseHoverTooltipTriggerSelector =
+export const sankeyNodeMouseHoverTooltipSelector: MouseHoverTooltipTriggerSelector =
   '.recharts-sankey-nodes .recharts-rectangle';
-export const scatterChartMouseHoverTooltipSelector: MouseHoverTooltipTriggerSelector = '.recharts-scatter-symbol';
-export const sankeyChartMouseHoverTooltipSelector: MouseHoverTooltipTriggerSelector =
+export const sankeyLinkMouseHoverTooltipSelector: MouseHoverTooltipTriggerSelector =
   '.recharts-sankey-links .recharts-sankey-link';
+export const scatterChartMouseHoverTooltipSelector: MouseHoverTooltipTriggerSelector = '.recharts-scatter-symbol';
 export const sunburstChartMouseHoverTooltipSelector: MouseHoverTooltipTriggerSelector = '.recharts-sector';
 export const treemapNodeChartMouseHoverTooltipSelector: MouseHoverTooltipTriggerSelector =
   '.recharts-treemap-depth-2 .recharts-rectangle';


### PR DESCRIPTION
## Description

This is unused now that Tooltip state is unified across all charts.

There's a similar structure in Treemap, I'm going to remove that next.
