### PR TITLE
fix: labelRef being passed to DOM node causing warning

### DIFF
--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -409,7 +409,7 @@ export function Label({ offset = 5, ...restProps }: Props) {
   }
 
   if (isValidElement(content)) {
-    return cloneElement(content, props);
+    return cloneElement(content, filterProps(props, true));
   }
 
   let label: ReactNode;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`labelRef` was being passed to a DOM node. It is not a valid node prop and was causing warning.

## Related Issue
#6004 
#5880 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
