### PR TITLE
fix: remove img roles which cause accessibily violations since there is no alt text on these elements

### DIFF
--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -176,7 +176,6 @@ function FunnelTrapezoids(props: FunnelTrapezoidsProps) {
             // @ts-expect-error the types need a bit of attention
             onClick={onClickFromContext(entry, i)}
             key={`trapezoid-${entry?.x}-${entry?.y}-${entry?.name}-${entry?.value}`}
-            role="img"
           >
             <FunnelTrapezoid {...trapezoidProps} />
           </Layer>

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -246,7 +246,6 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
             onClick={onClickFromContext(entry, i)}
             // eslint-disable-next-line react/no-array-index-key
             key={`symbol-${entry?.cx}-${entry?.cy}-${entry?.size}-${i}`}
-            role="img"
           >
             <ScatterSymbol option={option} isActive={isActive} {...symbolProps} />
           </Layer>

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -674,15 +674,7 @@ function renderNodeItem(option: SankeyNodeOptions, props: NodeProps) {
     return option(props);
   }
 
-  return (
-    <Rectangle
-      className="recharts-sankey-node"
-      fill="#0088fe"
-      fillOpacity="0.8"
-      {...filterProps(props, false)}
-      role="img"
-    />
-  );
+  return <Rectangle className="recharts-sankey-node" fill="#0088fe" fillOpacity="0.8" {...filterProps(props, false)} />;
 }
 
 const buildNodeProps = ({

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -428,7 +428,6 @@ function ContentItem({
         fill={nodeProps.depth < 2 ? colors[index % colors.length] : 'rgba(255,255,255,0)'}
         stroke="#fff"
         {...omit(nodeProps, 'children')}
-        role="img"
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         onClick={onClick}

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -138,7 +138,7 @@ export const generateCategoricalChart = ({
       if (this.props.accessibilityLayer) {
         // Set tabIndex to 0 by default (can be overwritten)
         attrs.tabIndex = this.props.tabIndex ?? 0;
-        // Set role to img by default (can be overwritten)
+        // Set role to application by default (can be overwritten)
         attrs.role = this.props.role ?? 'application';
       }
 

--- a/test/chart/AccessibilityScans.spec.tsx
+++ b/test/chart/AccessibilityScans.spec.tsx
@@ -31,14 +31,6 @@ import {
 import { PageData as data, exampleSankeyData, exampleTreemapData, exampleSunburstData } from '../_data';
 import { expectScatterPoints } from '../helper/expectScatterPoints';
 
-// const svgTagMustHaveLabelViolation = expect.objectContaining({
-//   description: 'Ensures <svg> elements with an img, graphics-document or graphics-symbol role have an accessible text',
-//   help: '<svg> elements with an img role must have an alternative text',
-//   helpUrl: 'https://dequeuniversity.com/rules/axe/4.9/svg-img-alt?application=axeAPI',
-//   id: 'svg-img-alt',
-//   impact: 'serious',
-// });
-
 describe('Static scanning for accessibility markup issues', () => {
   test('Area chart', async () => {
     const { container } = render(

--- a/test/chart/AccessibilityScans.spec.tsx
+++ b/test/chart/AccessibilityScans.spec.tsx
@@ -31,13 +31,13 @@ import {
 import { PageData as data, exampleSankeyData, exampleTreemapData, exampleSunburstData } from '../_data';
 import { expectScatterPoints } from '../helper/expectScatterPoints';
 
-const svgTagMustHaveLabelViolation = expect.objectContaining({
-  description: 'Ensures <svg> elements with an img, graphics-document or graphics-symbol role have an accessible text',
-  help: '<svg> elements with an img role must have an alternative text',
-  helpUrl: 'https://dequeuniversity.com/rules/axe/4.9/svg-img-alt?application=axeAPI',
-  id: 'svg-img-alt',
-  impact: 'serious',
-});
+// const svgTagMustHaveLabelViolation = expect.objectContaining({
+//   description: 'Ensures <svg> elements with an img, graphics-document or graphics-symbol role have an accessible text',
+//   help: '<svg> elements with an img role must have an alternative text',
+//   helpUrl: 'https://dequeuniversity.com/rules/axe/4.9/svg-img-alt?application=axeAPI',
+//   id: 'svg-img-alt',
+//   impact: 'serious',
+// });
 
 describe('Static scanning for accessibility markup issues', () => {
   test('Area chart', async () => {
@@ -105,7 +105,7 @@ describe('Static scanning for accessibility markup issues', () => {
       </FunnelChart>,
     );
 
-    expect((await axe(container)).violations).toEqual([svgTagMustHaveLabelViolation]);
+    expect((await axe(container)).violations).toHaveLength(0);
     expect(document.querySelector('.recharts-wrapper')).toHaveAttribute('role', 'application');
   });
 
@@ -160,7 +160,7 @@ describe('Static scanning for accessibility markup issues', () => {
 
   test('Sankey chart', async () => {
     const { container } = render(<Sankey width={1000} height={500} data={exampleSankeyData} />);
-    expect((await axe(container)).violations).toEqual([svgTagMustHaveLabelViolation]);
+    expect((await axe(container)).violations).toHaveLength(0);
     expect(document.querySelector('.recharts-wrapper')).toHaveAttribute('role', 'application');
   });
 
@@ -223,7 +223,7 @@ describe('Static scanning for accessibility markup issues', () => {
         width: '9.0270333367641',
       },
     ]);
-    expect((await axe(container)).violations).toEqual([svgTagMustHaveLabelViolation]);
+    expect((await axe(container)).violations).toHaveLength(0);
     expect(document.querySelector('.recharts-wrapper')).toHaveAttribute('role', 'application');
   });
 
@@ -246,7 +246,7 @@ describe('Static scanning for accessibility markup issues', () => {
       />,
     );
 
-    expect((await axe(container)).violations).toEqual([svgTagMustHaveLabelViolation]);
+    expect((await axe(container)).violations).toHaveLength(0);
     expect(document.querySelector('.recharts-wrapper')).toHaveAttribute('role', 'application');
   });
 });

--- a/test/chart/FunnelChart.spec.tsx
+++ b/test/chart/FunnelChart.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { expect, it, vi } from 'vitest';
 import { cleanupMockAnimation, mockAnimation } from '../helper/animation-frame-helper';
 import { Funnel, FunnelChart } from '../../src';
@@ -37,7 +37,7 @@ describe('<FunnelChart />', () => {
       </FunnelChart>,
     );
     expect(container.querySelectorAll('.recharts-trapezoids')).toHaveLength(1);
-    expect(screen.getAllByRole('img')).toHaveLength(5);
+    expect(container.querySelectorAll('.recharts-funnel-trapezoid')).toHaveLength(5);
 
     data.forEach(({ name }) => {
       expect(container.querySelectorAll(`[name="${name}"]`)).toHaveLength(1);

--- a/test/component/Text.spec.tsx
+++ b/test/component/Text.spec.tsx
@@ -214,24 +214,6 @@ describe('<Text />', () => {
 
       expect(lastLetter).toEqual('…');
     });
-
-    // test('adds an ellipsis at the end of a very long word', () => {
-    //   Element.prototype.getBoundingClientRect = vi.fn(() => ({ ...mock, width: 1 }));
-    //   const testString =
-    //     'longwooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooord';
-    //   render(
-    //     <Text role="img" width={200} maxLines={1}>
-    //       {testString}
-    //     </Text>,
-    //   );
-
-    //   const text = screen.getByRole('img');
-    //   expect(text).toBeInTheDocument();
-    //   const lastChild = text?.children[text?.children?.length - 1];
-    //   const lastLetter = lastChild.textContent?.[lastChild?.textContent?.length - 1];
-
-    //   expect(lastLetter).toEqual('…');
-    // });
   });
 });
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix https://github.com/recharts/recharts/issues/3449#issuecomment-2810550784 by removing `img` roles entirely, we already did this for `Sector`

I also think @julianna-langston agreed this was a good move in a different thread

Removes `role="img"` on Sankey, Scatter, Funnel, Treemap

Want to get this in as a "breaking change" before 3.0 since folks are bringing it up

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/3449#issuecomment-2810550784

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- Fix accessibility scanner issues

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- see updated accessibility tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
