### PR TITLE
touchMove handlers for Scatter

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -148,6 +148,7 @@
   "es6/state/selectors/selectTooltipState.js",
   "es6/state/selectors/selectors.js",
   "es6/state/selectors/tooltipSelectors.js",
+  "es6/state/selectors/touchSelectors.js",
   "es6/state/store.js",
   "es6/state/tooltipSlice.js",
   "es6/state/touchEventsMiddleware.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -148,6 +148,7 @@
   "lib/state/selectors/selectTooltipState.js",
   "lib/state/selectors/selectors.js",
   "lib/state/selectors/tooltipSelectors.js",
+  "lib/state/selectors/touchSelectors.js",
   "lib/state/store.js",
   "lib/state/tooltipSlice.js",
   "lib/state/touchEventsMiddleware.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -148,6 +148,7 @@
   "types/state/selectors/selectTooltipState.d.ts",
   "types/state/selectors/selectors.d.ts",
   "types/state/selectors/tooltipSelectors.d.ts",
+  "types/state/selectors/touchSelectors.d.ts",
   "types/state/store.d.ts",
   "types/state/tooltipSlice.d.ts",
   "types/state/touchEventsMiddleware.d.ts",

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -44,6 +44,7 @@ import { BaseAxisWithScale, ZAxisWithScale } from '../state/selectors/axisSelect
 import { useIsPanorama } from '../context/PanoramaContext';
 import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 import { SetLegendPayload } from '../state/SetLegendPayload';
+import { DATA_ITEM_DATAKEY_ATTRIBUTE_NAME, DATA_ITEM_INDEX_ATTRIBUTE_NAME } from '../util/Constants';
 
 interface ScatterPointNode {
   x?: number | string;
@@ -224,7 +225,13 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
       {points.map((entry, i) => {
         const isActive = activeShape && activeIndex === String(i);
         const option = isActive ? activeShape : shape;
-        const symbolProps = { key: `symbol-${i}`, ...baseProps, ...entry };
+        const symbolProps = {
+          key: `symbol-${i}`,
+          ...baseProps,
+          ...entry,
+          [DATA_ITEM_INDEX_ATTRIBUTE_NAME]: i,
+          [DATA_ITEM_DATAKEY_ATTRIBUTE_NAME]: dataKey,
+        };
 
         return (
           <Layer
@@ -240,13 +247,7 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
             key={`symbol-${entry?.cx}-${entry?.cy}-${entry?.size}-${i}`}
             role="img"
           >
-            <ScatterSymbol
-              option={option}
-              isActive={isActive}
-              {...symbolProps}
-              data-recharts-item-index={i}
-              data-recharts-item-dataKey={dataKey}
-            />
+            <ScatterSymbol option={option} isActive={isActive} {...symbolProps} />
           </Layer>
         );
       })}

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -230,7 +230,7 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
           ...baseProps,
           ...entry,
           [DATA_ITEM_INDEX_ATTRIBUTE_NAME]: i,
-          [DATA_ITEM_DATAKEY_ATTRIBUTE_NAME]: dataKey,
+          [DATA_ITEM_DATAKEY_ATTRIBUTE_NAME]: String(dataKey),
         };
 
         return (

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -201,7 +201,7 @@ function ScatterLine({ points, props }: { points: ReadonlyArray<ScatterPointItem
 
 function ScatterSymbols(props: ScatterSymbolsProps) {
   const { points, showLabels, allOtherScatterProps } = props;
-  const { shape, activeShape } = allOtherScatterProps;
+  const { shape, activeShape, dataKey } = allOtherScatterProps;
   const baseProps = filterProps(allOtherScatterProps, false);
 
   const activeIndex = useAppSelector(selectActiveTooltipIndex);
@@ -240,7 +240,13 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
             key={`symbol-${entry?.cx}-${entry?.cy}-${entry?.size}-${i}`}
             role="img"
           >
-            <ScatterSymbol option={option} isActive={isActive} {...symbolProps} />
+            <ScatterSymbol
+              option={option}
+              isActive={isActive}
+              {...symbolProps}
+              data-recharts-item-index={i}
+              data-recharts-item-dataKey={dataKey}
+            />
           </Layer>
         );
       })}

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -1,14 +1,4 @@
-// eslint-disable-next-line max-classes-per-file
-import React, {
-  Component,
-  MutableRefObject,
-  PureComponent,
-  ReactElement,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { Component, MutableRefObject, ReactElement, useCallback, useMemo, useRef, useState } from 'react';
 import Animate from 'react-smooth';
 
 import clsx from 'clsx';
@@ -500,38 +490,37 @@ const errorBarDataPointFormatter = (
   };
 };
 
-class ScatterWithState extends PureComponent<InternalProps> {
-  id = uniqueId('recharts-scatter-');
+function ScatterWithId(props: InternalProps) {
+  const idRef = useRef(uniqueId('recharts-scatter-'));
 
-  render() {
-    const { hide, points, className, needClip, xAxisId, yAxisId, id } = this.props;
-    if (hide) {
-      return null;
-    }
-    const layerClass = clsx('recharts-scatter', className);
-    const clipPathId = isNullish(id) ? this.id : id;
-    return (
-      <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
-        {needClip && (
-          <defs>
-            <GraphicalItemClipPath clipPathId={clipPathId} xAxisId={xAxisId} yAxisId={yAxisId} />
-          </defs>
-        )}
-        <SetErrorBarContext
-          xAxisId={xAxisId}
-          yAxisId={yAxisId}
-          data={points}
-          dataPointFormatter={errorBarDataPointFormatter}
-          errorBarOffset={0}
-        >
-          {this.props.children}
-        </SetErrorBarContext>
-        <Layer key="recharts-scatter-symbols">
-          <RenderSymbols {...this.props} />
-        </Layer>
-      </Layer>
-    );
+  const { hide, points, className, needClip, xAxisId, yAxisId, id, children } = props;
+  if (hide) {
+    return null;
   }
+  const layerClass = clsx('recharts-scatter', className);
+  const clipPathId = isNullish(id) ? idRef.current : id;
+
+  return (
+    <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
+      {needClip && (
+        <defs>
+          <GraphicalItemClipPath clipPathId={clipPathId} xAxisId={xAxisId} yAxisId={yAxisId} />
+        </defs>
+      )}
+      <SetErrorBarContext
+        xAxisId={xAxisId}
+        yAxisId={yAxisId}
+        data={points}
+        dataPointFormatter={errorBarDataPointFormatter}
+        errorBarOffset={0}
+      >
+        {children}
+      </SetErrorBarContext>
+      <Layer key="recharts-scatter-symbols">
+        <RenderSymbols {...props} />
+      </Layer>
+    </Layer>
+  );
 }
 
 const defaultScatterProps: Partial<Props> = {
@@ -587,7 +576,7 @@ function ScatterImpl(props: Props) {
   return (
     <>
       <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={{ ...props, points }} />
-      <ScatterWithState
+      <ScatterWithId
         {...everythingElse}
         xAxisId={xAxisId}
         yAxisId={yAxisId}

--- a/src/chart/RechartsWrapper.tsx
+++ b/src/chart/RechartsWrapper.tsx
@@ -96,6 +96,16 @@ export const RechartsWrapper = forwardRef(
     const myOnTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
       dispatch(externalEventAction({ handler: onTouchStart, reactEvent: e }));
     };
+
+    /*
+     * onTouchMove is special because it behaves different from mouse events.
+     * Mouse events have enter + leave combo that notify us when the mouse is over
+     * a certain element. Touch events don't have that; touch only gives us
+     * start (finger down), end (finger up) and move (finger moving).
+     * So we need to figure out which element the user is touching
+     * ourselves. Fortunately, there's a convenient method for that:
+     * https://developer.mozilla.org/en-US/docs/Web/API/Document/elementFromPoint
+     */
     const myOnTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
       dispatch(touchEventAction(e));
       dispatch(externalEventAction({ handler: onTouchMove, reactEvent: e }));

--- a/src/state/selectors/touchSelectors.ts
+++ b/src/state/selectors/touchSelectors.ts
@@ -1,0 +1,47 @@
+import { createSelector } from 'reselect';
+import { RechartsRootState } from '../store';
+import { TooltipIndex, TooltipPayloadConfiguration, TooltipPayloadSearcher } from '../tooltipSlice';
+import { Coordinate, DataKey } from '../../util/types';
+import { selectTooltipPayloadSearcher } from './selectTooltipPayloadSearcher';
+import { selectTooltipState } from './selectTooltipState';
+
+const selectAllTooltipPayloadConfiguration: (state: RechartsRootState) => ReadonlyArray<TooltipPayloadConfiguration> =
+  createSelector([selectTooltipState], tooltipState => tooltipState.tooltipItemPayloads);
+
+export const selectTooltipCoordinate: (
+  state: RechartsRootState,
+  tooltipIndex: TooltipIndex,
+  dataKey: DataKey<any> | undefined,
+) => Coordinate | undefined = createSelector(
+  [
+    selectAllTooltipPayloadConfiguration,
+    selectTooltipPayloadSearcher,
+    (_state: RechartsRootState, tooltipIndex: TooltipIndex, _dataKey: DataKey<any> | undefined): TooltipIndex =>
+      tooltipIndex,
+    (
+      _state: RechartsRootState,
+      _tooltipIndex: TooltipIndex,
+      dataKey: DataKey<any> | undefined,
+    ): DataKey<any> | undefined => dataKey,
+  ],
+  (
+    allTooltipConfigurations: ReadonlyArray<TooltipPayloadConfiguration>,
+    tooltipPayloadSearcher: TooltipPayloadSearcher | undefined,
+    tooltipIndex: TooltipIndex,
+    dataKey,
+  ): Coordinate | undefined => {
+    const mostRelevantTooltipConfiguration = allTooltipConfigurations.find(tooltipConfiguration => {
+      return tooltipConfiguration.settings.dataKey === dataKey;
+    });
+    if (mostRelevantTooltipConfiguration == null) {
+      return undefined;
+    }
+    const { positions } = mostRelevantTooltipConfiguration;
+    if (positions == null) {
+      return undefined;
+    }
+    // @ts-expect-error tooltipPayloadSearcher is not typed well
+    const maybePosition: Coordinate | undefined = tooltipPayloadSearcher(positions, tooltipIndex);
+    return maybePosition;
+  },
+);

--- a/src/state/touchEventsMiddleware.ts
+++ b/src/state/touchEventsMiddleware.ts
@@ -1,7 +1,7 @@
 import { createAction, createListenerMiddleware, ListenerEffectAPI, PayloadAction } from '@reduxjs/toolkit';
 import * as React from 'react';
 import { AppDispatch, RechartsRootState } from './store';
-import { setMouseOverAxisIndex } from './tooltipSlice';
+import { setActiveMouseOverItemIndex, setMouseOverAxisIndex } from './tooltipSlice';
 import { selectActivePropsFromChartPointer } from './selectors/selectActivePropsFromChartPointer';
 
 import { getChartPointer } from '../util/getChartPointer';
@@ -20,20 +20,37 @@ touchEventMiddleware.startListening({
     const touchEvent = action.payload;
     const state = listenerApi.getState();
     const tooltipEventType = selectTooltipEventType(state, state.tooltip.settings.shared);
-    const activeProps = selectActivePropsFromChartPointer(
-      state,
-      getChartPointer({
-        clientX: touchEvent.touches[0].clientX,
-        clientY: touchEvent.touches[0].clientY,
-        currentTarget: touchEvent.currentTarget,
-      }),
-    );
-    if (tooltipEventType === 'axis' && activeProps?.activeIndex != null) {
+    if (tooltipEventType === 'axis') {
+      const activeProps = selectActivePropsFromChartPointer(
+        state,
+        getChartPointer({
+          clientX: touchEvent.touches[0].clientX,
+          clientY: touchEvent.touches[0].clientY,
+          currentTarget: touchEvent.currentTarget,
+        }),
+      );
+      if (activeProps?.activeIndex != null) {
+        listenerApi.dispatch(
+          setMouseOverAxisIndex({
+            activeIndex: activeProps.activeIndex,
+            activeDataKey: undefined,
+            activeCoordinate: activeProps.activeCoordinate,
+          }),
+        );
+      }
+    } else if (tooltipEventType === 'item') {
+      const touch = touchEvent.touches[0];
+      const target = document.elementFromPoint(touch.clientX, touch.clientY);
+      if (!target || !target.getAttribute) {
+        return;
+      }
+      const itemIndex = target.getAttribute('data-recharts-item-index');
+      const dataKey = target.getAttribute('data-recharts-item-dataKey');
+
       listenerApi.dispatch(
-        setMouseOverAxisIndex({
-          activeIndex: activeProps.activeIndex,
-          activeDataKey: undefined,
-          activeCoordinate: activeProps.activeCoordinate,
+        setActiveMouseOverItemIndex({
+          activeDataKey: dataKey,
+          activeIndex: itemIndex,
         }),
       );
     }

--- a/src/state/touchEventsMiddleware.ts
+++ b/src/state/touchEventsMiddleware.ts
@@ -6,6 +6,8 @@ import { selectActivePropsFromChartPointer } from './selectors/selectActiveProps
 
 import { getChartPointer } from '../util/getChartPointer';
 import { selectTooltipEventType } from './selectors/selectTooltipEventType';
+import { DATA_ITEM_DATAKEY_ATTRIBUTE_NAME, DATA_ITEM_INDEX_ATTRIBUTE_NAME } from '../util/Constants';
+import { selectTooltipCoordinate } from './selectors/touchSelectors';
 
 export const touchEventAction = createAction<React.TouchEvent<HTMLDivElement>>('touchMove');
 
@@ -44,13 +46,15 @@ touchEventMiddleware.startListening({
       if (!target || !target.getAttribute) {
         return;
       }
-      const itemIndex = target.getAttribute('data-recharts-item-index');
-      const dataKey = target.getAttribute('data-recharts-item-dataKey');
+      const itemIndex = target.getAttribute(DATA_ITEM_INDEX_ATTRIBUTE_NAME);
+      const dataKey = target.getAttribute(DATA_ITEM_DATAKEY_ATTRIBUTE_NAME);
+      const coordinate = selectTooltipCoordinate(listenerApi.getState(), itemIndex, dataKey);
 
       listenerApi.dispatch(
         setActiveMouseOverItemIndex({
           activeDataKey: dataKey,
           activeIndex: itemIndex,
+          activeCoordinate: coordinate,
         }),
       );
     }

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -24,3 +24,33 @@ export const COLOR_PANEL = [
   '#FA7D92',
   '#D598D9',
 ];
+
+/**
+ * We use this attribute to identify which element is the one that the user is touching.
+ * The index is the position of the element in the data array.
+ * This can be either a number (for array-based charts) or a string (for the charts that have a matrix-shaped data).
+ */
+export const DATA_ITEM_INDEX_ATTRIBUTE_NAME = 'data-recharts-item-index';
+/**
+ * We use this attribute to identify which element is the one that the user is touching.
+ * DataKey works here as a kind of identifier for the element. It's not a perfect identifier for ~two~ three reasons:
+ *
+ * 1. There can be two different elements with the same dataKey; we won't know which is it
+ * 2. DataKey can be a function, and that serialized will be a `[Function: anonymous]` string
+ * which means we will be able to identify that it was a function but can't tell which one.
+ * This will lead to some weird bugs. A proper fix would be to either:
+ * a) use a unique identifier for each element (passed from props, or generated)
+ * b) figure out how to compare the dataKey or graphical item by object reference
+ *
+ * a) is a fuss because we don't have the unique identifier in props,
+ * and b) is possible most of the time except for touchMove events which work differently from mouseEnter/mouseLeave:
+ * - while mouseEnter is fired for the element that the mouse is over,
+ * touchMove is fired for the element where user has started touching. As the finger moves,
+ * we can identify the element that the user is touching by using the elementFromPoint method,
+ * but it keeps calling the handler on the element where touchStart was fired.
+ *
+ * Okay and now I discovered a third reason: the dataKey can be undefined and that's still fine
+ * because if dataKey is undefined then graphical elements assume the dataKey of the axes.
+ * Which makes it a convenient way of using recharts to render a chart but horrible identifier.
+ */
+export const DATA_ITEM_DATAKEY_ATTRIBUTE_NAME = 'data-recharts-item-data-key';

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -438,7 +438,7 @@ describe('Tooltip visibility', () => {
           context.skip();
         }
 
-        mockTouchingElement(tooltipIndex);
+        mockTouchingElement(tooltipIndex, 'uv');
 
         mockGetBoundingClientRect({
           width: 10,

--- a/test/helper/mockTouchingElement.ts
+++ b/test/helper/mockTouchingElement.ts
@@ -1,4 +1,6 @@
 import { TooltipIndex } from '../../src/state/tooltipSlice';
+import { DataKey } from '../../src/util/types';
+import { DATA_ITEM_DATAKEY_ATTRIBUTE_NAME, DATA_ITEM_INDEX_ATTRIBUTE_NAME } from '../../src/util/Constants';
 
 /**
  * This method will pretend that the user is touching an element at the given index.
@@ -10,11 +12,13 @@ import { TooltipIndex } from '../../src/state/tooltipSlice';
  * so we're left with mocking it out.
  * See https://github.com/jsdom/jsdom/issues/1435
  * @param touchItemIndex the index of the item that user is touching
+ * @param dataKey the dataKey of the item that user is touching
  * @returns void
  */
-export function mockTouchingElement(touchItemIndex: TooltipIndex): void {
+export function mockTouchingElement(touchItemIndex: TooltipIndex, dataKey: DataKey<any>): void {
   const fakeElement = document.createElement('g');
-  fakeElement.setAttribute('data-recharts-item-index', touchItemIndex);
+  fakeElement.setAttribute(DATA_ITEM_INDEX_ATTRIBUTE_NAME, touchItemIndex);
+  fakeElement.setAttribute(DATA_ITEM_DATAKEY_ATTRIBUTE_NAME, String(dataKey));
   document.elementFromPoint = () => fakeElement;
 }
 


### PR DESCRIPTION
## Description

So the approach I selected before wasn't doing well for Scatter - user had to _start_ the touch on a Scatter element for it to work. Scatters are single points so that was a pain. Now I changed it so that I can start the touch anywhere in the chart and then move my finger and the tooltip still appears.

There are multiple problems still, I left it in a comment. We will probably need a synchronizable ID before we can solve it properly. If you have a better idea I am all ears.

## Related Issue

https://github.com/recharts/recharts/issues/5565