### PR TITLE
fix: allow data-* props to be spread on svg element

### DIFF
--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -295,6 +295,7 @@ export const isValidSpreadableProp = (
   const matchingElementTypeKeys = FilteredElementKeyMap?.[svgElementType] ?? [];
 
   return (
+    key.startsWith('data-') ||
     (!isFunction(property) &&
       ((svgElementType && matchingElementTypeKeys.includes(key)) || SVGElementPropKeys.includes(key))) ||
     (includeEvents && EventKeys.includes(key))

--- a/test/util/ReactUtils.spec.tsx
+++ b/test/util/ReactUtils.spec.tsx
@@ -79,6 +79,12 @@ describe('ReactUtils untest tests', () => {
       expect(Object.keys(result ?? {})).toContain('fill');
       expect(Object.keys(result ?? {})).toContain('r');
     });
+
+    test('should maintain data-* attributes', () => {
+      expect(filterProps({ test: '1234', helloWorld: 1234, 'data-x': 'foo' }, false)).toEqual({
+        'data-x': 'foo',
+      });
+    });
   });
 
   describe('isValidSpreadableProp', () => {


### PR DESCRIPTION
## Description

Currently, spread props are passed to the svg element. To avoid this, we use `filterProps`.
However, `filterProps`. is also removing valid `data-*` attributes, which should not be filtered out.
This change ensures that `data-*` attributes are always preserved.

## Related Issue

https://github.com/recharts/recharts/issues/5664

## How Has This Been Tested?

`filterProps` is fully covered by unit tests.
I've added an additional unit test to check the correct behaviour for data attribute.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
