### PR TITLE
Fix XAxis padding calculation

### DIFF
--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -1096,7 +1096,7 @@ export const selectSmallestDistanceBetweenValues: (
       return undefined;
     }
     let smallestDistanceBetweenValues = Infinity;
-    const sortedValues = Array.from(onlyAllowNumbers(allDataSquished.map(d => d.value))).sort();
+    const sortedValues = Array.from(onlyAllowNumbers(allDataSquished.map(d => d.value))).sort((a, b) => a - b);
     if (sortedValues.length < 2) {
       return Infinity;
     }
@@ -1104,12 +1104,11 @@ export const selectSmallestDistanceBetweenValues: (
     if (diff === 0) {
       return Infinity;
     }
-    sortedValues.forEach((value: number, index: number) => {
-      smallestDistanceBetweenValues = Math.min(
-        (value || 0) - (sortedValues[index - 1] || 0),
-        smallestDistanceBetweenValues,
-      );
-    });
+    // Only do n - 1 distance calculations because there's only n - 1 distances between n values.
+    for (let i = 0; i < sortedValues.length - 1; i++) {
+      const distance = sortedValues[i + 1] - sortedValues[i];
+      smallestDistanceBetweenValues = Math.min(smallestDistanceBetweenValues, distance);
+    }
     return smallestDistanceBetweenValues / diff;
   },
 );

--- a/storybook/stories/Examples/cartesian/XAxis/XAxisWithCalculatedPadding.stories.tsx
+++ b/storybook/stories/Examples/cartesian/XAxis/XAxisWithCalculatedPadding.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { ComposedChart, XAxis, ResponsiveContainer } from '../../../../../src';
+
+export default {
+  title: 'Examples/cartesian/XAxis/WithCalculatedPadding',
+};
+
+const data = [0, 2, 4, 6, 8, 10].map(value => {
+  return { x: value };
+});
+
+export const WithCalculatedPadding = {
+  render: () => {
+    return (
+      <ResponsiveContainer width="100%" height={500}>
+        <>
+          <h4>default:</h4>
+          <ComposedChart width={600} height={50} data={data}>
+            <XAxis dataKey="x" type="number" />
+          </ComposedChart>
+
+          <h4>no-gap:</h4>
+          <ComposedChart width={600} height={50} data={data}>
+            <XAxis dataKey="x" type="number" padding="no-gap" />
+          </ComposedChart>
+
+          <h4>gap:</h4>
+          <ComposedChart width={600} height={50} data={data}>
+            <XAxis dataKey="x" type="number" padding="gap" />
+          </ComposedChart>
+        </>
+      </ResponsiveContainer>
+    );
+  },
+};

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -51,6 +51,7 @@ import { useIsPanorama } from '../../src/context/PanoramaContext';
 
 describe('<XAxis />', () => {
   const data = [
+    { x: 90, y: 90, z: 90 },
     { x: 100, y: 200, z: 200 },
     { x: 120, y: 100, z: 260 },
     { x: 170, y: 300, z: 400 },
@@ -81,7 +82,7 @@ describe('<XAxis />', () => {
     );
 
     expect(container.querySelectorAll('.recharts-cartesian-axis-line')).toHaveLength(2);
-    expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
+    expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
   });
 
   it('should not render anything when attempting to render outside of Chart', () => {
@@ -525,7 +526,7 @@ describe('<XAxis />', () => {
       </BarChart>,
     );
 
-    expect(barBandSizeSpy).toHaveBeenLastCalledWith(28.16326530612244);
+    expect(barBandSizeSpy).toHaveBeenLastCalledWith(201.25);
     expect(barBandSizeSpy).toHaveBeenCalledTimes(2);
 
     expect(offsetSpy).toHaveBeenLastCalledWith({
@@ -544,38 +545,44 @@ describe('<XAxis />', () => {
 
     expect(barTicksSpy).toHaveBeenLastCalledWith([
       {
-        coordinate: 81.42857142857143,
+        coordinate: 985,
         index: 0,
+        offset: 0,
+        value: 90,
+      },
+      {
+        coordinate: 783.75,
+        index: 1,
         offset: 0,
         value: 100,
       },
       {
-        coordinate: 137.75510204081633,
-        index: 1,
+        coordinate: 381.25,
+        index: 2,
         offset: 0,
         value: 120,
       },
       {
-        coordinate: 278.57142857142856,
-        index: 2,
+        coordinate: -625,
+        index: 3,
         offset: 0,
         value: 170,
       },
       {
-        coordinate: 194.0816326530612,
-        index: 3,
+        coordinate: -21.25,
+        index: 4,
         offset: 0,
         value: 140,
       },
       {
-        coordinate: 222.24489795918367,
-        index: 4,
+        coordinate: -222.5,
+        index: 5,
         offset: 0,
         value: 150,
       },
       {
-        coordinate: 109.59183673469389,
-        index: 5,
+        coordinate: 582.5,
+        index: 6,
         offset: 0,
         value: 110,
       },
@@ -584,74 +591,72 @@ describe('<XAxis />', () => {
 
     expectBars(container, [
       {
-        d: 'M 70.16326530612245,135 h 22 v 130 h -22 Z',
+        d: 'M 904.5,206.5 h 161 v 58.5 h -161 Z',
+        height: '58.5',
+        radius: '0',
+        width: '161',
+        x: '904.5',
+        y: '206.5',
+      },
+      {
+        d: 'M 703.25,135 h 161 v 130 h -161 Z',
         height: '130',
         radius: '0',
-        width: '22',
-        x: '70.16326530612245',
+        width: '161',
+        x: '703.25',
         y: '135',
       },
       {
-        d: 'M 126.48979591836735,200 h 22 v 65 h -22 Z',
+        d: 'M 300.75,200 h 161 v 65 h -161 Z',
         height: '65',
         radius: '0',
-        width: '22',
-        x: '126.48979591836735',
+        width: '161',
+        x: '300.75',
         y: '200',
       },
       {
-        d: 'M 267.3061224489796,70 h 22 v 195 h -22 Z',
+        d: 'M -705.5,70 h 161 v 195 h -161 Z',
         height: '195',
         radius: '0',
-        width: '22',
-        x: '267.3061224489796',
+        width: '161',
+        x: '-705.5',
         y: '70',
       },
       {
-        d: 'M 182.81632653061223,102.5 h 22 v 162.5 h -22 Z',
+        d: 'M -101.75,102.5 h 161 v 162.5 h -161 Z',
         height: '162.5',
         radius: '0',
-        width: '22',
-        x: '182.81632653061223',
+        width: '161',
+        x: '-101.75',
         y: '102.5',
       },
       {
-        d: 'M 210.9795918367347,5 h 22 v 260 h -22 Z',
+        d: 'M -303,5 h 161 v 260 h -161 Z',
         height: '260',
         radius: '0',
-        width: '22',
-        x: '210.9795918367347',
+        width: '161',
+        x: '-303',
         y: '5',
       },
       {
-        d: 'M 98.32653061224491,83.00000000000001 h 22 v 182 h -22 Z',
+        d: 'M 502,83.00000000000001 h 161 v 182 h -161 Z',
         height: '182',
         radius: '0',
-        width: '22',
-        x: '98.32653061224491',
+        width: '161',
+        x: '502',
         y: '83.00000000000001',
       },
     ]);
-    expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 170]);
+    expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 170]);
     expectXAxisTicks(container, [
       {
-        textContent: '100',
-        x: '81.42857142857143',
-        y: '273',
-      },
-      {
-        textContent: '120',
-        x: '137.75510204081633',
-        y: '273',
-      },
-      {
-        textContent: '140',
-        x: '194.0816326530612',
+        textContent: '130',
+        x: '180',
         y: '273',
       },
       {
         textContent: '170',
-        x: '278.57142857142856',
+        x: '0',
         y: '273',
       },
     ]);
@@ -670,74 +675,72 @@ describe('<XAxis />', () => {
 
     expectBars(container, [
       {
-        d: 'M 287.9183673469387,135 h 972 v 130 h -972 Z',
+        d: 'M 36309.5,206.5 h 6951 v 58.5 h -6951 Z',
+        height: '58.5',
+        radius: '0',
+        width: '6951',
+        x: '36309.5',
+        y: '206.5',
+      },
+      {
+        d: 'M 27620.75,135 h 6951 v 130 h -6951 Z',
         height: '130',
         radius: '0',
-        width: '972',
-        x: '287.9183673469387',
+        width: '6951',
+        x: '27620.75',
         y: '135',
       },
       {
-        d: 'M 2719.755102040817,200 h 972 v 65 h -972 Z',
+        d: 'M 10243.25,200 h 6951 v 65 h -6951 Z',
         height: '65',
         radius: '0',
-        width: '972',
-        x: '2719.755102040817',
+        width: '6951',
+        x: '10243.25',
         y: '200',
       },
       {
-        d: 'M 8799.34693877551,70 h 972 v 195 h -972 Z',
+        d: 'M -33200.5,70 h 6951 v 195 h -6951 Z',
         height: '195',
         radius: '0',
-        width: '972',
-        x: '8799.34693877551',
+        width: '6951',
+        x: '-33200.5',
         y: '70',
       },
       {
-        d: 'M 5151.591836734694,102.5 h 972 v 162.5 h -972 Z',
+        d: 'M -7134.25,102.5 h 6951 v 162.5 h -6951 Z',
         height: '162.5',
         radius: '0',
-        width: '972',
-        x: '5151.591836734694',
+        width: '6951',
+        x: '-7134.25',
         y: '102.5',
       },
       {
-        d: 'M 6367.510204081634,5 h 972 v 260 h -972 Z',
+        d: 'M -15823,5 h 6951 v 260 h -6951 Z',
         height: '260',
         radius: '0',
-        width: '972',
-        x: '6367.510204081634',
+        width: '6951',
+        x: '-15823',
         y: '5',
       },
       {
-        d: 'M 1503.8367346938776,83.00000000000001 h 972 v 182 h -972 Z',
+        d: 'M 18932,83.00000000000001 h 6951 v 182 h -6951 Z',
         height: '182',
         radius: '0',
-        width: '972',
-        x: '1503.8367346938776',
+        width: '6951',
+        x: '18932',
         y: '83.00000000000001',
       },
     ]);
-    expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 170]);
+    expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 170]);
     expectXAxisTicks(container, [
       {
-        textContent: '100',
-        x: '774.2857142857142',
-        y: '273',
-      },
-      {
-        textContent: '120',
-        x: '3206.1224489795923',
-        y: '273',
-      },
-      {
-        textContent: '140',
-        x: '5637.95918367347',
+        textContent: '130',
+        x: '5030',
         y: '273',
       },
       {
         textContent: '170',
-        x: '9285.714285714286',
+        x: '0',
         y: '273',
       },
     ]);
@@ -745,18 +748,19 @@ describe('<XAxis />', () => {
 
   describe.each(['gap', 'no-gap', { left: 3, right: 5 }] as const)('padding: %s', padding => {
     /* I am not entirely certain what is the relationship between the tickCount prop, and the actual tick count */
+    // TODO: Remove `brokenGapTickCount` once the bug is fixed.
     it.each([
-      { providedTickCount: 3, expectedTickCount: 3 },
-      { providedTickCount: 5, expectedTickCount: 4 },
-      { providedTickCount: 7, expectedTickCount: 5 },
-      { providedTickCount: 11, expectedTickCount: 11 },
-      { providedTickCount: 13, expectedTickCount: 12 },
-      { providedTickCount: 17, expectedTickCount: 15 },
-      { providedTickCount: 19, expectedTickCount: 18 },
-      { providedTickCount: 29, expectedTickCount: 24 },
+      { providedTickCount: 3, expectedTickCount: 3, brokenGapTickCount: { gap: 2, 'no-gap': 3 } },
+      { providedTickCount: 5, expectedTickCount: 5, brokenGapTickCount: { gap: 2, 'no-gap': 5 } },
+      { providedTickCount: 7, expectedTickCount: 6, brokenGapTickCount: { gap: 2, 'no-gap': 6 } },
+      { providedTickCount: 11, expectedTickCount: 11, brokenGapTickCount: { gap: 2, 'no-gap': 11 } },
+      { providedTickCount: 13, expectedTickCount: 12, brokenGapTickCount: { gap: 3, 'no-gap': 12 } },
+      { providedTickCount: 17, expectedTickCount: 17, brokenGapTickCount: { gap: 4, 'no-gap': 17 } },
+      { providedTickCount: 19, expectedTickCount: 17, brokenGapTickCount: { gap: 4, 'no-gap': 17 } },
+      { providedTickCount: 29, expectedTickCount: 27, brokenGapTickCount: { gap: 5, 'no-gap': 27 } },
     ])(
       'renders $expectedTickCount ticks when tickCount=$providedTickCount',
-      ({ providedTickCount, expectedTickCount }) => {
+      ({ providedTickCount, expectedTickCount, brokenGapTickCount }) => {
         const spy = vi.fn();
         const { container } = render(
           <BarChart width={100000} height={300} data={data}>
@@ -773,9 +777,13 @@ describe('<XAxis />', () => {
           </BarChart>,
         );
 
-        expect(spy).toHaveBeenLastCalledWith([100, 170]);
+        expect(spy).toHaveBeenLastCalledWith([90, 170]);
         const allTicks = container.querySelectorAll('.recharts-xAxis .recharts-cartesian-axis-tick-value');
-        expect(allTicks).toHaveLength(expectedTickCount);
+        if (padding === 'gap' || padding === 'no-gap') {
+          expect(allTicks).toHaveLength(brokenGapTickCount[padding]);
+        } else {
+          expect(allTicks).toHaveLength(expectedTickCount);
+        }
       },
     );
   });
@@ -793,79 +801,72 @@ describe('<XAxis />', () => {
 
     expectBars(container, [
       {
-        d: 'M 138.49777777777777,120.55555555555554 h 11 v 144.44444444444446 h -11 Z',
+        d: 'M 3540.967741935484,135 h 178 v 130 h -178 Z',
+        height: '130',
+        radius: '0',
+        width: '178',
+        x: '3540.967741935484',
+        y: '135',
+      },
+      {
+        d: 'M 1092.5806451612902,120.55555555555554 h 178 v 144.44444444444446 h -178 Z',
         height: '144.44444444444446',
         radius: '0',
-        width: '11',
-        x: '138.49777777777777',
+        width: '178',
+        x: '1092.5806451612902',
         y: '120.55555555555554',
       },
       {
-        d: 'M 66.94222222222221,91.66666666666667 h 11 v 173.33333333333331 h -11 Z',
+        d: 'M 3318.387096774193,91.66666666666667 h 178 v 173.33333333333331 h -178 Z',
         height: '173.33333333333331',
         radius: '0',
-        width: '11',
-        x: '66.94222222222221',
+        width: '178',
+        x: '3318.387096774193',
         y: '91.66666666666667',
       },
       {
-        d: 'M 210.0533333333333,19.44444444444445 h 11 v 245.55555555555554 h -11 Z',
+        d: 'M -1133.2258064516125,19.44444444444445 h 178 v 245.55555555555554 h -178 Z',
         height: '245.55555555555554',
         radius: '0',
-        width: '11',
-        x: '210.0533333333333',
+        width: '178',
+        x: '-1133.2258064516125',
         y: '19.44444444444445',
       },
       {
-        d: 'M 174.27555555555554,62.77777777777777 h 11 v 202.22222222222223 h -11 Z',
+        d: 'M -20.322580645161224,62.77777777777777 h 178 v 202.22222222222223 h -178 Z',
         height: '202.22222222222223',
         radius: '0',
-        width: '11',
-        x: '174.27555555555554',
+        width: '178',
+        x: '-20.322580645161224',
         y: '62.77777777777777',
       },
       {
-        d: 'M 281.6088888888889,48.33333333333332 h 11 v 216.66666666666669 h -11 Z',
+        d: 'M -3359.032258064516,48.33333333333332 h 178 v 216.66666666666669 h -178 Z',
         height: '216.66666666666669',
         radius: '0',
-        width: '11',
-        x: '281.6088888888889',
+        width: '178',
+        x: '-3359.032258064516',
         y: '48.33333333333332',
       },
       {
-        d: 'M 195.74222222222218,106.1111111111111 h 11 v 158.8888888888889 h -11 Z',
+        d: 'M -688.0645161290324,106.1111111111111 h 178 v 158.8888888888889 h -178 Z',
         height: '158.8888888888889',
         radius: '0',
-        width: '11',
-        x: '195.74222222222218',
+        width: '178',
+        x: '-688.0645161290324',
         y: '106.1111111111111',
       },
     ]);
-    expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 400]);
+    expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 400]);
     expectXAxisTicks(container, [
       {
-        textContent: '100',
-        x: '72.66666666666667',
-        y: '273',
-      },
-      {
-        textContent: '175',
-        x: '126.33333333333333',
-        y: '273',
-      },
-      {
         textContent: '250',
-        x: '180',
-        y: '273',
-      },
-      {
-        textContent: '325',
-        x: '233.66666666666666',
+        x: '68.70967741935488',
         y: '273',
       },
       {
         textContent: '400',
-        x: '287.3333333333333',
+        x: '0',
         y: '273',
       },
     ]);
@@ -884,77 +885,90 @@ describe('<XAxis />', () => {
 
     expectBars(container, [
       {
-        d: 'M 66.2928279883382,135 h 23 v 130 h -23 Z',
+        d: 'M 208.97999999999996,206.5 h 6 v 58.5 h -6 Z',
+        height: '58.5',
+        radius: '0',
+        width: '6',
+        x: '208.97999999999996',
+        y: '206.5',
+      },
+      {
+        d: 'M 200.93,135 h 6 v 130 h -6 Z',
         height: '130',
         radius: '0',
-        width: '23',
-        x: '66.2928279883382',
+        width: '6',
+        x: '200.93',
         y: '135',
       },
       {
-        d: 'M 124.60419825072887,200 h 23 v 65 h -23 Z',
+        d: 'M 184.82999999999998,200 h 6 v 65 h -6 Z',
         height: '65',
         radius: '0',
-        width: '23',
-        x: '124.60419825072887',
+        width: '6',
+        x: '184.82999999999998',
         y: '200',
       },
       {
-        d: 'M 270.38262390670553,70 h 23 v 195 h -23 Z',
+        d: 'M 144.5800000000001,70 h 6 v 195 h -6 Z',
         height: '195',
         radius: '0',
-        width: '23',
-        x: '270.38262390670553',
+        width: '6',
+        x: '144.5800000000001',
         y: '70',
       },
       {
-        d: 'M 182.91556851311952,102.5 h 23 v 162.5 h -23 Z',
+        d: 'M 168.73000000000005,102.5 h 6 v 162.5 h -6 Z',
         height: '162.5',
         radius: '0',
-        width: '23',
-        x: '182.91556851311952',
+        width: '6',
+        x: '168.73000000000005',
         y: '102.5',
       },
       {
-        d: 'M 212.07125364431488,5 h 23 v 260 h -23 Z',
+        d: 'M 160.68000000000006,5 h 6 v 260 h -6 Z',
         height: '260',
         radius: '0',
-        width: '23',
-        x: '212.07125364431488',
+        width: '6',
+        x: '160.68000000000006',
         y: '5',
       },
       {
-        d: 'M 95.44851311953354,83.00000000000001 h 23 v 182 h -23 Z',
+        d: 'M 192.88,83.00000000000001 h 6 v 182 h -6 Z',
         height: '182',
         radius: '0',
-        width: '23',
-        x: '95.44851311953354',
+        width: '6',
+        x: '192.88',
         y: '83.00000000000001',
       },
     ]);
     expectXAxisTicks(container, [
       {
-        textContent: '100',
-        x: '77.95510204081633',
+        textContent: '90',
+        x: '212.19999999999993',
         y: '273',
       },
       {
-        textContent: '120',
-        x: '136.266472303207',
+        textContent: '110',
+        x: '196.09999999999997',
         y: '273',
       },
       {
-        textContent: '140',
-        x: '194.57784256559765',
+        textContent: '130',
+        x: '180',
+        y: '273',
+      },
+      {
+        textContent: '150',
+        x: '163.90000000000003',
         y: '273',
       },
       {
         textContent: '170',
-        x: '282.0448979591837',
+        x: '147.80000000000007',
         y: '273',
       },
     ]);
-    expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 170]);
+    expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 170]);
   });
 
   it('Render Bars with custom gap', () => {
@@ -970,68 +984,81 @@ describe('<XAxis />', () => {
 
     expectBars(container, [
       {
-        d: 'M 64.45714285714286,135 h 23 v 130 h -23 Z',
+        d: 'M 65.9,206.5 h 20 v 58.5 h -20 Z',
+        height: '58.5',
+        radius: '0',
+        width: '20',
+        x: '65.9',
+        y: '206.5',
+      },
+      {
+        d: 'M 91.15,135 h 20 v 130 h -20 Z',
         height: '130',
         radius: '0',
-        width: '23',
-        x: '64.45714285714286',
+        width: '20',
+        x: '91.15',
         y: '135',
       },
       {
-        d: 'M 122.17142857142858,200 h 23 v 65 h -23 Z',
+        d: 'M 141.65,200 h 20 v 65 h -20 Z',
         height: '65',
         radius: '0',
-        width: '23',
-        x: '122.17142857142858',
+        width: '20',
+        x: '141.65',
         y: '200',
       },
       {
-        d: 'M 266.45714285714286,70 h 23 v 195 h -23 Z',
+        d: 'M 267.9,70 h 20 v 195 h -20 Z',
         height: '195',
         radius: '0',
-        width: '23',
-        x: '266.45714285714286',
+        width: '20',
+        x: '267.9',
         y: '70',
       },
       {
-        d: 'M 179.8857142857143,102.5 h 23 v 162.5 h -23 Z',
+        d: 'M 192.15,102.5 h 20 v 162.5 h -20 Z',
         height: '162.5',
         radius: '0',
-        width: '23',
-        x: '179.8857142857143',
+        width: '20',
+        x: '192.15',
         y: '102.5',
       },
       {
-        d: 'M 208.7428571428572,5 h 23 v 260 h -23 Z',
+        d: 'M 217.4,5 h 20 v 260 h -20 Z',
         height: '260',
         radius: '0',
-        width: '23',
-        x: '208.7428571428572',
+        width: '20',
+        x: '217.4',
         y: '5',
       },
       {
-        d: 'M 93.31428571428572,83.00000000000001 h 23 v 182 h -23 Z',
+        d: 'M 116.4,83.00000000000001 h 20 v 182 h -20 Z',
         height: '182',
         radius: '0',
-        width: '23',
-        x: '93.31428571428572',
+        width: '20',
+        x: '116.4',
         y: '83.00000000000001',
       },
     ]);
     expectXAxisTicks(container, [
       {
-        textContent: '100',
+        textContent: '90',
         x: '76',
         y: '273',
       },
       {
-        textContent: '120',
-        x: '133.71428571428572',
+        textContent: '110',
+        x: '126.5',
         y: '273',
       },
       {
-        textContent: '140',
-        x: '191.42857142857144',
+        textContent: '130',
+        x: '177',
+        y: '273',
+      },
+      {
+        textContent: '150',
+        x: '227.5',
         y: '273',
       },
       {
@@ -1040,7 +1067,7 @@ describe('<XAxis />', () => {
         y: '273',
       },
     ]);
-    expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 170]);
+    expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 170]);
   });
 
   it('Render Bars with padding on the left', () => {
@@ -1056,68 +1083,81 @@ describe('<XAxis />', () => {
 
     expectBars(container, [
       {
-        d: 'M 71.94285714285715,135 h 24 v 130 h -24 Z',
+        d: 'M 73.45,206.5 h 21 v 58.5 h -21 Z',
+        height: '58.5',
+        radius: '0',
+        width: '21',
+        x: '73.45',
+        y: '206.5',
+      },
+      {
+        d: 'M 99.825,135 h 21 v 130 h -21 Z',
         height: '130',
         radius: '0',
-        width: '24',
-        x: '71.94285714285715',
+        width: '21',
+        x: '99.825',
         y: '135',
       },
       {
-        d: 'M 132.22857142857143,200 h 24 v 65 h -24 Z',
+        d: 'M 152.575,200 h 21 v 65 h -21 Z',
         height: '65',
         radius: '0',
-        width: '24',
-        x: '132.22857142857143',
+        width: '21',
+        x: '152.575',
         y: '200',
       },
       {
-        d: 'M 282.9428571428572,70 h 24 v 195 h -24 Z',
+        d: 'M 284.45,70 h 21 v 195 h -21 Z',
         height: '195',
         radius: '0',
-        width: '24',
-        x: '282.9428571428572',
+        width: '21',
+        x: '284.45',
         y: '70',
       },
       {
-        d: 'M 192.5142857142857,102.5 h 24 v 162.5 h -24 Z',
+        d: 'M 205.325,102.5 h 21 v 162.5 h -21 Z',
         height: '162.5',
         radius: '0',
-        width: '24',
-        x: '192.5142857142857',
+        width: '21',
+        x: '205.325',
         y: '102.5',
       },
       {
-        d: 'M 222.65714285714287,5 h 24 v 260 h -24 Z',
+        d: 'M 231.7,5 h 21 v 260 h -21 Z',
         height: '260',
         radius: '0',
-        width: '24',
-        x: '222.65714285714287',
+        width: '21',
+        x: '231.7',
         y: '5',
       },
       {
-        d: 'M 102.08571428571429,83.00000000000001 h 24 v 182 h -24 Z',
+        d: 'M 126.2,83.00000000000001 h 21 v 182 h -21 Z',
         height: '182',
         radius: '0',
-        width: '24',
-        x: '102.08571428571429',
+        width: '21',
+        x: '126.2',
         y: '83.00000000000001',
       },
     ]);
     expectXAxisTicks(container, [
       {
-        textContent: '100',
+        textContent: '90',
         x: '84',
         y: '273',
       },
       {
-        textContent: '120',
-        x: '144.28571428571428',
+        textContent: '110',
+        x: '136.75',
         y: '273',
       },
       {
-        textContent: '140',
-        x: '204.57142857142856',
+        textContent: '130',
+        x: '189.5',
+        y: '273',
+      },
+      {
+        textContent: '150',
+        x: '242.25',
         y: '273',
       },
       {
@@ -1126,7 +1166,7 @@ describe('<XAxis />', () => {
         y: '273',
       },
     ]);
-    expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 170]);
+    expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 170]);
   });
 
   it('Render Bars with padding on the right', () => {
@@ -1142,68 +1182,81 @@ describe('<XAxis />', () => {
 
     expectBars(container, [
       {
-        d: 'M 53.17142857142858,135 h 23 v 130 h -23 Z',
+        d: 'M 54.65,206.5 h 20 v 58.5 h -20 Z',
+        height: '58.5',
+        radius: '0',
+        width: '20',
+        x: '54.65',
+        y: '206.5',
+      },
+      {
+        d: 'M 80.525,135 h 20 v 130 h -20 Z',
         height: '130',
         radius: '0',
-        width: '23',
-        x: '53.17142857142858',
+        width: '20',
+        x: '80.525',
         y: '135',
       },
       {
-        d: 'M 112.31428571428572,200 h 23 v 65 h -23 Z',
+        d: 'M 132.275,200 h 20 v 65 h -20 Z',
         height: '65',
         radius: '0',
-        width: '23',
-        x: '112.31428571428572',
+        width: '20',
+        x: '132.275',
         y: '200',
       },
       {
-        d: 'M 260.1714285714286,70 h 23 v 195 h -23 Z',
+        d: 'M 261.65,70 h 20 v 195 h -20 Z',
         height: '195',
         radius: '0',
-        width: '23',
-        x: '260.1714285714286',
+        width: '20',
+        x: '261.65',
         y: '70',
       },
       {
-        d: 'M 171.45714285714286,102.5 h 23 v 162.5 h -23 Z',
+        d: 'M 184.025,102.5 h 20 v 162.5 h -20 Z',
         height: '162.5',
         radius: '0',
-        width: '23',
-        x: '171.45714285714286',
+        width: '20',
+        x: '184.025',
         y: '102.5',
       },
       {
-        d: 'M 201.0285714285714,5 h 23 v 260 h -23 Z',
+        d: 'M 209.9,5 h 20 v 260 h -20 Z',
         height: '260',
         radius: '0',
-        width: '23',
-        x: '201.0285714285714',
+        width: '20',
+        x: '209.9',
         y: '5',
       },
       {
-        d: 'M 82.74285714285715,83.00000000000001 h 23 v 182 h -23 Z',
+        d: 'M 106.4,83.00000000000001 h 20 v 182 h -20 Z',
         height: '182',
         radius: '0',
-        width: '23',
-        x: '82.74285714285715',
+        width: '20',
+        x: '106.4',
         y: '83.00000000000001',
       },
     ]);
     expectXAxisTicks(container, [
       {
-        textContent: '100',
+        textContent: '90',
         x: '65',
         y: '273',
       },
       {
-        textContent: '120',
-        x: '124.14285714285714',
+        textContent: '110',
+        x: '116.75',
         y: '273',
       },
       {
-        textContent: '140',
-        x: '183.28571428571428',
+        textContent: '130',
+        x: '168.5',
+        y: '273',
+      },
+      {
+        textContent: '150',
+        x: '220.25',
         y: '273',
       },
       {
@@ -1212,7 +1265,7 @@ describe('<XAxis />', () => {
         y: '273',
       },
     ]);
-    expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 170]);
+    expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 170]);
   });
 
   it('Render axis with tick for a single data point', () => {
@@ -1229,7 +1282,7 @@ describe('<XAxis />', () => {
     const tick = container.querySelector('.xAxis .recharts-cartesian-axis-tick-value');
     assertNotNull(tick);
     expect(tick).toBeInTheDocument();
-    expect(tick.textContent).toEqual('100');
+    expect(tick.textContent).toEqual('90');
     expect(tick.getAttribute('x')).toEqual('180');
 
     // For a single data point, unless barSize is given, the bar will have no width and thus not be rendered.
@@ -1238,12 +1291,12 @@ describe('<XAxis />', () => {
     expect(bar).not.toBeInTheDocument();
     expectXAxisTicks(container, [
       {
-        textContent: '100',
+        textContent: '90',
         x: '180',
         y: '273',
       },
     ]);
-    expect(spy).toHaveBeenLastCalledWith([100, 100]);
+    expect(spy).toHaveBeenLastCalledWith([90, 90]);
   });
 
   it('Should render the axis line without any ticks', () => {
@@ -1321,24 +1374,29 @@ describe('<XAxis />', () => {
         value: 0,
       },
       {
-        coordinate: 200,
+        coordinate: 213,
         offset: 0,
-        value: 50,
+        value: 20,
       },
       {
-        coordinate: 135,
+        coordinate: 161,
         offset: 0,
-        value: 100,
+        value: 40,
       },
       {
-        coordinate: 70,
+        coordinate: 109,
         offset: 0,
-        value: 150,
+        value: 60,
+      },
+      {
+        coordinate: 56.999999999999986,
+        offset: 0,
+        value: 80,
       },
       {
         coordinate: 5,
         offset: 0,
-        value: 200,
+        value: 100,
       },
     ]);
     expect(yAxisTicksSpy).toHaveBeenCalledTimes(2);
@@ -1361,11 +1419,12 @@ describe('<XAxis />', () => {
     expect(chartDataSpy).toHaveBeenLastCalledWith({
       chartData: [
         {
-          x: 100,
-          y: 200,
-          z: 200,
+          x: 90,
+          y: 90,
+          z: 90,
         },
       ],
+      computedData: undefined,
       dataEndIndex: 0,
       dataStartIndex: 0,
     });
@@ -1373,12 +1432,12 @@ describe('<XAxis />', () => {
 
     expectBars(container, [
       {
-        d: 'M 123,5 h 115 v 260 h -115 Z',
-        height: '260',
+        d: 'M 100,30.999999999999993 h 115 v 234 h -115 Z',
+        height: '234',
         radius: '0',
         width: '115',
-        x: '123',
-        y: '5',
+        x: '100',
+        y: '30.999999999999993',
       },
     ]);
     expectXAxisTicks(container, [
@@ -1429,28 +1488,33 @@ describe('<XAxis />', () => {
     expect(bar.getAttribute('width')).toEqual('46');
     expectBars(container, [
       {
-        d: 'M 42,5 h 46 v 260 h -46 Z',
-        height: '260',
+        d: 'M 42,30.999999999999993 h 46 v 234 h -46 Z',
+        height: '234',
         radius: '0',
         width: '46',
         x: '42',
-        y: '5',
+        y: '30.999999999999993',
       },
     ]);
     expectXAxisTicks(container, [
       {
-        textContent: '100',
+        textContent: '90',
         x: '65',
         y: '273',
       },
       {
-        textContent: '115',
-        x: '134',
+        textContent: '105',
+        x: '122.5',
         y: '273',
       },
       {
-        textContent: '130',
-        x: '203',
+        textContent: '120',
+        x: '180',
+        y: '273',
+      },
+      {
+        textContent: '135',
+        x: '237.5',
         y: '273',
       },
       {
@@ -1459,7 +1523,7 @@ describe('<XAxis />', () => {
         y: '273',
       },
     ]);
-    expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 150]);
+    expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 150]);
   });
 
   test('Render no ticks if type is category and data is empty', () => {
@@ -2313,32 +2377,32 @@ describe('<XAxis />', () => {
           );
           expectXAxisTicks(container, [
             {
-              textContent: '100',
+              textContent: '75',
               x: '5',
               y: '273',
             },
             {
-              textContent: '120',
+              textContent: '100',
               x: '77.5',
               y: '273',
             },
             {
-              textContent: '140',
+              textContent: '125',
               x: '150',
               y: '273',
             },
             {
-              textContent: '160',
+              textContent: '150',
               x: '222.5',
               y: '273',
             },
             {
-              textContent: '180',
+              textContent: '175',
               x: '295',
               y: '273',
             },
           ]);
-          expect(spy).toHaveBeenLastCalledWith([100, 180]);
+          expect(spy).toHaveBeenLastCalledWith([75, 175]);
         });
 
         it('should render ticks from number, auto', () => {
@@ -2497,18 +2561,18 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
-            textContent: '100',
+            textContent: '90',
             x: '5',
             y: '273',
           },
           {
-            textContent: '120',
-            x: '82.33333333333334',
+            textContent: '115',
+            x: '90.29411764705883',
             y: '273',
           },
           {
             textContent: '140',
-            x: '159.66666666666669',
+            x: '175.58823529411765',
             y: '273',
           },
           {
@@ -2517,7 +2581,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([100, 175]);
+        expect(spy).toHaveBeenLastCalledWith([90, 175]);
 
         rerender(
           <Component>
@@ -2527,18 +2591,23 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
-            textContent: '100',
+            textContent: '90',
             x: '5',
             y: '273',
           },
           {
-            textContent: '120',
-            x: '87.85714285714285',
+            textContent: '110',
+            x: '77.5',
             y: '273',
           },
           {
-            textContent: '140',
-            x: '170.7142857142857',
+            textContent: '130',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '150',
+            x: '222.5',
             y: '273',
           },
           {
@@ -2547,7 +2616,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([100, 170]);
+        expect(spy).toHaveBeenLastCalledWith([90, 170]);
       });
 
       it('should default to dataMin, dataMax for domain where the larger number is first', () => {
@@ -2560,18 +2629,23 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
-            textContent: '100',
+            textContent: '90',
             x: '5',
             y: '273',
           },
           {
-            textContent: '120',
-            x: '87.85714285714285',
+            textContent: '110',
+            x: '77.5',
             y: '273',
           },
           {
-            textContent: '140',
-            x: '170.7142857142857',
+            textContent: '130',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '150',
+            x: '222.5',
             y: '273',
           },
           {
@@ -2580,7 +2654,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([100, 170]);
+        expect(spy).toHaveBeenLastCalledWith([90, 170]);
       });
 
       it('should reverse domain where the larger number is first, and allowDataOverflow is true', () => {
@@ -2763,18 +2837,23 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
-            textContent: '100',
+            textContent: '90',
             x: '5',
             y: '273',
           },
           {
-            textContent: '120',
-            x: '87.85714285714285',
+            textContent: '110',
+            x: '77.5',
             y: '273',
           },
           {
-            textContent: '140',
-            x: '170.7142857142857',
+            textContent: '130',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '150',
+            x: '222.5',
             y: '273',
           },
           {
@@ -2783,7 +2862,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([100, 170]);
+        expect(spy).toHaveBeenLastCalledWith([90, 170]);
       });
 
       it('should default to dataMin, dataMax when domain is provided as an array of invalid values', () => {
@@ -2801,18 +2880,23 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
-            textContent: '100',
+            textContent: '90',
             x: '5',
             y: '273',
           },
           {
-            textContent: '120',
-            x: '87.85714285714285',
+            textContent: '110',
+            x: '77.5',
             y: '273',
           },
           {
-            textContent: '140',
-            x: '170.7142857142857',
+            textContent: '130',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '150',
+            x: '222.5',
             y: '273',
           },
           {
@@ -2821,7 +2905,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([100, 170]);
+        expect(spy).toHaveBeenLastCalledWith([90, 170]);
       });
 
       it('should allow a function that returns a domain, and pass inside a computed domain and allowDataOverflow prop', () => {
@@ -2862,7 +2946,7 @@ describe('<XAxis />', () => {
           },
         ]);
         expect(domainPropSpy).toHaveBeenCalledTimes(2);
-        expect(domainPropSpy).toHaveBeenCalledWith([100, 170], true);
+        expect(domainPropSpy).toHaveBeenCalledWith([90, 170], true);
 
         rerender(
           <Component>
@@ -2898,7 +2982,7 @@ describe('<XAxis />', () => {
           },
         ]);
         expect(domainPropSpy).toHaveBeenCalledTimes(4);
-        expect(domainPropSpy).toHaveBeenLastCalledWith([100, 170], false);
+        expect(domainPropSpy).toHaveBeenLastCalledWith([90, 170], false);
         expect(reduxDomainSpy).toHaveBeenLastCalledWith([-500, 500]);
       });
 
@@ -2943,7 +3027,7 @@ describe('<XAxis />', () => {
         ]);
         expect(spyMin).toHaveBeenCalledTimes(2);
         expect(spyMax).toHaveBeenCalledTimes(2);
-        expect(spyMin).toHaveBeenLastCalledWith(100);
+        expect(spyMin).toHaveBeenLastCalledWith(90);
         expect(spyMax).toHaveBeenLastCalledWith(170);
         expect(reduxDomainSpy).toHaveBeenLastCalledWith([-500, 500]);
       });
@@ -3141,22 +3225,22 @@ describe('<XAxis />', () => {
             y: '243',
           },
           {
-            textContent: '45',
+            textContent: '30',
             x: '77.5',
             y: '243',
           },
           {
-            textContent: '90',
+            textContent: '60',
             x: '150',
             y: '243',
           },
           {
-            textContent: '135',
+            textContent: '90',
             x: '222.5',
             y: '243',
           },
           {
-            textContent: '180',
+            textContent: '120',
             x: '295',
             y: '243',
           },
@@ -3168,29 +3252,29 @@ describe('<XAxis />', () => {
             y: '273',
           },
           {
-            textContent: '40',
+            textContent: '45',
             x: '77.5',
             y: '273',
           },
           {
-            textContent: '80',
+            textContent: '90',
             x: '150',
             y: '273',
           },
           {
-            textContent: '120',
+            textContent: '135',
             x: '222.5',
             y: '273',
           },
           {
-            textContent: '160',
+            textContent: '180',
             x: '295',
             y: '273',
           },
         ]);
         expect(reduxDefaultDomainSpy).toHaveBeenLastCalledWith(undefined);
-        expect(reduxDomainSpyA).toHaveBeenLastCalledWith([0, 180]);
-        expect(reduxDomainSpyB).toHaveBeenLastCalledWith([0, 160]);
+        expect(reduxDomainSpyA).toHaveBeenLastCalledWith([0, 120]);
+        expect(reduxDomainSpyB).toHaveBeenLastCalledWith([0, 180]);
       });
 
       it('should only display domain of data with matching xAxisId, and dataMin dataMax domains', () => {
@@ -3212,22 +3296,22 @@ describe('<XAxis />', () => {
         expect(allXAxes).toHaveLength(2);
         expectXAxisTicks(allXAxes[0], [
           {
-            textContent: '100',
+            textContent: '90',
             x: '5',
             y: '243',
           },
           {
+            textContent: '98',
+            x: '82.33333333333334',
+            y: '243',
+          },
+          {
+            textContent: '106',
+            x: '159.66666666666669',
+            y: '243',
+          },
+          {
             textContent: '120',
-            x: '87.85714285714285',
-            y: '243',
-          },
-          {
-            textContent: '140',
-            x: '170.7142857142857',
-            y: '243',
-          },
-          {
-            textContent: '170',
             x: '295',
             y: '243',
           },
@@ -3239,29 +3323,29 @@ describe('<XAxis />', () => {
             y: '273',
           },
           {
-            textContent: '120',
+            textContent: '125',
             x: '77.5',
             y: '273',
           },
           {
-            textContent: '130',
+            textContent: '140',
             x: '150',
             y: '273',
           },
           {
-            textContent: '140',
+            textContent: '155',
             x: '222.5',
             y: '273',
           },
           {
-            textContent: '150',
+            textContent: '170',
             x: '295',
             y: '273',
           },
         ]);
         expect(reduxDefaultDomainSpy).toHaveBeenLastCalledWith(undefined);
-        expect(reduxDomainSpyA).toHaveBeenLastCalledWith([100, 170]);
-        expect(reduxDomainSpyB).toHaveBeenLastCalledWith([110, 150]);
+        expect(reduxDomainSpyA).toHaveBeenLastCalledWith([90, 120]);
+        expect(reduxDomainSpyB).toHaveBeenLastCalledWith([110, 170]);
       });
     });
 
@@ -3655,37 +3739,42 @@ describe('<XAxis />', () => {
       );
       expectXAxisTicks(container, [
         {
+          textContent: '90',
+          x: '25.714285714285715',
+          y: '273',
+        },
+        {
           textContent: '100',
-          x: '29.166666666666668',
+          x: '67.14285714285714',
           y: '273',
         },
         {
           textContent: '120',
-          x: '77.5',
+          x: '108.57142857142858',
           y: '273',
         },
         {
           textContent: '170',
-          x: '125.83333333333334',
+          x: '150',
           y: '273',
         },
         {
           textContent: '140',
-          x: '174.16666666666666',
+          x: '191.42857142857144',
           y: '273',
         },
         {
           textContent: '150',
-          x: '222.5',
+          x: '232.8571428571429',
           y: '273',
         },
         {
           textContent: '110',
-          x: '270.83333333333337',
+          x: '274.2857142857143',
           y: '273',
         },
       ]);
-      expect(spy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
+      expect(spy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
     });
 
     it('should reverse ticks', () => {
@@ -3698,37 +3787,42 @@ describe('<XAxis />', () => {
       );
       expectXAxisTicks(container, [
         {
+          textContent: '90',
+          x: '274.2857142857143',
+          y: '273',
+        },
+        {
           textContent: '100',
-          x: '270.83333333333337',
+          x: '232.8571428571429',
           y: '273',
         },
         {
           textContent: '120',
-          x: '222.5',
+          x: '191.42857142857144',
           y: '273',
         },
         {
           textContent: '170',
-          x: '174.16666666666666',
+          x: '150',
           y: '273',
         },
         {
           textContent: '140',
-          x: '125.83333333333334',
+          x: '108.57142857142858',
           y: '273',
         },
         {
           textContent: '150',
-          x: '77.5',
+          x: '67.14285714285714',
           y: '273',
         },
         {
           textContent: '110',
-          x: '29.166666666666668',
+          x: '25.714285714285715',
           y: '273',
         },
       ]);
-      expect(spy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
+      expect(spy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
     });
 
     it.each([undefined, true])(
@@ -3743,37 +3837,42 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
+            textContent: '90',
+            x: '25.714285714285715',
+            y: '273',
+          },
+          {
             textContent: '200',
-            x: '29.166666666666668',
+            x: '67.14285714285714',
             y: '273',
           },
           {
             textContent: '260',
-            x: '77.5',
+            x: '108.57142857142858',
             y: '273',
           },
           {
             textContent: '400',
-            x: '125.83333333333334',
+            x: '150',
             y: '273',
           },
           {
             textContent: '280',
-            x: '174.16666666666666',
+            x: '191.42857142857144',
             y: '273',
           },
           {
             textContent: '500',
-            x: '222.5',
+            x: '232.8571428571429',
             y: '273',
           },
           {
             textContent: '200',
-            x: '270.83333333333337',
+            x: '274.2857142857143',
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6]);
       },
     );
 
@@ -3787,32 +3886,37 @@ describe('<XAxis />', () => {
       );
       expectXAxisTicks(container, [
         {
+          textContent: '90',
+          x: '29.166666666666668',
+          y: '273',
+        },
+        {
           textContent: '200',
-          x: '34',
+          x: '77.5',
           y: '273',
         },
         {
           textContent: '260',
-          x: '92',
+          x: '125.83333333333334',
           y: '273',
         },
         {
           textContent: '400',
-          x: '150',
+          x: '174.16666666666666',
           y: '273',
         },
         {
           textContent: '280',
-          x: '208',
+          x: '222.5',
           y: '273',
         },
         {
           textContent: '500',
-          x: '266',
+          x: '270.83333333333337',
           y: '273',
         },
       ]);
-      expect(spy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500]);
+      expect(spy).toHaveBeenLastCalledWith([90, 200, 260, 400, 280, 500]);
     });
 
     it.each([undefined, 0, -1, 3, 7, 100, Infinity, NaN])('should ignore tickCount = %s', tickCount => {
@@ -3825,37 +3929,42 @@ describe('<XAxis />', () => {
       );
       expectXAxisTicks(container, [
         {
+          textContent: '90',
+          x: '25.714285714285715',
+          y: '273',
+        },
+        {
           textContent: '200',
-          x: '29.166666666666668',
+          x: '67.14285714285714',
           y: '273',
         },
         {
           textContent: '260',
-          x: '77.5',
+          x: '108.57142857142858',
           y: '273',
         },
         {
           textContent: '400',
-          x: '125.83333333333334',
+          x: '150',
           y: '273',
         },
         {
           textContent: '280',
-          x: '174.16666666666666',
+          x: '191.42857142857144',
           y: '273',
         },
         {
           textContent: '500',
-          x: '222.5',
+          x: '232.8571428571429',
           y: '273',
         },
         {
           textContent: '200',
-          x: '270.83333333333337',
+          x: '274.2857142857143',
           y: '273',
         },
       ]);
-      expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+      expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6]);
     });
 
     const variousDomains: ReadonlyArray<{ domain: ReadonlyArray<string> | ReadonlyArray<number> | undefined }> = [
@@ -3876,37 +3985,42 @@ describe('<XAxis />', () => {
       );
       expectXAxisTicks(container, [
         {
+          textContent: '90',
+          x: '25.714285714285715',
+          y: '273',
+        },
+        {
           textContent: '200',
-          x: '29.166666666666668',
+          x: '67.14285714285714',
           y: '273',
         },
         {
           textContent: '260',
-          x: '77.5',
+          x: '108.57142857142858',
           y: '273',
         },
         {
           textContent: '400',
-          x: '125.83333333333334',
+          x: '150',
           y: '273',
         },
         {
           textContent: '280',
-          x: '174.16666666666666',
+          x: '191.42857142857144',
           y: '273',
         },
         {
           textContent: '500',
-          x: '222.5',
+          x: '232.8571428571429',
           y: '273',
         },
         {
           textContent: '200',
-          x: '270.83333333333337',
+          x: '274.2857142857143',
           y: '273',
         },
       ]);
-      expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+      expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6]);
     });
 
     describe.each([true, false, undefined])('allowDecimals=%s', allowDecimals => {
@@ -4003,28 +4117,33 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
-            textContent: '200',
+            textContent: '90',
             x: '5',
             y: '273',
           },
           {
+            textContent: '200',
+            x: '53.333333333333336',
+            y: '273',
+          },
+          {
             textContent: '260',
-            x: '63',
+            x: '101.66666666666667',
             y: '273',
           },
           {
             textContent: '400',
-            x: '121',
+            x: '150',
             y: '273',
           },
           {
             textContent: '280',
-            x: '179',
+            x: '198.33333333333334',
             y: '273',
           },
           {
             textContent: '500',
-            x: '237',
+            x: '246.66666666666669',
             y: '273',
           },
           {
@@ -4033,7 +4152,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6]);
       });
 
       it('should merge and display domain of all data, and remove duplicates, even when the duplicates are defined on different elements', () => {
@@ -4048,23 +4167,28 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
-            textContent: '200',
+            textContent: '90',
             x: '5',
             y: '273',
           },
           {
+            textContent: '200',
+            x: '63',
+            y: '273',
+          },
+          {
             textContent: '260',
-            x: '77.5',
+            x: '121',
             y: '273',
           },
           {
             textContent: '400',
-            x: '150',
+            x: '179',
             y: '273',
           },
           {
             textContent: '280',
-            x: '222.5',
+            x: '237',
             y: '273',
           },
           {
@@ -4073,7 +4197,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500]);
+        expect(spy).toHaveBeenLastCalledWith([90, 200, 260, 400, 280, 500]);
       });
 
       it.each([true, false, undefined])(
@@ -4097,30 +4221,35 @@ describe('<XAxis />', () => {
           expect(allXAxes).toHaveLength(2);
           expectXAxisTicks(allXAxes[0], [
             {
-              textContent: '200',
+              textContent: '90',
               x: '5',
               y: '243',
             },
             {
-              textContent: '260',
+              textContent: '200',
               x: '150',
               y: '243',
             },
             {
-              textContent: '400',
+              textContent: '260',
               x: '295',
               y: '243',
             },
           ]);
           expectXAxisTicks(allXAxes[1], [
             {
-              textContent: '280',
+              textContent: '400',
               x: '5',
               y: '273',
             },
             {
+              textContent: '280',
+              x: '101.66666666666667',
+              y: '273',
+            },
+            {
               textContent: '500',
-              x: '150',
+              x: '198.33333333333334',
               y: '273',
             },
             {
@@ -4130,8 +4259,8 @@ describe('<XAxis />', () => {
             },
           ]);
           expect(defaultReduxDomainSpy).toHaveBeenLastCalledWith(undefined);
-          expect(reduxDomainSpyA).toHaveBeenLastCalledWith([200, 260, 400]);
-          expect(reduxDomainSpyB).toHaveBeenLastCalledWith([280, 500, 200]);
+          expect(reduxDomainSpyA).toHaveBeenLastCalledWith([90, 200, 260]);
+          expect(reduxDomainSpyB).toHaveBeenLastCalledWith([400, 280, 500, 200]);
         },
       );
     });
@@ -4147,37 +4276,42 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
+            textContent: '90',
+            x: '25.714285714285715',
+            y: '273',
+          },
+          {
             textContent: '200',
-            x: '29.166666666666668',
+            x: '67.14285714285714',
             y: '273',
           },
           {
             textContent: '260',
-            x: '77.5',
+            x: '108.57142857142858',
             y: '273',
           },
           {
             textContent: '400',
-            x: '125.83333333333334',
+            x: '150',
             y: '273',
           },
           {
             textContent: '280',
-            x: '174.16666666666666',
+            x: '191.42857142857144',
             y: '273',
           },
           {
             textContent: '500',
-            x: '222.5',
+            x: '232.8571428571429',
             y: '273',
           },
           {
             textContent: '200',
-            x: '270.83333333333337',
+            x: '274.2857142857143',
             y: '273',
           },
         ]);
-        expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+        expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6]);
       });
 
       it('should display every second tick when interval = 1', () => {
@@ -4190,22 +4324,27 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
+            textContent: '90',
+            x: '25.714285714285715',
+            y: '273',
+          },
+          {
+            textContent: '260',
+            x: '108.57142857142858',
+            y: '273',
+          },
+          {
+            textContent: '280',
+            x: '191.42857142857144',
+            y: '273',
+          },
+          {
             textContent: '200',
-            x: '29.166666666666668',
-            y: '273',
-          },
-          {
-            textContent: '400',
-            x: '125.83333333333334',
-            y: '273',
-          },
-          {
-            textContent: '500',
-            x: '222.5',
+            x: '274.2857142857143',
             y: '273',
           },
         ]);
-        expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+        expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6]);
       });
 
       it('should display every third tick when interval = 2', () => {
@@ -4218,17 +4357,22 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
-            textContent: '200',
-            x: '29.166666666666668',
+            textContent: '90',
+            x: '25.714285714285715',
             y: '273',
           },
           {
-            textContent: '280',
-            x: '174.16666666666666',
+            textContent: '400',
+            x: '150',
+            y: '273',
+          },
+          {
+            textContent: '200',
+            x: '274.2857142857143',
             y: '273',
           },
         ]);
-        expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+        expect(axisDomainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6]);
       });
 
       it('should attempt to show the ticks start with interval = preserveStart', () => {
@@ -4241,22 +4385,27 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
-            textContent: '100',
-            x: '6.666666666666667',
+            textContent: '90',
+            x: '6.428571428571429',
             y: '273',
           },
           {
-            textContent: '170',
-            x: '13.333333333333334',
+            textContent: '120',
+            x: '12.142857142857144',
             y: '273',
           },
           {
-            textContent: '150',
-            x: '20.000000000000004',
+            textContent: '140',
+            x: '17.857142857142858',
+            y: '273',
+          },
+          {
+            textContent: '110',
+            x: '23.57142857142857',
             y: '273',
           },
         ]);
-        expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
+        expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
       });
 
       it('should attempt to show the ticks end with interval = preserveEnd', () => {
@@ -4269,22 +4418,27 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
+            textContent: '90',
+            x: '6.428571428571429',
+            y: '273',
+          },
+          {
             textContent: '120',
-            x: '10',
+            x: '12.142857142857144',
             y: '273',
           },
           {
             textContent: '140',
-            x: '16.666666666666668',
+            x: '17.857142857142858',
             y: '273',
           },
           {
             textContent: '110',
-            x: '23.333333333333336',
+            x: '23.57142857142857',
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
+        expect(spy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
       });
 
       it('should attempt to show the ticks start and end with interval = preserveStartEnd', () => {
@@ -4297,22 +4451,27 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
-            textContent: '100',
-            x: '6.666666666666667',
+            textContent: '90',
+            x: '6.428571428571429',
             y: '273',
           },
           {
-            textContent: '170',
-            x: '13.333333333333334',
+            textContent: '120',
+            x: '12.142857142857144',
+            y: '273',
+          },
+          {
+            textContent: '140',
+            x: '17.857142857142858',
             y: '273',
           },
           {
             textContent: '110',
-            x: '23.333333333333336',
+            x: '23.57142857142857',
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
+        expect(spy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
       });
 
       it('should do ... same thing as preserveStart? with interval = equidistantPreserveStart', () => {
@@ -4325,22 +4484,27 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
-            textContent: '100',
-            x: '6.666666666666667',
+            textContent: '90',
+            x: '6.428571428571429',
             y: '273',
           },
           {
-            textContent: '170',
-            x: '13.333333333333334',
+            textContent: '120',
+            x: '12.142857142857144',
             y: '273',
           },
           {
-            textContent: '150',
-            x: '20.000000000000004',
+            textContent: '140',
+            x: '17.857142857142858',
+            y: '273',
+          },
+          {
+            textContent: '110',
+            x: '23.57142857142857',
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
+        expect(spy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
       });
     });
   });
@@ -4363,51 +4527,51 @@ describe('<XAxis />', () => {
       );
       expectXAxisTicks(container, [
         {
-          textContent: '120',
+          textContent: '100',
           x: '41.25',
           y: '233',
         },
         {
-          textContent: '170',
+          textContent: '120',
           x: '113.75',
           y: '233',
         },
         {
-          textContent: '140',
+          textContent: '170',
           x: '186.25',
           y: '233',
         },
         {
-          textContent: '150',
+          textContent: '140',
           x: '258.75',
           y: '233',
         },
       ]);
-      expect(axisDomainSpy).toHaveBeenLastCalledWith([120, 170, 140, 150]);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 120, 170, 140]);
       expect(ticksSpy).toHaveBeenLastCalledWith([
         {
           coordinate: 41.25,
           index: 0,
           offset: 36.25,
-          value: 120,
+          value: 100,
         },
         {
           coordinate: 113.75,
           index: 1,
           offset: 36.25,
-          value: 170,
+          value: 120,
         },
         {
           coordinate: 186.25,
           index: 2,
           offset: 36.25,
-          value: 140,
+          value: 170,
         },
         {
           coordinate: 258.75,
           index: 3,
           offset: 36.25,
-          value: 150,
+          value: 140,
         },
       ]);
     });
@@ -4429,72 +4593,83 @@ describe('<XAxis />', () => {
       );
       expectXAxisTicks(container, [
         {
+          textContent: '90',
+          x: '25.714285714285715',
+          y: '233',
+        },
+        {
           textContent: '100',
-          x: '29.166666666666668',
+          x: '67.14285714285714',
           y: '233',
         },
         {
           textContent: '120',
-          x: '77.5',
+          x: '108.57142857142858',
           y: '233',
         },
         {
           textContent: '170',
-          x: '125.83333333333334',
+          x: '150',
           y: '233',
         },
         {
           textContent: '140',
-          x: '174.16666666666666',
+          x: '191.42857142857144',
           y: '233',
         },
         {
           textContent: '150',
-          x: '222.5',
+          x: '232.8571428571429',
           y: '233',
         },
         {
           textContent: '110',
-          x: '270.83333333333337',
+          x: '274.2857142857143',
           y: '233',
         },
       ]);
-      expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 120, 170, 140, 150, 110]);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
       expect(ticksSpy).toHaveBeenLastCalledWith([
         {
-          coordinate: 29.166666666666668,
+          coordinate: 25.714285714285715,
           index: 0,
-          offset: 24.166666666666668,
+          offset: 20.714285714285715,
+          value: 90,
+        },
+        {
+          coordinate: 67.14285714285714,
+          index: 1,
+          offset: 20.714285714285715,
           value: 100,
         },
         {
-          coordinate: 77.5,
-          index: 1,
-          offset: 24.166666666666668,
+          coordinate: 108.57142857142858,
+          index: 2,
+          offset: 20.714285714285715,
           value: 120,
         },
         {
-          coordinate: 125.83333333333334,
-          index: 2,
-          offset: 24.166666666666668,
+          coordinate: 150,
+          index: 3,
+          offset: 20.714285714285715,
           value: 170,
         },
         {
-          coordinate: 174.16666666666666,
-          index: 3,
-          offset: 24.166666666666668,
+          coordinate: 191.42857142857144,
+          index: 4,
+          offset: 20.714285714285715,
           value: 140,
         },
         {
-          coordinate: 222.5,
-          index: 4,
-          offset: 24.166666666666668,
+          coordinate: 232.8571428571429,
+          index: 5,
+          offset: 20.714285714285715,
           value: 150,
         },
         {
-          coordinate: 270.83333333333337,
-          index: 5,
-          offset: 24.166666666666668,
+          coordinate: 274.2857142857143,
+          index: 6,
+          offset: 20.714285714285715,
           value: 110,
         },
       ]);
@@ -4508,52 +4683,52 @@ describe('<XAxis />', () => {
         </BarChart>,
       );
 
-      expect(axisDomainSpy).toHaveBeenLastCalledWith([120, 170, 140, 150]);
+      expect(axisDomainSpy).toHaveBeenLastCalledWith([100, 120, 170, 140]);
       expect(ticksSpy).toHaveBeenLastCalledWith([
         {
           coordinate: 41.25,
           index: 0,
           offset: 36.25,
-          value: 120,
+          value: 100,
         },
         {
           coordinate: 113.75,
           index: 1,
           offset: 36.25,
-          value: 170,
+          value: 120,
         },
         {
           coordinate: 186.25,
           index: 2,
           offset: 36.25,
-          value: 140,
+          value: 170,
         },
         {
           coordinate: 258.75,
           index: 3,
           offset: 36.25,
-          value: 150,
+          value: 140,
         },
       ]);
 
       expectXAxisTicks(container, [
         {
-          textContent: '120',
+          textContent: '100',
           x: '41.25',
           y: '233',
         },
         {
-          textContent: '170',
+          textContent: '120',
           x: '113.75',
           y: '233',
         },
         {
-          textContent: '140',
+          textContent: '170',
           x: '186.25',
           y: '233',
         },
         {
-          textContent: '150',
+          textContent: '140',
           x: '258.75',
           y: '233',
         },
@@ -4574,32 +4749,37 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
+            textContent: '90',
+            x: '29.166666666666668',
+            y: '273',
+          },
+          {
             textContent: '200',
-            x: '34',
+            x: '77.5',
             y: '273',
           },
           {
             textContent: '260',
-            x: '92',
+            x: '125.83333333333334',
             y: '273',
           },
           {
             textContent: '400',
-            x: '150',
+            x: '174.16666666666666',
             y: '273',
           },
           {
             textContent: '280',
-            x: '208',
+            x: '222.5',
             y: '273',
           },
           {
             textContent: '500',
-            x: '266',
+            x: '270.83333333333337',
             y: '273',
           },
         ]);
-        expect(axisDomainSpy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500]);
+        expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 200, 260, 400, 280, 500]);
       },
     );
 
@@ -4615,32 +4795,37 @@ describe('<XAxis />', () => {
         );
         expectXAxisTicks(container, [
           {
+            textContent: '90',
+            x: '29.166666666666668',
+            y: '273',
+          },
+          {
             textContent: '200',
-            x: '34',
+            x: '77.5',
             y: '273',
           },
           {
             textContent: '260',
-            x: '92',
+            x: '125.83333333333334',
             y: '273',
           },
           {
             textContent: '400',
-            x: '150',
+            x: '174.16666666666666',
             y: '273',
           },
           {
             textContent: '280',
-            x: '208',
+            x: '222.5',
             y: '273',
           },
           {
             textContent: '500',
-            x: '266',
+            x: '270.83333333333337',
             y: '273',
           },
         ]);
-        expect(axisDomainSpy).toHaveBeenLastCalledWith([200, 260, 400, 280, 500]);
+        expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 200, 260, 400, 280, 500]);
       },
     );
 

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -526,7 +526,7 @@ describe('<XAxis />', () => {
       </BarChart>,
     );
 
-    expect(barBandSizeSpy).toHaveBeenLastCalledWith(201.25);
+    expect(barBandSizeSpy).toHaveBeenLastCalledWith(25.15625);
     expect(barBandSizeSpy).toHaveBeenCalledTimes(2);
 
     expect(offsetSpy).toHaveBeenLastCalledWith({
@@ -545,43 +545,43 @@ describe('<XAxis />', () => {
 
     expect(barTicksSpy).toHaveBeenLastCalledWith([
       {
-        coordinate: 985,
+        coordinate: 79.375,
         index: 0,
         offset: 0,
         value: 90,
       },
       {
-        coordinate: 783.75,
+        coordinate: 104.53125,
         index: 1,
         offset: 0,
         value: 100,
       },
       {
-        coordinate: 381.25,
+        coordinate: 154.84375,
         index: 2,
         offset: 0,
         value: 120,
       },
       {
-        coordinate: -625,
+        coordinate: 280.625,
         index: 3,
         offset: 0,
         value: 170,
       },
       {
-        coordinate: -21.25,
+        coordinate: 205.15625,
         index: 4,
         offset: 0,
         value: 140,
       },
       {
-        coordinate: -222.5,
+        coordinate: 230.3125,
         index: 5,
         offset: 0,
         value: 150,
       },
       {
-        coordinate: 582.5,
+        coordinate: 129.6875,
         index: 6,
         offset: 0,
         value: 110,
@@ -591,72 +591,87 @@ describe('<XAxis />', () => {
 
     expectBars(container, [
       {
-        d: 'M 904.5,206.5 h 161 v 58.5 h -161 Z',
+        d: 'M 69.3125,206.5 h 20 v 58.5 h -20 Z',
         height: '58.5',
         radius: '0',
-        width: '161',
-        x: '904.5',
+        width: '20',
+        x: '69.3125',
         y: '206.5',
       },
       {
-        d: 'M 703.25,135 h 161 v 130 h -161 Z',
+        d: 'M 94.46875,135 h 20 v 130 h -20 Z',
         height: '130',
         radius: '0',
-        width: '161',
-        x: '703.25',
+        width: '20',
+        x: '94.46875',
         y: '135',
       },
       {
-        d: 'M 300.75,200 h 161 v 65 h -161 Z',
+        d: 'M 144.78125,200 h 20 v 65 h -20 Z',
         height: '65',
         radius: '0',
-        width: '161',
-        x: '300.75',
+        width: '20',
+        x: '144.78125',
         y: '200',
       },
       {
-        d: 'M -705.5,70 h 161 v 195 h -161 Z',
+        d: 'M 270.5625,70 h 20 v 195 h -20 Z',
         height: '195',
         radius: '0',
-        width: '161',
-        x: '-705.5',
+        width: '20',
+        x: '270.5625',
         y: '70',
       },
       {
-        d: 'M -101.75,102.5 h 161 v 162.5 h -161 Z',
+        d: 'M 195.09375,102.5 h 20 v 162.5 h -20 Z',
         height: '162.5',
         radius: '0',
-        width: '161',
-        x: '-101.75',
+        width: '20',
+        x: '195.09375',
         y: '102.5',
       },
       {
-        d: 'M -303,5 h 161 v 260 h -161 Z',
+        d: 'M 220.25,5 h 20 v 260 h -20 Z',
         height: '260',
         radius: '0',
-        width: '161',
-        x: '-303',
+        width: '20',
+        x: '220.25',
         y: '5',
       },
       {
-        d: 'M 502,83.00000000000001 h 161 v 182 h -161 Z',
+        d: 'M 119.625,83.00000000000001 h 20 v 182 h -20 Z',
         height: '182',
         radius: '0',
-        width: '161',
-        x: '502',
+        width: '20',
+        x: '119.625',
         y: '83.00000000000001',
       },
     ]);
     expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 170]);
     expectXAxisTicks(container, [
       {
+        textContent: '90',
+        x: '79.375',
+        y: '273',
+      },
+      {
+        textContent: '110',
+        x: '129.6875',
+        y: '273',
+      },
+      {
         textContent: '130',
         x: '180',
         y: '273',
       },
       {
+        textContent: '150',
+        x: '230.3125',
+        y: '273',
+      },
+      {
         textContent: '170',
-        x: '0',
+        x: '280.625',
         y: '273',
       },
     ]);
@@ -675,72 +690,87 @@ describe('<XAxis />', () => {
 
     expectBars(container, [
       {
-        d: 'M 36309.5,206.5 h 6951 v 58.5 h -6951 Z',
+        d: 'M 251.1875,206.5 h 868 v 58.5 h -868 Z',
         height: '58.5',
         radius: '0',
-        width: '6951',
-        x: '36309.5',
+        width: '868',
+        x: '251.1875',
         y: '206.5',
       },
       {
-        d: 'M 27620.75,135 h 6951 v 130 h -6951 Z',
+        d: 'M 1337.28125,135 h 868 v 130 h -868 Z',
         height: '130',
         radius: '0',
-        width: '6951',
-        x: '27620.75',
+        width: '868',
+        x: '1337.28125',
         y: '135',
       },
       {
-        d: 'M 10243.25,200 h 6951 v 65 h -6951 Z',
+        d: 'M 3509.46875,200 h 868 v 65 h -868 Z',
         height: '65',
         radius: '0',
-        width: '6951',
-        x: '10243.25',
+        width: '868',
+        x: '3509.46875',
         y: '200',
       },
       {
-        d: 'M -33200.5,70 h 6951 v 195 h -6951 Z',
+        d: 'M 8939.9375,70 h 868 v 195 h -868 Z',
         height: '195',
         radius: '0',
-        width: '6951',
-        x: '-33200.5',
+        width: '868',
+        x: '8939.9375',
         y: '70',
       },
       {
-        d: 'M -7134.25,102.5 h 6951 v 162.5 h -6951 Z',
+        d: 'M 5681.65625,102.5 h 868 v 162.5 h -868 Z',
         height: '162.5',
         radius: '0',
-        width: '6951',
-        x: '-7134.25',
+        width: '868',
+        x: '5681.65625',
         y: '102.5',
       },
       {
-        d: 'M -15823,5 h 6951 v 260 h -6951 Z',
+        d: 'M 6767.75,5 h 868 v 260 h -868 Z',
         height: '260',
         radius: '0',
-        width: '6951',
-        x: '-15823',
+        width: '868',
+        x: '6767.75',
         y: '5',
       },
       {
-        d: 'M 18932,83.00000000000001 h 6951 v 182 h -6951 Z',
+        d: 'M 2423.375,83.00000000000001 h 868 v 182 h -868 Z',
         height: '182',
         radius: '0',
-        width: '6951',
-        x: '18932',
+        width: '868',
+        x: '2423.375',
         y: '83.00000000000001',
       },
     ]);
     expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 170]);
     expectXAxisTicks(container, [
       {
+        textContent: '90',
+        x: '685.625',
+        y: '273',
+      },
+      {
+        textContent: '110',
+        x: '2857.8125',
+        y: '273',
+      },
+      {
         textContent: '130',
         x: '5030',
         y: '273',
       },
       {
+        textContent: '150',
+        x: '7202.1875',
+        y: '273',
+      },
+      {
         textContent: '170',
-        x: '0',
+        x: '9374.375',
         y: '273',
       },
     ]);
@@ -748,19 +778,18 @@ describe('<XAxis />', () => {
 
   describe.each(['gap', 'no-gap', { left: 3, right: 5 }] as const)('padding: %s', padding => {
     /* I am not entirely certain what is the relationship between the tickCount prop, and the actual tick count */
-    // TODO: Remove `brokenGapTickCount` once the bug is fixed.
     it.each([
-      { providedTickCount: 3, expectedTickCount: 3, brokenGapTickCount: { gap: 2, 'no-gap': 3 } },
-      { providedTickCount: 5, expectedTickCount: 5, brokenGapTickCount: { gap: 2, 'no-gap': 5 } },
-      { providedTickCount: 7, expectedTickCount: 6, brokenGapTickCount: { gap: 2, 'no-gap': 6 } },
-      { providedTickCount: 11, expectedTickCount: 11, brokenGapTickCount: { gap: 2, 'no-gap': 11 } },
-      { providedTickCount: 13, expectedTickCount: 12, brokenGapTickCount: { gap: 3, 'no-gap': 12 } },
-      { providedTickCount: 17, expectedTickCount: 17, brokenGapTickCount: { gap: 4, 'no-gap': 17 } },
-      { providedTickCount: 19, expectedTickCount: 17, brokenGapTickCount: { gap: 4, 'no-gap': 17 } },
-      { providedTickCount: 29, expectedTickCount: 27, brokenGapTickCount: { gap: 5, 'no-gap': 27 } },
+      { providedTickCount: 3, expectedTickCount: 3 },
+      { providedTickCount: 5, expectedTickCount: 5 },
+      { providedTickCount: 7, expectedTickCount: 6 },
+      { providedTickCount: 11, expectedTickCount: 11 },
+      { providedTickCount: 13, expectedTickCount: 12 },
+      { providedTickCount: 17, expectedTickCount: 17 },
+      { providedTickCount: 19, expectedTickCount: 17 },
+      { providedTickCount: 29, expectedTickCount: 27 },
     ])(
       'renders $expectedTickCount ticks when tickCount=$providedTickCount',
-      ({ providedTickCount, expectedTickCount, brokenGapTickCount }) => {
+      ({ providedTickCount, expectedTickCount }) => {
         const spy = vi.fn();
         const { container } = render(
           <BarChart width={100000} height={300} data={data}>
@@ -779,11 +808,7 @@ describe('<XAxis />', () => {
 
         expect(spy).toHaveBeenLastCalledWith([90, 170]);
         const allTicks = container.querySelectorAll('.recharts-xAxis .recharts-cartesian-axis-tick-value');
-        if (padding === 'gap' || padding === 'no-gap') {
-          expect(allTicks).toHaveLength(brokenGapTickCount[padding]);
-        } else {
-          expect(allTicks).toHaveLength(expectedTickCount);
-        }
+        expect(allTicks).toHaveLength(expectedTickCount);
       },
     );
   });
@@ -801,72 +826,82 @@ describe('<XAxis />', () => {
 
     expectBars(container, [
       {
-        d: 'M 3540.967741935484,135 h 178 v 130 h -178 Z',
+        d: 'M 65.83766909469301,135 h 5 v 130 h -5 Z',
         height: '130',
         radius: '0',
-        width: '178',
-        x: '3540.967741935484',
+        width: '5',
+        x: '65.83766909469301',
         y: '135',
       },
       {
-        d: 'M 1092.5806451612902,120.55555555555554 h 178 v 144.44444444444446 h -178 Z',
+        d: 'M 144.81789802289285,120.55555555555554 h 5 v 144.44444444444446 h -5 Z',
         height: '144.44444444444446',
         radius: '0',
-        width: '178',
-        x: '1092.5806451612902',
+        width: '5',
+        x: '144.81789802289285',
         y: '120.55555555555554',
       },
       {
-        d: 'M 3318.387096774193,91.66666666666667 h 178 v 173.33333333333331 h -178 Z',
+        d: 'M 73.01768990634756,91.66666666666667 h 5 v 173.33333333333331 h -5 Z',
         height: '173.33333333333331',
         radius: '0',
-        width: '178',
-        x: '3318.387096774193',
+        width: '5',
+        x: '73.01768990634756',
         y: '91.66666666666667',
       },
       {
-        d: 'M -1133.2258064516125,19.44444444444445 h 178 v 245.55555555555554 h -178 Z',
+        d: 'M 216.61810613943808,19.44444444444445 h 5 v 245.55555555555554 h -5 Z',
         height: '245.55555555555554',
         radius: '0',
-        width: '178',
-        x: '-1133.2258064516125',
+        width: '5',
+        x: '216.61810613943808',
         y: '19.44444444444445',
       },
       {
-        d: 'M -20.322580645161224,62.77777777777777 h 178 v 202.22222222222223 h -178 Z',
+        d: 'M 180.71800208116545,62.77777777777777 h 5 v 202.22222222222223 h -5 Z',
         height: '202.22222222222223',
         radius: '0',
-        width: '178',
-        x: '-20.322580645161224',
+        width: '5',
+        x: '180.71800208116545',
         y: '62.77777777777777',
       },
       {
-        d: 'M -3359.032258064516,48.33333333333332 h 178 v 216.66666666666669 h -178 Z',
+        d: 'M 288.4183142559834,48.33333333333332 h 5 v 216.66666666666669 h -5 Z',
         height: '216.66666666666669',
         radius: '0',
-        width: '178',
-        x: '-3359.032258064516',
+        width: '5',
+        x: '288.4183142559834',
         y: '48.33333333333332',
       },
       {
-        d: 'M -688.0645161290324,106.1111111111111 h 178 v 158.8888888888889 h -178 Z',
+        d: 'M 202.25806451612905,106.1111111111111 h 5 v 158.8888888888889 h -5 Z',
         height: '158.8888888888889',
         radius: '0',
-        width: '178',
-        x: '-688.0645161290324',
+        width: '5',
+        x: '202.25806451612905',
         y: '106.1111111111111',
       },
     ]);
     expect(axisDomainSpy).toHaveBeenLastCalledWith([90, 400]);
     expectXAxisTicks(container, [
       {
+        textContent: '90',
+        x: '68.70967741935483',
+        y: '273',
+      },
+      {
+        textContent: '170',
+        x: '126.14984391259105',
+        y: '273',
+      },
+      {
         textContent: '250',
-        x: '68.70967741935488',
+        x: '183.59001040582726',
         y: '273',
       },
       {
         textContent: '400',
-        x: '0',
+        x: '291.2903225806452',
         y: '273',
       },
     ]);
@@ -885,71 +920,71 @@ describe('<XAxis />', () => {
 
     expectBars(container, [
       {
-        d: 'M 208.97999999999996,206.5 h 6 v 58.5 h -6 Z',
+        d: 'M 65.99187500000001,206.5 h 20 v 58.5 h -20 Z',
         height: '58.5',
         radius: '0',
-        width: '6',
-        x: '208.97999999999996',
+        width: '20',
+        x: '65.99187500000001',
         y: '206.5',
       },
       {
-        d: 'M 200.93,135 h 6 v 130 h -6 Z',
+        d: 'M 91.90281250000001,135 h 20 v 130 h -20 Z',
         height: '130',
         radius: '0',
-        width: '6',
-        x: '200.93',
+        width: '20',
+        x: '91.90281250000001',
         y: '135',
       },
       {
-        d: 'M 184.82999999999998,200 h 6 v 65 h -6 Z',
+        d: 'M 143.72468750000002,200 h 20 v 65 h -20 Z',
         height: '65',
         radius: '0',
-        width: '6',
-        x: '184.82999999999998',
+        width: '20',
+        x: '143.72468750000002',
         y: '200',
       },
       {
-        d: 'M 144.5800000000001,70 h 6 v 195 h -6 Z',
+        d: 'M 273.2793750000001,70 h 20 v 195 h -20 Z',
         height: '195',
         radius: '0',
-        width: '6',
-        x: '144.5800000000001',
+        width: '20',
+        x: '273.2793750000001',
         y: '70',
       },
       {
-        d: 'M 168.73000000000005,102.5 h 6 v 162.5 h -6 Z',
+        d: 'M 195.5465625,102.5 h 20 v 162.5 h -20 Z',
         height: '162.5',
         radius: '0',
-        width: '6',
-        x: '168.73000000000005',
+        width: '20',
+        x: '195.5465625',
         y: '102.5',
       },
       {
-        d: 'M 160.68000000000006,5 h 6 v 260 h -6 Z',
+        d: 'M 221.45750000000004,5 h 20 v 260 h -20 Z',
         height: '260',
         radius: '0',
-        width: '6',
-        x: '160.68000000000006',
+        width: '20',
+        x: '221.45750000000004',
         y: '5',
       },
       {
-        d: 'M 192.88,83.00000000000001 h 6 v 182 h -6 Z',
+        d: 'M 117.81375000000003,83.00000000000001 h 20 v 182 h -20 Z',
         height: '182',
         radius: '0',
-        width: '6',
-        x: '192.88',
+        width: '20',
+        x: '117.81375000000003',
         y: '83.00000000000001',
       },
     ]);
     expectXAxisTicks(container, [
       {
         textContent: '90',
-        x: '212.19999999999993',
+        x: '76.35625',
         y: '273',
       },
       {
         textContent: '110',
-        x: '196.09999999999997',
+        x: '128.17812500000002',
         y: '273',
       },
       {
@@ -959,12 +994,12 @@ describe('<XAxis />', () => {
       },
       {
         textContent: '150',
-        x: '163.90000000000003',
+        x: '231.82187500000003',
         y: '273',
       },
       {
         textContent: '170',
-        x: '147.80000000000007',
+        x: '283.64375',
         y: '273',
       },
     ]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes the XAxis padding calculation similarly to #5759 except this time for `recharts@3`. The only differences to #5759 are (1) that the domain values are already constrained to numbers (so can use a number-only sort comparator) and (2) that there was another bug in the calculation of the smallest distance between consecutive values in an array.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#5758

## Motivation and Context

It fixes #5758 for `recharts@3`. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Created a storybook story for the XAxis calculated padding feature to demonstrate the change (seen below).
- Reproduced the bug with existing unit tests to confirm it was an issue.
  - Added a datum to XAxis test data to cover numerical inputs with heterogeneous digit counts.
  - Updated the XAxis tests' expectations to match the new test data. Notably, the asserted values for `x` locations in the `padding="gap"` or `padding="no-gap"` unit tests were often off-screen.
- Fixed the bug.
- Reran the unit tests to confirm the fix.
  - The only tests that were affected were the two tests related to `padding="gap"` and `padding="no-gap"`.
  - The new asserted values for `x` locations in these tests were now on-screen in a similar location as before changing the test data.

## Screenshots (if appropriate):

Storybook story before this PR:
<img width="618" alt="Screenshot 2025-04-16 at 4 14 35 PM" src="https://github.com/user-attachments/assets/e407d7d6-1e7b-4212-a542-3f1e14424ebf" />

Storybook story after this PR:
<img width="618" alt="Screenshot 2025-04-16 at 4 13 53 PM" src="https://github.com/user-attachments/assets/b96d2fcc-0961-4654-bc8f-2e383dac62b2" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
   - (*technically* this is a breaking change but I doubt anyone is depending on this broken behavior)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
