### PR TITLE
Prevent rerenders in selectChartOffset

### DIFF
--- a/src/state/legendSlice.ts
+++ b/src/state/legendSlice.ts
@@ -9,7 +9,14 @@ export type LegendSettings = {
   verticalAlign: VerticalAlignmentType;
 };
 
-export type LegendState = {
+/**
+ * The properties inside this state update independently of each other and quite often.
+ * When selecting, never select the whole state because you are going to get
+ * unnecessary re-renders. Select only the properties you need.
+ *
+ * This is why this state type is not exported - don't use it directly.
+ */
+type LegendState = {
   settings: LegendSettings;
   size: Size;
   /**

--- a/src/state/selectors/legendSelectors.ts
+++ b/src/state/selectors/legendSelectors.ts
@@ -1,12 +1,15 @@
 import { createSelector } from 'reselect';
 import { RechartsRootState } from '../store';
-import { LegendState } from '../legendSlice';
+import { LegendSettings } from '../legendSlice';
 import { LegendPayload } from '../../component/DefaultLegendContent';
+import { Size } from '../../util/types';
 
-export const selectLegendState = (state: RechartsRootState): LegendState => state.legend;
+export const selectLegendSettings = (state: RechartsRootState): LegendSettings => state.legend.settings;
+
+export const selectLegendSize = (state: RechartsRootState): Size => state.legend.size;
 
 const selectAllLegendPayload2DArray = (state: RechartsRootState): ReadonlyArray<ReadonlyArray<LegendPayload>> =>
-  selectLegendState(state).payload;
+  state.legend.payload;
 
 export const selectLegendPayload: (state: RechartsRootState) => ReadonlyArray<LegendPayload> = createSelector(
   [selectAllLegendPayload2DArray],

--- a/src/state/selectors/selectChartOffset.ts
+++ b/src/state/selectors/selectChartOffset.ts
@@ -1,9 +1,9 @@
 import { createSelector } from 'reselect';
 import get from 'lodash/get';
-import { selectLegendState } from './legendSelectors';
-import { CartesianViewBox, ChartOffset, Margin } from '../../util/types';
+import { selectLegendSettings, selectLegendSize } from './legendSelectors';
+import { CartesianViewBox, ChartOffset, Margin, Size } from '../../util/types';
 import { XAxisSettings, YAxisSettings } from '../cartesianAxisSlice';
-import { LegendState } from '../legendSlice';
+import { LegendSettings } from '../legendSlice';
 import { appendOffsetOfLegend } from '../../util/ChartUtils';
 import { selectChartHeight, selectChartWidth, selectMargin } from './containerSelectors';
 import { selectAllXAxes, selectAllYAxes } from './selectAllAxes';
@@ -12,13 +12,16 @@ import { RechartsRootState } from '../store';
 export const selectBrushHeight = (state: RechartsRootState) => state.brush.height;
 
 export const selectChartOffset: (state: RechartsRootState) => ChartOffset = createSelector(
-  selectChartWidth,
-  selectChartHeight,
-  selectMargin,
-  selectBrushHeight,
-  selectAllXAxes,
-  selectAllYAxes,
-  selectLegendState,
+  [
+    selectChartWidth,
+    selectChartHeight,
+    selectMargin,
+    selectBrushHeight,
+    selectAllXAxes,
+    selectAllYAxes,
+    selectLegendSettings,
+    selectLegendSize,
+  ],
   (
     chartWidth: number,
     chartHeight: number,
@@ -26,7 +29,8 @@ export const selectChartOffset: (state: RechartsRootState) => ChartOffset = crea
     brushHeight: number,
     xAxes: XAxisSettings[],
     yAxes: YAxisSettings[],
-    legendState: LegendState,
+    legendSettings: LegendSettings,
+    legendSize: Size,
   ): ChartOffset => {
     const offsetH = yAxes.reduce(
       (result, entry) => {
@@ -60,7 +64,7 @@ export const selectChartOffset: (state: RechartsRootState) => ChartOffset = crea
 
     offset.bottom += brushHeight;
 
-    offset = appendOffsetOfLegend(offset, legendState);
+    offset = appendOffsetOfLegend(offset, legendSettings, legendSize);
 
     const offsetWidth = chartWidth - offset.left - offset.right;
     const offsetHeight = chartHeight - offset.top - offset.bottom;

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -26,12 +26,13 @@ import {
   NumberDomain,
   PolarViewBox,
   RangeObj,
+  Size,
   StackOffsetType,
   TickItem,
 } from './types';
 import { ValueType } from '../component/DefaultTooltipContent';
 import { inRangeOfSector, polarToCartesian } from './PolarUtils';
-import { LegendState } from '../state/legendSlice';
+import { LegendSettings } from '../state/legendSlice';
 import { AxisRange, BaseAxisWithScale } from '../state/selectors/axisSelectors';
 
 export function getValueByDataKey<T>(obj: T, dataKey: DataKey<T>, defaultValue?: any): unknown {
@@ -153,12 +154,14 @@ export type BarPositionPosition = {
   size: number | undefined | typeof NaN;
 };
 
-export const appendOffsetOfLegend = (offset: ChartOffset, legendState: LegendState): ChartOffset => {
-  if (legendState) {
-    const {
-      size: { width: boxWidth, height: boxHeight },
-      settings: { align, verticalAlign, layout },
-    } = legendState;
+export const appendOffsetOfLegend = (
+  offset: ChartOffset,
+  legendSettings: LegendSettings,
+  legendSize: Size,
+): ChartOffset => {
+  if (legendSettings && legendSize) {
+    const { width: boxWidth, height: boxHeight } = legendSize;
+    const { align, verticalAlign, layout } = legendSettings;
 
     if (
       (layout === 'vertical' || (layout === 'horizontal' && verticalAlign === 'middle')) &&

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -29,11 +29,11 @@ import { assertNotNull } from '../helper/assertNotNull';
 import { expectBars } from '../helper/expectBars';
 import { useAppSelector } from '../../src/state/hooks';
 import { selectAxisRangeWithReverse } from '../../src/state/selectors/axisSelectors';
-import { selectLegendPayload, selectLegendState } from '../../src/state/selectors/legendSelectors';
+import { selectLegendPayload, selectLegendSize } from '../../src/state/selectors/legendSelectors';
 import { LegendPortalContext } from '../../src/context/legendPortalContext';
 import { dataWithSpecialNameAndFillProperties } from '../_data';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
-import { LegendState } from '../../src/state/legendSlice';
+import { Size } from '../../src/util/types';
 
 function assertHasLegend(container: Element): ReadonlyArray<Element> {
   expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(1);
@@ -3119,7 +3119,7 @@ describe('<Legend />', () => {
       mockGetBoundingClientRect({ width: 3, height: 11 });
       const legendSpy = vi.fn();
       const Comp = (): null => {
-        legendSpy(useAppSelector(selectLegendState));
+        legendSpy(useAppSelector(selectLegendSize));
         return null;
       };
 
@@ -3130,20 +3130,12 @@ describe('<Legend />', () => {
         </BarChart>,
       );
 
-      const expectedAfterFirstRender: LegendState = {
-        payload: [],
-        settings: {
-          align: 'center',
-          layout: 'horizontal',
-          verticalAlign: 'bottom',
-        },
-        size: {
-          height: 11,
-          width: 3,
-        },
+      const expectedAfterFirstRender: Size = {
+        height: 11,
+        width: 3,
       };
       expect(legendSpy).toHaveBeenLastCalledWith(expectedAfterFirstRender);
-      expect(legendSpy).toHaveBeenCalledTimes(3);
+      expect(legendSpy).toHaveBeenCalledTimes(2);
 
       rerender(
         <BarChart width={500} height={500} data={numericalData}>
@@ -3151,20 +3143,12 @@ describe('<Legend />', () => {
         </BarChart>,
       );
 
-      const expectedAfterSecondRender: LegendState = {
-        payload: [],
-        settings: {
-          align: 'center',
-          layout: 'horizontal',
-          verticalAlign: 'bottom',
-        },
-        size: {
-          height: 0,
-          width: 0,
-        },
+      const expectedAfterSecondRender: Size = {
+        height: 0,
+        width: 0,
       };
       expect(legendSpy).toHaveBeenLastCalledWith(expectedAfterSecondRender);
-      expect(legendSpy).toHaveBeenCalledTimes(5);
+      expect(legendSpy).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -80,7 +80,11 @@ import { selectChartLayout } from '../../../src/context/chartLayoutContext';
 import { TooltipState } from '../../../src/state/tooltipSlice';
 import { selectTooltipState } from '../../../src/state/selectors/selectTooltipState';
 import { selectChartOffset } from '../../../src/state/selectors/selectChartOffset';
-import { selectLegendState } from '../../../src/state/selectors/legendSelectors';
+import {
+  selectLegendPayload,
+  selectLegendSettings,
+  selectLegendSize,
+} from '../../../src/state/selectors/legendSelectors';
 
 type TooltipVisibilityTestCase = {
   // For identifying which test is running
@@ -725,49 +729,53 @@ describe('Tooltip visibility', () => {
       });
     });
 
-    it('should select legend state and dimensions', () => {
-      const { spy } = renderTestCase(selectLegendState);
+    it('should select legend settings', () => {
+      const { spy } = renderTestCase(selectLegendSettings);
       expect(spy).toHaveBeenLastCalledWith({
-        payload: [
-          [
-            {
-              color: '#82ca9d',
-              dataKey: 'uv',
-              inactive: false,
-              payload: {
-                activeDot: true,
-                animateNewValues: true,
-                animationBegin: 0,
-                animationDuration: 1500,
-                animationEasing: 'ease',
-                connectNulls: false,
-                dataKey: 'uv',
-                dot: true,
-                fill: '#fff',
-                hide: false,
-                isAnimationActive: true,
-                label: false,
-                legendType: 'line',
-                stroke: '#82ca9d',
-                strokeWidth: 1,
-                xAxisId: 0,
-                yAxisId: 0,
-              },
-              type: 'line',
-              value: 'uv',
-            },
-          ],
-        ],
-        settings: {
-          align: 'center',
-          layout: 'horizontal',
-          verticalAlign: 'bottom',
-        },
-        size: {
-          height: 100,
-          width: 100,
-        },
+        align: 'center',
+        layout: 'horizontal',
+        verticalAlign: 'bottom',
       });
+    });
+
+    it('should select legend size', () => {
+      const { spy } = renderTestCase(selectLegendSize);
+      expect(spy).toHaveBeenLastCalledWith({
+        height: 100,
+        width: 100,
+      });
+    });
+
+    it('should select legend payload', () => {
+      const { spy } = renderTestCase(selectLegendPayload);
+      expect(spy).toHaveBeenLastCalledWith([
+        {
+          color: '#82ca9d',
+          dataKey: 'uv',
+          inactive: false,
+          payload: {
+            activeDot: true,
+            animateNewValues: true,
+            animationBegin: 0,
+            animationDuration: 1500,
+            animationEasing: 'ease',
+            connectNulls: false,
+            dataKey: 'uv',
+            dot: true,
+            fill: '#fff',
+            hide: false,
+            isAnimationActive: true,
+            label: false,
+            legendType: 'line',
+            stroke: '#82ca9d',
+            strokeWidth: 1,
+            xAxisId: 0,
+            yAxisId: 0,
+          },
+          type: 'line',
+          value: 'uv',
+        },
+      ]);
     });
 
     it('should select tooltip axis type', () => {

--- a/test/state/selectors/legendSelectors.spec.tsx
+++ b/test/state/selectors/legendSelectors.spec.tsx
@@ -2,35 +2,33 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
-import { LegendState } from '../../../src/state/legendSlice';
-import { selectLegendState } from '../../../src/state/selectors/legendSelectors';
-import { BarChart, Customized, Legend } from '../../../src';
+import { LegendSettings } from '../../../src/state/legendSlice';
+import { BarChart, Customized, Legend, LegendPayload } from '../../../src';
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
 import {
   shouldReturnFromInitialState,
   shouldReturnUndefinedOutOfContext,
   useAppSelectorWithStableTest,
 } from '../../helper/selectorTestHelpers';
+import {
+  selectLegendPayload,
+  selectLegendSettings,
+  selectLegendSize,
+} from '../../../src/state/selectors/legendSelectors';
+import { Size } from '../../../src/util/types';
 
-describe('selectLegendState', () => {
-  shouldReturnUndefinedOutOfContext(selectLegendState);
-  shouldReturnFromInitialState(selectLegendState, {
-    payload: [],
-    settings: {
-      layout: 'horizontal',
-      align: 'center',
-      verticalAlign: 'middle',
-    },
-    size: {
-      width: 0,
-      height: 0,
-    },
+describe('selectLegendSettings', () => {
+  shouldReturnUndefinedOutOfContext(selectLegendSettings);
+  shouldReturnFromInitialState(selectLegendSettings, {
+    layout: 'horizontal',
+    align: 'center',
+    verticalAlign: 'middle',
   });
 
   it('should return Legend settings', () => {
     const legendSettingsSpy = vi.fn();
     const Comp = (): null => {
-      const legend = useAppSelectorWithStableTest(selectLegendState);
+      const legend = useAppSelectorWithStableTest(selectLegendSettings);
       legendSettingsSpy(legend);
       return null;
     };
@@ -41,16 +39,63 @@ describe('selectLegendState', () => {
         <Customized component={<Comp />} />
       </BarChart>,
     );
-    const expected: LegendState = {
-      payload: [],
-      size: { width: 17, height: 71 },
-      settings: {
-        align: 'left',
-        layout: 'vertical',
-        verticalAlign: 'top',
-      },
+    const expected: LegendSettings = {
+      align: 'left',
+      layout: 'vertical',
+      verticalAlign: 'top',
     };
     expect(legendSettingsSpy).toHaveBeenLastCalledWith(expected);
     expect(legendSettingsSpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('selectLegendSize', () => {
+  shouldReturnUndefinedOutOfContext(selectLegendSize);
+  shouldReturnFromInitialState(selectLegendSize, {
+    width: 0,
+    height: 0,
+  });
+
+  it('should return Legend size', () => {
+    const legendSettingsSpy = vi.fn();
+    const Comp = (): null => {
+      const legend = useAppSelectorWithStableTest(selectLegendSize);
+      legendSettingsSpy(legend);
+      return null;
+    };
+    mockGetBoundingClientRect({ width: 17, height: 71 });
+    render(
+      <BarChart width={100} height={100}>
+        <Legend align="left" layout="vertical" verticalAlign="top" />
+        <Customized component={<Comp />} />
+      </BarChart>,
+    );
+    const expected: Size = { width: 17, height: 71 };
+    expect(legendSettingsSpy).toHaveBeenLastCalledWith(expected);
+    expect(legendSettingsSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('selectLegendPayload', () => {
+  shouldReturnUndefinedOutOfContext(selectLegendPayload);
+  shouldReturnFromInitialState(selectLegendPayload, []);
+
+  it('should return Legend payload', () => {
+    const legendSettingsSpy = vi.fn();
+    const Comp = (): null => {
+      const legend = useAppSelectorWithStableTest(selectLegendPayload);
+      legendSettingsSpy(legend);
+      return null;
+    };
+    mockGetBoundingClientRect({ width: 17, height: 71 });
+    render(
+      <BarChart width={100} height={100}>
+        <Legend align="left" layout="vertical" verticalAlign="top" />
+        <Customized component={<Comp />} />
+      </BarChart>,
+    );
+    const expected: ReadonlyArray<LegendPayload> = [];
+    expect(legendSettingsSpy).toHaveBeenLastCalledWith(expected);
+    expect(legendSettingsSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/state/selectors/selectors.spec.tsx
+++ b/test/state/selectors/selectors.spec.tsx
@@ -1234,7 +1234,7 @@ describe('selectTooltipState.tooltipItemPayloads', () => {
         <Pie data={[{ y: 10 }, { y: 20 }, { y: 30 }]} dataKey="y" />
       </PieChart>,
     );
-    expect(spy).toHaveBeenCalledTimes(5);
+    expect(spy).toHaveBeenCalledTimes(4);
     expect(spy).toHaveBeenLastCalledWith([
       [
         [

--- a/test/util/ChartUtils/appendOffsetOfLegend.spec.tsx
+++ b/test/util/ChartUtils/appendOffsetOfLegend.spec.tsx
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import { appendOffsetOfLegend } from '../../../src/util/ChartUtils';
-import { ChartOffset } from '../../../src/util/types';
-import { LegendState } from '../../../src/state/legendSlice';
+import { ChartOffset, Size } from '../../../src/util/types';
+import { LegendSettings } from '../../../src/state/legendSlice';
 
 vi.mock('../../../src/util/ReactUtils');
 describe('appendOffsetOfLegend', () => {
@@ -10,7 +10,7 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       left: 5,
     };
-    const result = appendOffsetOfLegend(offset, undefined);
+    const result = appendOffsetOfLegend(offset, undefined, undefined);
     expect(result).toBe(offset);
     expect(result).toEqual({
       bottom: 9,
@@ -23,19 +23,16 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       left: 5,
     };
-    const props: LegendState = {
-      payload: [],
-      settings: {
-        verticalAlign: 'bottom',
-        layout: 'vertical',
-        align: 'left',
-      },
-      size: {
-        width: 100,
-        height: 200,
-      },
+    const settings: LegendSettings = {
+      verticalAlign: 'bottom',
+      layout: 'vertical',
+      align: 'left',
     };
-    const result = appendOffsetOfLegend(offset, props);
+    const size: Size = {
+      width: 100,
+      height: 200,
+    };
+    const result = appendOffsetOfLegend(offset, settings, size);
     expect(result).toEqual({ bottom: 9, left: 105 });
   });
 
@@ -44,19 +41,16 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       left: 5,
     };
-    const props: LegendState = {
-      payload: [],
-      settings: {
-        layout: 'horizontal',
-        verticalAlign: 'middle',
-        align: 'left',
-      },
-      size: {
-        width: 100,
-        height: 200,
-      },
+    const settings: LegendSettings = {
+      layout: 'horizontal',
+      verticalAlign: 'middle',
+      align: 'left',
     };
-    const result = appendOffsetOfLegend(offset, props);
+    const size: Size = {
+      width: 100,
+      height: 200,
+    };
+    const result = appendOffsetOfLegend(offset, settings, size);
     expect(result).toEqual({ bottom: 9, left: 105 });
   });
 
@@ -65,19 +59,16 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       left: 5,
     };
-    const props: LegendState = {
-      payload: [],
-      settings: {
-        layout: 'horizontal',
-        verticalAlign: 'middle',
-        align: 'left',
-      },
-      size: {
-        width: 100,
-        height: 200,
-      },
+    const settings: LegendSettings = {
+      layout: 'horizontal',
+      verticalAlign: 'middle',
+      align: 'left',
     };
-    appendOffsetOfLegend(offset, props);
+    const size: Size = {
+      width: 100,
+      height: 200,
+    };
+    appendOffsetOfLegend(offset, settings, size);
 
     expect(offset).toEqual({ bottom: 9, left: 5 });
   });
@@ -87,19 +78,16 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       right: 14,
     };
-    const props: LegendState = {
-      payload: [],
-      settings: {
-        align: 'left',
-        layout: 'horizontal',
-        verticalAlign: 'bottom',
-      },
-      size: {
-        width: 100,
-        height: 200,
-      },
+    const settings: LegendSettings = {
+      align: 'left',
+      layout: 'horizontal',
+      verticalAlign: 'bottom',
     };
-    const result = appendOffsetOfLegend(offset, props);
+    const size: Size = {
+      width: 100,
+      height: 200,
+    };
+    const result = appendOffsetOfLegend(offset, settings, size);
     expect(result).toEqual({ bottom: 209, right: 14 });
   });
 
@@ -108,19 +96,16 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       right: 14,
     };
-    const props: LegendState = {
-      payload: [],
-      settings: {
-        align: 'center',
-        layout: 'vertical',
-        verticalAlign: 'bottom',
-      },
-      size: {
-        width: 100,
-        height: 200,
-      },
+    const settings: LegendSettings = {
+      align: 'center',
+      layout: 'vertical',
+      verticalAlign: 'bottom',
     };
-    const result = appendOffsetOfLegend(offset, props);
+    const size: Size = {
+      width: 100,
+      height: 200,
+    };
+    const result = appendOffsetOfLegend(offset, settings, size);
     expect(result).toEqual({ bottom: 209, right: 14 });
   });
 
@@ -129,19 +114,16 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       right: 14,
     };
-    const props: LegendState = {
-      payload: [],
-      settings: {
-        align: 'center',
-        layout: 'vertical',
-        verticalAlign: 'middle',
-      },
-      size: {
-        width: 100,
-        height: 200,
-      },
+    const settings: LegendSettings = {
+      align: 'center',
+      layout: 'vertical',
+      verticalAlign: 'middle',
     };
-    const result = appendOffsetOfLegend(offset, props);
+    const size: Size = {
+      width: 100,
+      height: 200,
+    };
+    const result = appendOffsetOfLegend(offset, settings, size);
     expect(result).toEqual({ bottom: 9, right: 14 });
   });
 
@@ -150,20 +132,17 @@ describe('appendOffsetOfLegend', () => {
       bottom: 9,
       right: 14,
     };
-    const props: LegendState = {
-      settings: {
-        align: 'left',
-        layout: 'horizontal',
-        verticalAlign: 'middle',
-      },
-      size: {
-        width: 100,
-        height: 200,
-      },
-      payload: [],
+    const settings: LegendSettings = {
+      align: 'left',
+      layout: 'horizontal',
+      verticalAlign: 'middle',
+    };
+    const size: Size = {
+      width: 100,
+      height: 200,
     };
 
-    const result = appendOffsetOfLegend(offset, props);
+    const result = appendOffsetOfLegend(offset, settings, size);
     expect(result).toEqual({ bottom: 9, right: 14 });
   });
 });


### PR DESCRIPTION
## Description

selectChartOffset was accepting more properties than it needed. The payload which is extra is updating and that triggers extra re-renders and those extra re-renders break animations in Pie. Because selectChartOffset does not use the payload, we can fix this by using more targeted selectors which is what I did.

Pie animations are still broken because there are more problems but this is a step forward.

## Related Issue

https://github.com/recharts/recharts/issues/5625
