### PR TITLE
fix: add onTouchMove touchEvent middleware

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -150,6 +150,7 @@
   "es6/state/selectors/tooltipSelectors.js",
   "es6/state/store.js",
   "es6/state/tooltipSlice.js",
+  "es6/state/touchEventsMiddleware.js",
   "es6/synchronisation",
   "es6/synchronisation/syncSelectors.js",
   "es6/synchronisation/types.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -150,6 +150,7 @@
   "lib/state/selectors/tooltipSelectors.js",
   "lib/state/store.js",
   "lib/state/tooltipSlice.js",
+  "lib/state/touchEventsMiddleware.js",
   "lib/synchronisation",
   "lib/synchronisation/syncSelectors.js",
   "lib/synchronisation/types.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -150,6 +150,7 @@
   "types/state/selectors/tooltipSelectors.d.ts",
   "types/state/store.d.ts",
   "types/state/tooltipSlice.d.ts",
+  "types/state/touchEventsMiddleware.d.ts",
   "types/synchronisation",
   "types/synchronisation/syncSelectors.d.ts",
   "types/synchronisation/types.d.ts",

--- a/src/chart/RechartsWrapper.tsx
+++ b/src/chart/RechartsWrapper.tsx
@@ -8,6 +8,7 @@ import { focusAction, keyDownAction } from '../state/keyboardEventsMiddleware';
 import { useReportScale } from '../util/useReportScale';
 import { ExternalMouseEvents } from './types';
 import { externalEventAction } from '../state/externalEventsMiddleware';
+import { touchEventAction } from '../state/touchEventsMiddleware';
 
 type Nullable<T> = {
   [P in keyof T]: T[P] | undefined;
@@ -96,6 +97,7 @@ export const RechartsWrapper = forwardRef(
       dispatch(externalEventAction({ handler: onTouchStart, reactEvent: e }));
     };
     const myOnTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
+      dispatch(touchEventAction(e));
       dispatch(externalEventAction({ handler: onTouchMove, reactEvent: e }));
     };
     const myOnTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -15,6 +15,7 @@ import { polarAxisReducer } from './polarAxisSlice';
 import { polarOptionsReducer } from './polarOptionsSlice';
 import { keyboardEventsMiddleware } from './keyboardEventsMiddleware';
 import { externalEventsMiddleware } from './externalEventsMiddleware';
+import { touchEventMiddleware } from './touchEventsMiddleware';
 
 const rootReducer = combineReducers({
   brush: brushReducer,
@@ -48,6 +49,7 @@ export const createRechartsStore = (
         mouseMoveMiddleware.middleware,
         keyboardEventsMiddleware.middleware,
         externalEventsMiddleware.middleware,
+        touchEventMiddleware.middleware,
       ]),
     devTools: {
       serialize: {

--- a/src/state/touchEventsMiddleware.ts
+++ b/src/state/touchEventsMiddleware.ts
@@ -1,7 +1,7 @@
 import { createAction, createListenerMiddleware, ListenerEffectAPI, PayloadAction } from '@reduxjs/toolkit';
 import * as React from 'react';
 import { AppDispatch, RechartsRootState } from './store';
-import { setMouseOverAxisIndex } from './tooltipSlice';
+import { setActiveMouseOverItemIndex, setMouseOverAxisIndex } from './tooltipSlice';
 import { selectActivePropsFromChartPointer } from './selectors/selectActivePropsFromChartPointer';
 
 import { getChartPointer } from '../util/getChartPointer';
@@ -28,6 +28,13 @@ touchEventMiddleware.startListening({
     if (activeProps?.activeIndex != null) {
       listenerApi.dispatch(
         setMouseOverAxisIndex({
+          activeIndex: activeProps.activeIndex,
+          activeDataKey: undefined,
+          activeCoordinate: activeProps.activeCoordinate,
+        }),
+      );
+      listenerApi.dispatch(
+        setActiveMouseOverItemIndex({
           activeIndex: activeProps.activeIndex,
           activeDataKey: undefined,
           activeCoordinate: activeProps.activeCoordinate,

--- a/src/state/touchEventsMiddleware.ts
+++ b/src/state/touchEventsMiddleware.ts
@@ -5,6 +5,7 @@ import { setMouseOverAxisIndex } from './tooltipSlice';
 import { selectActivePropsFromChartPointer } from './selectors/selectActivePropsFromChartPointer';
 
 import { getChartPointer } from '../util/getChartPointer';
+import { selectTooltipEventType } from './selectors/selectTooltipEventType';
 
 export const touchEventAction = createAction<React.TouchEvent<HTMLDivElement>>('touchMove');
 
@@ -17,15 +18,17 @@ touchEventMiddleware.startListening({
     listenerApi: ListenerEffectAPI<RechartsRootState, AppDispatch>,
   ) => {
     const touchEvent = action.payload;
+    const state = listenerApi.getState();
+    const tooltipEventType = selectTooltipEventType(state, state.tooltip.settings.shared);
     const activeProps = selectActivePropsFromChartPointer(
-      listenerApi.getState(),
+      state,
       getChartPointer({
         clientX: touchEvent.touches[0].clientX,
         clientY: touchEvent.touches[0].clientY,
         currentTarget: touchEvent.currentTarget,
       }),
     );
-    if (activeProps?.activeIndex != null) {
+    if (tooltipEventType === 'axis' && activeProps?.activeIndex != null) {
       listenerApi.dispatch(
         setMouseOverAxisIndex({
           activeIndex: activeProps.activeIndex,

--- a/src/state/touchEventsMiddleware.ts
+++ b/src/state/touchEventsMiddleware.ts
@@ -1,0 +1,38 @@
+import { createAction, createListenerMiddleware, ListenerEffectAPI, PayloadAction } from '@reduxjs/toolkit';
+import * as React from 'react';
+import { AppDispatch, RechartsRootState } from './store';
+import { setMouseOverAxisIndex } from './tooltipSlice';
+import { selectActivePropsFromChartPointer } from './selectors/selectActivePropsFromChartPointer';
+
+import { getChartPointer } from '../util/getChartPointer';
+
+export const touchEventAction = createAction<React.TouchEvent<HTMLDivElement>>('touchMove');
+
+export const touchEventMiddleware = createListenerMiddleware();
+
+touchEventMiddleware.startListening({
+  actionCreator: touchEventAction,
+  effect: (
+    action: PayloadAction<React.TouchEvent<HTMLDivElement>>,
+    listenerApi: ListenerEffectAPI<RechartsRootState, AppDispatch>,
+  ) => {
+    const touchEvent = action.payload;
+    const activeProps = selectActivePropsFromChartPointer(
+      listenerApi.getState(),
+      getChartPointer({
+        clientX: touchEvent.touches[0].clientX,
+        clientY: touchEvent.touches[0].clientY,
+        currentTarget: touchEvent.currentTarget,
+      }),
+    );
+    if (activeProps?.activeIndex != null) {
+      listenerApi.dispatch(
+        setMouseOverAxisIndex({
+          activeIndex: activeProps.activeIndex,
+          activeDataKey: undefined,
+          activeCoordinate: activeProps.activeCoordinate,
+        }),
+      );
+    }
+  },
+});

--- a/src/state/touchEventsMiddleware.ts
+++ b/src/state/touchEventsMiddleware.ts
@@ -1,7 +1,7 @@
 import { createAction, createListenerMiddleware, ListenerEffectAPI, PayloadAction } from '@reduxjs/toolkit';
 import * as React from 'react';
 import { AppDispatch, RechartsRootState } from './store';
-import { setActiveMouseOverItemIndex, setMouseOverAxisIndex } from './tooltipSlice';
+import { setMouseOverAxisIndex } from './tooltipSlice';
 import { selectActivePropsFromChartPointer } from './selectors/selectActivePropsFromChartPointer';
 
 import { getChartPointer } from '../util/getChartPointer';
@@ -28,13 +28,6 @@ touchEventMiddleware.startListening({
     if (activeProps?.activeIndex != null) {
       listenerApi.dispatch(
         setMouseOverAxisIndex({
-          activeIndex: activeProps.activeIndex,
-          activeDataKey: undefined,
-          activeCoordinate: activeProps.activeCoordinate,
-        }),
-      );
-      listenerApi.dispatch(
-        setActiveMouseOverItemIndex({
           activeIndex: activeProps.activeIndex,
           activeDataKey: undefined,
           activeCoordinate: activeProps.activeCoordinate,

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -1,7 +1,6 @@
 import React, { ComponentType, ReactNode, useState } from 'react';
 import { beforeEach, describe, expect, it, test } from 'vitest';
 import { fireEvent, getByText, render } from '@testing-library/react';
-
 import {
   Area,
   AreaChart,
@@ -42,6 +41,7 @@ import {
   MouseCoordinate,
   showTooltip,
   showTooltipOnCoordinate,
+  showTooltipOnCoordinateTouch,
 } from './tooltipTestHelpers';
 import {
   areaChartMouseHoverTooltipSelector,
@@ -403,6 +403,50 @@ describe('Tooltip visibility', () => {
       expect(tooltip1.getAttribute('style')).toContain('left: 0px');
 
       fireEvent.mouseMove(tooltipTriggerElement, { clientX: 201, clientY: 201 });
+
+      const tooltip2 = getTooltip(container);
+
+      expect(tooltip2.getAttribute('style')).toContain(expectedTransform);
+    });
+
+    it('should move onTouchMove', async context => {
+      // TODO: these charts currently do not work onTouchMove. Did they before?
+      // This is because these are set via item rather than axis. The middleware currently only sets axis coordinates.
+      if (
+        name === 'SunburstChart' ||
+        name === 'Treemap' ||
+        name === 'FunnelChart' ||
+        name === 'Sankey' ||
+        name === 'PieChart' ||
+        name === 'ScatterChart'
+      ) {
+        context.skip();
+      }
+
+      mockGetBoundingClientRect({
+        width: 10,
+        height: 10,
+      });
+      const { container } = render(
+        <Wrapper>
+          <Tooltip />
+        </Wrapper>,
+      );
+
+      showTooltipOnCoordinateTouch(container, mouseHoverSelector, {
+        clientX: 200,
+        clientY: 200,
+      });
+
+      const tooltip1 = getTooltip(container);
+      expect(tooltip1.getAttribute('style')).toContain('position: absolute;');
+      expect(tooltip1.getAttribute('style')).toContain('top: 0px');
+      expect(tooltip1.getAttribute('style')).toContain('left: 0px');
+
+      showTooltipOnCoordinateTouch(container, mouseHoverSelector, {
+        clientX: 201,
+        clientY: 201,
+      });
 
       const tooltip2 = getTooltip(container);
 
@@ -1336,6 +1380,33 @@ describe('Tooltip visibility', () => {
       expect(tooltip1.getAttribute('style')).toContain('left: 0px');
 
       showTooltipOnCoordinate(container, RadialBarChartTestCase.mouseHoverSelector, { clientX: 201, clientY: 201 });
+
+      const tooltip2 = getTooltip(container);
+
+      expect(tooltip2.getAttribute('style')).toContain(RadialBarChartTestCase.expectedTransform);
+    });
+
+    it('should move onTouchMove', async () => {
+      mockGetBoundingClientRect({
+        width: 10,
+        height: 10,
+      });
+      const { container } = renderTestCase();
+
+      showTooltipOnCoordinateTouch(container, RadialBarChartTestCase.mouseHoverSelector, {
+        clientX: 200,
+        clientY: 200,
+      });
+
+      const tooltip1 = getTooltip(container);
+      expect(tooltip1.getAttribute('style')).toContain('position: absolute;');
+      expect(tooltip1.getAttribute('style')).toContain('top: 0px');
+      expect(tooltip1.getAttribute('style')).toContain('left: 0px');
+
+      showTooltipOnCoordinateTouch(container, RadialBarChartTestCase.mouseHoverSelector, {
+        clientX: 201,
+        clientY: 201,
+      });
 
       const tooltip2 = getTooltip(container);
 

--- a/test/component/Tooltip/tooltipTestHelpers.tsx
+++ b/test/component/Tooltip/tooltipTestHelpers.tsx
@@ -51,6 +51,33 @@ export function showTooltipOnCoordinate(
 }
 
 /**
+ * Whenever you're trying to use this function, remember to mock the bounding rect call too, otherwise the jsdom environment
+ * will never recognize the touch event as a chart event.
+ *
+ * @param container Element rendered in the test
+ * @param selector Tooltip reacts to different triggers based on props, this is the selector that will be used to find the trigger element. If undefined then uses the container element itself.
+ * @param coordinates X, Y coordinate of the touch event
+ * @param debug Optional function that will be called if the tooltip trigger element is not found
+ * @returns Tooltip trigger element
+ */
+export function showTooltipOnCoordinateTouch(
+  container: Element,
+  selector: string | undefined,
+  coordinates: MouseCoordinate | undefined,
+  debug?: () => void,
+): Element {
+  const tooltipTriggerElement = selector != null ? container.querySelector(selector) : container;
+  if (tooltipTriggerElement == null && debug != null) {
+    debug();
+  }
+  assertNotNull(tooltipTriggerElement);
+  expect(tooltipTriggerElement).toBeInTheDocument();
+  expect(tooltipTriggerElement).toBeVisible();
+  fireEvent.touchMove(tooltipTriggerElement, { touches: [coordinates] });
+  return tooltipTriggerElement;
+}
+
+/**
  * Test helper that will simulate a mouse over event on a given element which should trigger the tooltip to show.
  * This function will use default coordinates of 200, 200.
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- we forgot a touch middleware, add it back

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5565

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
https://github.com/recharts/recharts/issues/5565

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran the storybook in both Chrome and Firefox's phone simulations
- I need to add unit tests but 🙃 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
