### PR TITLE
feat: allow minPointSize function to receive null and undefined values (2.x)

### DIFF
--- a/src/util/BarUtils.tsx
+++ b/src/util/BarUtils.tsx
@@ -4,6 +4,7 @@ import { ActiveShape } from './types';
 import { Props as RectangleProps } from '../shape/Rectangle';
 import { BarProps } from '../cartesian/Bar';
 import { Shape } from './ActiveShapeUtils';
+import { isNullish, isNumber } from './DataUtils';
 
 // Rectangle props is expecting x, y, height, width as numbers, name as a string, and radius as a custom type
 // When props are being spread in from a user defined component in Bar,
@@ -50,7 +51,7 @@ export function BarRectangle(props: BarRectangleProps) {
   );
 }
 
-export type MinPointSize = number | ((value: number, index: number) => number);
+export type MinPointSize = number | ((value: number | undefined | null, index: number) => number);
 
 /**
  * Safely gets minPointSize from from the minPointSize prop if it is a function
@@ -62,14 +63,14 @@ export const minPointSizeCallback =
   (minPointSize: MinPointSize, defaultValue = 0) =>
   (value: unknown, index: number): number => {
     if (typeof minPointSize === 'number') return minPointSize;
-    const isValueNumber = typeof value === 'number';
-    if (isValueNumber) {
-      return minPointSize(value, index);
+    const isValueNumberOrNil = isNumber(value) || isNullish(value);
+    if (isValueNumberOrNil) {
+      return minPointSize(value as number | undefined | null, index);
     }
 
     invariant(
-      isValueNumber,
-      `minPointSize callback function received a value with type of ${typeof value}. Currently only numbers are supported.`,
+      isValueNumberOrNil,
+      `minPointSize callback function received a value with type of ${typeof value}. Currently only numbers or null/undefined are supported.`,
     );
     return defaultValue;
   };

--- a/src/util/DataUtils.ts
+++ b/src/util/DataUtils.ts
@@ -2,6 +2,7 @@ import isString from 'lodash/isString';
 import isNan from 'lodash/isNaN';
 import get from 'lodash/get';
 import lodashIsNumber from 'lodash/isNumber';
+import isNil from 'lodash/isNil';
 
 export const mathSign = (value: number) => {
   if (value === 0) {
@@ -18,6 +19,8 @@ export const isPercent = (value: string | number): value is `${number}%` =>
   isString(value) && value.indexOf('%') === value.length - 1;
 
 export const isNumber = (value: unknown): value is number => lodashIsNumber(value) && !isNan(value);
+
+export const isNullish = (value: unknown): value is null | undefined => isNil(value);
 
 export const isNumOrStr = (value: unknown): value is number | string => isNumber(value as number) || isString(value);
 

--- a/test/util/BarUtils.spec.tsx
+++ b/test/util/BarUtils.spec.tsx
@@ -15,6 +15,20 @@ describe('BarUtils', () => {
       expect(minPointSize).toEqual(10);
     });
 
+    test('should return a number if a function is passed that takes null and returns a number', () => {
+      const spy = vi.fn().mockReturnValue(10);
+      const minPointSize = minPointSizeCallback(spy)(null, 0);
+      expect(spy).toHaveBeenCalledWith(null, 0);
+      expect(minPointSize).toEqual(10);
+    });
+
+    test('should return a number if a function is passed that takes undefined and returns a number', () => {
+      const spy = vi.fn().mockReturnValue(10);
+      const minPointSize = minPointSizeCallback(spy)(undefined, 0);
+      expect(spy).toHaveBeenCalledWith(undefined, 0);
+      expect(minPointSize).toEqual(10);
+    });
+
     test('should throw an invariant when any other datatype is passed as value', () => {
       const spy = vi.fn().mockReturnValue(10);
       expect(() => minPointSizeCallback(spy, 1)('100', 0)).toThrow();

--- a/test/util/DataUtils.spec.ts
+++ b/test/util/DataUtils.spec.ts
@@ -10,6 +10,7 @@ import {
   getLinearRegression,
   findEntryInArray,
   uniqueId,
+  isNullish,
 } from '../../src/util/DataUtils';
 
 /**
@@ -80,6 +81,32 @@ describe('is functions', () => {
       const invalid: number[] = arr;
       const result: number[] = arr.filter(isNumber);
       expect(result).toEqual([1]);
+    });
+  });
+
+  describe('isNullish', () => {
+    const tests: IsFunctionTestDefinition<typeof isNullish>[] = [
+      { should: 'return true with input null', value: null, result: true },
+      { should: 'return true with input undefined', value: undefined, result: true },
+      { should: 'return false with input 0', value: 0, result: false },
+      { should: 'return false with input empty string', value: '', result: false },
+      { should: 'return false with input object', value: {}, result: false },
+      { should: 'return false with input array', value: [], result: false },
+    ];
+
+    tests.forEach(({ should, value, result }) => {
+      it(should, () => {
+        expect(isNullish(value)).toBe(result);
+      });
+    });
+
+    it('should allow type refinement', () => {
+      const arr: unknown[] = ['', 0, false, NaN, null, undefined];
+      // @ts-expect-error typescript should highlight this - invalid assignment
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const invalid: (null | undefined)[] = arr;
+      const result: (null | undefined)[] = arr.filter(isNullish);
+      expect(result).toEqual([null, undefined]);
     });
   });
 


### PR DESCRIPTION
## Description

A Bar's `minPointSize` attribute can be a function. This PR is aimed at allowing to pass `null` or `undefined` values to this function (rather than throwing)

## Related Issue

#5944 

## Motivation and Context

Null or undefined are valid values for datapoints, and are distinct from `0` (i.e. the absence of data). It's interesting to allow to use those values even if using a `minPointSize` function.

## How Has This Been Tested?

I tested the fork with a local dataset with null values, and a minPointSize function returning different values for null non-null values:

```
const minPointSize = useCallback((value: number | null, _index: number) => isNil(value) ? 0 : 2, []);
```

Other than that, there is little risk of side-effects:
- for existing `minPointSize` functions taking number values, the function will continue working as is.
- if someone has a codebase sending null values to `minPointSize`, rechart currently throws.
- minPointSizeCallback is only called at one place in the rechart code, so there's no other impact
 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
