### PR TITLE
fix: allow data-* props to be spread on svg element

### DIFF
--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -145,6 +145,7 @@ export const isValidSpreadableProp = (
   const matchingElementTypeKeys = FilteredElementKeyMap?.[svgElementType] ?? [];
 
   return (
+    key.startsWith('data-') ||
     (typeof property !== 'function' &&
       ((svgElementType && matchingElementTypeKeys.includes(key)) || SVGElementPropKeys.includes(key))) ||
     (includeEvents && EventKeys.includes(key))

--- a/test/util/ReactUtils.spec.tsx
+++ b/test/util/ReactUtils.spec.tsx
@@ -77,6 +77,12 @@ describe('ReactUtils untest tests', () => {
       expect(Object.keys(result ?? {})).toContain('fill');
       expect(Object.keys(result ?? {})).toContain('r');
     });
+
+    test('should maintain data-* attributes', () => {
+      expect(filterProps({ test: '1234', helloWorld: 1234, 'data-x': 'foo' }, false)).toEqual({
+        'data-x': 'foo',
+      });
+    });
   });
 
   describe('isValidSpreadableProp', () => {


### PR DESCRIPTION
Same as https://github.com/recharts/recharts/pull/5666 but for `3.x` branch.