### PR TITLE
Don't set dataEndIndex to -1 so that Scatter can show tooltip again

### DIFF
--- a/src/context/chartDataContext.tsx
+++ b/src/context/chartDataContext.tsx
@@ -10,7 +10,7 @@ export const ChartDataContextProvider = (props: { chartData: ChartData }): null 
   useEffect(() => {
     dispatch(setChartData(chartData));
     return () => {
-      dispatch(setChartData([]));
+      dispatch(setChartData(undefined));
     };
   }, [chartData, dispatch]);
   return null;
@@ -22,7 +22,7 @@ export const SetComputedData = (props: { computedData: any }): null => {
   useEffect(() => {
     dispatch(setComputedData(computedData));
     return () => {
-      dispatch(setChartData([]));
+      dispatch(setChartData(undefined));
     };
   }, [computedData, dispatch]);
   return null;

--- a/src/state/chartDataSlice.ts
+++ b/src/state/chartDataSlice.ts
@@ -54,7 +54,12 @@ const chartDataSlice = createSlice({
   reducers: {
     setChartData(state, action: PayloadAction<ChartData | undefined>) {
       state.chartData = action.payload;
-      if (action.payload != null && state.dataEndIndex !== action.payload.length - 1) {
+      if (action.payload == null) {
+        state.dataStartIndex = 0;
+        state.dataEndIndex = 0;
+        return;
+      }
+      if (action.payload.length > 0 && state.dataEndIndex !== action.payload.length - 1) {
         state.dataEndIndex = action.payload.length - 1;
       }
     },

--- a/test/state/chartDataSlice.spec.ts
+++ b/test/state/chartDataSlice.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+
+import { chartDataReducer, setChartData } from '../../src/state/chartDataSlice';
+
+describe('chartDataSlice', () => {
+  it('should start with undefined chartData', () => {
+    const state = chartDataReducer(undefined, { type: 'unknown' });
+    expect(state.chartData).toBeUndefined();
+    expect(state.dataStartIndex).toBe(0);
+    expect(state.dataEndIndex).toBe(0);
+  });
+
+  it('should set chartData array with start and end index', () => {
+    const chartData = [{ value: 1 }, { value: 2 }, { value: 3 }];
+    const action = setChartData(chartData);
+    const state = chartDataReducer(undefined, action);
+    expect(state.chartData).toBe(chartData);
+    expect(state.dataStartIndex).toBe(0);
+    expect(state.dataEndIndex).toBe(2);
+  });
+
+  it('should set empty array with start and end index', () => {
+    const chartData: never[] = [];
+    const action = setChartData(chartData);
+    const state = chartDataReducer(undefined, action);
+    expect(state.chartData).toBe(chartData);
+    expect(state.dataStartIndex).toBe(0);
+    expect(state.dataEndIndex).toBe(0);
+  });
+
+  it('should clear the state when set undefined', () => {
+    const chartData = [{ value: 1 }, { value: 2 }, { value: 3 }];
+    const action1 = setChartData(chartData);
+    const state1 = chartDataReducer(undefined, action1);
+    const action2 = setChartData(undefined);
+    const state2 = chartDataReducer(state1, action2);
+    expect(state2.chartData).toBeUndefined();
+    expect(state2.dataStartIndex).toBe(0);
+    expect(state2.dataEndIndex).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

This code was setting the dataEndIndex to `-1` which wasn't detected as "empty" because we only detect "empty" as "equals to zero" and -1 is not equal to zero.

This should fix the Scatter tooltip problem that @jurij reported here: https://github.com/recharts/recharts/issues/5445#issuecomment-2746356448

This bug only happened on when the `<ChartDataContextProvider />` got unmounted which doesn't happen in the storybook but happens outside and I am not entirely sure why but we need to guard against that anyway because React can mount and unmount things as it pleases.

## Related Issue

https://github.com/recharts/recharts/issues/5445
