### PR TITLE
Use d3-scale export for scaleType

### DIFF
--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -23,7 +23,7 @@ import {
   JSX,
 } from 'react';
 import isObject from 'lodash/isObject';
-import { ScaleContinuousNumeric as D3ScaleContinuousNumeric } from 'victory-vendor/d3-scale';
+import * as d3Scale from 'victory-vendor/d3-scale';
 import type { Props as XAxisProps } from '../cartesian/XAxis';
 import type { Props as YAxisProps } from '../cartesian/YAxis';
 
@@ -92,22 +92,11 @@ export interface ChartCoordinate extends Coordinate {
   outerRadius?: number;
 }
 
-export type ScaleType =
-  | 'auto'
-  | 'linear'
-  | 'pow'
-  | 'sqrt'
-  | 'log'
-  | 'identity'
-  | 'time'
-  | 'band'
-  | 'point'
-  | 'ordinal'
-  | 'quantile'
-  | 'quantize'
-  | 'utc'
-  | 'sequential'
-  | 'threshold';
+type D3ScaleType = {
+  [K in keyof typeof d3Scale]: K extends `scale${infer U}` ? Uncapitalize<U> : never;
+}[keyof typeof d3Scale];
+
+export type ScaleType = 'auto' | D3ScaleType;
 
 //
 // Event Handler Types -- Copied from @types/react/index.d.ts and adapted for Props.
@@ -1068,7 +1057,7 @@ export interface GeometrySector {
   cornerIsExternal?: boolean;
 }
 
-export type D3Scale<T> = D3ScaleContinuousNumeric<T, number>;
+export type D3Scale<T> = d3Scale.ScaleContinuousNumeric<T, number>;
 
 export type AxisDomainItem = string | number | Function | 'auto' | 'dataMin' | 'dataMax';
 


### PR DESCRIPTION
## Related Issue

#2804 

## Motivation and Context

I have stumbled upon issue #2804 where @ckifer suggested using `<YAxis scale="symlog" />`. However when I wanted to make the change in my codebase I immediately got a Typescript error saying that `symlog` is not valid for the type `ScaleType` although the chart was using the symlog scale. I dug down and it turned out that in `parseScale` function there is this fragment of code:

```ts
  if (isString(scale)) {
    const name = `scale${upperFirst(scale)}`;

    return {
      scale: ((d3Scales as Record<string, any>)[name] || d3Scales.scalePoint)(),
      realScaleType: (d3Scales as Record<string, any>)[name] ? name : 'point',
    };
  }
```

I figured out that the type is outdated, so I've modified it so that it can accept any scale that d3-scale exports.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
