### PR TITLE
Keyboard direction polar to ltr

### DIFF
--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -1871,6 +1871,12 @@ export const selectChartDirection: (state: RechartsRootState) => AxisDirection |
       case 'vertical': {
         return allYAxes.some(axis => axis.reversed) ? 'bottom-to-top' : 'top-to-bottom';
       }
+      // TODO: make this better. For now, right arrow triggers "forward", left arrow "back"
+      // however, the tooltip moves an unintuitive direction because of how the indices are rendered
+      case 'centric':
+      case 'radial': {
+        return 'left-to-right';
+      }
       default: {
         return undefined;
       }

--- a/test/polar/Pie.spec.tsx
+++ b/test/polar/Pie.spec.tsx
@@ -1507,16 +1507,18 @@ describe('<Pie />', () => {
 
       expectTooltipPayload(container, '', ['B : 250']);
 
+      // unsure why two are needed but they are in order to advance one
+      await userEvent.keyboard('{ArrowRight}');
       await userEvent.keyboard('{ArrowRight}');
 
-      // ArrowRight goes back instead of forwards?
-      expectTooltipPayload(container, '', ['A : 250']);
-
-      await userEvent.keyboard('{ArrowLeft}');
-      await userEvent.keyboard('{ArrowLeft}');
-
-      // ArrowLeft goes forwards instead of backwards?
+      // ArrowRight goes forwards
       expectTooltipPayload(container, '', ['C : 250']);
+
+      await userEvent.keyboard('{ArrowLeft}');
+      await userEvent.keyboard('{ArrowLeft}');
+
+      // ArrowLeft goes back
+      expectTooltipPayload(container, '', ['A : 250']);
     });
 
     test.fails('Arrows move between sectors, wrap around, and escape blurs', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Specifically set chart direction for polar charts

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Err, there might be one I forgot

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- Polar keyboard nav isn't great at the moment. This sets direction for polar charts to RTL which allows the user to nav with right arrow key rather than needing to use the left.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
