### PR TITLE
fix: combine custom-tick-className and cartesian-axis-tick-value

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -239,11 +239,18 @@ export class CartesianAxis extends Component<Props, IState> {
 
   static renderTickItem(option: Props['tick'], props: any, value: ReactNode) {
     let tickItem;
+    const combinedClassName = clsx(props.className, 'recharts-cartesian-axis-tick-value');
 
     if (React.isValidElement(option)) {
-      tickItem = React.cloneElement(option, props);
+      tickItem = React.cloneElement(option, {
+        ...props,
+        className: combinedClassName,
+      });
     } else if (isFunction(option)) {
-      tickItem = option(props);
+      tickItem = option({
+        ...props,
+        className: combinedClassName,
+      });
     } else {
       tickItem = (
         <Text {...props} className="recharts-cartesian-axis-tick-value">

--- a/test/cartesian/CartesianAxis.spec.tsx
+++ b/test/cartesian/CartesianAxis.spec.tsx
@@ -9,8 +9,8 @@ const CustomizeLabel = ({ x, y }: any) => (
   </text>
 );
 
-const CustomizedTick = ({ x, y }: any) => (
-  <text data-testid="customized-tick" x={x} y={y}>
+const CustomizedTick = ({ x, y, className }: any) => (
+  <text data-testid="customized-tick" x={x} y={y} className={className}>
     test
   </text>
 );
@@ -292,5 +292,30 @@ describe('<CartesianAxis />', () => {
     );
 
     expect(container.querySelectorAll('.recharts-cartesian-axis-tick')).toHaveLength(0);
+  });
+
+  it('Renders with merged className when customized tick is provided', () => {
+    render(
+      <Surface width={500} height={500}>
+        <CartesianAxis
+          orientation="bottom"
+          y={100}
+          width={400}
+          height={50}
+          viewBox={{ x: 0, y: 0, width: 500, height: 500 }}
+          ticks={ticks}
+          tick={CustomizedTick}
+          interval={0}
+        />
+      </Surface>,
+    );
+
+    const tickElements = screen.getAllByTestId('customized-tick');
+
+    expect(tickElements).toHaveLength(ticks.length);
+
+    tickElements.forEach(element => {
+      expect(element).toHaveClass('recharts-cartesian-axis-tick-value');
+    });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When a custom tick component is rendered, ensure that the 'recharts-cartesian-axis-tick-value' class name is included. 
(along with any existing className specified by the user if needed)

## Related Issue

#5738 

## Motivation and Context

When using a custom X-axis tick component (a user-defined component passed to the tick prop of XAxis), the CSS class (recharts-cartesian-axis-tick-value) that Recharts internally uses to measure text size is not properly applied (passed) to this custom tick component, resulting in text being cut off due to text size calculation errors, especially when the font-size of the body is different from the default value.

## How Has This Been Tested?

After modifying the library, I tested it in a local environment using npm link and vite config.

enviroment
1. windows 11(desktop), chrome
2. MacOS Sequoia(mac m1 pro 16inch), chrome
3. MacOS Sequoia(mac m1 pro 16inch), safari

## Screenshots (if appropriate):

Windows 11, Chrome
<img width="487" alt="Screenshot 2025-05-13 at 9 19 46 PM" src="https://github.com/user-attachments/assets/9a2fd43e-6d20-4a6b-866e-af0644d503bb" />

MacOS Sequoia, Chrome
<img width="487" alt="Screenshot 2025-05-13 at 9 19 46 PM" src="https://github.com/user-attachments/assets/97166a1e-e71f-4656-81c1-8223cf27fd80" />

MacOS Sequoia, Safari
<img width="512" alt="Screenshot 2025-05-13 at 9 20 43 PM" src="https://github.com/user-attachments/assets/7e7aa815-8709-489c-b131-7257b770f888" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
