### PR TITLE
fix: remove pie animation id

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -51,7 +51,6 @@ import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
 import { SetPolarLegendPayload } from '../state/SetLegendPayload';
 import { DATA_ITEM_DATAKEY_ATTRIBUTE_NAME, DATA_ITEM_INDEX_ATTRIBUTE_NAME } from '../util/Constants';
-import { useAnimationId } from '../util/useAnimationId';
 import { resolveDefaultProps } from '../util/resolveDefaultProps';
 
 interface PieDef {
@@ -594,7 +593,6 @@ function SectorsWithAnimation({
     onAnimationStart,
     onAnimationEnd,
   } = props;
-  const animationId = useAnimationId(props, 'recharts-pie-');
 
   const prevSectors = previousSectorsRef.current;
 
@@ -623,7 +621,6 @@ function SectorsWithAnimation({
       to={{ t: 1 }}
       onAnimationStart={handleAnimationStart}
       onAnimationEnd={handleAnimationEnd}
-      key={animationId}
     >
       {({ t }: { t: number }) => {
         const stepData: PieSectorDataItem[] = [];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Removing Pie `animationId` as it creates a regression from 2.x where the Pie animation pauses upon state being set in its event handlers. Removing the id doesn't cause any differences in instances where there is no custom state being set or passed

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/5804

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
solve issues before release

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test pass. See difference in storybooks
  - Current, bad - https://63da8268a0da9970db6992aa-tcfvxoomhy.chromatic.com/?path=/story/examples-pie-piewithtooltip--pie-with-tooltip

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
