### PR TITLE
Don't use categoricalDomain for time scale or custom scale ticks

### DIFF
--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -1683,8 +1683,9 @@ export const combineAxisTicks = (
     return result.filter((row: TickItem) => !isNan(row.coordinate));
   }
 
-  // When axis is a categorical axis, but the type of axis is number or the scale of axis is not "auto"
-  if (isCategorical && categoricalDomain) {
+  // When axis is a categorical axis, but the type of axis is number or the scale of axis is not "auto".
+  // Unless the scale is a time scale or a custom scale, in which case defer to the scale.ticks function below.
+  if (isCategorical && categoricalDomain && axis.scale !== 'time' && typeof axis.scale !== 'function') {
     return categoricalDomain.map(
       (entry: any, index: number): TickItem => ({
         coordinate: scale(entry) + offset,

--- a/storybook/stories/Examples/TimeSeries.stories.tsx
+++ b/storybook/stories/Examples/TimeSeries.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { scaleTime } from 'd3-scale';
 import { timeFormat } from 'd3-time-format';
 import { timeDay, timeHour, timeMinute, timeMonth, timeSecond, timeWeek, timeYear } from 'd3-time';
-import { timeData } from '../data';
+import { generateTimeData, timeData } from '../data';
 import { ComposedChart, Line, ResponsiveContainer, XAxis, Tooltip } from '../../../src';
 import { Props as XAxisProps } from '../../../src/cartesian/XAxis';
 
@@ -128,4 +128,67 @@ export const WithD3Scale = {
     );
   },
   parameters: { controls: { include: ['data'] } },
+};
+
+type TickSnappingArgs = {
+  numPoints: number;
+  intervalSeconds: number;
+};
+
+export const TickSnapping = {
+  ...StoryTemplate,
+  render: (args: TickSnappingArgs) => {
+    const timeData100Points = generateTimeData(args.numPoints, args.intervalSeconds);
+    return (
+      <ResponsiveContainer width="100%" height={400}>
+        <ComposedChart
+          data={timeData100Points}
+          margin={{
+            top: 20,
+            right: 20,
+            bottom: 20,
+            left: 20,
+          }}
+        >
+          <XAxis
+            dataKey="x"
+            type="number"
+            scale="time"
+            id="foo"
+            domain={['dataMin', 'dataMax']}
+            tickCount={10}
+            tickFormatter={timeFormat('%b %d %I:%M %p')}
+          />
+          <Line dataKey="y" xAxisId="foo" />
+        </ComposedChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    numPoints: 100,
+    intervalSeconds: 60,
+  },
+  argTypes: {
+    numPoints: {
+      control: { type: 'number' },
+      name: 'Number of points',
+    },
+    intervalSeconds: {
+      control: {
+        type: 'select',
+        labels: {
+          60: '1 minute',
+          [2 * 60]: '2 minutes',
+          [5 * 60]: '5 minutes',
+          [15 * 60]: '15 minutes',
+          [60 * 60]: '1 hour',
+          [6 * 60 * 60]: '6 hours',
+          [24 * 60 * 60]: '1 day',
+        },
+      },
+      options: [60, 2 * 60, 5 * 60, 15 * 60, 60 * 60, 6 * 60 * 60, 24 * 60 * 60],
+      name: 'Interval between points',
+    },
+  },
+  parameters: { controls: { include: ['Number of points', 'Interval between points'] } },
 };

--- a/storybook/stories/data/Time.ts
+++ b/storybook/stories/data/Time.ts
@@ -78,4 +78,15 @@ const dateWithValueData = [
   { time: 1483178400000, value: 60 },
 ];
 
-export { dateData, timeData, dateWithValueData };
+const generateTimeData = (numPoints: number, intervalSeconds: number) => {
+  const start = new Date('2018-10-16T00:00:00.000Z').getTime();
+  return Array.from({ length: numPoints }, (_, i) => {
+    const time = new Date(start + i * intervalSeconds * 1000);
+    return {
+      x: time,
+      y: Math.floor(Math.sin((25 * i) / numPoints) * 100),
+    };
+  });
+};
+
+export { dateData, timeData, dateWithValueData, generateTimeData };


### PR DESCRIPTION
## Description

First off, Recharts is an excellent charting library, thank you for all of the hard work that goes into it!

I'm trying to use it to build a chart with a time-based x-axis like this:

```js
<LineChart data={...}>
  [...]
  <XAxis type="number" scale="time" {...}  />
</LineChart>
```

What I'm finding is that the x-axis ticks do not snap to "round" time values and time intervals the way I would want them to. I tracked this down to the code I'm changing here, which uses the `categoricalDomain` instead of letting the d3 scale's `ticks` method choose the ticks.

## Related Issue

https://github.com/recharts/recharts/issues/5816

## Motivation and Context

Without this change, library consumers have to compute the ticks in user-land code and pass those tick values explicitly to `XAxis` component. The composability/ease-of-use of the `XAxis` component would be improved if the default behavior for a `"time"` scale could be relied upon to intelligently choose axis ticks.

## How Has This Been Tested?

I tested this by creating a Storybook example where different time-series data sets can be generated and ensuring that the tick selection looks correct

## Screenshots (if appropriate):

<img width="982" alt="Screenshot 2025-05-05 at 10 21 55 AM" src="https://github.com/user-attachments/assets/b9216eb2-6407-47aa-a859-37476df86ae7" />


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
