### PR TITLE
Fix for activeBar Prop Not Working with tooltip  shared is false

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1421,6 +1421,7 @@ export const generateCategoricalChart = ({
 
       const { xAxisMap, yAxisMap } = this.state;
       const tooltipEventType = this.getTooltipEventType();
+      const toolTipData = getTooltipData(this.state, this.props.data, this.props.layout, rangeObj);
 
       if (tooltipEventType !== 'axis' && xAxisMap && yAxisMap) {
         const xScale = getAnyElementOfObject(xAxisMap).scale;
@@ -1428,10 +1429,8 @@ export const generateCategoricalChart = ({
         const xValue = xScale && xScale.invert ? xScale.invert(e.chartX) : null;
         const yValue = yScale && yScale.invert ? yScale.invert(e.chartY) : null;
 
-        return { ...e, xValue, yValue };
+        return { ...e, xValue, yValue, ...toolTipData };
       }
-
-      const toolTipData = getTooltipData(this.state, this.props.data, this.props.layout, rangeObj);
 
       if (toolTipData) {
         return {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes the activeBar prop not working when tooltip `shared=false`.

## Description

<!--- Describe your changes in detail -->
Seems like tooltip data was missing on the `getMouseInfo` returned value when `tooltipEventType !== 'axis'` (shared is false)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5717
https://github.com/recharts/recharts/issues/4101
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This fixes a bug that makes the chart unusable when tooltip shared is false and bars has activeBars 

## How Has This Been Tested?
Tested locally using examples in storybook and ran all tests.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

