### PR TITLE
Add a RootSurface component to remove some more code from generateCategoricalChart

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -51,6 +51,7 @@
   "es6/container",
   "es6/container/ClipPathProvider.js",
   "es6/container/Layer.js",
+  "es6/container/RootSurface.js",
   "es6/container/Surface.js",
   "es6/context",
   "es6/context/CartesianGraphicalItemContext.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -51,6 +51,7 @@
   "lib/container",
   "lib/container/ClipPathProvider.js",
   "lib/container/Layer.js",
+  "lib/container/RootSurface.js",
   "lib/container/Surface.js",
   "lib/context",
   "lib/context/CartesianGraphicalItemContext.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -51,6 +51,7 @@
   "types/container",
   "types/container/ClipPathProvider.d.ts",
   "types/container/Layer.d.ts",
+  "types/container/RootSurface.d.ts",
   "types/container/Surface.d.ts",
   "types/context",
   "types/context/CartesianGraphicalItemContext.d.ts",

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Component, forwardRef } from 'react';
-import { Surface } from '../container/Surface';
 
 import { filterProps, validateWidthHeight } from '../util/ReactUtils';
 import { CategoricalChartOptions, DataKey, LayoutType, Margin, StackOffsetType } from '../util/types';
@@ -15,6 +14,7 @@ import { ReportPolarOptions } from '../state/ReportPolarOptions';
 import { SyncMethod } from '../synchronisation/types';
 import { ReportMainChartProps } from '../state/ReportMainChartProps';
 import { ClipPathProvider } from '../container/ClipPathProvider';
+import { RootSurface } from '../container/RootSurface';
 
 /**
  * Simplified version of the MouseEvent so that we don't have to mock the whole thing in tests.
@@ -36,8 +36,6 @@ export interface ChartPointer {
   chartX: number;
   chartY: number;
 }
-
-const FULL_WIDTH_AND_HEIGHT = { width: '100%', height: '100%' };
 
 export interface CategoricalChartProps extends Partial<ExternalMouseEvents> {
   accessibilityLayer?: boolean;
@@ -105,20 +103,13 @@ export const generateCategoricalChart = ({
       const { children, className, width, height, style, compact, title, desc, ...others } = this.props;
       const attrs = filterProps(others, false);
 
-      // The "compact" mode is mainly used as the panorama within Brush
+      // The "compact" mode is used as the panorama within Brush
       if (compact) {
         return (
-          <Surface {...attrs} width={width} height={height} title={title} desc={desc}>
+          <RootSurface otherAttributes={attrs} title={title} desc={desc}>
             {children}
-          </Surface>
+          </RootSurface>
         );
-      }
-
-      if (this.props.accessibilityLayer) {
-        // Set tabIndex to 0 by default (can be overwritten)
-        attrs.tabIndex = this.props.tabIndex ?? 0;
-        // Set role to application by default (can be overwritten)
-        attrs.role = this.props.role ?? 'application';
       }
 
       return (
@@ -139,9 +130,9 @@ export const generateCategoricalChart = ({
           onTouchMove={this.props.onTouchMove}
           onTouchEnd={this.props.onTouchEnd}
         >
-          <Surface {...attrs} width={width} height={height} title={title} desc={desc} style={FULL_WIDTH_AND_HEIGHT}>
+          <RootSurface otherAttributes={attrs} title={title} desc={desc}>
             <ClipPathProvider>{children}</ClipPathProvider>
-          </Surface>
+          </RootSurface>
         </RechartsWrapper>
       );
     }
@@ -184,7 +175,7 @@ export const generateCategoricalChart = ({
           margin={props.margin ?? defaultMargin}
         />
         <ReportChartProps
-          accessibilityLayer={props.accessibilityLayer}
+          accessibilityLayer={props.accessibilityLayer ?? true}
           barCategoryGap={props.barCategoryGap ?? '10%'}
           maxBarSize={props.maxBarSize}
           stackOffset={props.stackOffset ?? 'none'}

--- a/src/container/RootSurface.tsx
+++ b/src/container/RootSurface.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { ReactNode } from 'react';
+import { useChartHeight, useChartWidth } from '../context/chartLayoutContext';
+import { useAccessibilityLayer } from '../context/accessibilityContext';
+import { validateWidthHeight } from '../util/ReactUtils';
+import { useIsPanorama } from '../context/PanoramaContext';
+import { Surface } from './Surface';
+import { useAppSelector } from '../state/hooks';
+import { selectBrushDimensions } from '../state/selectors/brushSelectors';
+
+type RootSurfaceProps = {
+  children: ReactNode;
+  title: string | undefined;
+  desc: string | undefined;
+  otherAttributes: Record<string, unknown>;
+};
+
+const FULL_WIDTH_AND_HEIGHT = { width: '100%', height: '100%' };
+
+const MainChartSurface = (props: RootSurfaceProps) => {
+  const width = useChartWidth();
+  const height = useChartHeight();
+  const hasAccessibilityLayer = useAccessibilityLayer();
+
+  if (!validateWidthHeight({ width, height })) {
+    return null;
+  }
+  const { children, otherAttributes, title, desc } = props;
+
+  let tabIndex: number | undefined, role: string | undefined;
+
+  if (typeof otherAttributes.tabIndex === 'number') {
+    tabIndex = otherAttributes.tabIndex;
+  } else {
+    tabIndex = hasAccessibilityLayer ? 0 : undefined;
+  }
+
+  if (typeof otherAttributes.role === 'string') {
+    role = otherAttributes.role;
+  } else {
+    role = hasAccessibilityLayer ? 'application' : undefined;
+  }
+
+  return (
+    <Surface
+      {...otherAttributes}
+      title={title}
+      desc={desc}
+      role={role}
+      tabIndex={tabIndex}
+      width={width}
+      height={height}
+      style={FULL_WIDTH_AND_HEIGHT}
+    >
+      {children}
+    </Surface>
+  );
+};
+
+const BrushPanoramaSurface = ({ children }: { children: ReactNode }) => {
+  const brushDimensions = useAppSelector(selectBrushDimensions);
+
+  if (!brushDimensions) {
+    return null;
+  }
+
+  const { width, height, y, x } = brushDimensions;
+
+  return (
+    <Surface width={width} height={height} x={x} y={y}>
+      {children}
+    </Surface>
+  );
+};
+
+export const RootSurface = ({ children, ...rest }: RootSurfaceProps) => {
+  const isPanorama = useIsPanorama();
+
+  if (isPanorama) {
+    return <BrushPanoramaSurface>{children}</BrushPanoramaSurface>;
+  }
+  return <MainChartSurface {...rest}>{children}</MainChartSurface>;
+};

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -724,7 +724,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
 
           const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
           expect(allLines).toHaveLength(2);
@@ -772,7 +772,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
           const expectedYAxis: AxisPropsForCartesianGridTicksGeneration = {
             angle: 0,
             interval: 'preserveEnd',
@@ -818,7 +818,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
           const expectedYAxis: AxisPropsForCartesianGridTicksGeneration = {
             angle: 0,
             interval: 'preserveEnd',
@@ -865,7 +865,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               </ChartElement>,
             );
 
-            expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+            expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
             const expectedYAxis: AxisPropsForCartesianGridTicksGeneration = {
               angle: 0,
               interval: 'preserveEnd',
@@ -912,7 +912,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               </ChartElement>,
             );
 
-            expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+            expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
             const expectedYAxis: AxisPropsForCartesianGridTicksGeneration = {
               angle: 0,
               interval: 'preserveEnd',
@@ -958,7 +958,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               </ChartElement>,
             );
 
-            expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+            expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
 
             const allLines = container.querySelectorAll('.recharts-cartesian-grid-horizontal line');
             expect(allLines).toHaveLength(0);
@@ -1001,7 +1001,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
 
           const allLines = container.querySelectorAll('.recharts-cartesian-grid-vertical line');
           expect(allLines).toHaveLength(2);
@@ -1049,7 +1049,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
           const expectedXAxis: AxisPropsForCartesianGridTicksGeneration = {
             angle: 0,
             axisType: 'xAxis',
@@ -1095,7 +1095,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
           const expectedXAxis: AxisPropsForCartesianGridTicksGeneration = {
             angle: 0,
             axisType: 'xAxis',
@@ -1142,7 +1142,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               </ChartElement>,
             );
 
-            expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+            expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
             const expectedXAxis: AxisPropsForCartesianGridTicksGeneration = {
               angle: 0,
               axisType: 'xAxis',
@@ -1189,7 +1189,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               </ChartElement>,
             );
 
-            expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+            expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
             const expectedXAxis: AxisPropsForCartesianGridTicksGeneration = {
               angle: 0,
               axisType: 'xAxis',
@@ -1235,7 +1235,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               </ChartElement>,
             );
 
-            expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+            expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
 
             const allLines = container.querySelectorAll('.recharts-cartesian-grid-vertical line');
             expect(allLines).toHaveLength(0);
@@ -1279,7 +1279,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               />
             </ChartElement>,
           );
-          expect(horizontal).toHaveBeenCalledTimes(horizontalPoints.length * 2);
+          expect(horizontal).toHaveBeenCalledTimes(horizontalPoints.length);
 
           const expectedProps: GridLineTypeFunctionProps = {
             stroke: '#ccc',
@@ -1373,7 +1373,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               />
             </ChartElement>,
           );
-          expect(spy).toHaveBeenCalledTimes(horizontalPoints.length * 2);
+          expect(spy).toHaveBeenCalledTimes(horizontalPoints.length);
 
           const expectedProps: GridLineTypeFunctionProps = {
             stroke: '#ccc',
@@ -1463,7 +1463,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               />
             </ChartElement>,
           );
-          expect(vertical).toHaveBeenCalledTimes(verticalPoints.length * 2);
+          expect(vertical).toHaveBeenCalledTimes(verticalPoints.length);
 
           const expectedProps: GridLineTypeFunctionProps = {
             stroke: '#ccc',
@@ -1557,7 +1557,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
               />
             </ChartElement>,
           );
-          expect(spy).toHaveBeenCalledTimes(verticalPoints.length * 2);
+          expect(spy).toHaveBeenCalledTimes(verticalPoints.length);
 
           const expectedProps: GridLineTypeFunctionProps = {
             stroke: '#ccc',
@@ -1703,7 +1703,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+          expect(horizontalCoordinatesGenerator).toHaveBeenCalledTimes(1);
 
           const allLines = container.querySelectorAll('.recharts-cartesian-gridstripes-horizontal rect');
           expect(allLines).toHaveLength(3);
@@ -1920,7 +1920,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
             </ChartElement>,
           );
 
-          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(2);
+          expect(verticalCoordinatesGenerator).toHaveBeenCalledTimes(1);
 
           const allLines = container.querySelectorAll('.recharts-cartesian-gridstripes-vertical rect');
           expect(allLines).toHaveLength(3);

--- a/test/cartesian/ReferenceArea.spec.tsx
+++ b/test/cartesian/ReferenceArea.spec.tsx
@@ -478,7 +478,7 @@ describe('<ReferenceArea />', () => {
           <ReferenceArea x1="201106" x2="201110" fill="#666" shape={spy} radius={10} strokeWidth={3} />
         </BarChart>,
       );
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
       expect(spy).toHaveBeenCalledWith({
         clipPath: undefined,
         fill: '#666',

--- a/test/chart/AccessibilityLayer.spec.tsx
+++ b/test/chart/AccessibilityLayer.spec.tsx
@@ -46,8 +46,20 @@ function arrowLeft(container: Element) {
   });
 }
 
+function getMainSurface(container: HTMLElement | SVGElement): HTMLElement | SVGElement {
+  // DefaultLegendContent renders its own SVG surface, so we need to exclude it
+  const mainSurface = container.querySelector(
+    'svg.recharts-surface:not(.recharts-default-legend svg.recharts-surface)',
+  );
+  assertNotNull(mainSurface);
+  if (!(mainSurface instanceof HTMLElement || mainSurface instanceof SVGElement)) {
+    throw new Error('Main surface is not an HTMLElement or SVGElement');
+  }
+  return mainSurface;
+}
+
 function assertNoKeyboardInteractions(container: HTMLElement) {
-  const svg = container.querySelector('svg');
+  const svg = getMainSurface(container);
   assertNotNull(svg);
   expectTooltipNotVisible(container);
   act(() => {
@@ -87,7 +99,7 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
       expectTooltipNotVisible(container);
 
       // Once the chart receives focus, the tooltip should display
-      act(() => container.querySelector('svg')?.focus());
+      act(() => getMainSurface(container).focus());
 
       expectTooltipPayload(container, 'Page A', ['uv : 400']);
     });
@@ -105,7 +117,7 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
       expect(tooltip.textContent).toBe('');
 
       // Once the chart receives focus, the tooltip should display
-      act(() => container.querySelector('svg')?.focus());
+      act(() => container.querySelector('svg').focus());
       expect(tooltip).toHaveTextContent('uv : 400');
 
       // Use keyboard to move around
@@ -134,7 +146,7 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
         </AreaChart>,
       );
 
-      const svg = container.querySelector('svg');
+      const svg = getMainSurface(container);
       assertNotNull(svg);
       const tooltip = getTooltip(container);
 
@@ -204,7 +216,7 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
         </AreaChart>,
       );
 
-      const svg = container.querySelector('svg');
+      const svg = getMainSurface(container);
       assertNotNull(svg);
       const tooltip = getTooltip(container);
 
@@ -292,7 +304,7 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
 
         const pre = container.querySelector('pre');
         assertNotNull(pre);
-        const svg = container.querySelector('svg');
+        const svg = getMainSurface(container);
         assertNotNull(svg);
 
         expect(pre.textContent).toBe('6');
@@ -385,7 +397,7 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
 
       expect(container.querySelectorAll('button')).toHaveLength(1);
 
-      const svg = container.querySelector('svg');
+      const svg = getMainSurface(container);
       assertNotNull(svg);
       const tooltip = getTooltip(container);
 
@@ -437,7 +449,7 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
     test('When a tooltip is removed, the AccessibilityLayer does not throw', () => {
       const { container } = render(<BugExample />);
 
-      const svg = container.querySelector('svg');
+      const svg = getMainSurface(container);
       assertNotNull(svg);
       const tooltip = getTooltip(container);
 
@@ -486,7 +498,7 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
     test('AccessibilityLayer respects dynamic changes to the XAxis orientation', () => {
       const { container } = render(<DirectionSwitcher />);
 
-      const svg = container.querySelector('svg');
+      const svg = getMainSurface(container);
       assertNotNull(svg);
       const tooltip = getTooltip(container);
 
@@ -515,7 +527,7 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
         </PieChart>,
       );
 
-      const svg = container.querySelector('svg');
+      const svg = getMainSurface(container);
       assertChartA11yAttributes(svg);
     });
 
@@ -541,7 +553,7 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
         </FunnelChart>,
       );
 
-      const svg = container.querySelector('svg');
+      const svg = getMainSurface(container);
       assertChartA11yAttributes(svg);
     });
 
@@ -557,7 +569,7 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
       const tooltip = getTooltip(container);
       expect(tooltip).toHaveTextContent('');
 
-      act(() => container.querySelector('svg')?.focus());
+      act(() => getMainSurface(container).focus());
       expect(tooltip).toHaveTextContent('');
     });
 
@@ -578,7 +590,7 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
         </FunnelChart>,
       );
 
-      const svg = container.querySelector('svg');
+      const svg = getMainSurface(container);
       assertNotNull(svg);
       const tooltip = getTooltip(container);
 
@@ -641,7 +653,7 @@ describe('AccessibilityLayer with accessibilityLayer=false', () => {
         </AreaChart>,
       );
 
-      const svg = container.querySelector('svg');
+      const svg = getMainSurface(container);
       assertNoA11yAttributes(svg);
     });
 
@@ -668,7 +680,7 @@ describe('AccessibilityLayer with accessibilityLayer=false', () => {
         </FunnelChart>,
       );
 
-      const svg = container.querySelector('svg');
+      const svg = getMainSurface(container);
       assertNoA11yAttributes(svg);
     });
 
@@ -693,7 +705,7 @@ describe('AccessibilityLayer with accessibilityLayer=false', () => {
         </PieChart>,
       );
 
-      const svg = container.querySelector('svg');
+      const svg = getMainSurface(container);
       assertNoA11yAttributes(svg);
     });
 
@@ -728,7 +740,7 @@ describe('AreaChart horizontal', () => {
     const { container } = renderTestCase();
 
     expectTooltipNotVisible(container);
-    const svg = container.querySelector('svg');
+    const svg = getMainSurface(container);
     assertNotNull(svg);
 
     act(() => svg.focus());
@@ -739,7 +751,7 @@ describe('AreaChart horizontal', () => {
     const { container } = renderTestCase();
 
     expectTooltipNotVisible(container);
-    const svg = container.querySelector('svg');
+    const svg = getMainSurface(container);
     assertNotNull(svg);
 
     act(() => svg.focus());
@@ -753,7 +765,7 @@ describe('AreaChart horizontal', () => {
     const { container } = renderTestCase();
 
     expectTooltipNotVisible(container);
-    const svg = container.querySelector('svg');
+    const svg = getMainSurface(container);
     assertNotNull(svg);
 
     act(() => svg.focus());
@@ -767,7 +779,7 @@ describe('AreaChart horizontal', () => {
     const { container } = renderTestCase();
 
     expectTooltipNotVisible(container);
-    const svg = container.querySelector('svg');
+    const svg = getMainSurface(container);
     assertNotNull(svg);
 
     act(() => svg.focus());
@@ -811,7 +823,7 @@ describe('AreaChart vertical', () => {
     expectTooltipNotVisible(container);
 
     // Once the chart receives focus, the tooltip should display
-    act(() => container.querySelector('svg')?.focus());
+    act(() => getMainSurface(container).focus());
 
     expectTooltipPayload(container, 'Page A', ['uv : 400']);
   });

--- a/test/chart/AreaChart.spec.tsx
+++ b/test/chart/AreaChart.spec.tsx
@@ -533,7 +533,7 @@ describe('AreaChart', () => {
         </AreaChart>,
       );
 
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenLastCalledWith({ x: 5, y: 5, width: 90, height: 40 });
     });
 
@@ -565,7 +565,7 @@ describe('AreaChart', () => {
         </AreaChart>,
       );
 
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(100);
     });
 
@@ -581,7 +581,7 @@ describe('AreaChart', () => {
         </AreaChart>,
       );
 
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(50);
     });
   });

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -3240,7 +3240,7 @@ describe('<BarChart />', () => {
       );
 
       expect(spy).toHaveBeenCalledWith({ x: 5, y: 5, width: 90, height: 40 });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide clipPathId', () => {
@@ -3271,7 +3271,7 @@ describe('<BarChart />', () => {
         </BarChart>,
       );
 
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(100);
     });
 
@@ -3287,7 +3287,7 @@ describe('<BarChart />', () => {
         </BarChart>,
       );
 
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(50);
     });
   });
@@ -3404,7 +3404,7 @@ describe('<BarChart />', () => {
         right: 2,
         top: 1,
       });
-      expect(marginSpy).toHaveBeenCalledTimes(2);
+      expect(marginSpy).toHaveBeenCalledTimes(1);
 
       rerender(
         <BarChart width={100} height={100} margin={{ top: 10, right: 20, bottom: 30, left: 40 }}>
@@ -3417,7 +3417,7 @@ describe('<BarChart />', () => {
         right: 20,
         top: 10,
       });
-      expect(marginSpy).toHaveBeenCalledTimes(4);
+      expect(marginSpy).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/test/chart/ComposedChart.spec.tsx
+++ b/test/chart/ComposedChart.spec.tsx
@@ -89,7 +89,7 @@ describe('<ComposedChart />', () => {
       );
 
       expect(spy).toHaveBeenCalledWith({ height: 40, width: 90, x: 5, y: 5 });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide clipPathId', () => {
@@ -121,7 +121,7 @@ describe('<ComposedChart />', () => {
       );
 
       expect(spy).toHaveBeenCalledWith(100);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide height', () => {
@@ -137,7 +137,7 @@ describe('<ComposedChart />', () => {
       );
 
       expect(spy).toHaveBeenCalledWith(50);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/test/chart/FunnelChart.spec.tsx
+++ b/test/chart/FunnelChart.spec.tsx
@@ -117,7 +117,7 @@ describe('<FunnelChart />', () => {
       );
 
       expect(spy).toHaveBeenCalledWith({ height: 40, width: 90, x: 5, y: 5 });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide clipPathId', () => {
@@ -149,7 +149,7 @@ describe('<FunnelChart />', () => {
       );
 
       expect(spy).toHaveBeenCalledWith(100);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide height', () => {
@@ -165,7 +165,7 @@ describe('<FunnelChart />', () => {
       );
 
       expect(spy).toHaveBeenCalledWith(50);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -902,7 +902,7 @@ describe('<LineChart />', () => {
       );
 
       expect(spy).toHaveBeenCalledWith({ height: 40, width: 90, x: 5, y: 5 });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide clipPathId', () => {
@@ -936,7 +936,7 @@ describe('<LineChart />', () => {
       );
 
       expect(spy).toHaveBeenCalledWith(100);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide height', () => {
@@ -953,7 +953,7 @@ describe('<LineChart />', () => {
       );
 
       expect(spy).toHaveBeenCalledWith(50);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });
@@ -1448,7 +1448,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(6);
+    expect(axisSpy).toHaveBeenCalledTimes(4);
 
     fireEvent.mouseEnter(container, { clientX: 30, clientY: 200, bubbles: true, cancelable: true });
 
@@ -1457,7 +1457,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     fireEvent.mouseLeave(container);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(6);
+    expect(axisSpy).toHaveBeenCalledTimes(4);
   });
 
   // protect against the future where someone might mess up our clean rendering
@@ -1465,7 +1465,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(6);
+    expect(axisSpy).toHaveBeenCalledTimes(4);
 
     const leftCursor = container.querySelector('.recharts-brush-traveller');
     assertNotNull(leftCursor);
@@ -1474,7 +1474,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     fireEvent.mouseUp(window);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(6);
+    expect(axisSpy).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/test/chart/PieChart.spec.tsx
+++ b/test/chart/PieChart.spec.tsx
@@ -337,7 +337,7 @@ describe('<PieChart />', () => {
       );
 
       expect(spy).toBeCalledWith({ height: 40, width: 90, x: 5, y: 5 });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide clipPathId', () => {
@@ -371,7 +371,7 @@ describe('<PieChart />', () => {
       );
 
       expect(spy).toBeCalledWith(100);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide chart height', () => {
@@ -388,7 +388,7 @@ describe('<PieChart />', () => {
       );
 
       expect(spy).toBeCalledWith(100);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/test/chart/RadarChart.spec.tsx
+++ b/test/chart/RadarChart.spec.tsx
@@ -550,7 +550,7 @@ describe('<RadarChart />', () => {
       );
 
       expect(spy).toHaveBeenLastCalledWith({ height: 40, width: 90, x: 5, y: 5 });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide clipPathId', () => {
@@ -567,7 +567,7 @@ describe('<RadarChart />', () => {
       );
 
       expect(spy).toHaveBeenLastCalledWith({ height: 40, width: 90, x: 5, y: 5 });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide chart width', () => {
@@ -584,7 +584,7 @@ describe('<RadarChart />', () => {
       );
 
       expect(spy).toHaveBeenLastCalledWith(100);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide chart height', () => {
@@ -601,7 +601,7 @@ describe('<RadarChart />', () => {
       );
 
       expect(spy).toHaveBeenLastCalledWith(50);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/test/chart/RadialBarChart.spec.tsx
+++ b/test/chart/RadialBarChart.spec.tsx
@@ -207,7 +207,7 @@ describe('<RadialBarChart />', () => {
       </RadialBarChart>,
     );
     expect(barSizeSpy).toHaveBeenLastCalledWith(20);
-    expect(barSizeSpy).toHaveBeenCalledTimes(3);
+    expect(barSizeSpy).toHaveBeenCalledTimes(1);
 
     expectRadialBars(container, [
       {
@@ -249,7 +249,7 @@ describe('<RadialBarChart />', () => {
       </RadialBarChart>,
     );
     expect(barSizeSpy).toHaveBeenLastCalledWith(3);
-    expect(barSizeSpy).toHaveBeenCalledTimes(6);
+    expect(barSizeSpy).toHaveBeenCalledTimes(4);
 
     expectRadialBars(container, [
       {
@@ -612,7 +612,7 @@ describe('<RadialBarChart />', () => {
       );
 
       expect(spy).toHaveBeenLastCalledWith({ height: 40, width: 90, x: 5, y: 5 });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide clipPathId', () => {
@@ -646,7 +646,7 @@ describe('<RadialBarChart />', () => {
       );
 
       expect(spy).toHaveBeenLastCalledWith(100);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide height', () => {
@@ -663,7 +663,7 @@ describe('<RadialBarChart />', () => {
       );
 
       expect(spy).toHaveBeenLastCalledWith(50);
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     test('renders background in the exact same position as foreground', () => {

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -226,7 +226,7 @@ describe('ScatterChart of three dimension data', () => {
     expect(container.querySelectorAll('.recharts-symbol')).toHaveLength(0);
   });
 
-  test('mouse enter on one circle will trigger one Cross', () => {
+  test('mouse enter on scatter symbol should call onMouseEnter from props', () => {
     const onMouseEnter = vi.fn();
     const { container } = render(
       <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
@@ -241,7 +241,7 @@ describe('ScatterChart of three dimension data', () => {
       </ScatterChart>,
     );
 
-    const symbol = container.querySelectorAll('.recharts-symbols')[0];
+    const symbol = container.querySelectorAll('.recharts-scatter-symbol .recharts-symbols')[0];
     fireEvent.mouseEnter(symbol);
 
     expect(onMouseEnter).toHaveBeenCalled();
@@ -1289,7 +1289,7 @@ describe('ScatterChart of two dimension data', () => {
         </ScatterChart>,
       );
 
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenLastCalledWith({ x: 5, y: 5, width: 90, height: 40 });
     });
 
@@ -1321,7 +1321,7 @@ describe('ScatterChart of two dimension data', () => {
         </ScatterChart>,
       );
 
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(100);
     });
 
@@ -1337,7 +1337,7 @@ describe('ScatterChart of two dimension data', () => {
         </ScatterChart>,
       );
 
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(50);
     });
   });

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -1039,7 +1039,7 @@ describe('<Legend />', () => {
       expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(1);
 
       expect(yAxisRangeSpy).toHaveBeenLastCalledWith([485, 5]);
-      expect(yAxisRangeSpy).toHaveBeenCalledTimes(4);
+      expect(yAxisRangeSpy).toHaveBeenCalledTimes(3);
 
       expectBars(container, [
         {
@@ -1102,7 +1102,7 @@ describe('<Legend />', () => {
       expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(0);
 
       expect(yAxisRangeSpy).toHaveBeenLastCalledWith([495, 5]);
-      expect(yAxisRangeSpy).toHaveBeenCalledTimes(6);
+      expect(yAxisRangeSpy).toHaveBeenCalledTimes(5);
 
       expectBars(container, [
         {
@@ -1633,7 +1633,7 @@ describe('<Legend />', () => {
             spy(offset);
           },
         )();
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
         expect(spy).toHaveBeenLastCalledWith({
           brushBottom: 5,
           top: 5,
@@ -1662,7 +1662,7 @@ describe('<Legend />', () => {
             spy(offset);
           },
         )();
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
         expect(spy).toHaveBeenLastCalledWith({
           brushBottom: 5,
           top: 5,
@@ -1691,7 +1691,7 @@ describe('<Legend />', () => {
             spy(offset);
           },
         )();
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
         expect(spy).toHaveBeenLastCalledWith({
           brushBottom: 5,
           top: 5,
@@ -1720,7 +1720,7 @@ describe('<Legend />', () => {
             spy(offset);
           },
         )();
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
         expect(spy).toHaveBeenLastCalledWith({
           brushBottom: 5,
           top: 5,

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -1623,7 +1623,7 @@ describe('Tooltip payload', () => {
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
 
       showTooltipOnCoordinate(
         container,
@@ -1635,7 +1635,7 @@ describe('Tooltip payload', () => {
         activeIndex: '4',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(4);
     });
   });
 

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -934,7 +934,7 @@ describe('Tooltip visibility', () => {
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(3);
 
       showTooltipOnCoordinate(
         container,
@@ -946,7 +946,7 @@ describe('Tooltip visibility', () => {
         activeIndex: '4',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(4);
     });
   });
 

--- a/test/container/chartDimensions.spec.tsx
+++ b/test/container/chartDimensions.spec.tsx
@@ -6,15 +6,28 @@ import { useOffset } from '../../src/context/chartLayoutContext';
 import { selectBrushDimensions } from '../../src/state/selectors/brushSelectors';
 import { useClipPathId } from '../../src/container/ClipPathProvider';
 import { useIsPanorama } from '../../src/context/PanoramaContext';
+import { useAccessibilityLayer } from '../../src/context/accessibilityContext';
 
 describe('Chart dimensions', () => {
   describe('simple chart', () => {
     const renderTestCase = createSelectorTestCase(({ children }) => (
-      <LineChart width={100} height={200} data={PageData} margin={{ top: 11, right: 12, bottom: 13, left: 14 }}>
+      <LineChart
+        width={100}
+        height={200}
+        data={PageData}
+        margin={{ top: 11, right: 12, bottom: 13, left: 14 }}
+        title="Line Chart"
+        desc="This is a line chart"
+      >
         <Line dataKey="uv" />
         {children}
       </LineChart>
     ));
+
+    it('should select accessibility layer', () => {
+      const { spy } = renderTestCase(useAccessibilityLayer);
+      expect(spy).toHaveBeenCalledWith(true);
+    });
 
     it('should return chart width', () => {
       const { spy } = renderTestCase(useChartWidth);
@@ -69,7 +82,7 @@ describe('Chart dimensions', () => {
         x: 0,
         y: 0,
       });
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should render one root Surface', () => {
@@ -86,6 +99,17 @@ describe('Chart dimensions', () => {
       expect(surface).toHaveAttribute('role', 'application');
     });
 
+    it('should render title and desc', () => {
+      const { container } = renderTestCase();
+      const title = container.querySelector('title');
+      expect(title).toBeInTheDocument();
+      expect(title).toHaveTextContent('Line Chart');
+
+      const desc = container.querySelector('desc');
+      expect(desc).toBeInTheDocument();
+      expect(desc).toHaveTextContent('This is a line chart');
+    });
+
     it('should always say that the chart is not panorama', () => {
       const { spy } = renderTestCase(useIsPanorama);
       expect(spy).toHaveBeenCalledWith(false);
@@ -96,7 +120,14 @@ describe('Chart dimensions', () => {
   describe('chart with brush and panorama', () => {
     describe('dimensions in the main chart', () => {
       const renderTestCase = createSelectorTestCase(({ children }) => (
-        <LineChart width={100} height={200} data={PageData} margin={{ top: 11, right: 12, bottom: 13, left: 14 }}>
+        <LineChart
+          width={100}
+          height={200}
+          data={PageData}
+          margin={{ top: 11, right: 12, bottom: 13, left: 14 }}
+          title="Line Chart"
+          desc="This is a line chart"
+        >
           <Line dataKey="uv" />
           <Brush>
             <LineChart data={PageData}>
@@ -106,6 +137,22 @@ describe('Chart dimensions', () => {
           {children}
         </LineChart>
       ));
+
+      it('should select accessibility layer', () => {
+        const { spy } = renderTestCase(useAccessibilityLayer);
+        expect(spy).toHaveBeenCalledWith(true);
+      });
+
+      it('should render title and desc', () => {
+        const { container } = renderTestCase();
+        const title = container.querySelector('title');
+        expect(title).toBeInTheDocument();
+        expect(title).toHaveTextContent('Line Chart');
+
+        const desc = container.querySelector('desc');
+        expect(desc).toBeInTheDocument();
+        expect(desc).toHaveTextContent('This is a line chart');
+      });
 
       it('should return chart width', () => {
         const { spy } = renderTestCase(useChartWidth);
@@ -220,6 +267,11 @@ describe('Chart dimensions', () => {
           </Brush>
         </LineChart>
       ));
+
+      it('should select accessibility layer', () => {
+        const { spy } = renderTestCase(useAccessibilityLayer);
+        expect(spy).toHaveBeenCalledWith(true);
+      });
 
       it('should return chart width from the main chart', () => {
         const { spy } = renderTestCase(useChartWidth);

--- a/test/context/chartLayoutContext.spec.tsx
+++ b/test/context/chartLayoutContext.spec.tsx
@@ -57,7 +57,7 @@ describe('useOffset', () => {
       </ComposedChart>,
     );
 
-    expect(offsetSpy).toHaveBeenCalledTimes(2);
+    expect(offsetSpy).toHaveBeenCalledTimes(1);
     expect(offsetSpy).toHaveBeenLastCalledWith({
       top: 5,
       right: 5,
@@ -82,7 +82,7 @@ describe('useOffset', () => {
       </ComposedChart>,
     );
 
-    expect(offsetSpy).toHaveBeenCalledTimes(2);
+    expect(offsetSpy).toHaveBeenCalledTimes(1);
     expect(offsetSpy).toHaveBeenLastCalledWith({
       top: 10,
       right: 20,

--- a/test/polar/PolarAngleAxis.spec.tsx
+++ b/test/polar/PolarAngleAxis.spec.tsx
@@ -135,7 +135,7 @@ describe('<PolarAngleAxis />', () => {
           type: 'category',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select polar items', () => {
@@ -152,19 +152,19 @@ describe('<PolarAngleAxis />', () => {
             radiusAxisId: 0,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([420, 460, 999, 500, 864, 650, 765, 365]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([90, -270]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select real scale type', () => {
@@ -176,7 +176,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select scale', () => {
         const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
         expectLastCalledWithScale(spy, { domain: [420, 460, 999, 500, 864, 650, 765, 365], range: [90, -270] });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select ticks', () => {
@@ -231,7 +231,7 @@ describe('<PolarAngleAxis />', () => {
             value: 365,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select nice ticks', () => {
@@ -252,7 +252,7 @@ describe('<PolarAngleAxis />', () => {
           { value: 765 },
           { value: 365 },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should render axis ticks', () => {
@@ -384,7 +384,7 @@ describe('<PolarAngleAxis />', () => {
           type: 'category',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select polar items', () => {
@@ -401,19 +401,19 @@ describe('<PolarAngleAxis />', () => {
             radiusAxisId: 0,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([90, -270]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select real scale type', () => {
@@ -424,7 +424,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select scale', () => {
         const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
         expectLastCalledWithScale(spy, { domain: [0, 1, 2, 3, 4, 5, 6, 7], range: [90, -270] });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select applied data', () => {
@@ -439,7 +439,7 @@ describe('<PolarAngleAxis />', () => {
           { value: 765 },
           { value: 365 },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should render ticks', () => {
@@ -587,7 +587,7 @@ describe('<PolarAngleAxis />', () => {
             radiusAxisId: 0,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select applied values', () => {
@@ -607,13 +607,13 @@ describe('<PolarAngleAxis />', () => {
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([90, -270]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select real scale type', () => {
@@ -624,7 +624,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select scale', () => {
         const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
         expectLastCalledWithScale(spy, { domain: [0, 1, 2, 3, 4, 5, 6, 7], range: [90, -270] });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should not render ticks', () => {
@@ -673,7 +673,7 @@ describe('<PolarAngleAxis />', () => {
           type: 'number',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select polar items', () => {
@@ -690,31 +690,31 @@ describe('<PolarAngleAxis />', () => {
             radiusAxisId: 0,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 360]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([90, -270]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith('linear');
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select scale', () => {
         const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
         expectLastCalledWithScale(spy, { domain: [0, 360], range: [90, -270] });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select ticks', () => {
@@ -745,7 +745,7 @@ describe('<PolarAngleAxis />', () => {
             value: 270,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select nice ticks', () => {
@@ -757,7 +757,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select applied data', () => {
         const { spy } = renderTestCase(state => selectPolarAppliedValues(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([{ value: 0 }, { value: 90 }, { value: 180 }, { value: 270 }]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should render axis ticks', () => {
@@ -1081,7 +1081,7 @@ describe('<PolarAngleAxis />', () => {
         </RadarChart>,
       );
 
-      expect(tick).toHaveBeenCalledTimes(exampleRadarData.length);
+      expect(tick).toHaveBeenCalledTimes(2 * exampleRadarData.length);
       expect(tick).toHaveBeenNthCalledWith(1, {
         cx: 250,
         cy: 250,
@@ -1749,7 +1749,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 360]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -1760,7 +1760,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith('linear');
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select polarItemsSettings', () => {
@@ -1859,7 +1859,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 360]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -1871,7 +1871,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith('linear');
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select polarItemsSettings', () => {
@@ -2142,7 +2142,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([20, 220]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -2452,7 +2452,7 @@ describe('<PolarAngleAxis />', () => {
       );
 
       expect(realScaleTypeSpy).toHaveBeenLastCalledWith(expectedScale);
-      expect(realScaleTypeSpy).toHaveBeenCalledTimes(3);
+      expect(realScaleTypeSpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -2564,15 +2564,15 @@ describe('<PolarAngleAxis />', () => {
         unit: undefined,
       };
       expect(axisSettingsSpy).toHaveBeenLastCalledWith(expectedSettings);
-      expect(axisSettingsSpy).toHaveBeenCalledTimes(3);
+      expect(axisSettingsSpy).toHaveBeenCalledTimes(2);
 
       expect(angleAxisRangeSpy).toHaveBeenLastCalledWith([-270, 90]);
-      expect(angleAxisRangeSpy).toHaveBeenCalledTimes(3);
+      expect(angleAxisRangeSpy).toHaveBeenCalledTimes(2);
 
       expect(angleAxisDomainSpy).toHaveBeenLastCalledWith([420, 460, 999, 500, 864, 650, 765, 365]);
-      expect(angleAxisDomainSpy).toHaveBeenCalledTimes(3);
+      expect(angleAxisDomainSpy).toHaveBeenCalledTimes(2);
 
-      expect(angleAxisScaleSpy).toHaveBeenCalledTimes(3);
+      expect(angleAxisScaleSpy).toHaveBeenCalledTimes(2);
 
       expectLastCalledWithScale(angleAxisScaleSpy, { domain: [420, 365], range: [-270, 90] });
 
@@ -2638,10 +2638,10 @@ describe('<PolarAngleAxis />', () => {
           index: 9,
         },
       ]);
-      expect(angleAxisTicksSpy).toHaveBeenCalledTimes(3);
+      expect(angleAxisTicksSpy).toHaveBeenCalledTimes(2);
 
       expect(angleAxisNiceTicksSpy).toHaveBeenLastCalledWith(undefined);
-      expect(angleAxisNiceTicksSpy).toHaveBeenCalledTimes(3);
+      expect(angleAxisNiceTicksSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/test/polar/PolarRadiusAxis.spec.tsx
+++ b/test/polar/PolarRadiusAxis.spec.tsx
@@ -123,7 +123,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 196]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -349,13 +349,13 @@ describe('<PolarRadiusAxis />', () => {
           type: 'number',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 999]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
@@ -367,13 +367,13 @@ describe('<PolarRadiusAxis />', () => {
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 1000]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 196]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -382,7 +382,7 @@ describe('<PolarRadiusAxis />', () => {
           domain: [0, 1000],
           range: [0, 196],
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should render ticks', () => {
@@ -446,7 +446,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 999]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
@@ -458,13 +458,13 @@ describe('<PolarRadiusAxis />', () => {
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 1000]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 196]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -473,7 +473,7 @@ describe('<PolarRadiusAxis />', () => {
           domain: [0, 1000],
           range: [0, 196],
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should not render ticks', () => {
@@ -730,7 +730,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select angle settings', () => {
         const { spy } = renderTestCase(state => selectRadiusAxis(state, 0));
         expect(spy).toHaveBeenLastCalledWith(implicitRadialBarRadiusAxis);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain', () => {
@@ -742,7 +742,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith('band');
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain with nice ticks', () => {
@@ -754,7 +754,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 196]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -819,7 +819,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith('band');
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain with nice ticks', () => {
@@ -831,7 +831,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 196]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -933,7 +933,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith('band');
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain with nice ticks', () => {
@@ -945,7 +945,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 196]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -1020,7 +1020,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
         expect(spy).toHaveBeenLastCalledWith('band');
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain with nice ticks', () => {
@@ -1032,7 +1032,7 @@ describe('<PolarRadiusAxis />', () => {
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
         expect(spy).toHaveBeenLastCalledWith([0, 196]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select scale', () => {
@@ -1182,13 +1182,13 @@ describe('<PolarRadiusAxis />', () => {
         unit: undefined,
       };
       expect(radiusAxisSpy).toHaveBeenLastCalledWith(expectedAxis);
-      expect(radiusAxisSpy).toHaveBeenCalledTimes(3);
+      expect(radiusAxisSpy).toHaveBeenCalledTimes(2);
 
       expect(radiusAxisRangeSpy).toHaveBeenLastCalledWith([76, 0]);
-      expect(radiusAxisRangeSpy).toHaveBeenCalledTimes(3);
+      expect(radiusAxisRangeSpy).toHaveBeenCalledTimes(2);
 
       expect(radiusAxisDomainSpy).toHaveBeenLastCalledWith([420, 460, 999, 500, 864, 650, 765, 365]);
-      expect(radiusAxisDomainSpy).toHaveBeenCalledTimes(3);
+      expect(radiusAxisDomainSpy).toHaveBeenCalledTimes(2);
     });
 
     it('should select numerical radius axis domain', () => {
@@ -1210,10 +1210,10 @@ describe('<PolarRadiusAxis />', () => {
       );
 
       expect(radiusAxisDomainSpy).toHaveBeenLastCalledWith([0, 999]);
-      expect(radiusAxisDomainSpy).toHaveBeenCalledTimes(3);
+      expect(radiusAxisDomainSpy).toHaveBeenCalledTimes(2);
 
       expect(realScaleTypeSpy).toHaveBeenLastCalledWith('linear');
-      expect(realScaleTypeSpy).toHaveBeenCalledTimes(3);
+      expect(realScaleTypeSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/test/polar/Radar.spec.tsx
+++ b/test/polar/Radar.spec.tsx
@@ -157,7 +157,7 @@ describe('<Radar />', () => {
         radiusAxisId: 0,
       };
       expect(polarItemsSpy).toHaveBeenLastCalledWith([expectedPolarItemsSettings]);
-      expect(polarItemsSpy).toHaveBeenCalledTimes(3);
+      expect(polarItemsSpy).toHaveBeenCalledTimes(2);
 
       rerender(
         <RadarChart width={100} height={100} data={exampleRadarData}>
@@ -166,7 +166,7 @@ describe('<Radar />', () => {
       );
 
       expect(polarItemsSpy).toHaveBeenLastCalledWith([]);
-      expect(polarItemsSpy).toHaveBeenCalledTimes(5);
+      expect(polarItemsSpy).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/test/state/redux-nesting.spec.tsx
+++ b/test/state/redux-nesting.spec.tsx
@@ -59,7 +59,7 @@ describe('when a Recharts chart is used in another Redux app as a neighbour', ()
   it('should allow selecting data from recharts store', () => {
     const spy = vi.fn();
     render(<App spy={spy} />);
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenLastCalledWith(100);
   });
 
@@ -108,7 +108,7 @@ describe('when a Recharts chart is used in another Redux app as a parent', () =>
   it('should allow selecting data from recharts store', () => {
     const spy = vi.fn();
     render(<App spy={spy} />);
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenLastCalledWith(100);
   });
 

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -613,7 +613,6 @@ describe('selectAxisDomain', () => {
       expectXAxisTicks(container, []);
     });
 
-    // this test fails because the generateCategoricalChart code path throws
     it('should not throw an error when the data includes a Symbol', () => {
       const data = [{ x: Symbol.for('unit test') }];
       const spy = vi.fn();
@@ -630,7 +629,7 @@ describe('selectAxisDomain', () => {
         </BarChart>,
       );
       expect(spy).toHaveBeenLastCalledWith(undefined);
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
     });
 
     it('should parse strings, and ignore values that are not numbers', () => {
@@ -2244,7 +2243,7 @@ describe('selectDisplayedData', () => {
         z: 1184,
       },
     ]);
-    expect(displayedDataSpy).toHaveBeenCalledTimes(2);
+    expect(displayedDataSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should slice chart root data by dataStartIndex and dataEndIndex', () => {
@@ -2451,7 +2450,7 @@ describe('selectAllAppliedValues', () => {
         },
       },
     ]);
-    expect(displayedDataSpy).toHaveBeenCalledTimes(2);
+    expect(displayedDataSpy).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -3236,8 +3235,6 @@ describe('selectAxisWithScale', () => {
     const { container } = render(<TestCase />);
 
     expect(xAxisSpy).toHaveBeenCalledTimes(2);
-    // first call is with undefined, the chart is still parsing, fine
-    expect(xAxisSpy).toHaveBeenNthCalledWith(1, undefined);
     const expectedXAxis: XAxisSettings & BaseAxisWithScale = {
       allowDataOverflow: false,
       allowDecimals: true,
@@ -3314,7 +3311,6 @@ describe('selectAxisWithScale', () => {
     expect(xAxisSpy).toHaveBeenCalledTimes(4);
     expect(xAxisSpy).toHaveBeenNthCalledWith(3, expectedXAxis);
     expect(xAxisSpy).toHaveBeenNthCalledWith(4, expectedXAxis);
-    expect(xAxisSpy.mock.calls[0][0]).toBe(undefined);
     expect(xAxisSpy.mock.calls[1][0]).toBe(xAxisSpy.mock.calls[2][0]);
 
     /*

--- a/test/state/selectors/containerSelectors.spec.tsx
+++ b/test/state/selectors/containerSelectors.spec.tsx
@@ -113,7 +113,7 @@ describe('selectMargin', () => {
       bottom: 10,
       left: 10,
     });
-    expect(marginSpy).toHaveBeenCalledTimes(2);
+    expect(marginSpy).toHaveBeenCalledTimes(1);
 
     rerender(
       <BarChart margin={{ top: 20, right: 20, bottom: 20, left: 20 }} width={500} height={300}>
@@ -126,7 +126,7 @@ describe('selectMargin', () => {
       bottom: 20,
       left: 20,
     });
-    expect(marginSpy).toHaveBeenCalledTimes(4);
+    expect(marginSpy).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -152,7 +152,7 @@ describe('selectChartWidth', () => {
       </BarChart>,
     );
     expect(widthSpy).toHaveBeenLastCalledWith(500);
-    expect(widthSpy).toHaveBeenCalledTimes(2);
+    expect(widthSpy).toHaveBeenCalledTimes(1);
 
     rerender(
       <BarChart width={600} height={400}>
@@ -160,7 +160,7 @@ describe('selectChartWidth', () => {
       </BarChart>,
     );
     expect(widthSpy).toHaveBeenLastCalledWith(600);
-    expect(widthSpy).toHaveBeenCalledTimes(4);
+    expect(widthSpy).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -186,7 +186,7 @@ describe('selectChartHeight', () => {
       </BarChart>,
     );
     expect(heightSpy).toHaveBeenLastCalledWith(300);
-    expect(heightSpy).toHaveBeenCalledTimes(2);
+    expect(heightSpy).toHaveBeenCalledTimes(1);
 
     rerender(
       <BarChart width={600} height={400}>
@@ -194,6 +194,6 @@ describe('selectChartHeight', () => {
       </BarChart>,
     );
     expect(heightSpy).toHaveBeenLastCalledWith(400);
-    expect(heightSpy).toHaveBeenCalledTimes(4);
+    expect(heightSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/test/state/selectors/dataSelectors.spec.tsx
+++ b/test/state/selectors/dataSelectors.spec.tsx
@@ -62,9 +62,9 @@ describe('selectChartDataWithIndexes', () => {
       </ComposedChart>,
     );
     const expected: ChartDataState = {
-      chartData: undefined,
-      dataEndIndex: 0,
+      chartData: PageData,
       dataStartIndex: 0,
+      dataEndIndex: 5,
       computedData: undefined,
     };
     expect(spy).toHaveBeenCalledWith(expected);

--- a/test/state/selectors/radarSelectors.spec.tsx
+++ b/test/state/selectors/radarSelectors.spec.tsx
@@ -163,7 +163,7 @@ describe('selectRadarPoints', () => {
         },
       ],
     });
-    expect(radarPointsSpy).toHaveBeenCalledTimes(3);
+    expect(radarPointsSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should return new data after interaction', () => {
@@ -330,11 +330,7 @@ describe('selectRadarPoints', () => {
 
     expect(spy).toHaveBeenNthCalledWith(1, undefined); // first render does not yet have the state done and parsed so it will provide undefined
     expect(spy).toHaveBeenNthCalledWith(2, expectedResultBefore); // second render has the right sectors
-    // third render is because Radar has dispatched new information after the first sectors it had received.
-    expect(spy).toHaveBeenNthCalledWith(3, expectedResultBefore);
-    // the sectors however did not change so they should be the same reference
-    expect(spy.mock.calls[1][0]).toBe(spy.mock.calls[2][0]);
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
 
     const button = container.querySelector('button');
     assertNotNull(button);
@@ -477,12 +473,10 @@ describe('selectRadarPoints', () => {
       ],
     };
 
-    // fourth render is when the Radar has dispatched new information and chart is in the middle of synchronization
-    expect(spy).toHaveBeenNthCalledWith(4, undefined);
-    // render five is stabilized, the points are now updated
-    expect(spy).toHaveBeenNthCalledWith(5, expectedResultAfter);
+    // render four is stabilized, the points are now updated
+    expect(spy).toHaveBeenNthCalledWith(4, expectedResultAfter);
 
-    expect(spy).toHaveBeenCalledTimes(5);
+    expect(spy).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/test/state/selectors/rootPropsSelectors.spec.tsx
+++ b/test/state/selectors/rootPropsSelectors.spec.tsx
@@ -49,7 +49,7 @@ describe('selectRootMaxBarSize', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith(10);
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
 
     rerender(
       <BarChart width={100} height={100} maxBarSize={20}>
@@ -59,7 +59,7 @@ describe('selectRootMaxBarSize', () => {
     );
 
     expect(spy).toHaveBeenLastCalledWith(20);
-    expect(spy).toHaveBeenCalledTimes(4);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -95,7 +95,7 @@ describe('selectBarGap', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith(10);
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
 
     rerender(
       <BarChart width={100} height={100} barGap={20}>
@@ -104,7 +104,7 @@ describe('selectBarGap', () => {
     );
 
     expect(spy).toHaveBeenLastCalledWith(20);
-    expect(spy).toHaveBeenCalledTimes(4);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -155,7 +155,7 @@ describe('selectBarCategoryGap', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith(10);
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
 
     rerender(
       <BarChart width={100} height={100} barCategoryGap={20}>
@@ -164,7 +164,7 @@ describe('selectBarCategoryGap', () => {
     );
 
     expect(spy).toHaveBeenLastCalledWith(20);
-    expect(spy).toHaveBeenCalledTimes(4);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -200,7 +200,7 @@ describe('selectRootBarSize', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith(10);
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
 
     rerender(
       <BarChart width={100} height={100} barSize={20}>
@@ -209,7 +209,7 @@ describe('selectRootBarSize', () => {
     );
 
     expect(spy).toHaveBeenLastCalledWith(20);
-    expect(spy).toHaveBeenCalledTimes(4);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -232,7 +232,7 @@ describe('selectSyncMethod', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenLastCalledWith('value');
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
 
     const fn = () => 1;
 
@@ -243,6 +243,6 @@ describe('selectSyncMethod', () => {
     );
 
     expect(spy).toHaveBeenLastCalledWith(fn);
-    expect(spy).toHaveBeenCalledTimes(4);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 });

--- a/test/state/selectors/selectChartOffset.spec.tsx
+++ b/test/state/selectors/selectChartOffset.spec.tsx
@@ -19,7 +19,7 @@ describe('selectChartOffset', () => {
   });
 
   it('should be stable', () => {
-    expect.assertions(4);
+    expect.assertions(2);
     const Comp = (): null => {
       const offset1 = useAppSelector(selectChartOffset);
       const offset2 = useAppSelector(selectChartOffset);


### PR DESCRIPTION
This one had many many test failures so it comes in its own PR. Notably: most selectors render less (except 1), and Legend now renders immediately where previously it was invisible on the first tick (which is good but it wreaks havoc in the tests that don't expect it).

## Related Issue

https://github.com/recharts/recharts/issues/5768

Still no visual diff https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=2317