### PR TITLE
Shorten animationDuration in storybook

### DIFF
--- a/storybook/stories/Examples/BarChart/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart/BarChart.stories.tsx
@@ -1013,7 +1013,7 @@ export const ChangingDataKey = {
             stroke="#8884d8"
             strokeDasharray="5 5"
             label={{ fill: 'red' }}
-            animationDuration={3000}
+            animationDuration={1000}
           />
         </BarChart>
       </>
@@ -1090,7 +1090,7 @@ export const ChangingDataKeyAndStacked = {
             stroke="yellow"
             strokeDasharray="5 5"
             label={{ fill: 'red' }}
-            animationDuration={3000}
+            animationDuration={1000}
           />
         </BarChart>
       </>


### PR DESCRIPTION
So that the labels have a chance to render. Fixes https://www.chromatic.com/test?appId=63da8268a0da9970db6992aa&id=680cddec497ffd985b09a16a
