### PR TITLE
LineChart no longer uses generateCategoricalChart

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -21,6 +21,7 @@
   "es6/chart",
   "es6/chart/AreaChart.js",
   "es6/chart/BarChart.js",
+  "es6/chart/CartesianChart.js",
   "es6/chart/ComposedChart.js",
   "es6/chart/FunnelChart.js",
   "es6/chart/LineChart.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -21,6 +21,7 @@
   "lib/chart",
   "lib/chart/AreaChart.js",
   "lib/chart/BarChart.js",
+  "lib/chart/CartesianChart.js",
   "lib/chart/ComposedChart.js",
   "lib/chart/FunnelChart.js",
   "lib/chart/LineChart.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -21,6 +21,7 @@
   "types/chart",
   "types/chart/AreaChart.d.ts",
   "types/chart/BarChart.d.ts",
+  "types/chart/CartesianChart.d.ts",
   "types/chart/ComposedChart.d.ts",
   "types/chart/FunnelChart.d.ts",
   "types/chart/LineChart.d.ts",

--- a/src/chart/CartesianChart.tsx
+++ b/src/chart/CartesianChart.tsx
@@ -1,0 +1,146 @@
+import { forwardRef } from 'react';
+import * as React from 'react';
+import { filterProps, validateWidthHeight } from '../util/ReactUtils';
+import { ChartOptions } from '../state/optionsSlice';
+import { PolarChartOptions } from '../state/polarOptionsSlice';
+import { RechartsStoreProvider } from '../state/RechartsStoreProvider';
+import { ChartDataContextProvider } from '../context/chartDataContext';
+import { ReportMainChartProps } from '../state/ReportMainChartProps';
+import { ReportChartProps } from '../state/ReportChartProps';
+import { ReportPolarOptions } from '../state/ReportPolarOptions';
+import { CategoricalChartProps } from './generateCategoricalChart';
+import { Margin, TooltipEventType } from '../util/types';
+import { TooltipPayloadSearcher } from '../state/tooltipSlice';
+import { RootSurface } from '../container/RootSurface';
+import { RechartsWrapper } from './RechartsWrapper';
+import { ClipPathProvider } from '../container/ClipPathProvider';
+
+const defaultMargin: Margin = { top: 5, right: 5, bottom: 5, left: 5 };
+
+const defaultProps: Partial<CategoricalChartProps> = {
+  accessibilityLayer: true,
+  layout: 'horizontal',
+  stackOffset: 'none',
+  barCategoryGap: '10%',
+  barGap: 4,
+  margin: defaultMargin,
+  reverseStackOrder: false,
+  syncMethod: 'index',
+};
+
+const CategoricalChart = forwardRef<SVGSVGElement, CategoricalChartProps>((props: CategoricalChartProps, ref) => {
+  const { children, className, width, height, style, compact, title, desc, ...others } = props;
+  const attrs = filterProps(others, false);
+
+  // The "compact" mode is used as the panorama within Brush
+  if (compact) {
+    return (
+      <RootSurface otherAttributes={attrs} title={title} desc={desc}>
+        {children}
+      </RootSurface>
+    );
+  }
+
+  return (
+    <RechartsWrapper
+      className={className}
+      style={style}
+      width={width}
+      height={height}
+      onClick={props.onClick}
+      onMouseLeave={props.onMouseLeave}
+      onMouseEnter={props.onMouseEnter}
+      onMouseMove={props.onMouseMove}
+      onMouseDown={props.onMouseDown}
+      onMouseUp={props.onMouseUp}
+      onContextMenu={props.onContextMenu}
+      onDoubleClick={props.onDoubleClick}
+      onTouchStart={props.onTouchStart}
+      onTouchMove={props.onTouchMove}
+      onTouchEnd={props.onTouchEnd}
+    >
+      <RootSurface otherAttributes={attrs} title={title} desc={desc} ref={ref}>
+        <ClipPathProvider>{children}</ClipPathProvider>
+      </RootSurface>
+    </RechartsWrapper>
+  );
+});
+
+export type CartesianChartProps = {
+  chartName: string;
+  defaultTooltipEventType: TooltipEventType;
+  validateTooltipEventTypes: ReadonlyArray<TooltipEventType>;
+  tooltipPayloadSearcher: TooltipPayloadSearcher;
+  categoricalChartProps: CategoricalChartProps;
+};
+
+export const CartesianChart = forwardRef<SVGSVGElement, CartesianChartProps>(function CartesianChart(
+  props: CartesianChartProps,
+  ref,
+) {
+  if (!validateWidthHeight({ width: props.categoricalChartProps.width, height: props.categoricalChartProps.height })) {
+    return null;
+  }
+
+  const {
+    chartName,
+    defaultTooltipEventType,
+    validateTooltipEventTypes,
+    tooltipPayloadSearcher,
+    categoricalChartProps,
+  } = props;
+
+  const options: ChartOptions = {
+    chartName,
+    defaultTooltipEventType,
+    validateTooltipEventTypes,
+    tooltipPayloadSearcher,
+    eventEmitter: undefined,
+  };
+  let polarOptions: PolarChartOptions;
+  const { innerRadius = defaultProps.innerRadius, outerRadius = defaultProps.outerRadius } = categoricalChartProps;
+  if (defaultProps.startAngle != null) {
+    polarOptions = {
+      cx: categoricalChartProps.cx,
+      cy: categoricalChartProps.cy,
+      startAngle: defaultProps.startAngle,
+      endAngle: defaultProps.endAngle,
+      innerRadius,
+      outerRadius,
+    };
+  }
+  return (
+    <RechartsStoreProvider
+      preloadedState={{ options, polarOptions }}
+      reduxStoreName={categoricalChartProps.id ?? chartName}
+    >
+      <ChartDataContextProvider chartData={categoricalChartProps.data} />
+      <ReportMainChartProps
+        width={categoricalChartProps.width}
+        height={categoricalChartProps.height}
+        layout={categoricalChartProps.layout ?? defaultProps.layout}
+        margin={categoricalChartProps.margin ?? defaultMargin}
+      />
+      <ReportChartProps
+        accessibilityLayer={categoricalChartProps.accessibilityLayer ?? true}
+        barCategoryGap={categoricalChartProps.barCategoryGap ?? '10%'}
+        maxBarSize={categoricalChartProps.maxBarSize}
+        stackOffset={categoricalChartProps.stackOffset ?? 'none'}
+        barGap={categoricalChartProps.barGap}
+        barSize={categoricalChartProps.barSize}
+        syncId={categoricalChartProps.syncId}
+        syncMethod={categoricalChartProps.syncMethod ?? 'index'}
+        className={categoricalChartProps.className}
+      />
+      <ReportPolarOptions
+        cx={categoricalChartProps.cx}
+        cy={categoricalChartProps.cy}
+        startAngle={categoricalChartProps.startAngle ?? defaultProps.startAngle}
+        endAngle={categoricalChartProps.endAngle ?? defaultProps.endAngle}
+        innerRadius={innerRadius}
+        outerRadius={outerRadius}
+      />
+      <CategoricalChart {...categoricalChartProps} ref={ref} />
+    </RechartsStoreProvider>
+  );
+});

--- a/src/chart/LineChart.tsx
+++ b/src/chart/LineChart.tsx
@@ -1,10 +1,18 @@
-/**
- * @fileOverview Line Chart
- */
-import { generateCategoricalChart } from './generateCategoricalChart';
+import * as React from 'react';
+import { forwardRef } from 'react';
 import { arrayTooltipSearcher } from '../state/optionsSlice';
+import { CartesianChart } from './CartesianChart';
+import { CategoricalChartProps } from './generateCategoricalChart';
 
-export const LineChart = generateCategoricalChart({
-  chartName: 'LineChart',
-  tooltipPayloadSearcher: arrayTooltipSearcher,
+export const LineChart = forwardRef<SVGSVGElement, CategoricalChartProps>((props: CategoricalChartProps, ref) => {
+  return (
+    <CartesianChart
+      chartName="LineChart"
+      defaultTooltipEventType="axis"
+      validateTooltipEventTypes={['axis']}
+      tooltipPayloadSearcher={arrayTooltipSearcher}
+      categoricalChartProps={props}
+      ref={ref}
+    />
+  );
 });

--- a/src/chart/LineChart.tsx
+++ b/src/chart/LineChart.tsx
@@ -3,13 +3,16 @@ import { forwardRef } from 'react';
 import { arrayTooltipSearcher } from '../state/optionsSlice';
 import { CartesianChart } from './CartesianChart';
 import { CategoricalChartProps } from './generateCategoricalChart';
+import { TooltipEventType } from '../util/types';
+
+const allowedTooltipTypes: ReadonlyArray<TooltipEventType> = ['axis'];
 
 export const LineChart = forwardRef<SVGSVGElement, CategoricalChartProps>((props: CategoricalChartProps, ref) => {
   return (
     <CartesianChart
       chartName="LineChart"
       defaultTooltipEventType="axis"
-      validateTooltipEventTypes={['axis']}
+      validateTooltipEventTypes={allowedTooltipTypes}
       tooltipPayloadSearcher={arrayTooltipSearcher}
       categoricalChartProps={props}
       ref={ref}

--- a/src/container/RootSurface.tsx
+++ b/src/container/RootSurface.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 import { useChartHeight, useChartWidth } from '../context/chartLayoutContext';
 import { useAccessibilityLayer } from '../context/accessibilityContext';
 import { validateWidthHeight } from '../util/ReactUtils';
@@ -17,7 +17,7 @@ type RootSurfaceProps = {
 
 const FULL_WIDTH_AND_HEIGHT = { width: '100%', height: '100%' };
 
-const MainChartSurface = (props: RootSurfaceProps) => {
+const MainChartSurface = forwardRef<SVGSVGElement, RootSurfaceProps>((props: RootSurfaceProps, ref) => {
   const width = useChartWidth();
   const height = useChartHeight();
   const hasAccessibilityLayer = useAccessibilityLayer();
@@ -51,11 +51,12 @@ const MainChartSurface = (props: RootSurfaceProps) => {
       width={width}
       height={height}
       style={FULL_WIDTH_AND_HEIGHT}
+      ref={ref}
     >
       {children}
     </Surface>
   );
-};
+});
 
 const BrushPanoramaSurface = ({ children }: { children: ReactNode }) => {
   const brushDimensions = useAppSelector(selectBrushDimensions);
@@ -73,11 +74,17 @@ const BrushPanoramaSurface = ({ children }: { children: ReactNode }) => {
   );
 };
 
-export const RootSurface = ({ children, ...rest }: RootSurfaceProps) => {
-  const isPanorama = useIsPanorama();
+export const RootSurface = forwardRef<SVGSVGElement, RootSurfaceProps>(
+  ({ children, ...rest }: RootSurfaceProps, ref) => {
+    const isPanorama = useIsPanorama();
 
-  if (isPanorama) {
-    return <BrushPanoramaSurface>{children}</BrushPanoramaSurface>;
-  }
-  return <MainChartSurface {...rest}>{children}</MainChartSurface>;
-};
+    if (isPanorama) {
+      return <BrushPanoramaSurface>{children}</BrushPanoramaSurface>;
+    }
+    return (
+      <MainChartSurface ref={ref} {...rest}>
+        {children}
+      </MainChartSurface>
+    );
+  },
+);

--- a/src/container/Surface.tsx
+++ b/src/container/Surface.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Surface
  */
 import * as React from 'react';
-import { ReactNode, CSSProperties, SVGProps } from 'react';
+import { ReactNode, CSSProperties, SVGProps, forwardRef } from 'react';
 import { clsx } from 'clsx';
 import { filterProps } from '../util/ReactUtils';
 
@@ -24,7 +24,7 @@ interface SurfaceProps {
 
 export type Props = Omit<SVGProps<SVGSVGElement>, 'viewBox'> & SurfaceProps;
 
-export function Surface(props: Props) {
+export const Surface = forwardRef<SVGSVGElement, Props>((props: Props, ref) => {
   const { children, width, height, viewBox, className, style, title, desc, ...others } = props;
   const svgView = viewBox || { width, height, x: 0, y: 0 };
   const layerClass = clsx('recharts-surface', className);
@@ -37,10 +37,11 @@ export function Surface(props: Props) {
       height={height}
       style={style}
       viewBox={`${svgView.x} ${svgView.y} ${svgView.width} ${svgView.height}`}
+      ref={ref}
     >
       <title>{title}</title>
       <desc>{desc}</desc>
       {children}
     </svg>
   );
-}
+});

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -857,11 +857,13 @@ describe('<LineChart />', () => {
   });
 
   describe('LineChart - test ref access', () => {
-    test('should allow access to the CategoricalChartWrapper through the ref prop forwarded from CategoricalChart', () => {
-      // TODO we need to fix the ref typing in generateCategoricalChart, this class is created dynamically and cannot be typed
-      // @ts-expect-error TODO remove in followup PR
-      // eslint-disable-next-line no-undef
-      let refNode: CategoricalChartWrapper | null = null;
+    test('should allow access to the main SVG through the ref prop forwarded from CategoricalChart', () => {
+      /*
+       * This is a breaking change from v2.0.0, where the ref was not forwarded
+       * and used to refer to the CategoricalChartWrapper component instead.
+       * In 3.0 we no longer use CategoricalChartWrapper, and the ref now refers to the main SVG element.
+       */
+      let refNode: SVGSVGElement | null = null;
 
       const MyComponent = () => {
         return (
@@ -883,7 +885,9 @@ describe('<LineChart />', () => {
       render(<MyComponent />);
 
       expect(refNode).toBeDefined();
-      expect(refNode.props).toBeDefined();
+      expect(refNode).not.toBeNull();
+      expect(refNode.tagName).toBe('svg');
+      expect(refNode).toHaveAttribute('class', 'recharts-surface');
     });
   });
 


### PR DESCRIPTION
## Description

If we agree we want to go this direction, here is what I will do next (followup PR):
1. Introduce PolarChart (as a sibling to CartesianChart)
2. Move all charts to use either CartesianChart or PolarChart
3. Create a separate state type for polar charts
4. remove cartesian data from polar state, and remove polar data from cartesian state
5. strict null checks!

## Related Issue

https://github.com/recharts/recharts/issues/5768