### PR TITLE
fix(Area): normalize stackId to a string if a number is passed

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -9,7 +9,7 @@ import { Layer } from '../container/Layer';
 import { LabelList } from '../component/LabelList';
 import { Global } from '../util/Global';
 import { interpolateNumber, isNan, isNullish, isNumber, uniqueId } from '../util/DataUtils';
-import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
+import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey, StackId } from '../util/ChartUtils';
 import {
   ActiveDotType,
   AnimationDuration,
@@ -71,7 +71,7 @@ interface InternalAreaProps {
   onAnimationStart?: () => void;
 
   points?: ReadonlyArray<AreaPointItem>;
-  stackId?: string | number;
+  stackId?: StackId;
 
   tooltipType?: TooltipType;
   top: number;

--- a/src/state/selectors/areaSelectors.ts
+++ b/src/state/selectors/areaSelectors.ts
@@ -13,7 +13,7 @@ import { RechartsRootState } from '../store';
 import { AxisId } from '../cartesianAxisSlice';
 import { selectChartLayout } from '../../context/chartLayoutContext';
 import { selectChartDataWithIndexesIfNotInPanorama } from './dataSelectors';
-import { getBandSizeOfAxis, isCategoricalAxis, StackId } from '../../util/ChartUtils';
+import { getBandSizeOfAxis, getNormalizedStackId, isCategoricalAxis, StackId } from '../../util/ChartUtils';
 import { ChartData } from '../chartDataSlice';
 import { Point as CurvePoint } from '../../shape/Curve';
 
@@ -111,7 +111,7 @@ const selectSynchronisedAreaSettings: (
         cgis =>
           cgis.type === 'area' &&
           areaSettingsFromProps.dataKey === cgis.dataKey &&
-          areaSettingsFromProps.stackId === cgis.stackId &&
+          getNormalizedStackId(areaSettingsFromProps.stackId) === cgis.stackId &&
           areaSettingsFromProps.data === cgis.data,
       )
     ) {

--- a/test/chart/AreaChart.spec.tsx
+++ b/test/chart/AreaChart.spec.tsx
@@ -9,6 +9,7 @@ import { AreaSettings, selectArea } from '../../src/state/selectors/areaSelector
 import { selectTicksOfAxis } from '../../src/state/selectors/axisSelectors';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 import { useChartHeight, useChartWidth, useClipPathId, useViewBox } from '../../src/context/chartLayoutContext';
+import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 
 type ExpectedArea = {
   d: string;
@@ -374,6 +375,36 @@ describe('AreaChart', () => {
       },
       {
         d: 'M80,10L145,10L210,10L275,10L340,10L405,10L470,10',
+      },
+    ]);
+  });
+
+  test('renders a stacked chart when stackId is a number', () => {
+    const areaSettings: AreaSettings = {
+      baseValue: undefined,
+      stackId: 1,
+      dataKey: 'uv',
+      connectNulls: false,
+      data: undefined,
+    };
+
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <AreaChart width={500} height={400} data={pageData}>
+        <Area dataKey="uv" stackId={areaSettings.stackId} />
+        <Area dataKey="pv" stackId={areaSettings.stackId} />
+        {children}
+      </AreaChart>
+    ));
+
+    const { container } = renderTestCase(state => selectArea(state, 0, 0, false, areaSettings));
+
+    // if number stackId breaks this will return an empty array
+    expectAreaCurve(container, [
+      {
+        d: 'M5,312.821L86.667,312.821L168.333,274.1L250,200.418L331.667,188.857L413.333,183.286L495,200',
+      },
+      {
+        d: 'M5,201.393L86.667,201.393L168.333,139.411L250,47.482L331.667,21.714L413.333,28.957L495,105.286',
       },
     ]);
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix https://github.com/recharts/recharts/issues/5687

stackId cannot be passed as a number at the moment in 3.x for Area

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5687

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix a bug

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
![image](https://github.com/user-attachments/assets/b52ac3e3-96cc-4d61-83ad-bbb88ad0e4b5)
- visual diff
- unit test


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
