### PR TITLE
resolveDefaultProps has better types

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -36,6 +36,7 @@ import { useChartName } from '../state/selectors/selectors';
 import { SetLegendPayload } from '../state/SetLegendPayload';
 import { useAppSelector } from '../state/hooks';
 import { useAnimationId } from '../util/useAnimationId';
+import { resolveDefaultProps } from '../util/resolveDefaultProps';
 
 export type BaseValue = number | 'dataMin' | 'dataMax';
 
@@ -673,7 +674,7 @@ class AreaWithState extends PureComponent<InternalProps> {
   }
 }
 
-const defaultAreaProps: Partial<Props> = {
+const defaultAreaProps = {
   activeDot: true,
   animationBegin: 0,
   animationDuration: 1500,
@@ -688,43 +689,43 @@ const defaultAreaProps: Partial<Props> = {
   stroke: '#3182bd',
   xAxisId: 0,
   yAxisId: 0,
-};
+} as const satisfies Partial<Props>;
 
 function AreaImpl(props: Props) {
+  const {
+    activeDot,
+    animationBegin,
+    animationDuration,
+    animationEasing,
+    connectNulls,
+    dot,
+    fill,
+    fillOpacity,
+    hide,
+    isAnimationActive,
+    legendType,
+    stroke,
+    xAxisId,
+    yAxisId,
+    ...everythingElse
+  } = resolveDefaultProps(props, defaultAreaProps);
   const layout = useChartLayout();
   const chartName = useChartName();
-  const { needClip } = useNeedsClip(props.xAxisId, props.yAxisId);
-  const {
-    activeDot = defaultAreaProps.activeDot,
-    animationBegin = defaultAreaProps.animationBegin,
-    animationDuration = defaultAreaProps.animationDuration,
-    animationEasing = defaultAreaProps.animationEasing,
-    connectNulls = defaultAreaProps.connectNulls,
-    dot = defaultAreaProps.dot,
-    fill = defaultAreaProps.fill,
-    fillOpacity = defaultAreaProps.fillOpacity,
-    hide = defaultAreaProps.hide,
-    isAnimationActive = defaultAreaProps.isAnimationActive,
-    legendType = defaultAreaProps.legendType,
-    stroke = defaultAreaProps.stroke,
-    xAxisId = defaultAreaProps.xAxisId,
-    yAxisId = defaultAreaProps.yAxisId,
-    ...everythingElse
-  } = props;
+  const { needClip } = useNeedsClip(xAxisId, yAxisId);
   const isPanorama = useIsPanorama();
 
-  const areaSettings = useMemo(
+  const areaSettings: AreaSettings = useMemo(
     () => ({
       baseValue: props.baseValue,
       stackId: props.stackId,
-      connectNulls: props.connectNulls,
+      connectNulls,
       data: props.data,
       dataKey: props.dataKey,
     }),
-    [props.baseValue, props.stackId, props.connectNulls, props.data, props.dataKey],
+    [props.baseValue, props.stackId, connectNulls, props.data, props.dataKey],
   );
   const { points, isRange, baseLine } =
-    useAppSelector(state => selectArea(state, props.xAxisId, props.yAxisId, isPanorama, areaSettings)) ?? {};
+    useAppSelector(state => selectArea(state, xAxisId, yAxisId, isPanorama, areaSettings)) ?? {};
   const { height, width, left, top } = useOffset();
 
   if (layout !== 'horizontal' && layout !== 'vertical') {

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -67,6 +67,7 @@ import { useIsPanorama } from '../context/PanoramaContext';
 import { selectActiveTooltipDataKey, selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 import { SetLegendPayload } from '../state/SetLegendPayload';
 import { useAnimationId } from '../util/useAnimationId';
+import { resolveDefaultProps } from '../util/resolveDefaultProps';
 
 export interface BarRectangleItem extends RectangleProps {
   value?: number | [number, number];
@@ -526,7 +527,7 @@ class BarWithState extends PureComponent<InternalProps> {
   }
 }
 
-const defaultBarProps: Partial<Props> = {
+const defaultBarProps = {
   activeBar: false,
   animationBegin: 0,
   animationDuration: 400,
@@ -537,10 +538,23 @@ const defaultBarProps: Partial<Props> = {
   minPointSize: defaultMinPointSize,
   xAxisId: 0,
   yAxisId: 0,
-};
+} as const satisfies Partial<Props>;
 
 function BarImpl(props: Props) {
-  const { needClip } = useNeedsClip(props.xAxisId, props.yAxisId);
+  const {
+    xAxisId,
+    yAxisId,
+    hide,
+    legendType,
+    minPointSize,
+    activeBar,
+    animationBegin,
+    animationDuration,
+    animationEasing,
+    isAnimationActive,
+  } = resolveDefaultProps(props, defaultBarProps);
+
+  const { needClip } = useNeedsClip(xAxisId, yAxisId);
   const layout = useChartLayout();
 
   const isPanorama = useIsPanorama();
@@ -551,17 +565,15 @@ function BarImpl(props: Props) {
       data: undefined,
       dataKey: props.dataKey,
       maxBarSize: props.maxBarSize,
-      minPointSize: props.minPointSize,
+      minPointSize,
       stackId: getNormalizedStackId(props.stackId),
     }),
-    [props.barSize, props.dataKey, props.maxBarSize, props.minPointSize, props.stackId],
+    [props.barSize, props.dataKey, props.maxBarSize, minPointSize, props.stackId],
   );
 
   const cells = findAllByType(props.children, Cell);
 
-  const rects = useAppSelector(state =>
-    selectBarRectangles(state, props.xAxisId, props.yAxisId, isPanorama, barSettings, cells),
-  );
+  const rects = useAppSelector(state => selectBarRectangles(state, xAxisId, yAxisId, isPanorama, barSettings, cells));
 
   if (layout !== 'vertical' && layout !== 'horizontal') {
     return null;
@@ -569,24 +581,11 @@ function BarImpl(props: Props) {
 
   let errorBarOffset: number;
   const firstDataPoint = rects?.[0];
-  if (firstDataPoint == null) {
+  if (firstDataPoint == null || firstDataPoint.height == null || firstDataPoint.width == null) {
     errorBarOffset = 0;
   } else {
     errorBarOffset = layout === 'vertical' ? firstDataPoint.height / 2 : firstDataPoint.width / 2;
   }
-
-  const {
-    xAxisId = defaultBarProps.xAxisId,
-    yAxisId = defaultBarProps.yAxisId,
-    hide = defaultBarProps.hide,
-    legendType = defaultBarProps.legendType,
-    minPointSize = defaultBarProps.minPointSize,
-    activeBar = defaultBarProps.activeBar,
-    animationBegin = defaultBarProps.animationBegin,
-    animationDuration = defaultBarProps.animationDuration,
-    animationEasing = defaultBarProps.animationEasing,
-    isAnimationActive = defaultBarProps.isAnimationActive,
-  } = props;
 
   return (
     <SetErrorBarContext

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -378,22 +378,16 @@ export function CartesianGrid(props: Props) {
   const chartWidth = useChartWidth();
   const chartHeight = useChartHeight();
   const offset = useOffset();
-  const propsIncludingDefaults = resolveDefaultProps(props, defaultProps);
+  const propsIncludingDefaults = {
+    ...resolveDefaultProps(props, defaultProps),
+    x: isNumber(props.x) ? props.x : offset.left,
+    y: isNumber(props.y) ? props.y : offset.top,
+    width: isNumber(props.width) ? props.width : offset.width,
+    height: isNumber(props.height) ? props.height : offset.height,
+  };
 
-  const {
-    xAxisId,
-    yAxisId,
-    x: xFromProps,
-    y: yFromProps,
-    width,
-    height,
-    syncWithTicks,
-    horizontalValues,
-    verticalValues,
-  } = propsIncludingDefaults;
-
-  const x = isNumber(xFromProps) ? xFromProps : offset.left;
-  const y = isNumber(yFromProps) ? yFromProps : offset.top;
+  const { xAxisId, yAxisId, x, y, width, height, syncWithTicks, horizontalValues, verticalValues } =
+    propsIncludingDefaults;
 
   const isPanorama = useIsPanorama();
   const xAxis: AxisPropsForCartesianGridTicksGeneration = useAppSelector(state =>

--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -11,6 +11,7 @@ import { LinePointItem } from './Line';
 import { ScatterPointItem } from './Scatter';
 import { ReportErrorBarSettings, useErrorBarContext } from '../context/CartesianGraphicalItemContext';
 import { useXAxis, useYAxis } from '../hooks';
+import { resolveDefaultProps } from '../util/resolveDefaultProps';
 
 export interface ErrorBarDataItem {
   x: number;
@@ -210,7 +211,7 @@ export function SetErrorBarPreferredDirection({
   return <ErrorBarPreferredDirection.Provider value={direction}>{children}</ErrorBarPreferredDirection.Provider>;
 }
 
-const errorBarDefaultProps: Partial<Props> = {
+const errorBarDefaultProps = {
   stroke: 'black',
   strokeWidth: 1.5,
   width: 5,
@@ -219,18 +220,15 @@ const errorBarDefaultProps: Partial<Props> = {
   animationBegin: 0,
   animationDuration: 400,
   animationEasing: 'ease-in-out',
-};
+} as const satisfies Partial<Props>;
 
 function ErrorBarInternal(props: Props) {
   const realDirection: ErrorBarDirection = useErrorBarDirection(props.direction);
 
-  const {
-    width = errorBarDefaultProps.width,
-    isAnimationActive = errorBarDefaultProps.isAnimationActive,
-    animationBegin = errorBarDefaultProps.animationBegin,
-    animationDuration = errorBarDefaultProps.animationDuration,
-    animationEasing = errorBarDefaultProps.animationEasing,
-  } = props;
+  const { width, isAnimationActive, animationBegin, animationDuration, animationEasing } = resolveDefaultProps(
+    props,
+    errorBarDefaultProps,
+  );
 
   return (
     <>

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -36,6 +36,7 @@ import { useOffset } from '../context/chartLayoutContext';
 import { ResolvedFunnelSettings, selectFunnelTrapezoids } from '../state/selectors/funnelSelectors';
 import { filterProps, findAllByType } from '../util/ReactUtils';
 import { Cell } from '../component/Cell';
+import { resolveDefaultProps } from '../util/resolveDefaultProps';
 
 export interface FunnelTrapezoidItem extends TrapezoidProps {
   value?: number | string;
@@ -354,7 +355,7 @@ export class FunnelWithState extends PureComponent<InternalProps> {
   }
 }
 
-const defaultFunnelProps: Partial<Props> = {
+const defaultFunnelProps = {
   stroke: '#fff',
   fill: '#808080',
   legendType: 'rect',
@@ -365,24 +366,24 @@ const defaultFunnelProps: Partial<Props> = {
   animationEasing: 'ease',
   nameKey: 'name',
   lastShapeType: 'triangle',
-};
+} as const satisfies Partial<Props>;
 
 function FunnelImpl(props: Props) {
   const { height, width } = useOffset();
 
   const {
-    stroke = defaultFunnelProps.stroke,
-    fill = defaultFunnelProps.fill,
-    legendType = defaultFunnelProps.legendType,
-    hide = defaultFunnelProps.hide,
-    isAnimationActive = defaultFunnelProps.isAnimationActive,
-    animationBegin = defaultFunnelProps.animationBegin,
-    animationDuration = defaultFunnelProps.animationDuration,
-    animationEasing = defaultFunnelProps.animationEasing,
-    nameKey = defaultFunnelProps.nameKey,
-    lastShapeType = defaultFunnelProps.lastShapeType,
+    stroke,
+    fill,
+    legendType,
+    hide,
+    isAnimationActive,
+    animationBegin,
+    animationDuration,
+    animationEasing,
+    nameKey,
+    lastShapeType,
     ...everythingElse
-  } = props;
+  } = resolveDefaultProps(props, defaultFunnelProps);
 
   const presentationProps = filterProps(props, false);
   const cells = findAllByType(props.children, Cell);

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -37,6 +37,7 @@ import { AxisId } from '../state/cartesianAxisSlice';
 import { SetLegendPayload } from '../state/SetLegendPayload';
 import { AreaPointItem } from '../state/selectors/areaSelectors';
 import { useAnimationId } from '../util/useAnimationId';
+import { resolveDefaultProps } from '../util/resolveDefaultProps';
 
 export interface LinePointItem extends CurvePoint {
   readonly value?: number;
@@ -571,7 +572,7 @@ class LineWithState extends Component<InternalProps> {
   }
 }
 
-const defaultLineProps: Partial<Props> = {
+const defaultLineProps = {
   activeDot: true,
   animateNewValues: true,
   animationBegin: 0,
@@ -588,10 +589,27 @@ const defaultLineProps: Partial<Props> = {
   strokeWidth: 1,
   xAxisId: 0,
   yAxisId: 0,
-};
+} as const satisfies Partial<Props>;
 
 function LineImpl(props: Props) {
-  const { needClip } = useNeedsClip(props.xAxisId, props.yAxisId);
+  const {
+    activeDot,
+    animateNewValues,
+    animationBegin,
+    animationDuration,
+    animationEasing,
+    connectNulls,
+    dot,
+    hide,
+    isAnimationActive,
+    label,
+    legendType,
+    xAxisId,
+    yAxisId,
+    ...everythingElse
+  } = resolveDefaultProps(props, defaultLineProps);
+
+  const { needClip } = useNeedsClip(xAxisId, yAxisId);
   const { height, width, left, top } = useOffset();
   const layout = useChartLayout();
   const isPanorama = useIsPanorama();
@@ -600,29 +618,12 @@ function LineImpl(props: Props) {
     [props.dataKey, props.data],
   );
   const points: ReadonlyArray<LinePointItem> = useAppSelector(state =>
-    selectLinePoints(state, props.xAxisId, props.yAxisId, isPanorama, lineSettings),
+    selectLinePoints(state, xAxisId, yAxisId, isPanorama, lineSettings),
   );
   if (layout !== 'horizontal' && layout !== 'vertical') {
     // Cannot render Line in an unsupported layout
     return null;
   }
-
-  const {
-    activeDot = defaultLineProps.activeDot,
-    animateNewValues = defaultLineProps.animateNewValues,
-    animationBegin = defaultLineProps.animationBegin,
-    animationDuration = defaultLineProps.animationDuration,
-    animationEasing = defaultLineProps.animationEasing,
-    connectNulls = defaultLineProps.connectNulls,
-    dot = defaultLineProps.dot,
-    hide = defaultLineProps.hide,
-    isAnimationActive = defaultLineProps.isAnimationActive,
-    label = defaultLineProps.label,
-    legendType = defaultLineProps.legendType,
-    xAxisId = defaultLineProps.xAxisId,
-    yAxisId = defaultLineProps.yAxisId,
-    ...everythingElse
-  } = props;
 
   return (
     <LineWithState

--- a/src/component/Cursor.tsx
+++ b/src/component/Cursor.tsx
@@ -59,6 +59,7 @@ export function CursorInternal(props: CursorConnectedProps) {
     restProps = getCursorRectangle(layout, activeCoordinate, offset, tooltipAxisBandSize);
     cursorComp = Rectangle;
   } else if (layout === 'radial') {
+    // @ts-expect-error TODO the state is marked as containing Coordinate but actually in polar charts it contains PolarCoordinate, we should keep the polar state separate
     const { cx, cy, radius, startAngle, endAngle } = getRadialCursorPoints(activeCoordinate);
     restProps = {
       cx,

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -120,7 +120,7 @@ export type TooltipProps<TValue extends ValueType, TName extends NameType> = Omi
 
 const emptyPayload: TooltipPayload = [];
 
-const defaultTooltipProps: Partial<TooltipProps<any, any>> = {
+const defaultTooltipProps = {
   allowEscapeViewBox: { x: false, y: false },
   animationDuration: 400,
   animationEasing: 'ease',
@@ -138,7 +138,7 @@ const defaultTooltipProps: Partial<TooltipProps<any, any>> = {
   trigger: 'hover',
   useTranslate3d: false,
   wrapperStyle: {},
-};
+} as const satisfies Partial<TooltipProps<any, any>>;
 
 export function Tooltip<TValue extends ValueType, TName extends NameType>(outsideProps: TooltipProps<TValue, TName>) {
   const props = resolveDefaultProps(outsideProps, defaultTooltipProps);

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -51,6 +51,7 @@ import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 import { SetPolarLegendPayload } from '../state/SetLegendPayload';
 import { DATA_ITEM_DATAKEY_ATTRIBUTE_NAME, DATA_ITEM_INDEX_ATTRIBUTE_NAME } from '../util/Constants';
 import { useAnimationId } from '../util/useAnimationId';
+import { resolveDefaultProps } from '../util/resolveDefaultProps';
 
 interface PieDef {
   /** The abscissa of pole in polar coordinate  */
@@ -712,7 +713,7 @@ function PieWithTouchMove(props: InternalProps) {
   );
 }
 
-const defaultPieProps: Partial<Props> = {
+const defaultPieProps = {
   stroke: '#fff',
   fill: '#808080',
   legendType: 'rect',
@@ -732,9 +733,12 @@ const defaultPieProps: Partial<Props> = {
   animationEasing: 'ease',
   nameKey: 'name',
   rootTabIndex: 0,
-};
+} as const satisfies Partial<Props>;
 
 function PieImpl(props: Props) {
+  const { animationBegin, animationDuration, animationEasing, hide, isAnimationActive, legendType, ...everythingElse } =
+    resolveDefaultProps(props, defaultPieProps);
+
   const cells = useMemo(() => findAllByType(props.children, Cell), [props.children]);
   const presentationProps = filterProps(props, false);
 
@@ -780,16 +784,6 @@ function PieImpl(props: Props) {
   );
 
   const sectors = useAppSelector(state => selectPieSectors(state, pieSettings, cells));
-
-  const {
-    animationBegin = defaultPieProps.animationBegin,
-    animationDuration = defaultPieProps.animationDuration,
-    animationEasing = defaultPieProps.animationEasing,
-    hide = defaultPieProps.hide,
-    isAnimationActive = defaultPieProps.isAnimationActive,
-    legendType = defaultPieProps.legendType,
-    ...everythingElse
-  } = props;
 
   return (
     <>

--- a/src/shape/Rectangle.tsx
+++ b/src/shape/Rectangle.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import Animate from 'react-smooth';
 import { AnimationDuration, AnimationTiming } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
+import { resolveDefaultProps } from '../util/resolveDefaultProps';
 
 export type RectRadius = [number, number, number, number];
 
@@ -94,10 +95,10 @@ const defaultProps = {
   animationBegin: 0,
   animationDuration: 1500,
   animationEasing: 'ease',
-};
+} as const satisfies Partial<Props>;
 
 export const Rectangle: React.FC<Props> = rectangleProps => {
-  const props = { ...defaultProps, ...rectangleProps };
+  const props = resolveDefaultProps(rectangleProps, defaultProps);
   const pathRef = useRef<SVGPathElement>();
   const [totalLength, setTotalLength] = useState(-1);
 

--- a/src/shape/Sector.tsx
+++ b/src/shape/Sector.tsx
@@ -7,6 +7,7 @@ import { GeometrySector } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { polarToCartesian, RADIAN } from '../util/PolarUtils';
 import { getPercentValue, mathSign } from '../util/DataUtils';
+import { resolveDefaultProps } from '../util/resolveDefaultProps';
 
 const getDeltaAngle = (startAngle: number, endAngle: number) => {
   const sign = mathSign(endAngle - startAngle);
@@ -208,7 +209,7 @@ const defaultProps = {
 };
 
 export const Sector: React.FC<Props> = sectorProps => {
-  const props = { ...defaultProps, ...sectorProps };
+  const props = resolveDefaultProps(sectorProps, defaultProps);
   const {
     cx,
     cy,

--- a/src/shape/Trapezoid.tsx
+++ b/src/shape/Trapezoid.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import Animate from 'react-smooth';
 import { AnimationDuration, AnimationTiming } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
+import { resolveDefaultProps } from '../util/resolveDefaultProps';
 
 const getTrapezoidPath = (x: number, y: number, upperWidth: number, lowerWidth: number, height: number): string => {
   const widthGap = upperWidth - lowerWidth;
@@ -34,7 +35,7 @@ interface TrapezoidProps {
 
 export type Props = SVGProps<SVGPathElement> & TrapezoidProps;
 
-const defaultProps: Props = {
+const defaultProps = {
   x: 0,
   y: 0,
   upperWidth: 0,
@@ -44,10 +45,10 @@ const defaultProps: Props = {
   animationBegin: 0,
   animationDuration: 1500,
   animationEasing: 'ease',
-};
+} as const satisfies Partial<Props>;
 
 export const Trapezoid: React.FC<Props> = props => {
-  const trapezoidProps: Props = { ...defaultProps, ...props };
+  const trapezoidProps = resolveDefaultProps(props, defaultProps);
 
   const pathRef = useRef<SVGPathElement>();
   const [totalLength, setTotalLength] = useState(-1);

--- a/src/state/selectors/funnelSelectors.ts
+++ b/src/state/selectors/funnelSelectors.ts
@@ -15,14 +15,14 @@ type FunnelComposedData = {
 
 export type ResolvedFunnelSettings = {
   dataKey: DataKey<any>;
-  data: any[];
+  data: any[] | undefined;
   nameKey: DataKey<any>;
   tooltipType?: TooltipType;
   lastShapeType?: 'triangle' | 'rectangle';
   reversed?: boolean;
   customWidth?: string | number;
   cells: ReadonlyArray<ReactElement>;
-  presentationProps: Record<string, any>;
+  presentationProps: Record<string, any> | null;
 };
 
 const pickFunnelSettings = (
@@ -50,9 +50,9 @@ export const selectFunnelTrapezoids: (
     { chartData },
   ) => {
     let displayedData: ChartData | undefined;
-    if (data?.length > 0) {
+    if (data != null && data.length > 0) {
       displayedData = data;
-    } else if (chartData?.length > 0) {
+    } else if (chartData != null && chartData.length > 0) {
       displayedData = chartData;
     }
 

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -160,6 +160,7 @@ export const selectActiveCoordinate: (
   tooltipEventType: TooltipEventType,
   trigger: TooltipTrigger,
   defaultIndex: TooltipIndex | undefined,
+  // TODO the state is marked as containing Coordinate but actually in polar charts it contains PolarCoordinate, we should keep the polar state separate
 ) => Coordinate | undefined = createSelector(
   [selectTooltipInteractionState, selectCoordinateForDefaultIndex],
   (tooltipInteractionState: TooltipInteractionState, defaultIndexCoordinate: Coordinate): Coordinate | undefined => {

--- a/src/util/cursor/getCursorPoints.ts
+++ b/src/util/cursor/getCursorPoints.ts
@@ -29,6 +29,7 @@ export function getCursorPoints(
       x2 = outerPoint.x;
       y2 = outerPoint.y;
     } else {
+      // @ts-expect-error TODO the state is marked as containing Coordinate but actually in polar charts it contains PolarCoordinate, we should keep the polar state separate
       return getRadialCursorPoints(activeCoordinate);
     }
   }

--- a/src/util/cursor/getRadialCursorPoints.ts
+++ b/src/util/cursor/getRadialCursorPoints.ts
@@ -1,5 +1,5 @@
 import { polarToCartesian } from '../PolarUtils';
-import { ChartCoordinate, Coordinate } from '../types';
+import { Coordinate, PolarCoordinate } from '../types';
 
 export type RadialCursorPoints = {
   points: [startPoint: Coordinate, endPoint: Coordinate];
@@ -15,7 +15,7 @@ export type RadialCursorPoints = {
  * @param {Object} activeCoordinate ChartCoordinate
  * @returns {Object} RadialCursorPoints
  */
-export function getRadialCursorPoints(activeCoordinate: ChartCoordinate): RadialCursorPoints {
+export function getRadialCursorPoints(activeCoordinate: PolarCoordinate): RadialCursorPoints {
   const { cx, cy, radius, startAngle, endAngle } = activeCoordinate;
   const startPoint = polarToCartesian(cx, cy, radius, startAngle);
   const endPoint = polarToCartesian(cx, cy, radius, endAngle);

--- a/src/util/resolveDefaultProps.tsx
+++ b/src/util/resolveDefaultProps.tsx
@@ -2,23 +2,107 @@
  * This function mimics the behavior of the `defaultProps` static property in React.
  * Functional components do not have a defaultProps property, so this function is useful to resolve default props.
  *
- * The common recommendation is to use ES6 destructuring with default values in the function signature
+ * The common recommendation is to use ES6 destructuring with default values in the function signature,
  * but you need to be careful there and make sure you destructure all the individual properties
  * and not the whole object. See the test file for example.
  *
- * And because destructuring all properties one by one is a faff and it's easy to miss one property,
+ * And because destructuring all properties one by one is a faff, and it's easy to miss one property,
  * this function exists.
  *
  * @param realProps - the props object passed to the component by the user
  * @param defaultProps - the default props object defined in the component by Recharts
  * @returns - the props object with all the default props resolved. All `undefined` values are replaced with the default value.
  */
-export function resolveDefaultProps<T extends Record<string, any>>(realProps: T, defaultProps: Partial<T>): T {
+export function resolveDefaultProps<T, D extends Partial<T>>(
+  realProps: T,
+  defaultProps: D & DisallowExtraKeys<T, D>,
+): RequiresDefaultProps<T, D> {
+  /*
+   * To avoid mutating the original `realProps` object passed to the function, create a shallow copy of it.
+   * `resolvedProps` will be modified directly with the defaults.
+   */
   const resolvedProps: T = { ...realProps };
-  return (Object.keys(defaultProps) as (keyof T)[]).reduce((acc: T, key: keyof T): T => {
-    if (acc[key] === undefined && defaultProps[key] !== undefined) {
-      acc[key] = defaultProps[key];
+  /*
+   * Since the function guarantees `D extends Partial<T>`, this assignment is safe.
+   * It allows TypeScript to work with the well-defined `Partial<T>` type inside the loop,
+   * making subsequent type inference (especially for `dp[key]`) much more straightforward for the compiler.
+   * This is a key step to improve type safety *without* value assertions later.
+   */
+  const dp: Partial<T> = defaultProps;
+  /*
+   * `Object.keys` doesn't preserve strong key types - it always returns Array<string>.
+   * However, due to the `D extends Partial<T>` constraint,
+   * we know these keys *must* also be valid keys of `T`.
+   * This assertion informs TypeScript of this relationship, avoiding type errors when using `key` to index `acc` (type T).
+   *
+   * Type assertions are not sound but in this case it's necessary
+   * as `Object.keys` does not do what we want it to do.
+   */
+  const keys = Object.keys(defaultProps) as Array<keyof T>;
+  const withDefaults: T = keys.reduce((acc: T, key: keyof T): T => {
+    if (acc[key] === undefined && dp[key] !== undefined) {
+      acc[key] = dp[key];
     }
     return acc;
   }, resolvedProps);
+  /*
+   * And again type assertions are not safe but here we have done the runtime work
+   * so let's bypass the lack of static type safety and tell the compiler what happened.
+   */
+  return withDefaults as RequiresDefaultProps<T, D>;
 }
+
+/**
+ * Helper type to extract the keys of T that are required.
+ * It iterates through each key K in T. If Pick<T, K> cannot be assigned an empty object {},
+ * it means K is required, so we keep K; otherwise, we discard it (never).
+ * [keyof T] at the end creates a union of the kept keys.
+ */
+export type RequiredKeys<T> = {
+  [K in keyof T]-?: object extends Pick<T, K> ? never : K;
+}[keyof T];
+
+/**
+ * Helper type to extract the keys of T that are optional.
+ * It iterates through each key K in T. If Pick<T, K> can be assigned an empty object {},
+ * it means K is optional (or potentially missing), so we keep K; otherwise, we discard it (never).
+ * [keyof T] at the end creates a union of the kept keys.
+ */
+export type OptionalKeys<T> = {
+  [K in keyof T]-?: object extends Pick<T, K> ? K : never;
+}[keyof T];
+
+/**
+ * Helper type to ensure keys of D exist in T.
+ * For each key K in D, if K is also a key of T, keep the type D[K].
+ * If K is NOT a key of T, map it to type `never`.
+ * An object cannot have a property of type `never`, effectively disallowing extra keys.
+ */
+export type DisallowExtraKeys<T, D> = { [K in keyof D]: K extends keyof T ? D[K] : never };
+
+/**
+ * This type will take a source type `T` and a default type `D` and will return a new type
+ * where all properties that are optional in `T` but required in `D` are made required in the result.
+ * Properties that are required in `T` and optional in `D` will remain required.
+ * Properties that are optional in both `T` and `D` will remain optional.
+ *
+ * This is useful for creating a type that represents the resolved props of a component with default props.
+ */
+export type RequiresDefaultProps<T, D extends Partial<T>> =
+  // Section 1: Properties that were already required in T.
+  // We use Pick<T, RequiredKeys<T>> to select only the keys that were originally
+  // required in T. Pick preserves their required status and original types.
+  Pick<T, RequiredKeys<T>> &
+    // Section 2: Properties that were optional in T BUT have a default specified in D.
+    // These properties should become required in the resulting type.
+    // - OptionalKeys<T>: Gets the union of keys that are optional in T.
+    // - RequiredKeys<D>: Gets the keys that are required in the default props D.
+    // - Extract<..., ...>: Finds the intersection of these two sets – the keys that are optional in T AND required in D.
+    // - Pick<T, Extract<...>>: Selects these specific properties from T. At this stage, they still retain their original optional ('?') status from T.
+    // - Required<...>: Wraps the picked properties, removing the '?' modifier and making them required. Their underlying type (e.g., `string | undefined`) remains unchanged.
+    Required<Pick<T, Extract<OptionalKeys<T>, RequiredKeys<D>>>> &
+    // Section 3: Properties that were optional in T AND do NOT have a default in D.
+    // These properties should remain optional.
+    // - Exclude<OptionalKeys<T>, keyof D>: Finds the keys that are optional in T but are NOT present in D.
+    // - Pick<T, Exclude<...>>: Selects these properties from T. Pick preserves their original optional status and types.
+    Pick<T, Exclude<OptionalKeys<T>, keyof D>>;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -92,6 +92,14 @@ export interface ChartCoordinate extends Coordinate {
   outerRadius?: number;
 }
 
+export type PolarCoordinate = {
+  cx: number;
+  cy: number;
+  radius: number;
+  startAngle: number;
+  endAngle: number;
+};
+
 export type ScaleType =
   | 'auto'
   | 'linear'

--- a/storybook/stories/API/cartesian/Funnel.stories.tsx
+++ b/storybook/stories/API/cartesian/Funnel.stories.tsx
@@ -52,7 +52,7 @@ export const API = {
     return (
       <ResponsiveContainer width="100%" height={200}>
         <FunnelChart layout="horizontal">
-          <Funnel {...args}>
+          <Funnel dataKey={args.dataKey} {...args}>
             <LabelList dataKey="name" fill="#000" position="right" stroke="none" />
             <Legend />
           </Funnel>

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -1868,8 +1868,7 @@ describe('<Legend />', () => {
       const { container } = render(
         <AreaChart width={500} height={500} data={numericalData}>
           <Legend />
-          {/* ts-expect-error TypeScript should say that dataKey is required here! */}
-          <Area />
+          <Area dataKey={undefined} />
         </AreaChart>,
       );
       expectLegendLabels(container, [{ fill: 'none', textContent: '' }]);

--- a/test/helper/assertType.ts
+++ b/test/helper/assertType.ts
@@ -1,0 +1,40 @@
+/**
+ * Helper type to check if two types A and B are exactly equal
+ */
+export type AreEqual<A, B> = A | B extends A & B ? true : false;
+
+/**
+ * Helper function to assert that a type is valid at compile time.
+ * If a type is `never`, it means that the type is invalid and will throw a compile-time error.
+ * This is a no-op function that does nothing at runtime.
+ * It is used to ensure that the type passed to it is valid and will throw a compile-time error if not.
+ *
+ * Use it together with `AreEqual` to assert that two types are equal, for example:
+ *
+ * ```ts
+ * assertType<AreEqual<'a', 'a'>>(true);
+ * assertType<AreEqual<'a', 'b'>>(false);
+ * ```
+ *
+ * @param _assert - The value to assert the type of.
+ * @returns - Nothing. This is a no-op function.
+ */
+export function assertType<T>(_assert: T): void {}
+
+// Example usage (and unit tests):
+
+// passing cases
+assertType<AreEqual<'a', 'a'>>(true);
+assertType<AreEqual<'a' | 'b', 'a' | 'b'>>(true);
+assertType<AreEqual<'a', 'b'>>(false);
+assertType<AreEqual<'a' | 'b', 'a'>>(false);
+
+// failing cases
+// @ts-expect-error this should fail
+assertType<AreEqual<'a', 'b'>>(true);
+// @ts-expect-error this should fail
+assertType<AreEqual<'a', 'a'>>(false);
+// @ts-expect-error this should fail
+assertType<AreEqual<'a' | 'b', 'a'>>(true);
+// @ts-expect-error this should fail
+assertType<AreEqual<'a', 'a' | 'b'>>(true);

--- a/test/polar/Pie.spec.tsx
+++ b/test/polar/Pie.spec.tsx
@@ -263,9 +263,9 @@ describe('<Pie />', () => {
     const renderedSectors2 = container.querySelectorAll('.recharts-sector');
     expect(renderedSectors2).toHaveLength(PageData.length);
     expect(renderedSectors2[0].getAttributeNames()).toEqual([
+      'fill',
       'cx',
       'cy',
-      'fill',
       'stroke',
       'name',
       'tabindex',

--- a/test/util/cursor/getRadialCursorPoints.spec.ts
+++ b/test/util/cursor/getRadialCursorPoints.spec.ts
@@ -1,31 +1,9 @@
 import { RadialCursorPoints, getRadialCursorPoints } from '../../../src/util/cursor/getRadialCursorPoints';
-import { ChartCoordinate } from '../../../src/util/types';
+import { PolarCoordinate } from '../../../src/util/types';
 
 describe('getRadialCursorPoints', () => {
-  it('should return undefineds and NaNs when passed trivial ChartCoordinate', () => {
-    const activeCoordinate: ChartCoordinate = {
-      x: 0,
-      y: 0,
-    };
-    const result = getRadialCursorPoints(activeCoordinate);
-    const expected: RadialCursorPoints = {
-      points: [
-        { x: NaN, y: NaN },
-        { x: NaN, y: NaN },
-      ],
-      cx: undefined,
-      cy: undefined,
-      radius: undefined,
-      startAngle: undefined,
-      endAngle: undefined,
-    };
-    expect(result).toEqual(expected);
-  });
-
-  it('should add cartesian startPoint and endPoint to activeCoordinate', () => {
-    const activeCoordinate: ChartCoordinate = {
-      x: 0,
-      y: 0,
+  it('should add startPoint and endPoint to activeCoordinate', () => {
+    const activeCoordinate: PolarCoordinate = {
       cx: 10,
       cy: 15,
       radius: 5,

--- a/test/util/resolveDefaultProps.spec-d.ts
+++ b/test/util/resolveDefaultProps.spec-d.ts
@@ -1,0 +1,214 @@
+import { describe, it } from 'vitest';
+import {
+  DisallowExtraKeys,
+  OptionalKeys,
+  RequiredKeys,
+  RequiresDefaultProps,
+  resolveDefaultProps,
+} from '../../src/util/resolveDefaultProps';
+import { AreEqual, assertType } from '../helper/assertType';
+
+/*
+ * I started this file with the intention of using `expectTypeOf`
+ * but I couldn't get it to work with the current setup.
+ * `satisfies` works just as well so let's stick with that for now.
+ *
+ * https://vitest.dev/guide/testing-types.html
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+describe('resolveDefaultProps types', () => {
+  it('should return same type as input if there are no defaults', () => {
+    type OutsideProps = {
+      a: number;
+      b?: string;
+      c?: boolean;
+    };
+    type DefaultProps = object;
+    const input: OutsideProps = { a: 1, b: 'test' };
+    const defaults: DefaultProps = {};
+    const result = resolveDefaultProps(input, defaults);
+    type Actual = typeof result;
+    type Expected = OutsideProps;
+    result satisfies Expected;
+    assertType<AreEqual<Actual, Expected>>(true);
+  });
+
+  it('should make the optional properties required if they are filled in from the defaults', () => {
+    type OutsideProps = {
+      a: number;
+      b?: string;
+      c?: boolean;
+    };
+    type DefaultProps = {
+      b: string;
+    };
+    const input: OutsideProps = { a: 1 };
+    const defaults: DefaultProps = { b: 'test' };
+    const result = resolveDefaultProps(input, defaults);
+    type Actual = typeof result;
+    type Expected = { a: number; b: string; c?: boolean };
+    result satisfies Expected;
+    assertType<AreEqual<Actual, Expected>>(true);
+  });
+
+  it('should not allow defaults to have extra properties that the input does not', () => {
+    type OutsideProps = {
+      a: number;
+      b: string;
+    };
+    type DefaultProps = {
+      b: string;
+      c: string;
+    };
+    const input: OutsideProps = { a: 1, b: 'test' };
+    const defaults: DefaultProps = { b: 'test', c: 'does not exist in OutsideProps and should be a TS error' };
+    // @ts-expect-error defaults have extra properties
+    const result = resolveDefaultProps(input, defaults);
+  });
+
+  it('should not allow defaults to have properties with different type than the input', () => {
+    type OutsideProps = {
+      a: number;
+    };
+    type DefaultProps = {
+      a: string;
+    };
+    const input: OutsideProps = { a: 1 };
+    const defaults: DefaultProps = { a: 'test' };
+    // @ts-expect-error string is not assignable to type number
+    const result = resolveDefaultProps(input, defaults);
+  });
+
+  it('should not, but it does allow defaults to have properties that are explicitly undefined', () => {
+    type OutsideProps = {
+      a: number;
+    };
+    type DefaultProps = {
+      a: number | undefined;
+    };
+    const input: OutsideProps = { a: 1 };
+    const defaults: DefaultProps = { a: undefined };
+    // ... I wish this one showed a TS error, but it doesn't. Just be careful and never put explicit `undefined` in defaultProps okay?
+    const result = resolveDefaultProps(input, defaults);
+  });
+});
+
+describe('type RequiredKeys', () => {
+  it('should return the keys that are required', () => {
+    type TestType = {
+      a: number;
+      b?: string;
+      c: boolean;
+    };
+    type Result = RequiredKeys<TestType>;
+    type Expected = 'a' | 'c';
+    assertType<AreEqual<Result, Expected>>(true);
+  });
+});
+
+describe('type OptionalKeys', () => {
+  it('should return the keys that are optional', () => {
+    type TestType = {
+      a: number;
+      b?: string;
+      c: boolean;
+    };
+    type Result = OptionalKeys<TestType>;
+    type Expected = 'b';
+    assertType<AreEqual<Result, Expected>>(true);
+  });
+});
+
+describe('RequiresDefaultProps', () => {
+  it('should keep output properties optional if defaults do not have those', () => {
+    type TestType = {
+      a: number;
+      b?: string;
+      c: boolean;
+    };
+    type DefaultType = { a: number };
+    type Result = RequiresDefaultProps<TestType, DefaultType>;
+    type Expected = { a: number; b?: string; c: boolean };
+    const foo: Result = { a: 1, c: true } satisfies Expected;
+    assertType<AreEqual<Result, Expected>>(true);
+  });
+
+  it('should keep output properties optional if defaults have the same properties also optional', () => {
+    type TestType = {
+      a: number;
+      b?: string;
+      c: boolean;
+    };
+    type DefaultType = { b?: string };
+    type Result = RequiresDefaultProps<TestType, DefaultType>;
+    type Expected = { a: number; b?: string; c: boolean };
+    const foo: Result = { a: 1, c: true } satisfies Expected;
+    assertType<AreEqual<Result, Expected>>(true);
+  });
+
+  it('should allow specifying the type explicitly', () => {
+    type Input = {
+      a?: number;
+      b?: string;
+    };
+    const input: Input = {};
+    type Defaults = {
+      a: number;
+    };
+    const defaults: Defaults = { a: 1 };
+    type Output = {
+      a: number;
+      b?: string;
+    };
+    const result: Output = resolveDefaultProps(input, defaults);
+  });
+});
+
+describe('DisallowExtraKeys', () => {
+  it('should allow two types with the same keys', () => {
+    type A = {
+      a: string;
+      b: number;
+    };
+    type B = {
+      a: string;
+      b: number;
+    };
+    type Result = DisallowExtraKeys<A, B>;
+    assertType<AreEqual<Result, A>>(true);
+  });
+
+  it('should allow two types with keys of different type', () => {
+    type A = {
+      a: string;
+      b: number;
+    };
+    type B = {
+      a: string;
+      b: string;
+    };
+    type Result = DisallowExtraKeys<A, B>;
+    /*
+     * This is not exactly the behaviour that we want, but it looks like this type can't do everything alone
+     * and so we get the final result by combining DisallowExtraKeys with resolveDefaultProps signature
+     */
+    assertType<AreEqual<Result, A>>(false);
+    assertType<AreEqual<Result, B>>(true);
+    assertType<AreEqual<Result, never>>(false);
+  });
+
+  it('should allow the second type have fewer keys', () => {
+    type A = {
+      a: string;
+      b: number;
+    };
+    type B = {
+      a: string;
+    };
+    type Result = DisallowExtraKeys<A, B>;
+    assertType<AreEqual<Result, A>>(false);
+    assertType<AreEqual<Result, B>>(true);
+    assertType<AreEqual<Result, never>>(false);
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -17,8 +17,5 @@ export default defineConfig({
       include: ['src', 'test'],
     },
     restoreMocks: true,
-    typecheck: {
-      enabled: true,
-    },
   },
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -17,5 +17,8 @@ export default defineConfig({
       include: ['src', 'test'],
     },
     restoreMocks: true,
+    typecheck: {
+      enabled: true,
+    },
   },
 });


### PR DESCRIPTION
## Description

`resolveDefaultProps` function now checks that the input objects are matching, and gives strong types on the output - if the defaults have property defined, the output object also has it defined.

1105 -> 1070 errors

## Related Issue

https://github.com/recharts/recharts/issues/5768
