### PR TITLE
Label reads viewBox from context when the parsed coordinates are unavailable in the parent component

### DIFF
--- a/storybook/stories/API/chart/PieChart.stories.tsx
+++ b/storybook/stories/API/chart/PieChart.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { StoryContext } from '@storybook/react';
-import { Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from '../../../../src';
+import { Label, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from '../../../../src';
 import { pageData } from '../../data';
 import { CategoricalChartProps } from '../props/ChartProps';
 import { ActiveShapeProps } from '../props/ActiveShapeProps';
@@ -48,7 +48,14 @@ export const Donut = {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <PieChart {...args}>
-          <Pie data={data} dataKey="uv" nameKey="name" innerRadius={50} outerRadius={80} />
+          <Pie data={data} dataKey="uv" nameKey="name" innerRadius={50} outerRadius={80}>
+            <Label position="center" fill="#000" fontSize={12} fontWeight="bold" dy={-7}>
+              Donut
+            </Label>
+            <Label position="center" fontSize={12} fontWeight="bold" dy={8}>
+              Chart
+            </Label>
+          </Pie>
           <RechartsHookInspector rechartsInspectorEnabled={context.rechartsInspectorEnabled} />
         </PieChart>
       </ResponsiveContainer>

--- a/test/polar/Pie.spec.tsx
+++ b/test/polar/Pie.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { it, vi } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { LabelProps, Pie, PieChart, PieProps, Sector, SectorProps, Tooltip } from '../../src';
+import { Label, LabelProps, Pie, PieChart, PieProps, Sector, SectorProps, Tooltip } from '../../src';
 import { Point } from '../../src/shape/Curve';
 import { PieSectorDataItem } from '../../src/polar/Pie';
 import { generateMockData } from '../helper/generateMockData';
@@ -428,7 +428,7 @@ describe('<Pie />', () => {
 
   describe('label', () => {
     test('Render customized label when label is set to be a react element', () => {
-      const Label = (props: LabelProps) => {
+      const MyCustomLabel = (props: LabelProps) => {
         const { x, y } = props;
         return (
           <text x={x} y={y} className="customized-label">
@@ -442,7 +442,7 @@ describe('<Pie />', () => {
             isAnimationActive={false}
             cx={250}
             cy={250}
-            label={<Label />}
+            label={<MyCustomLabel />}
             innerRadius={0}
             outerRadius={200}
             data={sectorsData}
@@ -455,7 +455,7 @@ describe('<Pie />', () => {
     });
 
     test('Render customized label when label is set to be a function that returns the label text', () => {
-      const Label = (props: LabelProps) => {
+      const MyCustomLabel = (props: LabelProps) => {
         const { name, value } = props;
         return `${name}: ${value}`;
       };
@@ -465,7 +465,7 @@ describe('<Pie />', () => {
             isAnimationActive={false}
             cx={250}
             cy={250}
-            label={Label}
+            label={MyCustomLabel}
             innerRadius={0}
             outerRadius={200}
             data={sectorsData}
@@ -559,6 +559,37 @@ describe('<Pie />', () => {
       );
 
       expect(container.querySelectorAll('.customized-label-line')).toHaveLength(sectorsData.length);
+    });
+
+    it('should render label with position=center', () => {
+      // https://github.com/recharts/recharts/issues/5985
+      const { container } = render(
+        <PieChart width={500} height={500}>
+          <Pie isAnimationActive={false} innerRadius={100} outerRadius={200} data={sectorsData} dataKey="cy">
+            <Label position="center" value="My test label" />
+          </Pie>
+        </PieChart>,
+      );
+
+      const label = container.querySelector('.recharts-label');
+      expect(label).toBeInTheDocument();
+      expect(label).toHaveAttribute('x', '250');
+      expect(label).toHaveAttribute('y', '250');
+    });
+
+    it('should shift the label left and right with dx and dy', () => {
+      const { container } = render(
+        <PieChart width={500} height={500}>
+          <Pie isAnimationActive={false} innerRadius={100} outerRadius={200} data={sectorsData} dataKey="cy">
+            <Label position="center" value="My test label" dx={50} dy={-20} />
+          </Pie>
+        </PieChart>,
+      );
+
+      const label = container.querySelector('.recharts-label');
+      expect(label).toBeInTheDocument();
+      expect(label).toHaveAttribute('x', '300');
+      expect(label).toHaveAttribute('y', '230');
     });
   });
 


### PR DESCRIPTION
## Description

Fixing just the cartesian position for now to unblock https://github.com/recharts/recharts/issues/5985 but Label deserves some more attention for sure.

## Related Issue

fixes https://github.com/recharts/recharts/issues/5985

## Screenshots (if appropriate):

<img width="320" alt="image" src="https://github.com/user-attachments/assets/85cc6c90-ab6f-45d3-bae1-da51fb38ea06" />

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
