### PR TITLE
Bar stacks when stackId is a number

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -443,8 +443,10 @@ function RectanglesWithAnimation({
                 return { ...entry, width: w };
               });
 
-        // eslint-disable-next-line no-param-reassign
-        previousRectanglesRef.current = stepData;
+        if (t > 0) {
+          // eslint-disable-next-line no-param-reassign
+          previousRectanglesRef.current = stepData;
+        }
         return (
           <Layer>
             <BarRectangles props={props} data={stepData} showLabels={!isAnimating} />

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -27,8 +27,10 @@ import {
   BarPositionPosition,
   getBaseValueOfBar,
   getCateCoordinateOfBar,
+  getNormalizedStackId,
   getTooltipNameProp,
   getValueByDataKey,
+  StackId,
   truncateByDomain,
 } from '../util/ChartUtils';
 import {
@@ -82,7 +84,7 @@ export interface BarProps {
   index?: Key;
   xAxisId?: string | number;
   yAxisId?: string | number;
-  stackId?: string | number;
+  stackId?: StackId;
   barSize?: string | number;
   unit?: string | number;
   name?: string | number;
@@ -546,7 +548,7 @@ function BarImpl(props: Props) {
       dataKey: props.dataKey,
       maxBarSize: props.maxBarSize,
       minPointSize: props.minPointSize,
-      stackId: props.stackId,
+      stackId: getNormalizedStackId(props.stackId),
     }),
     [props.barSize, props.dataKey, props.maxBarSize, props.minPointSize, props.stackId],
   );

--- a/src/state/SetGraphicalItem.ts
+++ b/src/state/SetGraphicalItem.ts
@@ -8,13 +8,22 @@ import {
   removeCartesianGraphicalItem,
   removePolarGraphicalItem,
 } from './graphicalItemsSlice';
+import { getNormalizedStackId, StackId } from '../util/ChartUtils';
 
-export function SetCartesianGraphicalItem(props: CartesianGraphicalItemSettings): null {
+type SetCartesianGraphicalItemProps = Omit<CartesianGraphicalItemSettings, 'stackId'> & {
+  stackId: StackId | undefined;
+};
+
+export function SetCartesianGraphicalItem(props: SetCartesianGraphicalItemProps): null {
   const dispatch = useAppDispatch();
   useEffect(() => {
-    dispatch(addCartesianGraphicalItem(props));
+    const settings: CartesianGraphicalItemSettings = {
+      ...props,
+      stackId: getNormalizedStackId(props.stackId),
+    };
+    dispatch(addCartesianGraphicalItem(settings));
     return () => {
-      dispatch(removeCartesianGraphicalItem(props));
+      dispatch(removeCartesianGraphicalItem(settings));
     };
   }, [dispatch, props]);
   return null;

--- a/src/state/graphicalItemsSlice.ts
+++ b/src/state/graphicalItemsSlice.ts
@@ -4,7 +4,7 @@ import { ChartData } from './chartDataSlice';
 import { AxisId } from './cartesianAxisSlice';
 import { DataKey } from '../util/types';
 import { ErrorBarDirection } from '../cartesian/ErrorBar';
-import { StackId } from '../util/ChartUtils';
+import { NormalizedStackId } from '../util/ChartUtils';
 import { MaybeStackedGraphicalItem } from './selectors/barSelectors';
 
 /**
@@ -64,7 +64,7 @@ export type CartesianGraphicalItemSettings = GraphicalItemSettings & {
    * One graphical item can have multiple error bars. This probably only makes sense in Scatter.
    */
   errorBars: ReadonlyArray<ErrorBarsSettings> | undefined;
-  stackId: StackId | undefined;
+  stackId: NormalizedStackId | undefined;
   /**
    * This property is only used in Bar and RadialBar items
    */

--- a/src/state/selectors/barSelectors.ts
+++ b/src/state/selectors/barSelectors.ts
@@ -14,7 +14,7 @@ import {
 import { AxisId } from '../cartesianAxisSlice';
 import { getPercentValue, isNullish } from '../../util/DataUtils';
 import { CartesianGraphicalItemSettings } from '../graphicalItemsSlice';
-import { BarPositionPosition, getBandSizeOfAxis, StackId } from '../../util/ChartUtils';
+import { BarPositionPosition, getBandSizeOfAxis, NormalizedStackId, StackId } from '../../util/ChartUtils';
 import { ChartOffset, DataKey, LayoutType, TickItem } from '../../util/types';
 import { BarRectangleItem, computeBarRectangles } from '../../cartesian/Bar';
 import { selectChartLayout } from '../../context/chartLayoutContext';
@@ -30,7 +30,7 @@ export type BarSettings = {
   dataKey: DataKey<any>;
   maxBarSize: number | undefined;
   minPointSize: MinPointSize;
-  stackId: StackId | undefined;
+  stackId: NormalizedStackId | undefined;
 };
 
 const pickXAxisId = (_state: RechartsRootState, xAxisId: AxisId): AxisId => xAxisId;
@@ -364,6 +364,7 @@ export const combineAllBarPositions = (
 
   return allBarPositions;
 };
+
 export const selectAllBarPositions: (
   state: RechartsRootState,
   xAxisId: AxisId,
@@ -395,7 +396,7 @@ const selectXAxisTicks = (state: RechartsRootState, xAxisId: AxisId, _yAxisId: A
 const selectYAxisTicks = (state: RechartsRootState, _xAxisId: AxisId, yAxisId: AxisId, isPanorama: boolean) =>
   selectTicksOfGraphicalItem(state, 'yAxis', yAxisId, isPanorama);
 
-const selectBarPosition: (
+export const selectBarPosition: (
   state: RechartsRootState,
   xAxisId: AxisId,
   yAxisId: AxisId,

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -522,7 +522,17 @@ export const getStackedData = (
   return stack(data);
 };
 
-export type StackId = string | number | symbol;
+export type StackId = string | number;
+/**
+ * Stack IDs in the external props allow numbers; but internally we use it as an object key
+ * and object keys are always strings. Also it would be kinda confusing if stackId=8 and stackId='8' were different stacks
+ * so let's just force a string.
+ */
+export type NormalizedStackId = string;
+
+export function getNormalizedStackId(publicStackId: StackId | undefined): NormalizedStackId | undefined {
+  return publicStackId == null ? undefined : String(publicStackId);
+}
 
 /**
  * @deprecated do not use - depends on passing around DOM elements

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -19,6 +19,7 @@ import {
   selectAllBarPositions,
   selectAllVisibleBars,
   selectBarCartesianAxisSize,
+  selectBarPosition,
   selectBarRectangles,
   selectBarSizeList,
 } from '../../src/state/selectors/barSelectors';
@@ -29,6 +30,7 @@ import { CartesianGraphicalItemSettings } from '../../src/state/graphicalItemsSl
 import { BarRectangleItem } from '../../src/cartesian/Bar';
 import { CategoricalChartProps } from '../../src/chart/generateCategoricalChart';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
+import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 
 type DataType = {
   name: string;
@@ -608,6 +610,258 @@ describe('<BarChart />', () => {
           y: '5',
         },
       ]);
+    });
+
+    describe('when stackId is a number', () => {
+      const barSettings: BarSettings = {
+        barSize: '',
+        data,
+        dataKey: 'pv',
+        maxBarSize: 0,
+        minPointSize: 0,
+        stackId: '8',
+      };
+      const cells: never[] = [];
+
+      const renderTestCase = createSelectorTestCase(({ children }) => (
+        <BarChart width={100} height={50} data={data}>
+          <YAxis />
+          <Bar dataKey="uv" stackId={barSettings.stackId} fill="#ff7300" isAnimationActive={false} />
+          <Bar dataKey="pv" stackId={barSettings.stackId} fill="#387908" isAnimationActive={false} />
+          {children}
+        </BarChart>
+      ));
+
+      it('should select bars', () => {
+        const { spy } = renderTestCase(state => selectBarRectangles(state, 0, 0, false, barSettings, cells));
+        expect(spy).toHaveBeenLastCalledWith([
+          {
+            background: {
+              height: 40,
+              width: 0,
+              x: 68.75,
+              y: 5,
+            },
+            height: 9.600000000000001,
+            name: 'food',
+            payload: {
+              name: 'food',
+              pv: 2400,
+              uv: 400,
+            },
+            pv: 2400,
+            tooltipPosition: {
+              x: 68.75,
+              y: 38.599999999999994,
+            },
+            uv: 400,
+            value: [400, 2800],
+            width: 0,
+            x: 68.75,
+            y: 33.8,
+          },
+          {
+            background: {
+              height: 40,
+              width: 0,
+              x: 76.25,
+              y: 5,
+            },
+            height: 18.268,
+            name: 'cosmetic',
+            payload: {
+              name: 'cosmetic',
+              pv: 4567,
+              uv: 300,
+            },
+            pv: 4567,
+            tooltipPosition: {
+              x: 76.25,
+              y: 34.666,
+            },
+            uv: 300,
+            value: [300, 4867],
+            width: 0,
+            x: 76.25,
+            y: 25.531999999999996,
+          },
+          {
+            background: {
+              height: 40,
+              width: 0,
+              x: 83.75,
+              y: 5,
+            },
+            height: 5.591999999999999,
+            name: 'storage',
+            payload: {
+              name: 'storage',
+              pv: 1398,
+              uv: 300,
+            },
+            pv: 1398,
+            tooltipPosition: {
+              x: 83.75,
+              y: 41.004,
+            },
+            uv: 300,
+            value: [300, 1698],
+            width: 0,
+            x: 83.75,
+            y: 38.208,
+          },
+          {
+            background: {
+              height: 40,
+              width: 0,
+              x: 91.25,
+              y: 5,
+            },
+            height: 39.2,
+            name: 'digital',
+            payload: {
+              name: 'digital',
+              pv: 9800,
+              uv: 200,
+            },
+            pv: 9800,
+            tooltipPosition: {
+              x: 91.25,
+              y: 24.6,
+            },
+            uv: 200,
+            value: [200, 10000],
+            width: 0,
+            x: 91.25,
+            y: 5,
+          },
+        ]);
+      });
+
+      it('should select bar size list', () => {
+        const { spy } = renderTestCase(state => selectBarSizeList(state, 0, 0, false, barSettings));
+        expect(spy).toHaveBeenLastCalledWith([
+          {
+            barSize: undefined,
+            dataKeys: ['uv', 'pv'],
+            stackId: '8',
+          },
+        ]);
+      });
+
+      it('should select all bar positions', () => {
+        const { spy } = renderTestCase(state => selectAllBarPositions(state, 0, 0, false, barSettings));
+        expect(spy).toHaveBeenLastCalledWith([
+          {
+            dataKeys: ['uv', 'pv'],
+            position: {
+              offset: 3.75,
+              size: 0,
+            },
+            stackId: '8',
+          },
+        ]);
+      });
+
+      it('should select bar position', () => {
+        const { spy } = renderTestCase(state => selectBarPosition(state, 0, 0, false, barSettings));
+        expect(spy).toHaveBeenLastCalledWith({
+          offset: 3.75,
+          size: 0,
+        });
+      });
+
+      it('should render bars', () => {
+        const matchingStackConfig = [
+          { name: 'food', firstBarIndex: 0, secondBarIndex: 4 },
+          { name: 'cosmetic', firstBarIndex: 1, secondBarIndex: 5 },
+          { name: 'storage', firstBarIndex: 2, secondBarIndex: 6 },
+          { name: 'digital', firstBarIndex: 3, secondBarIndex: 7 },
+        ];
+
+        const { container } = renderTestCase();
+
+        const rects = container.querySelectorAll('.recharts-rectangle');
+        expect(rects).toHaveLength(8);
+
+        matchingStackConfig.forEach(({ name, firstBarIndex, secondBarIndex }) => {
+          // bar one and bar two should be the same category
+          const barOne = rects[firstBarIndex];
+          const barTwo = rects[secondBarIndex];
+          expect(barOne.getAttribute('name')).toEqual(name);
+          expect(barTwo.getAttribute('name')).toEqual(name);
+
+          // these bars should have the same x (cannot compare y accurately as Y does not start from 0)
+          expect(barOne.getAttribute('x')).toEqual(barTwo.getAttribute('x'));
+        });
+
+        expectBars(container, [
+          {
+            d: 'M 65.75,43.4 h 6 v 1.6000000000000014 h -6 Z',
+            height: '1.6000000000000014',
+            radius: '0',
+            width: '6',
+            x: '65.75',
+            y: '43.4',
+          },
+          {
+            d: 'M 73.25,43.8 h 6 v 1.2000000000000028 h -6 Z',
+            height: '1.2000000000000028',
+            radius: '0',
+            width: '6',
+            x: '73.25',
+            y: '43.8',
+          },
+          {
+            d: 'M 80.75,43.8 h 6 v 1.2000000000000028 h -6 Z',
+            height: '1.2000000000000028',
+            radius: '0',
+            width: '6',
+            x: '80.75',
+            y: '43.8',
+          },
+          {
+            d: 'M 88.25,44.2 h 6 v 0.7999999999999972 h -6 Z',
+            height: '0.7999999999999972',
+            radius: '0',
+            width: '6',
+            x: '88.25',
+            y: '44.2',
+          },
+          {
+            d: 'M 65.75,33.8 h 6 v 9.600000000000001 h -6 Z',
+            height: '9.600000000000001',
+            radius: '0',
+            width: '6',
+            x: '65.75',
+            y: '33.8',
+          },
+          {
+            d: 'M 73.25,25.531999999999996 h 6 v 18.268 h -6 Z',
+            height: '18.268',
+            radius: '0',
+            width: '6',
+            x: '73.25',
+            y: '25.531999999999996',
+          },
+          {
+            d: 'M 80.75,38.208 h 6 v 5.591999999999999 h -6 Z',
+            height: '5.591999999999999',
+            radius: '0',
+            width: '6',
+            x: '80.75',
+            y: '38.208',
+          },
+          {
+            d: 'M 88.25,5 h 6 v 39.2 h -6 Z',
+            height: '39.2',
+            radius: '0',
+            width: '6',
+            x: '88.25',
+            y: '5',
+          },
+        ]);
+      });
     });
 
     test('Stacked bars are actually stacked', () => {

--- a/test/helper/selectorTestHelpers.tsx
+++ b/test/helper/selectorTestHelpers.tsx
@@ -45,7 +45,7 @@ export function shouldReturnFromInitialState<T>(
  *
  * This is generally what we want from all selectors so it's a good idea to run this on all selector functions.
  *
- * Redux out of the box does something similar but it only prints warnings to console, this version throws.
+ * Redux out of the box does something similar, but it only prints warnings to console, this version throws.
  *
  * @param selector accepts RechartsRootState and returns T
  * @return T that the selector returned


### PR DESCRIPTION
## Description

Let's allow passing the `stackId` as a number from the outside, but internally move it to a string.

Also I noticed a bug in the animation when Legend is in the chart so I fixed that too.

Visual diff: https://www.chromatic.com/test?appId=63da8268a0da9970db6992aa&id=67d65c5606d4ff054c684039

## Related Issue

Fixes https://github.com/recharts/recharts/issues/5648
