### PR TITLE
Use list.js from the integration repository instead of parsing folders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         # This command finds all integration test directories
         # and formats them as a JSON array.
         run: |
-          JSON_ARRAY=$(find integrations* -maxdepth 1 -mindepth 1 -type d | awk 'BEGIN { printf "[" } NR > 1 { printf "," } { printf "\"%s\"", $0 } END { printf "]" }')
+          JSON_ARRAY=$(node list.js --ci --json)
           echo "Generated directory list: $JSON_ARRAY"
           echo "directories=$JSON_ARRAY" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Description

Use the script we merged in https://github.com/recharts/recharts-integ/pull/51

This script allows us to better define which integration tests we want to run in CI - and keep that list synchronised between the two repositories.
