### PR TITLE
feat: allow minPointSize function to receive null and undefined values (3.x)

### DIFF
--- a/src/util/BarUtils.tsx
+++ b/src/util/BarUtils.tsx
@@ -5,7 +5,7 @@ import { ActiveShape } from './types';
 import { Props as RectangleProps } from '../shape/Rectangle';
 import { BarProps } from '../cartesian/Bar';
 import { Shape } from './ActiveShapeUtils';
-import { isNumber } from './DataUtils';
+import { isNullish, isNumber } from './DataUtils';
 
 // Rectangle props is expecting x, y, height, width as numbers, name as a string, and radius as a custom type
 // When props are being spread in from a user defined component in Bar,
@@ -57,7 +57,7 @@ export function BarRectangle(props: BarRectangleProps) {
   );
 }
 
-export type MinPointSize = number | ((value: number, index: number) => number);
+export type MinPointSize = number | ((value: number | undefined | null, index: number) => number);
 
 /**
  * Safely gets minPointSize from the minPointSize prop if it is a function
@@ -69,14 +69,14 @@ export const minPointSizeCallback =
   (minPointSize: MinPointSize, defaultValue = 0) =>
   (value: unknown, index: number): number => {
     if (isNumber(minPointSize)) return minPointSize;
-    const isValueNumber = isNumber(value);
-    if (isValueNumber) {
+    const isValueNumberOrNil = isNumber(value) || isNullish(value);
+    if (isValueNumberOrNil) {
       return minPointSize(value, index);
     }
 
     invariant(
-      isValueNumber,
-      `minPointSize callback function received a value with type of ${typeof value}. Currently only numbers are supported.`,
+      isValueNumberOrNil,
+      `minPointSize callback function received a value with type of ${typeof value}. Currently only numbers or null/undefined are supported.`,
     );
     return defaultValue;
   };

--- a/test/util/BarUtils.spec.tsx
+++ b/test/util/BarUtils.spec.tsx
@@ -15,6 +15,20 @@ describe('BarUtils', () => {
       expect(minPointSize).toEqual(10);
     });
 
+    test('should return a number if a function is passed that takes null and returns a number', () => {
+      const spy = vi.fn().mockReturnValue(10);
+      const minPointSize = minPointSizeCallback(spy)(null, 0);
+      expect(spy).toHaveBeenCalledWith(null, 0);
+      expect(minPointSize).toEqual(10);
+    });
+
+    test('should return a number if a function is passed that takes undefined and returns a number', () => {
+      const spy = vi.fn().mockReturnValue(10);
+      const minPointSize = minPointSizeCallback(spy)(undefined, 0);
+      expect(spy).toHaveBeenCalledWith(undefined, 0);
+      expect(minPointSize).toEqual(10);
+    });
+
     test('should throw an invariant when any other datatype is passed as value', () => {
       const spy = vi.fn().mockReturnValue(10);
       expect(() => minPointSizeCallback(spy, 1)('100', 0)).toThrow();


### PR DESCRIPTION
## Description

A Bar's `minPointSize` attribute can be a function. This PR is aimed at allowing rechart v 3.x to call `minPointSize` with `null` or `undefined` values, rather than throwing.

## Related Issue

#5944 

## Motivation and Context

Null or undefined are valid values for datapoints, and are distinct from `0` (i.e. the absence of data). It's interesting to allow to use those values even if using a `minPointSize` function.

## How Has This Been Tested?

I tested the fork with a local dataset with null values, and a minPointSize function returning different values for null non-null values:

```
const minPointSize = useCallback((value: number | null, _index: number) => isNil(value) ? 0 : 2, []);
```

Other than that, there is little risk of side-effects:
- for existing `minPointSize` functions taking number values, the function will continue working as is.
- if someone has a codebase sending null values to `minPointSize`, rechart currently throws.
- minPointSizeCallback is only called at one place in the rechart code, so there's no other impact


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
