### PR TITLE
Remove Tooltip state from Treemap, and unused function findChildByType

### DIFF
--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -3,7 +3,6 @@ import omit from 'lodash/omit';
 import get from 'lodash/get';
 import Smooth from 'react-smooth';
 
-import { Tooltip } from '../component/Tooltip';
 import { Layer } from '../container/Layer';
 import { Surface } from '../container/Surface';
 import { Polygon } from '../shape/Polygon';
@@ -13,7 +12,7 @@ import { COLOR_PANEL } from '../util/Constants';
 import { isNan, uniqueId } from '../util/DataUtils';
 import { getStringSize } from '../util/DOMUtils';
 import { Global } from '../util/Global';
-import { findChildByType, validateWidthHeight, filterProps } from '../util/ReactUtils';
+import { validateWidthHeight, filterProps } from '../util/ReactUtils';
 import { AnimationDuration, AnimationTiming, DataKey, Margin } from '../util/types';
 import { ReportChartMargin, ReportChartSize } from '../context/chartLayoutContext';
 import { TooltipPortalContext } from '../context/tooltipPortalContext';
@@ -338,11 +337,7 @@ export interface Props {
 }
 
 interface State {
-  isTooltipActive: boolean;
-
   isAnimationFinished: boolean;
-
-  activeNode?: TreemapNode;
 
   formatRoot?: TreemapNode;
 
@@ -366,11 +361,7 @@ interface State {
 }
 
 const defaultState: State = {
-  isTooltipActive: false,
-
   isAnimationFinished: false,
-
-  activeNode: null as TreemapNode,
 
   formatRoot: null as TreemapNode,
 
@@ -572,44 +563,18 @@ export class Treemap extends PureComponent<Props, State> {
 
   handleMouseEnter(node: TreemapNode, e: any) {
     e.persist();
-    const { onMouseEnter, children } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip);
+    const { onMouseEnter } = this.props;
 
-    if (tooltipItem) {
-      this.setState(
-        {
-          isTooltipActive: true,
-          activeNode: node,
-        },
-        () => {
-          if (onMouseEnter) {
-            onMouseEnter(node, e);
-          }
-        },
-      );
-    } else if (onMouseEnter) {
+    if (onMouseEnter) {
       onMouseEnter(node, e);
     }
   }
 
   handleMouseLeave(node: TreemapNode, e: any) {
     e.persist();
-    const { onMouseLeave, children } = this.props;
-    const tooltipItem = findChildByType(children, Tooltip);
+    const { onMouseLeave } = this.props;
 
-    if (tooltipItem) {
-      this.setState(
-        {
-          isTooltipActive: false,
-          activeNode: null,
-        },
-        () => {
-          if (onMouseLeave) {
-            onMouseLeave(node, e);
-          }
-        },
-      );
-    } else if (onMouseLeave) {
+    if (onMouseLeave) {
       onMouseLeave(node, e);
     }
   }

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -104,25 +104,6 @@ export function findAllByType<
 }
 
 /**
- * @deprecated instead find another approach that does not require reading React Elements from DOM.
- *
- * Return the first matched child by type, return null otherwise.
- * `type` must be a React.ComponentType
- *
- * @param children do not use
- * @param type do not use
- * @return deprecated do not use
- */
-export function findChildByType<ComponentType extends React.ComponentType>(
-  children: ReactNode[],
-  type: ComponentType | ComponentType[],
-) {
-  const result = findAllByType(children, type);
-
-  return result && result[0];
-}
-
-/**
  * validate the width and height props of a chart element
  * @param  {Object} el A chart element
  * @return {Boolean}   true If the props width and height are number, and greater than 0


### PR DESCRIPTION
## Description

This state is no longer necessary now that we have Tooltip state in redux and middleware.
