### PR TITLE
Return of animationId

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -196,6 +196,7 @@
   "es6/util/tooltip",
   "es6/util/tooltip/translate.js",
   "es6/util/types.js",
+  "es6/util/useAnimationId.js",
   "es6/util/useElementOffset.js",
   "es6/util/useReportScale.js",
 ]

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -196,6 +196,7 @@
   "lib/util/tooltip",
   "lib/util/tooltip/translate.js",
   "lib/util/types.js",
+  "lib/util/useAnimationId.js",
   "lib/util/useElementOffset.js",
   "lib/util/useReportScale.js",
 ]

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -196,6 +196,7 @@
   "types/util/tooltip",
   "types/util/tooltip/translate.d.ts",
   "types/util/types.d.ts",
+  "types/util/useAnimationId.d.ts",
   "types/util/useElementOffset.d.ts",
   "types/util/useReportScale.d.ts",
 ]

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -35,6 +35,7 @@ import { useChartLayout, useOffset } from '../context/chartLayoutContext';
 import { useChartName } from '../state/selectors/selectors';
 import { SetLegendPayload } from '../state/SetLegendPayload';
 import { useAppSelector } from '../state/hooks';
+import { useAnimationId } from '../util/useAnimationId';
 
 export type BaseValue = number | 'dataMin' | 'dataMax';
 
@@ -420,6 +421,7 @@ function AreaWithAnimation({
     onAnimationStart,
     onAnimationEnd,
   } = props;
+  const animationId = useAnimationId(props, 'recharts-area-');
 
   const [isAnimating, setIsAnimating] = useState(true);
 
@@ -449,6 +451,7 @@ function AreaWithAnimation({
       to={{ t: 1 }}
       onAnimationEnd={handleAnimationEnd}
       onAnimationStart={handleAnimationStart}
+      key={animationId}
     >
       {({ t }: { t: number }) => {
         if (prevPoints) {

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -66,6 +66,7 @@ import { useAppSelector } from '../state/hooks';
 import { useIsPanorama } from '../context/PanoramaContext';
 import { selectActiveTooltipDataKey, selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 import { SetLegendPayload } from '../state/SetLegendPayload';
+import { useAnimationId } from '../util/useAnimationId';
 
 export interface BarRectangleItem extends RectangleProps {
   value?: number | [number, number];
@@ -376,6 +377,7 @@ function RectanglesWithAnimation({
     onAnimationStart,
   } = props;
   const prevData = previousRectanglesRef.current;
+  const animationId = useAnimationId(props, 'recharts-bar-');
 
   const [isAnimating, setIsAnimating] = useState(false);
 
@@ -392,7 +394,6 @@ function RectanglesWithAnimation({
     }
     setIsAnimating(true);
   }, [onAnimationStart]);
-
   return (
     <Animate
       begin={animationBegin}
@@ -403,6 +404,7 @@ function RectanglesWithAnimation({
       to={{ t: 1 }}
       onAnimationEnd={handleAnimationEnd}
       onAnimationStart={handleAnimationStart}
+      key={animationId}
     >
       {({ t }: { t: number }) => {
         const stepData =

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -36,6 +36,7 @@ import { useAppSelector } from '../state/hooks';
 import { AxisId } from '../state/cartesianAxisSlice';
 import { SetLegendPayload } from '../state/SetLegendPayload';
 import { AreaPointItem } from '../state/selectors/areaSelectors';
+import { useAnimationId } from '../util/useAnimationId';
 
 export interface LinePointItem extends CurvePoint {
   readonly value?: number;
@@ -342,6 +343,7 @@ function CurveWithAnimation({
   } = props;
 
   const prevPoints = previousPointsRef.current;
+  const animationId = useAnimationId(props, 'recharts-line-');
 
   const [isAnimating, setIsAnimating] = useState(false);
 
@@ -388,6 +390,7 @@ function CurveWithAnimation({
       to={{ t: 1 }}
       onAnimationEnd={handleAnimationEnd}
       onAnimationStart={handleAnimationStart}
+      key={animationId}
     >
       {({ t }: { t: number }) => {
         const interpolator = interpolateNumber(startingPoint, totalLength + startingPoint);

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -45,6 +45,7 @@ import { useIsPanorama } from '../context/PanoramaContext';
 import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 import { SetLegendPayload } from '../state/SetLegendPayload';
 import { DATA_ITEM_DATAKEY_ATTRIBUTE_NAME, DATA_ITEM_INDEX_ATTRIBUTE_NAME } from '../util/Constants';
+import { useAnimationId } from '../util/useAnimationId';
 
 interface ScatterPointNode {
   x?: number | string;
@@ -265,6 +266,7 @@ function SymbolsWithAnimation({
 }) {
   const { points, isAnimationActive, animationBegin, animationDuration, animationEasing } = props;
   const prevPoints = previousPointsRef.current;
+  const animationId = useAnimationId(props, 'recharts-scatter-');
 
   const [isAnimating, setIsAnimating] = useState(false);
 
@@ -293,6 +295,7 @@ function SymbolsWithAnimation({
       to={{ t: 1 }}
       onAnimationEnd={handleAnimationEnd}
       onAnimationStart={handleAnimationStart}
+      key={animationId}
     >
       {({ t }: { t: number }) => {
         const stepData =

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -50,6 +50,7 @@ import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 import { SetPolarLegendPayload } from '../state/SetLegendPayload';
 import { DATA_ITEM_DATAKEY_ATTRIBUTE_NAME, DATA_ITEM_INDEX_ATTRIBUTE_NAME } from '../util/Constants';
+import { useAnimationId } from '../util/useAnimationId';
 
 interface PieDef {
   /** The abscissa of pole in polar coordinate  */
@@ -591,6 +592,7 @@ function SectorsWithAnimation({
     onAnimationStart,
     onAnimationEnd,
   } = props;
+  const animationId = useAnimationId(props, 'recharts-pie-');
 
   const prevSectors = previousSectorsRef.current;
 
@@ -619,6 +621,7 @@ function SectorsWithAnimation({
       to={{ t: 1 }}
       onAnimationStart={handleAnimationStart}
       onAnimationEnd={handleAnimationEnd}
+      key={animationId}
     >
       {({ t }: { t: number }) => {
         const stepData: PieSectorDataItem[] = [];

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -33,6 +33,7 @@ import { selectRadarPoints } from '../state/selectors/radarSelectors';
 import { useAppSelector } from '../state/hooks';
 import { useIsPanorama } from '../context/PanoramaContext';
 import { SetPolarLegendPayload } from '../state/SetLegendPayload';
+import { useAnimationId } from '../util/useAnimationId';
 
 interface RadarPoint {
   x: number;
@@ -70,7 +71,6 @@ interface RadarProps {
   animationBegin?: number;
   animationDuration?: AnimationDuration;
   isAnimationActive?: boolean;
-  animationId?: number;
   animationEasing?: AnimationTiming;
 
   onMouseEnter?: (props: any, e: MouseEvent<SVGPolygonElement>) => void;
@@ -309,11 +309,11 @@ function PolygonWithAnimation({
     animationBegin,
     animationDuration,
     animationEasing,
-    animationId,
     onAnimationEnd,
     onAnimationStart,
   } = props;
   const prevPoints = previousPointsRef.current;
+  const animationId = useAnimationId(props, 'recharts-radar-');
   const [isAnimating, setIsAnimating] = useState(true);
 
   const handleAnimationEnd = useCallback(() => {

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -50,6 +50,7 @@ import {
 import { useAppSelector } from '../state/hooks';
 import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 import { SetPolarLegendPayload } from '../state/SetLegendPayload';
+import { useAnimationId } from '../util/useAnimationId';
 
 export type RadialBarDataItem = SectorProps & {
   value?: any;
@@ -135,6 +136,7 @@ function SectorsWithAnimation({
     onAnimationEnd,
     onAnimationStart,
   } = props;
+  const animationId = useAnimationId(props, 'recharts-radialbar-');
 
   const prevData = previousSectorsRef.current;
 
@@ -163,6 +165,7 @@ function SectorsWithAnimation({
       to={{ t: 1 }}
       onAnimationStart={handleAnimationStart}
       onAnimationEnd={handleAnimationEnd}
+      key={animationId}
     >
       {({ t }: { t: number }) => {
         const stepData =

--- a/src/util/useAnimationId.tsx
+++ b/src/util/useAnimationId.tsx
@@ -1,0 +1,28 @@
+import { useRef } from 'react';
+import { uniqueId } from './DataUtils';
+
+/**
+ * This hook returns a unique animation id for the object input.
+ * If input changes (as in, reference equality is different), the animation id will change.
+ * If input does not change, the animation id will not change.
+ *
+ * This is useful for react-smooth animations. The Animate component
+ * does have a `shouldReAnimate` prop but that doesn't seem to be doing what the name implies.
+ * Also, we don't always want to re-animate on every render;
+ * we only want to re-animate when the input changes. Not the internal state (e.g. `isAnimating`).
+ *
+ * @param input The object to check for changes. Uses reference equality (=== operator)
+ * @param prefix Optional prefix to use for the animation id
+ * @returns A unique animation id
+ */
+export function useAnimationId(input: unknown, prefix: string = 'animation-'): string {
+  const animationId = useRef<string>(uniqueId(prefix));
+  const prevProps = useRef<unknown>(input);
+
+  if (prevProps.current !== input) {
+    animationId.current = uniqueId(prefix);
+    prevProps.current = input;
+  }
+
+  return animationId.current;
+}

--- a/storybook/stories/Examples/BarChart/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart/BarChart.stories.tsx
@@ -1108,3 +1108,54 @@ export const ChangingDataKeyAndStacked = {
     },
   },
 };
+
+export const ChangingData = {
+  render: (args: Record<string, any>, context: StoryContext) => {
+    type MyDataShape = Array<{ number: number }>;
+
+    const [data, setData] = useState<MyDataShape>([{ number: 10 }]);
+
+    const reset = () => {
+      setData([{ number: 10 }]);
+    };
+
+    const changeSynchronously = () => {
+      setData([{ number: 50 }]);
+    };
+
+    const changeAsynchronously = () => {
+      setData([{ number: 90 }]);
+
+      setTimeout(() => {
+        setData([{ number: 30 }]);
+      }, 150);
+    };
+
+    return (
+      <div style={{ display: 'flex', gap: '4rem', alignItems: 'center' }}>
+        <BarChart {...args} data={data}>
+          <YAxis hide domain={[0, 100]} />
+          <Bar dataKey="number" fill="chocolate" background={{ fill: 'bisque' }} />
+          <RechartsHookInspector rechartsInspectorEnabled={context.rechartsInspectorEnabled} />
+        </BarChart>
+
+        <button type="button" onClick={changeSynchronously}>
+          Change data synchronously
+        </button>
+
+        <button type="button" onClick={changeAsynchronously}>
+          Change data with setTimeout
+        </button>
+
+        <button type="button" onClick={reset}>
+          Reset
+        </button>
+      </div>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(BarChartProps),
+    width: 100,
+    height: 100,
+  },
+};

--- a/test/util/useAnimationId.spec.tsx
+++ b/test/util/useAnimationId.spec.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAnimationId } from '../../src/util/useAnimationId';
+
+describe('useAnimationId', () => {
+  it('should return a unique animation id', () => {
+    const input = { foo: 'bar' };
+    const prefix = 'test-';
+    const { result } = renderHook(() => useAnimationId(input, prefix));
+    const animationId = result.current;
+    expect(animationId).toBeDefined();
+    expect(animationId.startsWith(prefix)).toBe(true);
+  });
+
+  it('should change animation id when input changes', () => {
+    const input1 = { foo: 'bar' };
+    const input2 = { foo: 'baz' };
+    const prefix = 'test-';
+
+    const { result, rerender } = renderHook(({ input }) => useAnimationId(input, prefix), {
+      initialProps: { input: input1 },
+    });
+
+    const animationId1 = result.current;
+
+    rerender({ input: input2 });
+
+    const animationId2 = result.current;
+
+    expect(animationId1).not.toEqual(animationId2);
+  });
+
+  it('should not change animation id when input does not change', () => {
+    const input1 = { foo: 'bar' };
+    const prefix = 'test-';
+
+    const { result, rerender } = renderHook(({ input }) => useAnimationId(input, prefix), {
+      initialProps: { input: input1 },
+    });
+
+    const animationId1 = result.current;
+
+    rerender({ input: input1 });
+
+    const animationId2 = result.current;
+
+    expect(animationId1).toBe(animationId2);
+  });
+});


### PR DESCRIPTION
## Description

Okay so changing the dataKey has the middle step where selectors return `undefined` which marks a reset for the animation component. Changing the data itself doesn't do that so we need a manual restart. animationId will do that.

https://github.com/user-attachments/assets/1fd29d5b-5fa7-4931-8810-7e2cbe4994b0

## Related Issue

Fixes https://github.com/recharts/recharts/issues/5752