### PR TITLE
Update bar chart double axis example to properly layout ticks and lines

### DIFF
--- a/storybook/stories/Examples/BarChart/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart/BarChart.stories.tsx
@@ -712,19 +712,19 @@ export const WithMultiXAxis = {
     };
 
     const renderQuarterTick = (tickProps: any) => {
-      const { x, y, payload } = tickProps;
+      const { x, y, payload, width, visibleTicksCount } = tickProps;
       const { value, offset } = payload;
       const date = new Date(value);
       const month = date.getMonth();
       const quarterNo = Math.floor(month / 3) + 1;
       if (month % 3 === 1) {
-        return <text x={x} y={y - 4} textAnchor="middle">{`Q${quarterNo}`}</text>;
+        return <text x={x + width / visibleTicksCount / 2 - offset} y={y - 4} textAnchor="middle">{`Q${quarterNo}`}</text>;
       }
 
       const isLast = month === 11;
 
       if (month % 3 === 0 || isLast) {
-        const pathX = Math.floor(isLast ? x + offset : x - offset) + 0.5;
+        const pathX = Math.floor(isLast ? x - offset + width / visibleTicksCount : x - offset) + 0.5;
 
         return <path d={`M${pathX},${y - 4}v${-35}`} stroke="red" />;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
When working through some recent visuals I noticed that the example for the multi X axis for the bar chart had a few issues. 
- The final quarter cuts out the final month
- The quarter labels are not centred within the quarter groups

![{0C3EBA4B-7F20-4464-9E60-FCDD2B8199C0}](https://github.com/user-attachments/assets/9239c476-b096-442e-867d-3e165a7fbf74)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#5798 


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

In playing around with the example I found a way to get these issues resolved and thought I'd see if you wanted to update the docs to reflect.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've tested the changes in CodeSandbox and also the docs built in editor, screenshots from this testing is in the next section.

## Screenshots (if appropriate):

This is the current example in the docs, note that the final quarter cuts out December, also note that the quarter names aren't centred in the full quarters.
![{0C3EBA4B-7F20-4464-9E60-FCDD2B8199C0}](https://github.com/user-attachments/assets/9239c476-b096-442e-867d-3e165a7fbf74)

With the suggested changes made the chart instead renders like this:
![{7EAE9569-DC67-43D3-A51B-EF03FC92AB33}](https://github.com/user-attachments/assets/452b0806-8c24-4772-8d6d-0c82ddf6652e)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
