### PR TITLE
Update tooltip `label` type

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -41,7 +41,7 @@ function defaultUniqBy<TValue extends ValueType, TName extends NameType>(entry: 
 }
 
 export type TooltipContentProps<TValue extends ValueType, TName extends NameType> = TooltipProps<TValue, TName> & {
-  label: string;
+  label?: string | number;
   payload: any[];
   coordinate: ChartCoordinate;
   active: boolean;

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -173,7 +173,7 @@ export const selectActiveLabel: (
   tooltipEventType: TooltipEventType,
   trigger: TooltipTrigger,
   defaultIndex: TooltipIndex | undefined,
-) => string | undefined = createSelector(selectTooltipAxisTicks, selectActiveIndex, combineActiveLabel);
+) => string | number | undefined = createSelector(selectTooltipAxisTicks, selectActiveIndex, combineActiveLabel);
 
 function selectFinalData(dataDefinedOnItem: unknown, dataDefinedOnChart: ReadonlyArray<unknown>) {
   /*

--- a/src/synchronisation/useChartSynchronisation.tsx
+++ b/src/synchronisation/useChartSynchronisation.tsx
@@ -174,7 +174,7 @@ export function useTooltipChartSynchronisation(
   tooltipEventType: TooltipEventType,
   trigger: TooltipTrigger,
   activeCoordinate: ChartCoordinate | undefined,
-  activeLabel: string | undefined,
+  activeLabel: string | number | undefined,
   activeIndex: string | undefined,
   isTooltipActive: boolean,
 ) {
@@ -204,7 +204,6 @@ export function useTooltipChartSynchronisation(
       coordinate: activeCoordinate,
       dataKey: activeDataKey,
       index: activeIndex,
-      // despite the typescript annotation, the state sometimes returns activeLabel as a number
       label: typeof activeLabel === 'number' ? String(activeLabel) : activeLabel,
     });
     eventCenter.emit(TOOLTIP_SYNC_EVENT, syncId, syncAction, eventEmitterSymbol);

--- a/storybook/stories/Examples/AreaChart.stories.tsx
+++ b/storybook/stories/Examples/AreaChart.stories.tsx
@@ -122,7 +122,7 @@ export const PercentAreaChart = {
       return toPercent(ratio, 2);
     };
 
-    const renderTooltipContent = (o: { payload?: Array<{ value?: number }>; label?: string }) => {
+    const renderTooltipContent = (o: { payload?: Array<{ value?: number }>; label?: string | number }) => {
       const { payload, label } = o;
       const total = payload?.reduce((result, entry) => result + (entry.value ?? 0), 0);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Update `TooltipContent` `label` prop to be undefined, string, or number.

This might not always be 100% true because this is based on the users data but it should be true most of the time

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#5788

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#5788

be more accurate in terms of types

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
    - Anyone who currently references `label` as a value that is required or as solely a `string` will get a type error

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have added a storybook story or extended an existing story to show my changes
