### PR TITLE
Fix Line animation when Legend is present in the chart

### DIFF
--- a/test/cartesian/Line.animation.spec.tsx
+++ b/test/cartesian/Line.animation.spec.tsx
@@ -458,15 +458,14 @@ describe('Line animation', () => {
       </LineChart>
     ));
 
-    // this test should fail because I can see this bug in the storybook
-    it.fails('should not move the path during the animation', async () => {
+    it('should not move the path during the animation', async () => {
       const { container, animationManager } = renderTestCase();
 
       const line = getLine(container);
       expect(line).toBeInTheDocument();
       // the path is fully rendered
       const initialPath = line.getAttribute('d');
-      expect(initialPath).toBe('M5,5L23,27.5L41,27.5L59,50L77,32.45L95,52.475');
+      expect(initialPath).toBe('M5,5L23,15L41,15L59,25L77,17.2L95,26.1');
       expect(line.getAttribute('d')).toBe(initialPath);
 
       // the path should not move during the animation but unfortunately it does


### PR DESCRIPTION
## Description

Line used to animate slightly up when Legend was present below due to how the Legend height is calculated.

Before

https://github.com/user-attachments/assets/a663a1a0-4e89-4598-a049-8ad1c18f2552

After

https://github.com/user-attachments/assets/a613be79-1392-45f3-8bdf-9c37397f8c69
