### PR TITLE
Support onTouchMove on Pie

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-classes-per-file */
 import React, {
   MutableRefObject,
   PureComponent,
@@ -15,7 +14,7 @@ import get from 'lodash/get';
 
 import clsx from 'clsx';
 import { ResolvedPieSettings, selectPieLegend, selectPieSectors } from '../state/selectors/pieSelectors';
-import { useAppSelector } from '../state/hooks';
+import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { SetPolarGraphicalItem } from '../state/SetGraphicalItem';
 import { Layer } from '../container/Layer';
 import { Props as SectorProps } from '../shape/Sector';
@@ -46,7 +45,7 @@ import {
   useMouseEnterItemDispatch,
   useMouseLeaveItemDispatch,
 } from '../context/tooltipContext';
-import { TooltipPayload, TooltipPayloadConfiguration } from '../state/tooltipSlice';
+import { setActiveMouseOverItemIndex, TooltipPayload, TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 import { UpdateId, useUpdateId } from '../context/chartLayoutContext';
 import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
@@ -450,6 +449,7 @@ function PieSectors(props: PieSectorsProps) {
           ...entry,
           stroke: entry.stroke,
           tabIndex: -1,
+          'data-recharts-item-index': i,
         };
 
         return (
@@ -695,22 +695,52 @@ function RenderSectors(props: InternalProps) {
   );
 }
 
-export class PieWithState extends PureComponent<InternalProps> {
-  render() {
-    const { hide, className } = this.props;
+function PieWithTouchMove(props: InternalProps) {
+  const dispatch = useAppDispatch();
+  const { hide, className, onTouchMove, rootTabIndex, sectors } = props;
 
-    if (hide) {
-      return null;
+  const layerClass = clsx('recharts-pie', className);
+
+  if (hide) {
+    return null;
+  }
+
+  /*
+   * onTouchMove is special because it behaves different from mouse events.
+   * Mouse events have enter + leave combo that notify us when the mouse is over
+   * a certain element. Touch events don't have that; touch only gives us
+   * start (finger down), end (finger up) and move (finger moving).
+   * So we need to figure out which element the user is touching
+   * ourselves. Fortunately, there's a convenient method for that:
+   * https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint
+   */
+  const myOnTouchMove = (e: React.TouchEvent<SVGElement>) => {
+    const touchEvent = e.touches[0];
+    const target = document.elementFromPoint(touchEvent.clientX, touchEvent.clientY);
+    if (!target || !target.getAttribute) {
+      return;
+    }
+    const itemIndex = Number(target.getAttribute('data-recharts-item-index'));
+    const activeSector = sectors[itemIndex];
+    if (!activeSector) {
+      return;
     }
 
-    const layerClass = clsx('recharts-pie', className);
-
-    return (
-      <Layer tabIndex={this.props.rootTabIndex} className={layerClass}>
-        <RenderSectors {...this.props} />
-      </Layer>
+    onTouchMove?.(activeSector, itemIndex, e);
+    dispatch(
+      setActiveMouseOverItemIndex({
+        activeIndex: String(itemIndex),
+        activeDataKey: props.dataKey,
+        activeCoordinate: activeSector.tooltipPosition,
+      }),
     );
-  }
+  };
+
+  return (
+    <Layer tabIndex={rootTabIndex} className={layerClass} onTouchMove={myOnTouchMove}>
+      <RenderSectors {...props} />
+    </Layer>
+  );
 }
 
 const defaultPieProps: Partial<Props> = {
@@ -796,7 +826,7 @@ function PieImpl(props: Props) {
   return (
     <>
       <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={{ ...props, sectors }} />
-      <PieWithState
+      <PieWithTouchMove
         {...everythingElse}
         legendType={legendType}
         hide={hide}

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -720,7 +720,7 @@ function PieWithTouchMove(props: InternalProps) {
     if (!target || !target.getAttribute) {
       return;
     }
-    const itemIndex = Number(target.getAttribute('data-recharts-item-index'));
+    const itemIndex = Number.parseInt(target.getAttribute('data-recharts-item-index'), 10);
     const activeSector = sectors[itemIndex];
     if (!activeSector) {
       return;

--- a/storybook/stories/Examples/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart.stories.tsx
@@ -1116,7 +1116,6 @@ export const ChangingDataKey = {
             strokeDasharray="5 5"
             activeDot={{ r: 8 }}
             label={{ fill: 'red', dy: -25 }}
-            animationDuration={3000}
           />
         </LineChart>
       </>

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -85,6 +85,7 @@ import {
   selectLegendSettings,
   selectLegendSize,
 } from '../../../src/state/selectors/legendSelectors';
+import { mockTouchingElement } from '../../helper/mockTouchingElement';
 
 type TooltipVisibilityTestCase = {
   // For identifying which test is running
@@ -420,11 +421,12 @@ describe('Tooltip visibility', () => {
         name === 'Treemap' ||
         name === 'FunnelChart' ||
         name === 'Sankey' ||
-        name === 'PieChart' ||
         name === 'ScatterChart'
       ) {
         context.skip();
       }
+
+      mockTouchingElement('0');
 
       mockGetBoundingClientRect({
         width: 10,

--- a/test/helper/mockTouchingElement.ts
+++ b/test/helper/mockTouchingElement.ts
@@ -1,0 +1,19 @@
+import { TooltipIndex } from '../../src/state/tooltipSlice';
+
+/**
+ * This method will pretend that the user is touching an element at the given index.
+ * This is useful for testing purposes, as it allows us to simulate touch events
+ * without having to actually touch the screen.
+ *
+ * jsdom does not support elementFromPoint because it doesn't support layouting
+ * which is unfortunate because it is a very useful function for us
+ * so we're left with mocking it out.
+ * See https://github.com/jsdom/jsdom/issues/1435
+ * @param touchItemIndex the index of the item that user is touching
+ * @returns void
+ */
+export function mockTouchingElement(touchItemIndex: TooltipIndex): void {
+  const fakeElement = document.createElement('g');
+  fakeElement.setAttribute('data-recharts-item-index', touchItemIndex);
+  document.elementFromPoint = () => fakeElement;
+}

--- a/test/helper/mockTouchingElement.ts
+++ b/test/helper/mockTouchingElement.ts
@@ -17,3 +17,13 @@ export function mockTouchingElement(touchItemIndex: TooltipIndex): void {
   fakeElement.setAttribute('data-recharts-item-index', touchItemIndex);
   document.elementFromPoint = () => fakeElement;
 }
+
+/**
+ * This method will mock that the user is touching some element
+ * that is not any of the chart elements.
+ * @return void
+ */
+export function mockTouchingUnrelatedElement(): void {
+  const fakeElement = document.createElement('g');
+  document.elementFromPoint = () => fakeElement;
+}

--- a/test/polar/Pie.spec.tsx
+++ b/test/polar/Pie.spec.tsx
@@ -241,6 +241,7 @@ describe('<Pie />', () => {
       'stroke',
       'name',
       'tabindex',
+      'data-recharts-item-index',
       'class',
       'd',
     ]);
@@ -304,6 +305,7 @@ describe('<Pie />', () => {
       cx: 255,
       cy: 255,
       endAngle: 77.15833835039133,
+      'data-recharts-item-index': 0,
       fill: '#808080',
       innerRadius: 0,
       label: 'Iter: 0',

--- a/test/polar/Pie.spec.tsx
+++ b/test/polar/Pie.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { vi } from 'vitest';
+import { it, vi } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { LabelProps, Pie, PieChart, PieProps, Sector, SectorProps, Tooltip } from '../../src';
@@ -13,6 +13,7 @@ import {
   expectTooltipPayload,
   showTooltip,
   showTooltipOnCoordinate,
+  showTooltipOnCoordinateTouch,
 } from '../component/Tooltip/tooltipTestHelpers';
 import { pieChartMouseHoverTooltipSelector } from '../component/Tooltip/tooltipMouseHoverSelectors';
 import { PageData } from '../_data';
@@ -31,6 +32,7 @@ import {
   selectTooltipDisplayedData,
 } from '../../src/state/selectors/tooltipSelectors';
 import { expectLastCalledWithScale } from '../helper/expectScale';
+import { mockTouchingUnrelatedElement } from '../helper/mockTouchingElement';
 
 type CustomizedLabelLineProps = { points?: Array<Point> };
 
@@ -81,6 +83,25 @@ describe('<Pie />', () => {
     );
 
     expect(container.querySelectorAll('.recharts-pie-sector')).toHaveLength(PageData.length);
+  });
+
+  test('Renders nothing if hide=true', () => {
+    const { container } = render(
+      <PieChart width={500} height={500}>
+        <Pie
+          hide
+          isAnimationActive={false}
+          cx={250}
+          cy={250}
+          innerRadius={0}
+          outerRadius={200}
+          data={PageData}
+          dataKey="uv"
+        />
+      </PieChart>,
+    );
+
+    expect(container.querySelectorAll('.recharts-pie-sector')).toHaveLength(0);
   });
 
   test('Render customized active sector when activeShape is set to be an element', () => {
@@ -651,6 +672,19 @@ describe('<Pie />', () => {
 
         expectTooltipPayload(container, '', ['A : 250']);
         expectTooltipCoordinate(container, { x: 273.1033255612459, y: 164.15275032118709 });
+      });
+
+      it('should not display tooltip when touchMove is triggered without touching an element', () => {
+        mockTouchingUnrelatedElement();
+
+        const { container } = renderTestCase();
+
+        showTooltipOnCoordinateTouch(container, pieChartMouseHoverTooltipSelector, {
+          clientX: 200,
+          clientY: 200,
+        });
+
+        expectTooltipNotVisible(container);
       });
     });
 


### PR DESCRIPTION
## Description

Needs a different approach than the mouse events. I tested in Firefox with simulated touch events, Firefox on Android phone, Firefox on iPad, all work fine.

## Related Issue

https://github.com/recharts/recharts/issues/5565

## Screenshots (if appropriate):


https://github.com/user-attachments/assets/eacf5ee0-6aeb-4dfe-a905-398c142dd7b3


https://github.com/user-attachments/assets/af7d216c-056d-40b3-a8a1-4d4e72325962

