### PR TITLE
Import react with namespace import

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview X Axis
  */
-import React from 'react';
+import * as React from 'react';
 import clsx from 'clsx';
 import { useChartHeight, useChartWidth, useXAxisOrThrow } from '../context/chartLayoutContext';
 import { CartesianAxis } from './CartesianAxis';

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Y Axis
  */
-import React from 'react';
+import * as React from 'react';
 import clsx from 'clsx';
 import { BaseAxisProps, AxisInterval, PresentationAttributesAdaptChildEvent } from '../util/types';
 import { useChartHeight, useChartWidth, useYAxisOrThrow } from '../context/chartLayoutContext';

--- a/src/cartesian/ZAxis.tsx
+++ b/src/cartesian/ZAxis.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Z Axis
  */
-import React from 'react';
+import * as React from 'react';
 import { ScaleType, DataKey, AxisDomain } from '../util/types';
 
 export interface Props {

--- a/src/shape/Curve.tsx
+++ b/src/shape/Curve.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Curve
  */
-import React from 'react';
+import * as React from 'react';
 import {
   line as shapeLine,
   area as shapeArea,

--- a/src/shape/Dot.tsx
+++ b/src/shape/Dot.tsx
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Dot
  */
-import React from 'react';
+import * as React from 'react';
 import clsx from 'clsx';
 import { PresentationAttributesWithProps, adaptEventHandlers } from '../util/types';
 import { filterProps } from '../util/ReactUtils';

--- a/src/util/ScatterUtils.tsx
+++ b/src/util/ScatterUtils.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ActiveShape, SymbolType } from './types';
 import { ScatterPointItem } from '../cartesian/Scatter';
 import { Symbols } from '../shape/Symbols';


### PR DESCRIPTION
This fixes components that will have type errors like

> JSX element class does not support attributes because it does not have a 'props' property.

If your app has disabled `allowSyntheticDefaultImports`

## Description

Use the namespace import of react for these components.

## Related Issue

#5809

## Motivation and Context

The provided d.ts types of these components should work regardless how your apps `allowSyntheticDefaultImports` is configured.

## How Has This Been Tested?

Yes, this fixes mentioned type error.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
