### PR TITLE
Remove @storybook/addon-storysource plugin and replace with codePanel: true

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@storybook/addon-interactions": "^8.6.13",
         "@storybook/addon-links": "^8.6.13",
         "@storybook/addon-mdx-gfm": "^8.6.13",
-        "@storybook/addon-storysource": "^8.6.13",
         "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
         "@storybook/components": "^8.6.13",
         "@storybook/icons": "^1.2.12",
@@ -5331,24 +5330,6 @@
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.6.13"
-      }
-    },
-    "node_modules/@storybook/addon-storysource": {
-      "version": "8.6.13",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-storysource/-/addon-storysource-8.6.13.tgz",
-      "integrity": "sha512-/6w91ICfNwxHb7sbSxPKu8ZlbCyHBI26b4ZJJlPnwEBlRF9HLetLv4RqN1BlooS1n2wbO1dv1jMJOtEiDQA3ZA==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/source-loader": "8.6.13",
-        "estraverse": "^5.2.0",
-        "tiny-invariant": "^1.3.1"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "@storybook/addon-interactions": "^8.6.13",
     "@storybook/addon-links": "^8.6.13",
     "@storybook/addon-mdx-gfm": "^8.6.13",
-    "@storybook/addon-storysource": "^8.6.13",
     "@storybook/addon-webpack5-compiler-swc": "^3.0.0",
     "@storybook/components": "^8.6.13",
     "@storybook/icons": "^1.2.12",

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -12,7 +12,6 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
     '@storybook/addon-a11y',
-    '@storybook/addon-storysource',
     '@storybook/addon-docs',
     '@storybook/addon-mdx-gfm',
     '@storybook/addon-webpack5-compiler-swc',

--- a/storybook/preview.ts
+++ b/storybook/preview.ts
@@ -14,6 +14,7 @@ const preview: Preview = {
     docs: {
       container: DocsContainer,
       page: DocsPage,
+      codePanel: true,
     },
     backgrounds: {
       default: 'light',


### PR DESCRIPTION
## Description

I noticed the "Code" panel in storybook renders compiled code and I didn't like it:

<img width="1013" alt="image" src="https://github.com/user-attachments/assets/69b67fe3-be0b-4633-a713-43eeb28030a0" />

so I went and discovered that the plugin we use is deprecated: https://storybook.js.org/docs/writing-docs/code-panel

> Code Panel is a replacement for the [Storysource addon](https://storybook.js.org/addons/@storybook/addon-storysource), which was [discontinued in Storybook 9](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#storysource-addon-removed).

so I uninstalled the plugin and turned on the built-in code panel and turns out it looks way better:

<img width="917" alt="image" src="https://github.com/user-attachments/assets/e3619230-28e8-4130-9c1f-d92b3fbf497c" />
