### PR TITLE
fix: make Treemap content layer a Layer component instead of a g tag

### DIFF
--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -394,16 +394,16 @@ function ContentItem({
 }: ContentItemProps): React.ReactElement {
   if (React.isValidElement(content)) {
     return (
-      <g onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} onClick={onClick}>
+      <Layer onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} onClick={onClick}>
         {React.cloneElement(content, nodeProps)}
-      </g>
+      </Layer>
     );
   }
   if (typeof content === 'function') {
     return (
-      <g onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} onClick={onClick}>
+      <Layer onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} onClick={onClick}>
         {content(nodeProps)}
-      </g>
+      </Layer>
     );
   }
   // optimize default shape


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
n/a

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

- follow up from previous treemap PR https://github.com/recharts/recharts/pull/5826. We use `Layer` for `g` tags, so use `Layer` here
