### PR TITLE
Fix: Update CartesianGrid component

### DIFF
--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -492,6 +492,10 @@ export function CartesianGrid(props: Props) {
         height={propsIncludingDefaults.height}
         ry={propsIncludingDefaults.ry}
       />
+
+      <HorizontalStripes {...propsIncludingDefaults} horizontalPoints={horizontalPoints} />
+      <VerticalStripes {...propsIncludingDefaults} verticalPoints={verticalPoints} />
+
       <HorizontalGridLines
         {...propsIncludingDefaults}
         offset={offset}
@@ -507,10 +511,6 @@ export function CartesianGrid(props: Props) {
         xAxis={xAxis}
         yAxis={yAxis}
       />
-
-      <HorizontalStripes {...propsIncludingDefaults} horizontalPoints={horizontalPoints} />
-
-      <VerticalStripes {...propsIncludingDefaults} verticalPoints={verticalPoints} />
     </g>
   );
 }

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -92,10 +92,11 @@ interface CartesianGridProps extends InternalCartesianGridProps {
    * The values from this array will be passed in as the `fill` property in a `rect` SVG element.
    * For possible values see: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill#rect
    *
-   * In case there are more stripes than colors, the colors will start from beginning
+   * In case there are more stripes than colors, the colors will start from beginning.
    * So for example: verticalFill['yellow', 'black'] produces a pattern of yellow|black|yellow|black
    *
    * If this is undefined, or an empty array, then there is no background fill.
+   * Note: Grid lines will be rendered above these background stripes.
    */
   verticalFill?: string[];
   /**
@@ -104,10 +105,11 @@ interface CartesianGridProps extends InternalCartesianGridProps {
    * The values from this array will be passed in as the `fill` property in a `rect` SVG element.
    * For possible values see: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill#rect
    *
-   * In case there are more stripes than colors, the colors will start from beginning
+   * In case there are more stripes than colors, the colors will start from beginning.
    * So for example: horizontalFill['yellow', 'black'] produces a pattern of yellow|black|yellow|black
    *
    * If this is undefined, or an empty array, then there is no background fill.
+   * Note: Grid lines will be rendered above these background stripes.
    */
   horizontalFill?: string[];
   /**


### PR DESCRIPTION
# fix: render grid lines above background stripes

## Description

When using verticalFill or horizontalFill, the grid lines were being rendered
     behind the stripes, making them invisible. This PR reorders the SVG elements
     to render grid lines above the background stripes while maintaining the
     existing functionality.

## Related Issue 
Fixes #5690

https://github.com/recharts/recharts/issues/5690

## Motivation and Context

Currently, when using verticalFill or horizontalFill properties in CartesianGrid, the grid lines are rendered behind the background stripes, making them invisible. This change reorders the SVG elements to ensure grid lines are visible by rendering them above the background stripes while maintaining all existing functionality.

## How Has This Been Tested?

The change has been tested by:
1. Running the existing test suite (`npm run test`)
2. Visual verification using Storybook with different combinations of:
   - verticalFill
   - horizontalFill
   - grid lines
   to ensure the grid lines are now visible above the stripes while maintaining all other functionality.


## Screenshots (if appropriate):

<img width="1082" alt="Screenshot 2025-03-20 at 9 54 09 am" src="https://github.com/user-attachments/assets/277b7cb7-b352-4a71-93b4-e315b460a64d" />

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
