### PR TITLE
Generate categorical chart

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -93,7 +93,6 @@ export const generateCategoricalChart = ({
 
     clipPathId: string;
 
-    // todo join specific chart propTypes
     static defaultProps: CategoricalChartProps = {
       accessibilityLayer: true,
       layout: defaultLayout,
@@ -105,8 +104,6 @@ export const generateCategoricalChart = ({
       syncMethod: 'index',
       ...defaultProps,
     };
-
-    container?: HTMLElement;
 
     constructor(props: CategoricalChartProps) {
       super(props);
@@ -155,7 +152,6 @@ export const generateCategoricalChart = ({
                   width={width}
                   height={height}
                   ref={(node: HTMLDivElement) => {
-                    this.container = node;
                     if (this.state.tooltipPortal == null) {
                       this.setState({ tooltipPortal: node });
                     }

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { Component, forwardRef } from 'react';
-import { LegendPortalContext } from '../context/legendPortalContext';
 import { Surface } from '../container/Surface';
 
 import { filterProps, validateWidthHeight } from '../util/ReactUtils';
 import { uniqueId } from '../util/DataUtils';
 import { CategoricalChartOptions, DataKey, LayoutType, Margin, StackOffsetType } from '../util/types';
 import { ChartLayoutContextProvider } from '../context/chartLayoutContext';
-import { CategoricalChartState, ExternalMouseEvents } from './types';
+import { ExternalMouseEvents } from './types';
 import { ChartDataContextProvider } from '../context/chartDataContext';
 import { ClipPath } from '../container/ClipPath';
 import { ChartOptions } from '../state/optionsSlice';
 import { RechartsStoreProvider } from '../state/RechartsStoreProvider';
-import { TooltipPortalContext } from '../context/tooltipPortalContext';
 import { RechartsWrapper } from './RechartsWrapper';
 import { ReportChartProps } from '../state/ReportChartProps';
 import { PolarChartOptions } from '../state/polarOptionsSlice';
@@ -88,7 +86,7 @@ export const generateCategoricalChart = ({
   defaultProps = {},
   tooltipPayloadSearcher,
 }: CategoricalChartOptions) => {
-  class CategoricalChartWrapper extends Component<CategoricalChartProps, CategoricalChartState> {
+  class CategoricalChartWrapper extends Component<CategoricalChartProps> {
     static displayName = chartName;
 
     clipPathId: string;
@@ -109,8 +107,6 @@ export const generateCategoricalChart = ({
       super(props);
 
       this.clipPathId = `${props.id ?? uniqueId('recharts')}-clip`;
-
-      this.state = {};
     }
 
     render() {
@@ -143,49 +139,30 @@ export const generateCategoricalChart = ({
       return (
         <>
           <ChartDataContextProvider chartData={this.props.data} />
-          <TooltipPortalContext.Provider value={this.state.tooltipPortal}>
-            <LegendPortalContext.Provider value={this.state.legendPortal}>
-              <ChartLayoutContextProvider clipPathId={this.clipPathId}>
-                <RechartsWrapper
-                  className={className}
-                  style={style}
-                  width={width}
-                  height={height}
-                  ref={(node: HTMLDivElement) => {
-                    if (this.state.tooltipPortal == null) {
-                      this.setState({ tooltipPortal: node });
-                    }
-                    if (this.state.legendPortal == null) {
-                      this.setState({ legendPortal: node });
-                    }
-                  }}
-                  onClick={this.props.onClick}
-                  onMouseLeave={this.props.onMouseLeave}
-                  onMouseEnter={this.props.onMouseEnter}
-                  onMouseMove={this.props.onMouseMove}
-                  onMouseDown={this.props.onMouseDown}
-                  onMouseUp={this.props.onMouseUp}
-                  onContextMenu={this.props.onContextMenu}
-                  onDoubleClick={this.props.onDoubleClick}
-                  onTouchStart={this.props.onTouchStart}
-                  onTouchMove={this.props.onTouchMove}
-                  onTouchEnd={this.props.onTouchEnd}
-                >
-                  <Surface
-                    {...attrs}
-                    width={width}
-                    height={height}
-                    title={title}
-                    desc={desc}
-                    style={FULL_WIDTH_AND_HEIGHT}
-                  >
-                    <ClipPath clipPathId={this.clipPathId} />
-                    {children}
-                  </Surface>
-                </RechartsWrapper>
-              </ChartLayoutContextProvider>
-            </LegendPortalContext.Provider>
-          </TooltipPortalContext.Provider>
+          <ChartLayoutContextProvider clipPathId={this.clipPathId}>
+            <RechartsWrapper
+              className={className}
+              style={style}
+              width={width}
+              height={height}
+              onClick={this.props.onClick}
+              onMouseLeave={this.props.onMouseLeave}
+              onMouseEnter={this.props.onMouseEnter}
+              onMouseMove={this.props.onMouseMove}
+              onMouseDown={this.props.onMouseDown}
+              onMouseUp={this.props.onMouseUp}
+              onContextMenu={this.props.onContextMenu}
+              onDoubleClick={this.props.onDoubleClick}
+              onTouchStart={this.props.onTouchStart}
+              onTouchMove={this.props.onTouchMove}
+              onTouchEnd={this.props.onTouchEnd}
+            >
+              <Surface {...attrs} width={width} height={height} title={title} desc={desc} style={FULL_WIDTH_AND_HEIGHT}>
+                <ClipPath clipPathId={this.clipPathId} />
+                {children}
+              </Surface>
+            </RechartsWrapper>
+          </ChartLayoutContextProvider>
         </>
       );
     }

--- a/src/chart/types.ts
+++ b/src/chart/types.ts
@@ -1,11 +1,6 @@
 import { SyntheticEvent } from 'react';
 import { MouseHandlerDataParam } from '../synchronisation/types';
 
-export interface CategoricalChartState {
-  tooltipPortal?: HTMLElement | null;
-  legendPortal?: HTMLElement | null;
-}
-
 export type TooltipTrigger = 'hover' | 'click';
 
 export type CategoricalChartFunc = (nextState: MouseHandlerDataParam, event: SyntheticEvent) => void;


### PR DESCRIPTION
## Description

Thinning generateCategoricalChart

## Related Issue

https://github.com/recharts/recharts/issues/5768

## Motivation and Context

So I believe to solve https://github.com/recharts/recharts/issues/5768 we have to split the state into two. One for cartesian charts, and another for polar charts. These two chart families share very little (dimensions, data array, that's about it) and so everything everywhere has to deal with inevitable `undefined` and "if layout equals horizontal".

Let's just have one cartesian state, cartesian selectors, cartesian components; and on the side, separated: polar state, polar selectors, polar components.

And we start by getting rid of generateCategoricalChart completely because that's the shared heart of multiple cartesian + polar charts.

So, this PR moves code away from it. I will continue until generateCategoricalChart is removed and replaced with `CartesianChart` and `PolarChart` abstract components.
