### PR TITLE
Add SVGElements to payload type

### DIFF
--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Default Tooltip Content
  */
 
-import React, { CSSProperties, HTMLAttributes, ReactNode } from 'react';
+import React, { CSSProperties, HTMLAttributes, ReactNode, SVGProps } from 'react';
 import sortBy from 'lodash/sortBy';
 import isNil from 'lodash/isNil';
 import clsx from 'clsx';
@@ -23,7 +23,7 @@ export type Formatter<TValue extends ValueType, TName extends NameType> = (
   payload: Array<Payload<TValue, TName>>,
 ) => [React.ReactNode, TName] | React.ReactNode;
 
-export interface Payload<TValue extends ValueType, TName extends NameType> {
+export interface Payload<TValue extends ValueType, TName extends NameType> extends Omit<SVGProps<SVGElement>, 'name'> {
   type?: TooltipType;
   color?: string;
   formatter?: Formatter<TValue, TName>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added SVGProps<SVGElement> into the Payload type to reference all SVG possible fields at the payload

<!--- Describe your changes in detail -->

## Related Issue

#5711

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

It solves problem when trying to access SVG props at the payload content inside a Tooltip component

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
