### PR TITLE
Disable allowSyntheticDefaultImports

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line max-classes-per-file
-import React, { MutableRefObject, PureComponent, useCallback, useMemo, useRef, useState } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { MutableRefObject, PureComponent, useCallback, useMemo, useRef, useState } from 'react';
+import { clsx } from 'clsx';
 import Animate from 'react-smooth';
 import { Curve, CurveType, Point as CurvePoint, Props as CurveProps } from '../shape/Curve';
 import { Dot } from '../shape/Dot';

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -2,17 +2,9 @@
  * @fileOverview Render a group of bar
  */
 // eslint-disable-next-line max-classes-per-file
-import React, {
-  Key,
-  MutableRefObject,
-  PureComponent,
-  ReactElement,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { Key, MutableRefObject, PureComponent, ReactElement, useCallback, useMemo, useRef, useState } from 'react';
+import { clsx } from 'clsx';
 import Animate from 'react-smooth';
 import { Series } from 'victory-vendor/d3-shape';
 import { Props as RectangleProps } from '../shape/Rectangle';

--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -2,7 +2,8 @@
  * After we refactor classes to functional components, we can remove this eslint-disable
  */
 /* eslint-disable max-classes-per-file */
-import React, {
+import * as React from 'react';
+import {
   Children,
   PureComponent,
   ReactElement,
@@ -13,7 +14,7 @@ import React, {
   useContext,
   useEffect,
 } from 'react';
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { scalePoint, ScalePoint } from 'victory-vendor/d3-scale';
 import { range } from 'es-toolkit';
 import { Layer } from '../container/Layer';

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -1,10 +1,11 @@
 /**
  * @fileOverview Cartesian Axis
  */
-import React, { ReactElement, ReactNode, Component, SVGProps } from 'react';
+import * as React from 'react';
+import { ReactElement, ReactNode, Component, SVGProps } from 'react';
 
 import { get } from 'es-toolkit/compat';
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { shallowEqual } from '../util/ShallowEqual';
 import { Layer } from '../container/Layer';
 import { Text } from '../component/Text';

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Cartesian Grid
  */
-import React, { ReactElement, SVGProps } from 'react';
+import * as React from 'react';
+import { ReactElement, SVGProps } from 'react';
 
 import { warn } from '../util/LogUtils';
 import { isNumber } from '../util/DataUtils';

--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Render a group of error bar
  */
-import React, { Component, createContext, SVGProps, useContext } from 'react';
+import * as React from 'react';
+import { Component, createContext, SVGProps, useContext } from 'react';
 import Animate from 'react-smooth';
 import { Layer } from '../container/Layer';
 import { AnimationTiming, DataKey } from '../util/types';

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable max-classes-per-file */
-import React, { MutableRefObject, PureComponent, useCallback, useMemo, useRef, useState } from 'react';
+import * as React from 'react';
+import { MutableRefObject, PureComponent, useCallback, useMemo, useRef, useState } from 'react';
 import Animate from 'react-smooth';
 import { omit } from 'es-toolkit';
 
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { selectActiveIndex } from '../state/selectors/selectors';
 import { useAppSelector } from '../state/hooks';
 import { Layer } from '../container/Layer';

--- a/src/cartesian/GraphicalItemClipPath.tsx
+++ b/src/cartesian/GraphicalItemClipPath.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { AxisId } from '../state/cartesianAxisSlice';
 import { useOffset } from '../context/chartLayoutContext';
 import { useAppSelector } from '../state/hooks';

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -1,8 +1,9 @@
 // eslint-disable-next-line max-classes-per-file
-import React, { Component, MutableRefObject, PureComponent, Ref, useCallback, useMemo, useRef, useState } from 'react';
+import * as React from 'react';
+import { Component, MutableRefObject, PureComponent, Ref, useCallback, useMemo, useRef, useState } from 'react';
 import Animate from 'react-smooth';
 
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { Curve, CurveType, Point as CurvePoint, Props as CurveProps } from '../shape/Curve';
 import { Dot } from '../shape/Dot';
 import { Layer } from '../container/Layer';

--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -1,5 +1,6 @@
-import React, { Component, ReactElement, useEffect } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { Component, ReactElement, useEffect } from 'react';
+import { clsx } from 'clsx';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelType, Label } from '../component/Label';
 import { createLabeledScales, rectWithPoints } from '../util/CartesianUtils';

--- a/src/cartesian/ReferenceDot.tsx
+++ b/src/cartesian/ReferenceDot.tsx
@@ -1,5 +1,6 @@
-import React, { Component, ReactElement, useEffect } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { Component, ReactElement, useEffect } from 'react';
+import { clsx } from 'clsx';
 import { Layer } from '../container/Layer';
 import { Dot, Props as DotProps } from '../shape/Dot';
 import { ImplicitLabelType, Label } from '../component/Label';

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -1,8 +1,9 @@
 /**
  * @fileOverview Reference Line
  */
-import React, { Component, ReactElement, SVGProps, useEffect } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { Component, ReactElement, SVGProps, useEffect } from 'react';
+import { clsx } from 'clsx';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelType, Label } from '../component/Label';
 import { IfOverflow } from '../util/IfOverflow';

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -1,7 +1,8 @@
-import React, { Component, MutableRefObject, ReactElement, useCallback, useMemo, useRef, useState } from 'react';
+import * as React from 'react';
+import { Component, MutableRefObject, ReactElement, useCallback, useMemo, useRef, useState } from 'react';
 import Animate from 'react-smooth';
 
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { Layer } from '../container/Layer';
 import { ImplicitLabelListType, LabelList } from '../component/LabelList';
 import { filterProps, findAllByType } from '../util/ReactUtils';

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -1,8 +1,9 @@
 /**
  * @fileOverview X Axis
  */
-import React, { Component, useEffect } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { Component, useEffect } from 'react';
+import { clsx } from 'clsx';
 import { CartesianAxis } from './CartesianAxis';
 import { AxisInterval, AxisTick, BaseAxisProps, PresentationAttributesAdaptChildEvent } from '../util/types';
 import { useAppDispatch, useAppSelector } from '../state/hooks';

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -1,5 +1,6 @@
-import React, { Component, FunctionComponent, useEffect } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { Component, FunctionComponent, useEffect } from 'react';
+import { clsx } from 'clsx';
 import { AxisInterval, AxisTick, BaseAxisProps, PresentationAttributesAdaptChildEvent } from '../util/types';
 import { CartesianAxis } from './CartesianAxis';
 import { addYAxis, removeYAxis, YAxisOrientation, YAxisPadding, YAxisSettings } from '../state/cartesianAxisSlice';

--- a/src/cartesian/ZAxis.tsx
+++ b/src/cartesian/ZAxis.tsx
@@ -1,4 +1,5 @@
-import React, { Component, useEffect } from 'react';
+import * as React from 'react';
+import { Component, useEffect } from 'react';
 import { ScaleType, DataKey, AxisDomain } from '../util/types';
 import { addZAxis, removeZAxis, ZAxisSettings } from '../state/cartesianAxisSlice';
 import { useAppDispatch } from '../state/hooks';

--- a/src/chart/RechartsWrapper.tsx
+++ b/src/chart/RechartsWrapper.tsx
@@ -1,5 +1,6 @@
-import React, { CSSProperties, forwardRef, ReactNode, Ref } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { CSSProperties, forwardRef, ReactNode, Ref } from 'react';
+import { clsx } from 'clsx';
 import { mouseLeaveChart } from '../state/tooltipSlice';
 import { useAppDispatch } from '../state/hooks';
 import { mouseClickAction, mouseMoveAction } from '../state/mouseEventsMiddleware';

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -1,4 +1,5 @@
-import React, { MouseEvent, PureComponent, ReactElement, SVGProps } from 'react';
+import * as React from 'react';
+import { MouseEvent, PureComponent, ReactElement, SVGProps } from 'react';
 import { maxBy, sumBy } from 'es-toolkit';
 import { get } from 'es-toolkit/compat';
 import { Surface } from '../container/Surface';

--- a/src/chart/SunburstChart.tsx
+++ b/src/chart/SunburstChart.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import * as React from 'react';
+import { useState } from 'react';
 import { scaleLinear } from 'victory-vendor/d3-scale';
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { get } from 'es-toolkit/compat';
 import { Surface } from '../container/Surface';
 import { Layer } from '../container/Layer';

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -1,4 +1,5 @@
-import React, { PureComponent } from 'react';
+import * as React from 'react';
+import { PureComponent } from 'react';
 import { omit } from 'es-toolkit';
 import { get } from 'es-toolkit/compat';
 import Smooth from 'react-smooth';

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1,4 +1,5 @@
-import React, { Component, forwardRef } from 'react';
+import * as React from 'react';
+import { Component, forwardRef } from 'react';
 import { LegendPortalContext } from '../context/legendPortalContext';
 import { Surface } from '../container/Surface';
 

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -1,4 +1,5 @@
-import React, { cloneElement, isValidElement } from 'react';
+import * as React from 'react';
+import { cloneElement, isValidElement } from 'react';
 import { ActiveDotProps, ActiveDotType, adaptEventHandlers, DataKey } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { Dot } from '../shape/Dot';

--- a/src/component/Cursor.tsx
+++ b/src/component/Cursor.tsx
@@ -1,5 +1,6 @@
-import React, { ReactElement, cloneElement, createElement, isValidElement, SVGProps } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { ReactElement, cloneElement, createElement, isValidElement, SVGProps } from 'react';
+import { clsx } from 'clsx';
 import { ChartCoordinate, ChartOffsetRequired, LayoutType, TooltipEventType } from '../util/types';
 import { Curve } from '../shape/Curve';
 import { Cross } from '../shape/Cross';

--- a/src/component/Customized.tsx
+++ b/src/component/Customized.tsx
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Customized
  */
-import React, { isValidElement, cloneElement, createElement, Component, FunctionComponent, ReactElement } from 'react';
+import * as React from 'react';
+import { isValidElement, cloneElement, createElement, Component, FunctionComponent, ReactElement } from 'react';
 
 import { Layer } from '../container/Layer';
 import { warn } from '../util/LogUtils';

--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -1,9 +1,10 @@
 /**
  * @fileOverview Default Legend Content
  */
-import React, { PureComponent, ReactNode, MouseEvent, ReactElement } from 'react';
+import * as React from 'react';
+import { PureComponent, ReactNode, MouseEvent, ReactElement } from 'react';
 
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { sortBy } from 'es-toolkit/compat';
 import { Surface } from '../container/Surface';
 import { Symbols } from '../shape/Symbols';

--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -2,9 +2,10 @@
  * @fileOverview Default Tooltip Content
  */
 
-import React, { CSSProperties, HTMLAttributes, ReactNode, SVGProps } from 'react';
+import * as React from 'react';
+import { CSSProperties, HTMLAttributes, ReactNode, SVGProps } from 'react';
 import { sortBy } from 'es-toolkit/compat';
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { isNullish, isNumOrStr } from '../util/DataUtils';
 import { DataKey } from '../util/types';
 

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -1,5 +1,6 @@
-import React, { cloneElement, isValidElement, ReactNode, ReactElement, createElement, SVGProps } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { cloneElement, isValidElement, ReactNode, ReactElement, createElement, SVGProps } from 'react';
+import { clsx } from 'clsx';
 import { Text } from './Text';
 import { findAllByType, filterProps } from '../util/ReactUtils';
 import { isNumOrStr, isNumber, isPercent, getPercentValue, uniqueId, mathSign, isNullish } from '../util/DataUtils';

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -1,4 +1,5 @@
-import React, { cloneElement, ReactElement, ReactNode, SVGProps } from 'react';
+import * as React from 'react';
+import { cloneElement, ReactElement, ReactNode, SVGProps } from 'react';
 import { last } from 'es-toolkit';
 
 import { Label, ContentType, Props as LabelProps, LabelPosition, isLabelContentAFunction } from './Label';

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties, PureComponent, useEffect } from 'react';
+import * as React from 'react';
+import { CSSProperties, PureComponent, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useLegendPortal } from '../context/legendPortalContext';
 import { DefaultLegendContent, LegendPayload, Props as DefaultProps } from './DefaultLegendContent';

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -1,5 +1,6 @@
-import clsx from 'clsx';
-import React, {
+import { clsx } from 'clsx';
+import * as React from 'react';
+import {
   ReactElement,
   forwardRef,
   cloneElement,

--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -1,6 +1,7 @@
-import React, { CSSProperties, SVGProps, useMemo } from 'react';
+import * as React from 'react';
+import { CSSProperties, SVGProps, useMemo } from 'react';
 
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { isNullish, isNumber, isNumOrStr } from '../util/DataUtils';
 import { Global } from '../util/Global';
 import { filterProps } from '../util/ReactUtils';

--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties, ReactElement, ReactNode, useEffect } from 'react';
+import * as React from 'react';
+import { CSSProperties, ReactElement, ReactNode, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import {
   DefaultTooltipContent,

--- a/src/component/TooltipBoundingBox.tsx
+++ b/src/component/TooltipBoundingBox.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties, PureComponent, ReactNode } from 'react';
+import * as React from 'react';
+import { CSSProperties, PureComponent, ReactNode } from 'react';
 import { AllowInDimension, AnimationDuration, AnimationTiming, CartesianViewBox, Coordinate } from '../util/types';
 import { getTooltipTranslate } from '../util/tooltip/translate';
 import { ElementOffset, SetElementOffset } from '../util/useElementOffset';

--- a/src/container/ClipPath.tsx
+++ b/src/container/ClipPath.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { useOffset } from '../context/chartLayoutContext';
 
 type ClipPathProps = {

--- a/src/container/Layer.tsx
+++ b/src/container/Layer.tsx
@@ -1,5 +1,6 @@
-import React, { ReactNode, SVGAttributes } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { ReactNode, SVGAttributes } from 'react';
+import { clsx } from 'clsx';
 import { filterProps } from '../util/ReactUtils';
 
 interface LayerProps {

--- a/src/container/Surface.tsx
+++ b/src/container/Surface.tsx
@@ -1,8 +1,9 @@
 /**
  * @fileOverview Surface
  */
-import React, { ReactNode, CSSProperties, SVGProps } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { ReactNode, CSSProperties, SVGProps } from 'react';
+import { clsx } from 'clsx';
 import { filterProps } from '../util/ReactUtils';
 
 interface SurfaceProps {

--- a/src/context/CartesianGraphicalItemContext.tsx
+++ b/src/context/CartesianGraphicalItemContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useCallback, useContext, useEffect } from 'react';
+import * as React from 'react';
+import { createContext, useCallback, useContext, useEffect } from 'react';
 import { CartesianGraphicalItemType, ErrorBarsSettings } from '../state/graphicalItemsSlice';
 import { SetCartesianGraphicalItem } from '../state/SetGraphicalItem';
 import { ChartData } from '../state/chartDataSlice';

--- a/src/context/PanoramaContext.tsx
+++ b/src/context/PanoramaContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, ReactNode, useContext } from 'react';
+import * as React from 'react';
+import { createContext, ReactNode, useContext } from 'react';
 
 const PanoramaContext = createContext<boolean | null>(null);
 

--- a/src/context/PolarGraphicalItemContext.tsx
+++ b/src/context/PolarGraphicalItemContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { SetPolarGraphicalItem } from '../state/SetGraphicalItem';
 import { PolarGraphicalItemSettings } from '../state/graphicalItemsSlice';
 

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, ReactNode, useContext, useEffect } from 'react';
+import * as React from 'react';
+import { createContext, ReactNode, useContext, useEffect } from 'react';
 import { CartesianViewBoxRequired, ChartOffsetRequired, LayoutType, Margin, Size } from '../util/types';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { RechartsRootState } from '../state/store';

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Coordinate, DataKey } from '../util/types';
 import { useAppDispatch } from '../state/hooks';
 import { mouseLeaveItem, setActiveClickItemIndex, setActiveMouseOverItemIndex } from '../state/tooltipSlice';

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -1,4 +1,5 @@
-import React, {
+import * as React from 'react';
+import {
   MutableRefObject,
   PureComponent,
   ReactElement,
@@ -12,7 +13,7 @@ import React, {
 import Animate from 'react-smooth';
 import { get } from 'es-toolkit/compat';
 
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { ResolvedPieSettings, selectPieLegend, selectPieSectors } from '../state/selectors/pieSelectors';
 import { useAppSelector } from '../state/hooks';
 import { SetPolarGraphicalItem } from '../state/SetGraphicalItem';

--- a/src/polar/PolarAngleAxis.tsx
+++ b/src/polar/PolarAngleAxis.tsx
@@ -1,5 +1,6 @@
-import React, { FunctionComponent, PureComponent, ReactElement, SVGProps, useEffect } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { FunctionComponent, PureComponent, ReactElement, SVGProps, useEffect } from 'react';
+import { clsx } from 'clsx';
 import { Layer } from '../container/Layer';
 import { Dot } from '../shape/Dot';
 import { Polygon } from '../shape/Polygon';

--- a/src/polar/PolarGrid.tsx
+++ b/src/polar/PolarGrid.tsx
@@ -1,5 +1,6 @@
-import clsx from 'clsx';
-import React, { SVGProps } from 'react';
+import { clsx } from 'clsx';
+import * as React from 'react';
+import { SVGProps } from 'react';
 import { polarToCartesian } from '../util/PolarUtils';
 import { filterProps } from '../util/ReactUtils';
 import { AxisId } from '../state/cartesianAxisSlice';

--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -1,7 +1,8 @@
-import React, { FunctionComponent, PureComponent, ReactElement, useEffect } from 'react';
+import * as React from 'react';
+import { FunctionComponent, PureComponent, ReactElement, useEffect } from 'react';
 import { maxBy, minBy } from 'es-toolkit';
 
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { Text } from '../component/Text';
 import { Label } from '../component/Label';
 import { Layer } from '../container/Layer';

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -1,5 +1,6 @@
 // eslint-disable-next-line max-classes-per-file
-import React, {
+import * as React from 'react';
+import {
   PureComponent,
   ReactElement,
   MouseEvent,
@@ -13,7 +14,7 @@ import Animate from 'react-smooth';
 import { last } from 'es-toolkit';
 import { first } from 'es-toolkit/compat';
 
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { interpolateNumber, isNullish } from '../util/DataUtils';
 import { Global } from '../util/Global';
 import { polarToCartesian } from '../util/PolarUtils';

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line max-classes-per-file
-import React, { MutableRefObject, PureComponent, ReactElement, useCallback, useRef, useState } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { MutableRefObject, PureComponent, ReactElement, useCallback, useRef, useState } from 'react';
+import { clsx } from 'clsx';
 import Animate from 'react-smooth';
 
 import { Series } from 'victory-vendor/d3-shape';

--- a/src/shape/Cross.tsx
+++ b/src/shape/Cross.tsx
@@ -1,8 +1,9 @@
 /**
  * @fileOverview Cross
  */
-import React, { SVGProps } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { SVGProps } from 'react';
+import { clsx } from 'clsx';
 import { isNumber } from '../util/DataUtils';
 import { filterProps } from '../util/ReactUtils';
 

--- a/src/shape/Curve.tsx
+++ b/src/shape/Curve.tsx
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Curve
  */
-import React, { Ref } from 'react';
+import * as React from 'react';
+import { Ref } from 'react';
 import {
   line as shapeLine,
   area as shapeArea,
@@ -21,7 +22,7 @@ import {
   curveStepBefore,
 } from 'victory-vendor/d3-shape';
 
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { LayoutType, PresentationAttributesWithProps, adaptEventHandlers } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { isNumber, upperFirst } from '../util/DataUtils';

--- a/src/shape/Dot.tsx
+++ b/src/shape/Dot.tsx
@@ -1,8 +1,8 @@
 /**
  * @fileOverview Dot
  */
-import React from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { clsx } from 'clsx';
 import { PresentationAttributesWithProps, adaptEventHandlers } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 

--- a/src/shape/Polygon.tsx
+++ b/src/shape/Polygon.tsx
@@ -1,8 +1,9 @@
 /**
  * @fileOverview Polygon
  */
-import React, { SVGProps } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { SVGProps } from 'react';
+import { clsx } from 'clsx';
 import { Coordinate } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 

--- a/src/shape/Rectangle.tsx
+++ b/src/shape/Rectangle.tsx
@@ -1,8 +1,9 @@
 /**
  * @fileOverview Rectangle
  */
-import React, { SVGProps, useEffect, useRef, useState } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { SVGProps, useEffect, useRef, useState } from 'react';
+import { clsx } from 'clsx';
 import Animate from 'react-smooth';
 import { AnimationDuration, AnimationTiming } from '../util/types';
 import { filterProps } from '../util/ReactUtils';

--- a/src/shape/Sector.tsx
+++ b/src/shape/Sector.tsx
@@ -1,8 +1,9 @@
 /**
  * @fileOverview Sector
  */
-import React, { SVGProps } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { SVGProps } from 'react';
+import { clsx } from 'clsx';
 import { GeometrySector } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { polarToCartesian, RADIAN } from '../util/PolarUtils';

--- a/src/shape/Symbols.tsx
+++ b/src/shape/Symbols.tsx
@@ -1,7 +1,8 @@
 /**
  * @fileOverview Curve
  */
-import React, { SVGProps } from 'react';
+import * as React from 'react';
+import { SVGProps } from 'react';
 
 import {
   symbol as shapeSymbol,
@@ -14,7 +15,7 @@ import {
   symbolWye,
   SymbolType as D3SymbolType,
 } from 'victory-vendor/d3-shape';
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { SymbolType } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
 import { upperFirst } from '../util/DataUtils';

--- a/src/shape/Trapezoid.tsx
+++ b/src/shape/Trapezoid.tsx
@@ -1,8 +1,9 @@
 /**
  * @fileOverview Rectangle
  */
-import React, { SVGProps, useEffect, useRef, useState } from 'react';
-import clsx from 'clsx';
+import * as React from 'react';
+import { SVGProps, useEffect, useRef, useState } from 'react';
+import { clsx } from 'clsx';
 import Animate from 'react-smooth';
 import { AnimationDuration, AnimationTiming } from '../util/types';
 import { filterProps } from '../util/ReactUtils';

--- a/src/state/RechartsStoreProvider.tsx
+++ b/src/state/RechartsStoreProvider.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, useRef } from 'react';
+import * as React from 'react';
+import { ReactNode, useRef } from 'react';
 import { Provider } from 'react-redux';
 import { createRechartsStore, RechartsRootState } from './store';
 import { useIsPanorama } from '../context/PanoramaContext';

--- a/src/util/ActiveShapeUtils.tsx
+++ b/src/util/ActiveShapeUtils.tsx
@@ -1,4 +1,5 @@
-import React, { cloneElement, isValidElement, SVGProps } from 'react';
+import * as React from 'react';
+import { cloneElement, isValidElement, SVGProps } from 'react';
 import { isPlainObject } from 'es-toolkit';
 
 import { Rectangle } from '../shape/Rectangle';

--- a/src/util/BarUtils.tsx
+++ b/src/util/BarUtils.tsx
@@ -1,4 +1,5 @@
-import React, { SVGProps } from 'react';
+import * as React from 'react';
+import { SVGProps } from 'react';
 import invariant from 'tiny-invariant';
 import { ActiveShape } from './types';
 import { Props as RectangleProps } from '../shape/Rectangle';

--- a/src/util/FunnelUtils.tsx
+++ b/src/util/FunnelUtils.tsx
@@ -1,4 +1,5 @@
-import React, { SVGProps } from 'react';
+import * as React from 'react';
+import { SVGProps } from 'react';
 import { Props as FunnelProps, FunnelTrapezoidItem } from '../cartesian/Funnel';
 import { Props as TrapezoidProps } from '../shape/Trapezoid';
 import { Shape, getPropsFromShapeOption } from './ActiveShapeUtils';

--- a/src/util/RadialBarUtils.tsx
+++ b/src/util/RadialBarUtils.tsx
@@ -1,4 +1,5 @@
-import React, { SVGProps } from 'react';
+import * as React from 'react';
+import { SVGProps } from 'react';
 import { RadialBarProps } from '../polar/RadialBar';
 import { Props as SectorProps } from '../shape/Sector';
 import { Shape } from './ActiveShapeUtils';

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -1,6 +1,7 @@
 import { get } from 'es-toolkit/compat';
 
-import React, { Children, Component, FunctionComponent, isValidElement, ReactNode } from 'react';
+import * as React from 'react';
+import { Children, Component, FunctionComponent, isValidElement, ReactNode } from 'react';
 import { isFragment } from 'react-is';
 import { isNullish, isNumber } from './DataUtils';
 import { FilteredSvgElementType, FilteredElementKeyMap, SVGElementPropKeys, EventKeys, ActiveDotType } from './types';

--- a/src/util/ScatterUtils.tsx
+++ b/src/util/ScatterUtils.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ActiveShape, SymbolType } from './types';
 import { ScatterPointItem } from '../cartesian/Scatter';
 import { Symbols } from '../shape/Symbols';

--- a/src/util/tooltip/translate.ts
+++ b/src/util/tooltip/translate.ts
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { CSSProperties } from 'react';
 import { isNumber } from '../DataUtils';
 import { Coordinate, CartesianViewBox, AllowInDimension } from '../types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
+    "allowSyntheticDefaultImports": false /* Must be disabled to prevent type issues at dependants. */,
     "baseUrl": ".",
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "declarationDir": "./types" /* Output directory for generated declaration files. */,
-    "esModuleInterop": true,
     "jsx": "react",
     "module": "commonjs",
     "noImplicitAny": true,


### PR DESCRIPTION
Disables the tsconfig.json `allowSyntheticDefaultImports`.

## Description

As mentioned in #5809 apps can have type issues if they don't have `allowSyntheticDefaultImports` enabled. PR #5810 fixes some of these issues for 2.x. But as @PavelVanecek comments, this is not a permanent fix. The actual fix is to disable `allowSyntheticDefaultImports` (disabled is also the TS default). This PR does all necessary changes to make this possible.

* Update all violating imports
* ~~Migrate from lodash to lodash-es~~
* Disable allowSyntheticDefaultImports
* Remove esModuleInterop (not needed anymore as well because of these changes)

~~We could still use lodash instead of lodash-es, but this results in larger bundles, because tree shaking is not possible without a Babel or Webpack plugin. You can't do `import get from 'lodash/get'` anymore with `allowSyntheticDefaultImports` disabled, only `import { get } from 'lodash'`.~~

~~The UMD bundle `Recharts.js` decreased with this PR from 494K to 487K. While a bundle which still uses lodash (without working tree shaking) would have 528K.~~

## Related Issue

#5809 and #5810 

## Motivation and Context

Improved compatibility and alignd settings of `allowSyntheticDefaultImports` and `esModuleInterop` according the TS default.

## How Has This Been Tested?

Yes. All tests succeed as before, plus type issues are resolved.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
