### PR TITLE
Add width 'auto' support in storybook

### DIFF
--- a/storybook/stories/API/cartesian/YAxis.stories.tsx
+++ b/storybook/stories/API/cartesian/YAxis.stories.tsx
@@ -9,14 +9,25 @@ export default {
   argTypes: YAxisProps,
 };
 
+const getWidth = (width: string | number) => {
+  if (width === 'auto' || typeof width === 'number') {
+    return width;
+  }
+
+  const num = parseInt(width, 10);
+  return Number.isNaN(num) ? 120 : num;
+};
+
 export const API = {
   render: (args: Record<string, any>) => {
+    const width = getWidth(args.width);
+
     return (
       <ResponsiveContainer width="100%" height={500}>
         <LineChart width={600} height={300} data={coordinateWithValueData}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis />
-          <YAxis {...args} />
+          <YAxis {...args} width={width} />
           <Legend />
           <Line dataKey="y" />
           <Tooltip />
@@ -32,7 +43,7 @@ export const API = {
     allowDataOverflow: true,
     tickMargin: 20,
     angle: 45,
-    width: 120,
+    width: '120',
     label: { value: 'The Axis Label', position: 'center', angle: 90 },
   },
 };

--- a/storybook/stories/API/props/YAxisProps.ts
+++ b/storybook/stories/API/props/YAxisProps.ts
@@ -14,13 +14,16 @@ export const YAxisProps: StorybookArgs = {
     },
   },
   width: {
-    description: 'The width of axis element in pixels.',
+    description: 'The width of axis element in pixels. When set to "auto", the width will be calculated dynamically.',
     table: {
       type: {
-        summary: 'Number',
+        summary: 'Number | "auto"',
       },
       defaultValue: 60,
       category: 'Layout',
+    },
+    control: {
+      type: 'text',
     },
   },
   orientation: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding `width='auto'` support in storybook. Refer to this: #5880 

**Implementation summary:**
Changed control type to `text` for YAxis. Then inside `YAxis.stories.tsx`, wrote a function to convert entered text to number or 'auto' and passed it to YAxis.

<!--- Describe your changes in detail -->

## Related Issue
#5880 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
By entering different values in the input field for width.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
