### PR TITLE
Move resolveDefaultProps to a separate file, add docs and tests

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -187,6 +187,7 @@
   "es6/util/isWellBehavedNumber.js",
   "es6/util/payload",
   "es6/util/payload/getUniqPayload.js",
+  "es6/util/resolveDefaultProps.js",
   "es6/util/scale",
   "es6/util/scale/getNiceTickValues.js",
   "es6/util/scale/index.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -187,6 +187,7 @@
   "lib/util/isWellBehavedNumber.js",
   "lib/util/payload",
   "lib/util/payload/getUniqPayload.js",
+  "lib/util/resolveDefaultProps.js",
   "lib/util/scale",
   "lib/util/scale/getNiceTickValues.js",
   "lib/util/scale/index.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -187,6 +187,7 @@
   "types/util/isWellBehavedNumber.d.ts",
   "types/util/payload",
   "types/util/payload/getUniqPayload.d.ts",
+  "types/util/resolveDefaultProps.d.ts",
   "types/util/scale",
   "types/util/scale/getNiceTickValues.d.ts",
   "types/util/scale/index.d.ts",

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -29,6 +29,7 @@ import { setTooltipSettingsState, TooltipIndex, TooltipPayload } from '../state/
 import { AxisId } from '../state/cartesianAxisSlice';
 import { useTooltipChartSynchronisation } from '../synchronisation/useChartSynchronisation';
 import { useTooltipEventType } from '../state/selectors/selectTooltipEventType';
+import { resolveDefaultProps } from '../util/resolveDefaultProps';
 
 export type ContentType<TValue extends ValueType, TName extends NameType> =
   | ReactElement
@@ -138,16 +139,6 @@ const defaultTooltipProps: Partial<TooltipProps<any, any>> = {
   useTranslate3d: false,
   wrapperStyle: {},
 };
-
-function resolveDefaultProps<T extends Record<string, any>>(realProps: T, defaultProps: Partial<T>): T {
-  const resolvedProps: T = { ...realProps };
-  return (Object.keys(defaultProps) as (keyof T)[]).reduce((acc: T, key: keyof T): T => {
-    if (acc[key] === undefined) {
-      acc[key] = defaultProps[key];
-    }
-    return acc;
-  }, resolvedProps);
-}
 
 export function Tooltip<TValue extends ValueType, TName extends NameType>(outsideProps: TooltipProps<TValue, TName>) {
   const props = resolveDefaultProps(outsideProps, defaultTooltipProps);

--- a/src/util/resolveDefaultProps.tsx
+++ b/src/util/resolveDefaultProps.tsx
@@ -1,0 +1,24 @@
+/**
+ * This function mimics the behavior of the `defaultProps` static property in React.
+ * Functional components do not have a defaultProps property, so this function is useful to resolve default props.
+ *
+ * The common recommendation is to use ES6 destructuring with default values in the function signature
+ * but you need to be careful there and make sure you destructure all the individual properties
+ * and not the whole object. See the test file for example.
+ *
+ * And because destructuring all properties one by one is a faff and it's easy to miss one property,
+ * this function exists.
+ *
+ * @param realProps - the props object passed to the component by the user
+ * @param defaultProps - the default props object defined in the component by Recharts
+ * @returns - the props object with all the default props resolved. All `undefined` values are replaced with the default value.
+ */
+export function resolveDefaultProps<T extends Record<string, any>>(realProps: T, defaultProps: Partial<T>): T {
+  const resolvedProps: T = { ...realProps };
+  return (Object.keys(defaultProps) as (keyof T)[]).reduce((acc: T, key: keyof T): T => {
+    if (acc[key] === undefined && defaultProps[key] !== undefined) {
+      acc[key] = defaultProps[key];
+    }
+    return acc;
+  }, resolvedProps);
+}

--- a/test/util/resolveDefaultProps.spec.tsx
+++ b/test/util/resolveDefaultProps.spec.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDefaultProps } from '../../src/util/resolveDefaultProps';
+
+type MyExampleType = Record<string, unknown>;
+
+const valuesThatShouldBeKept: ReadonlyArray<unknown> = [null, false, 0, '0', NaN, '', []];
+
+describe('resolveDefaultProps', () => {
+  it('should return original object if all properties are already defined', () => {
+    const original: MyExampleType = { a: 1, b: 2, c: 3 };
+    const defaults: MyExampleType = { a: 0, b: 0, c: 0 };
+    const result = resolveDefaultProps(original, defaults);
+    expect(result).toEqual(original);
+  });
+
+  it('should replace undefined with default', () => {
+    const original: MyExampleType = { a: undefined, b: 2, c: undefined };
+    const defaults: MyExampleType = { a: 1, b: 0, c: 3 };
+    const result = resolveDefaultProps(original, defaults);
+    expect(result).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it.each(valuesThatShouldBeKept)('should keep %s', val => {
+    const original: MyExampleType = { a: val, b: 2, c: val };
+    const defaults: MyExampleType = { a: 1, b: 0, c: 3 };
+    const result = resolveDefaultProps(original, defaults);
+    expect(result).toEqual({ a: val, b: 2, c: val });
+  });
+
+  it('should return an empty object if both original and defaults are empty', () => {
+    const original: MyExampleType = {};
+    const defaults: MyExampleType = {};
+    const result = resolveDefaultProps(original, defaults);
+    expect(result).toEqual({});
+  });
+
+  it('should return the default object if original is empty', () => {
+    const original: MyExampleType = {};
+    const defaults: MyExampleType = { a: 1, b: 2 };
+    const result = resolveDefaultProps(original, defaults);
+    expect(result).toEqual(defaults);
+  });
+
+  it('should return the original object if defaults are empty', () => {
+    const original: MyExampleType = { a: 1, b: 2 };
+    const defaults: MyExampleType = {};
+    const result = resolveDefaultProps(original, defaults);
+    expect(result).toEqual(original);
+  });
+
+  it('should not replace properties of nested objects', () => {
+    const original: MyExampleType = { a: { x: undefined }, b: 2 };
+    const defaults: MyExampleType = { a: { x: 1 }, b: 0 };
+    const result = resolveDefaultProps(original, defaults);
+    expect(result).toEqual({ a: { x: undefined }, b: 2 });
+  });
+
+  it('should not replace nested array items', () => {
+    const original: MyExampleType = { a: [undefined], b: 2 };
+    const defaults: MyExampleType = { a: [1], b: 0 };
+    const result = resolveDefaultProps(original, defaults);
+    expect(result).toEqual({ a: [undefined], b: 2 });
+  });
+
+  it('should return original object if defaults are not defined', () => {
+    const original: MyExampleType = { a: undefined, b: 2 };
+    const defaults: MyExampleType = {};
+    const result = resolveDefaultProps(original, defaults);
+    expect(result).toEqual(original);
+  });
+});
+
+describe('ES6 destructuring with default values demonstration - good behaviour', () => {
+  /*
+   * This too is acceptable to use in case you do not want to import the `resolveDefaultProps`.
+   * But it's a lot of extra typing, and it's easy to forget to add the default value to the destructuring.
+   */
+  function fn({ param = 1 }: { param: unknown }) {
+    /*
+     * So an even simpler version would look like this:
+     * function fn(param: unknown = 1) {
+     *   return param;
+     * }
+     * And it would be acceptable to use as it behaves as we want but functional components never accept primitives,
+     * they always accept an object of props.
+     */
+    return param;
+  }
+  it('should resolve undefined to the default', () => {
+    const result = fn({ param: undefined });
+    expect(result).toEqual(1);
+  });
+
+  it.each(valuesThatShouldBeKept)('should keep %s', value => {
+    const result = fn({ param: value });
+    expect(result).toEqual(value);
+  });
+});
+
+describe('ES6 destructuring with default values demonstration - bad behaviour', () => {
+  /*
+   * Do not use this to resolve default props - this is different from the class defaultProps
+   * and will not work as expected.
+   */
+  function fn(props: MyExampleType = { param: 1 }) {
+    return props.param;
+  }
+  /*
+   * This is an example of bad behaviour - the default value should be set to 1, but it is not
+   * because the descriptor sees the object as defined and does not visit individual properties.
+   */
+  it.fails('should resolve undefined to the default', () => {
+    const result = fn({ param: undefined });
+    expect(result).toEqual(1);
+  });
+
+  it.each(valuesThatShouldBeKept)('should keep %s', value => {
+    const result = fn({ param: value });
+    expect(result).toEqual(value);
+  });
+});


### PR DESCRIPTION
## Description

`resolveDefaultProps` is useful for moving all the class components into functional components so let's have some docs and tests. The types could be better so I will do that next.

To confirm what is the class defaultProps behaviour I wrote this thing in codesandbox, I figured I don't need to add these as tests:

```
import { Component } from "react";

function stringify(val) {
  if (val === undefined) {
    return "undefined";
  }
  if (Number.isNaN(val)) {
    return "NaN";
  }
  return JSON.stringify(val);
}

class Foo extends Component {
  static defaultProps = {
    val: 1,
  };

  render() {
    return stringify(this.props.val);
  }
}

export default function App() {
  return (
    <table>
      <thead>
        <tr>
          <th>Input</th>
          <th>Resolved prop</th>
        </tr>
      </thead>
      <tr>
        <td>No prop at all:</td>
        <td>
          <Foo />
        </td>
      </tr>
      {[undefined, null, false, 0, "0", NaN, "", "undefined", []].map((val) => (
        <tr>
          <td>{stringify(val)}:</td>
          <td>
            <Foo val={val} />
          </td>
        </tr>
      ))}
    </table>
  );
}
```

This shows that only `undefined` gets filled with a default:

<img width="374" alt="image" src="https://github.com/user-attachments/assets/d975fdda-22b8-4b75-abfc-e35b2f77944f" />
