### PR TITLE
Apply Legend itemSorter for custom content too

### DIFF
--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import { PureComponent, ReactNode, MouseEvent, ReactElement } from 'react';
 
 import { clsx } from 'clsx';
-import sortBy from 'es-toolkit/compat/sortBy';
 import { Surface } from '../container/Surface';
 import { Symbols } from '../shape/Symbols';
 import {
@@ -58,7 +57,6 @@ interface InternalProps {
    * A custom payload can be passed here if desired or it can be passed from the Legend "content" callback.
    */
   payload?: ReadonlyArray<LegendPayload>;
-  itemSorter?: 'value' | 'dataKey' | ((item: LegendPayload) => number | string);
 }
 
 export type Props = InternalProps & Omit<PresentationAttributesAdaptChildEvent<any, ReactElement>, keyof InternalProps>;
@@ -70,7 +68,6 @@ export class DefaultLegendContent extends PureComponent<Props> {
     align: 'center',
     iconSize: 14,
     inactiveColor: '#ccc',
-    itemSorter: 'value',
     layout: 'horizontal',
     verticalAlign: 'middle',
   };
@@ -145,7 +142,7 @@ export class DefaultLegendContent extends PureComponent<Props> {
    * @return Items
    */
   renderItems() {
-    const { payload, iconSize, layout, formatter, inactiveColor, iconType, itemSorter } = this.props;
+    const { payload, iconSize, layout, formatter, inactiveColor, iconType } = this.props;
     const viewBox = { x: 0, y: 0, width: SIZE, height: SIZE };
     const itemStyle = {
       display: layout === 'horizontal' ? 'inline-block' : 'block',
@@ -153,7 +150,7 @@ export class DefaultLegendContent extends PureComponent<Props> {
     };
     const svgStyle = { display: 'inline-block', verticalAlign: 'middle', marginRight: 4 };
 
-    return (itemSorter ? sortBy(payload, itemSorter) : payload).map((entry: LegendPayload, i: number) => {
+    return payload.map((entry: LegendPayload, i: number) => {
       const finalFormatter = entry.formatter || formatter;
       const className = clsx({
         'recharts-legend-item': true,

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -85,6 +85,8 @@ function getDefaultPosition(
   return { ...hPos, ...vPos };
 }
 
+export type LegendItemSorter = 'value' | 'dataKey' | ((item: LegendPayload) => number | string);
+
 export type Props = Omit<DefaultProps, 'payload' | 'ref'> & {
   wrapperStyle?: CSSProperties;
   width?: number;
@@ -98,6 +100,7 @@ export type Props = Omit<DefaultProps, 'payload' | 'ref'> & {
    * If this is undefined then Legend renders inside the recharts-wrapper element.
    */
   portal?: HTMLElement | null;
+  itemSorter?: LegendItemSorter;
 };
 
 interface State {
@@ -156,7 +159,12 @@ function LegendWrapper(props: Props) {
 
   const legendElement = (
     <div className="recharts-legend-wrapper" style={outerStyle} ref={updateBoundingBox}>
-      <LegendSettingsDispatcher layout={props.layout} align={props.align} verticalAlign={props.verticalAlign} />
+      <LegendSettingsDispatcher
+        layout={props.layout}
+        align={props.align}
+        verticalAlign={props.verticalAlign}
+        itemSorter={props.itemSorter}
+      />
       <LegendSizeDispatcher width={lastBoundingBox.width} height={lastBoundingBox.height} />
       <LegendContent
         {...props}
@@ -178,6 +186,7 @@ export class Legend extends PureComponent<Props, State> {
   static defaultProps = {
     align: 'center',
     iconSize: 14,
+    itemSorter: 'value',
     layout: 'horizontal',
     verticalAlign: 'bottom',
   };

--- a/src/state/legendSlice.ts
+++ b/src/state/legendSlice.ts
@@ -2,11 +2,13 @@ import { createSlice, current, PayloadAction } from '@reduxjs/toolkit';
 import { castDraft } from 'immer';
 import { LayoutType, Size } from '../util/types';
 import { HorizontalAlignmentType, LegendPayload, VerticalAlignmentType } from '../component/DefaultLegendContent';
+import type { LegendItemSorter } from '../component/Legend';
 
 export type LegendSettings = {
   layout: LayoutType;
   align: HorizontalAlignmentType;
   verticalAlign: VerticalAlignmentType;
+  itemSorter: LegendItemSorter;
 };
 
 /**
@@ -31,6 +33,7 @@ const initialState: LegendState = {
     layout: 'horizontal',
     align: 'center',
     verticalAlign: 'middle',
+    itemSorter: 'value',
   },
   size: {
     width: 0,
@@ -51,6 +54,7 @@ const legendSlice = createSlice({
       state.settings.align = action.payload.align;
       state.settings.layout = action.payload.layout;
       state.settings.verticalAlign = action.payload.verticalAlign;
+      state.settings.itemSorter = action.payload.itemSorter;
     },
     addLegendPayload(state, action: PayloadAction<ReadonlyArray<LegendPayload>>) {
       state.payload.push(castDraft(action.payload));

--- a/src/state/selectors/legendSelectors.ts
+++ b/src/state/selectors/legendSelectors.ts
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import sortBy from 'es-toolkit/compat/sortBy';
 import { RechartsRootState } from '../store';
 import { LegendSettings } from '../legendSlice';
 import { LegendPayload } from '../../component/DefaultLegendContent';
@@ -12,6 +13,9 @@ const selectAllLegendPayload2DArray = (state: RechartsRootState): ReadonlyArray<
   state.legend.payload;
 
 export const selectLegendPayload: (state: RechartsRootState) => ReadonlyArray<LegendPayload> = createSelector(
-  [selectAllLegendPayload2DArray],
-  payloads => payloads.flat(1),
+  [selectAllLegendPayload2DArray, selectLegendSettings],
+  (payloads, { itemSorter }) => {
+    const flat = payloads.flat(1);
+    return itemSorter ? sortBy(flat, itemSorter) : flat;
+  },
 );

--- a/storybook/stories/Examples/AreaChart.stories.tsx
+++ b/storybook/stories/Examples/AreaChart.stories.tsx
@@ -13,6 +13,7 @@ import {
   Area,
   Legend,
   ComposedChart,
+  LegendPayload,
 } from '../../../src';
 import { CategoricalChartProps } from '../API/props/ChartProps';
 import { getStoryArgsFromArgsTypesObject } from '../API/props/utils';
@@ -621,6 +622,94 @@ export const WithChangingDataKeyAndAnimations = {
           </ResponsiveContainer>
         </ManualAnimations>
       </>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(CategoricalChartProps),
+    width: 500,
+    height: 400,
+    data: pageData,
+    margin: {
+      top: 10,
+      right: 30,
+      left: 0,
+      bottom: 0,
+    },
+  },
+};
+
+export const StackedAreaWithCustomLegend = {
+  // Reproducing https://github.com/recharts/recharts/issues/5992
+  render: (args: Record<string, any>, context: StoryContext) => {
+    const [hiddenItems, setHiddenItems] = React.useState<ReadonlyArray<string>>([]);
+
+    const handleClick = ({ dataKey }: LegendPayload) => {
+      if (typeof dataKey !== 'string') {
+        return;
+      }
+      setHiddenItems(prev => (prev.includes(dataKey) ? prev.filter(key => key !== dataKey) : [...prev, dataKey]));
+    };
+
+    return (
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart {...args}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Area
+            type="monotone"
+            dataKey="uv"
+            stackId="1"
+            stroke="#8884d8"
+            strokeWidth={3}
+            fill="rgba(136,132,216,0.47)"
+            hide={hiddenItems.includes('uv')}
+          />
+          <Area
+            type="monotone"
+            dataKey="pv"
+            stackId="1"
+            stroke="#82ca9d"
+            strokeWidth={3}
+            fill="rgba(130,202,157,0.47)"
+            hide={hiddenItems.includes('pv')}
+          />
+          <Area
+            type="monotone"
+            dataKey="amt"
+            stackId="1"
+            stroke="#ffc658"
+            strokeWidth={3}
+            fill="rgba(255,198,88,0.47)"
+            hide={hiddenItems.includes('amt')}
+          />
+          <RechartsHookInspector rechartsInspectorEnabled={context.rechartsInspectorEnabled} />
+          <Legend
+            content={({ payload }) => (
+              <ul style={{ display: 'flex', flexDirection: 'row', listStyleType: 'none', padding: 0 }}>
+                {payload.map((entry, index) => (
+                  <li key={`item-${index}`} style={{ color: entry.color }}>
+                    <button
+                      type="button"
+                      onClick={() => handleClick(entry)}
+                      style={{
+                        background: 'none',
+                        border: entry.inactive ? '3px solid #ccc' : `3px solid ${entry.color}`,
+                        borderRadius: '20%',
+                        padding: '10px',
+                        cursor: 'pointer',
+                        opacity: typeof entry.dataKey === 'string' && hiddenItems.includes(entry.dataKey) ? 0.2 : 1,
+                      }}
+                    >
+                      {entry.value}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
     );
   },
   args: {

--- a/storybook/stories/Examples/AreaChart.stories.tsx
+++ b/storybook/stories/Examples/AreaChart.stories.tsx
@@ -652,7 +652,7 @@ export const StackedAreaWithCustomLegend = {
 
     return (
       <ResponsiveContainer width="100%" height="100%">
-        <AreaChart {...args}>
+        <AreaChart {...args} stackOffset="silhouette">
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="name" />
           <YAxis />

--- a/test/_data.ts
+++ b/test/_data.ts
@@ -351,3 +351,12 @@ export const dataWithSpecialNameAndFillProperties = [
   { name: 'name3', fill: 'fill3', value: 56 },
   { name: 'name4', fill: 'fill4', value: 78 },
 ];
+
+export const numericalData = [
+  { value: 'Luck', percent: 10 },
+  { value: 'Skill', percent: 20 },
+  { value: 'Concentrated power of will', percent: 15 },
+  { value: 'Pleasure', percent: 50 },
+  { value: 'Pain', percent: 50 },
+  { value: 'Reason to remember the name', percent: 100 },
+];

--- a/test/component/Legend.itemSorter.spec.tsx
+++ b/test/component/Legend.itemSorter.spec.tsx
@@ -40,7 +40,7 @@ describe('Legend.itemSorter', () => {
   });
 
   describe('when Legend content is a function', () => {
-    it.fails('should pass legend items sorted by label value by default', () => {
+    it('should pass legend items sorted by label value by default', () => {
       // this should sort by label value, but it does not
       const customContent = vi.fn();
 
@@ -59,6 +59,7 @@ describe('Legend.itemSorter', () => {
           chartWidth: 500,
           content: customContent,
           iconSize: 14,
+          itemSorter: 'value',
           layout: 'horizontal',
           margin: {
             bottom: 5,
@@ -487,7 +488,7 @@ describe('Legend.itemSorter', () => {
             expect.objectContaining({
               payload: [
                 expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'red', inactive: false }),
-                expect.objectContaining({ value: 'A', dataKey: 'value', color: 'blue', inactive: true }),
+                expect.objectContaining({ value: 'A', dataKey: 'value', color: 'silver', inactive: true }),
               ],
             }),
           );
@@ -528,7 +529,7 @@ describe('Legend.itemSorter', () => {
             expect.objectContaining({
               payload: [
                 expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'red', inactive: false }),
-                expect.objectContaining({ value: 'A', dataKey: 'value', color: 'blue', inactive: true }),
+                expect.objectContaining({ value: 'A', dataKey: 'value', color: 'silver', inactive: true }),
               ],
             }),
           );
@@ -542,16 +543,6 @@ describe('Legend.itemSorter', () => {
                 expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'red', inactive: false }),
                 expect.objectContaining({ value: 'A', dataKey: 'value', color: 'blue', inactive: false }),
               ],
-            }),
-          );
-
-          // let's click again to ensure it does not change the order
-          act(() => {
-            getByText('B').click();
-          });
-          expect(spy).toHaveBeenLastCalledWith(
-            expect.objectContaining({
-              payload: [expect.objectContaining({ value: 'B' }), expect.objectContaining({ value: 'A' })],
             }),
           );
         });

--- a/test/component/Legend.itemSorter.spec.tsx
+++ b/test/component/Legend.itemSorter.spec.tsx
@@ -1,0 +1,422 @@
+import { describe, it, expect, test, vi, beforeEach } from 'vitest';
+import { act, render } from '@testing-library/react';
+import React, { ReactNode } from 'react';
+import { DefaultLegendContentProps, Legend, LegendPayload, Line, LineChart } from '../../src';
+import { numericalData } from '../_data';
+import { expectLegendLabels } from '../helper/expectLegendLabels';
+import { createSelectorTestCase } from '../helper/createSelectorTestCase';
+
+describe('Legend.itemSorter', () => {
+  describe('with default content', () => {
+    test('sorts legend items by label value by default', () => {
+      const { container } = render(
+        <LineChart width={500} height={500} data={numericalData}>
+          <Legend />
+          <Line dataKey="percent" name="B" />
+          <Line dataKey="value" name="A" />
+        </LineChart>,
+      );
+
+      expectLegendLabels(container, [
+        { textContent: 'A', stroke: '#3182bd', fill: 'none' },
+        { textContent: 'B', stroke: '#3182bd', fill: 'none' },
+      ]);
+    });
+
+    test('sorts legend items when itemSorter=dataKey', () => {
+      const { container } = render(
+        <LineChart width={500} height={500} data={numericalData}>
+          <Legend itemSorter="dataKey" />
+          <Line dataKey="percent" name="B" />
+          <Line dataKey="value" name="A" />
+        </LineChart>,
+      );
+
+      expectLegendLabels(container, [
+        { textContent: 'B', stroke: '#3182bd', fill: 'none' },
+        { textContent: 'A', stroke: '#3182bd', fill: 'none' },
+      ]);
+    });
+  });
+
+  describe('when Legend content is a function', () => {
+    it('should pass legend items sorted by label value by default', () => {
+      const customContent = vi.fn();
+
+      render(
+        <LineChart width={500} height={500} data={numericalData}>
+          <Legend content={customContent} />
+          <Line dataKey="percent" name="B" />
+          <Line dataKey="value" name="A" />
+        </LineChart>,
+      );
+
+      expect(customContent).toHaveBeenLastCalledWith(
+        {
+          align: 'center',
+          chartHeight: 500,
+          chartWidth: 500,
+          content: customContent,
+          iconSize: 14,
+          layout: 'horizontal',
+          margin: {
+            bottom: 5,
+            left: 5,
+            right: 5,
+            top: 5,
+          },
+          payload: [
+            {
+              color: '#3182bd',
+              dataKey: 'value',
+              inactive: false,
+              payload: {
+                activeDot: true,
+                animateNewValues: true,
+                animationBegin: 0,
+                animationDuration: 1500,
+                animationEasing: 'ease',
+                connectNulls: false,
+                dataKey: 'value',
+                dot: true,
+                fill: '#fff',
+                hide: false,
+                isAnimationActive: true,
+                label: false,
+                legendType: 'line',
+                name: 'A',
+                stroke: '#3182bd',
+                strokeWidth: 1,
+                xAxisId: 0,
+                yAxisId: 0,
+              },
+              type: 'line',
+              value: 'A',
+            },
+            {
+              color: '#3182bd',
+              dataKey: 'percent',
+              inactive: false,
+              payload: {
+                activeDot: true,
+                animateNewValues: true,
+                animationBegin: 0,
+                animationDuration: 1500,
+                animationEasing: 'ease',
+                connectNulls: false,
+                dataKey: 'percent',
+                dot: true,
+                fill: '#fff',
+                hide: false,
+                isAnimationActive: true,
+                label: false,
+                legendType: 'line',
+                name: 'B',
+                stroke: '#3182bd',
+                strokeWidth: 1,
+                xAxisId: 0,
+                yAxisId: 0,
+              },
+              type: 'line',
+              value: 'B',
+            },
+          ],
+          verticalAlign: 'bottom',
+          width: 490,
+        },
+        {},
+      );
+    });
+
+    it('should pass legend items sorted by dataKey when itemSorter is set', () => {
+      const customContent = vi.fn();
+
+      render(
+        <LineChart width={500} height={500} data={numericalData}>
+          <Legend content={customContent} itemSorter="dataKey" />
+          <Line dataKey="percent" name="B" />
+          <Line dataKey="value" name="A" />
+        </LineChart>,
+      );
+
+      expect(customContent).toHaveBeenLastCalledWith(
+        {
+          align: 'center',
+          chartHeight: 500,
+          chartWidth: 500,
+          content: customContent,
+          iconSize: 14,
+          itemSorter: 'dataKey',
+          layout: 'horizontal',
+          margin: {
+            bottom: 5,
+            left: 5,
+            right: 5,
+            top: 5,
+          },
+          payload: [
+            {
+              color: '#3182bd',
+              dataKey: 'percent',
+              inactive: false,
+              payload: {
+                activeDot: true,
+                animateNewValues: true,
+                animationBegin: 0,
+                animationDuration: 1500,
+                animationEasing: 'ease',
+                connectNulls: false,
+                dataKey: 'percent',
+                dot: true,
+                fill: '#fff',
+                hide: false,
+                isAnimationActive: true,
+                label: false,
+                legendType: 'line',
+                name: 'B',
+                stroke: '#3182bd',
+                strokeWidth: 1,
+                xAxisId: 0,
+                yAxisId: 0,
+              },
+              type: 'line',
+              value: 'B',
+            },
+            {
+              color: '#3182bd',
+              dataKey: 'value',
+              inactive: false,
+              payload: {
+                activeDot: true,
+                animateNewValues: true,
+                animationBegin: 0,
+                animationDuration: 1500,
+                animationEasing: 'ease',
+                connectNulls: false,
+                dataKey: 'value',
+                dot: true,
+                fill: '#fff',
+                hide: false,
+                isAnimationActive: true,
+                label: false,
+                legendType: 'line',
+                name: 'A',
+                stroke: '#3182bd',
+                strokeWidth: 1,
+                xAxisId: 0,
+                yAxisId: 0,
+              },
+              type: 'line',
+              value: 'A',
+            },
+          ],
+          verticalAlign: 'bottom',
+          width: 490,
+        },
+        {},
+      );
+    });
+  });
+
+  describe('when Legend content hides and shows items on click', () => {
+    function MyLegendHidingComponent({ children }: { children: ReactNode }) {
+      const [hiddenItems, setHiddenItems] = React.useState<ReadonlyArray<string>>([]);
+
+      const handleClick = ({ dataKey }: LegendPayload) => {
+        if (typeof dataKey !== 'string') {
+          return;
+        }
+        setHiddenItems(prev => (prev.includes(dataKey) ? prev.filter(key => key !== dataKey) : [...prev, dataKey]));
+      };
+
+      return (
+        <LineChart width={500} height={500} data={numericalData}>
+          <Legend itemSorter="dataKey" onClick={handleClick} />
+          <Line
+            dataKey="percent"
+            name="B"
+            stroke={hiddenItems.includes('percent') ? 'gold' : 'red'}
+            hide={hiddenItems.includes('percent')}
+          />
+          <Line
+            dataKey="value"
+            name="A"
+            stroke={hiddenItems.includes('percent') ? 'silver' : 'blue'}
+            hide={hiddenItems.includes('value')}
+          />
+          {children}
+        </LineChart>
+      );
+    }
+
+    const renderTestCase = createSelectorTestCase(MyLegendHidingComponent);
+
+    describe('on initial render', () => {
+      it('should render all items sorted by dataKey', () => {
+        const { container } = renderTestCase();
+
+        expectLegendLabels(container, [
+          { textContent: 'B', stroke: 'red', fill: 'none' },
+          { textContent: 'A', stroke: 'blue', fill: 'none' },
+        ]);
+      });
+    });
+
+    describe('after clicking on legend items', () => {
+      it('should hide the clicked item and keep the order', () => {
+        const { container, getByText } = renderTestCase();
+
+        act(() => {
+          getByText('A').click();
+        });
+        expectLegendLabels(container, [
+          { textContent: 'B', stroke: 'red', fill: 'none' },
+          { textContent: 'A', stroke: '#ccc', fill: 'none' },
+        ]);
+
+        act(() => {
+          getByText('B').click();
+        });
+        expectLegendLabels(container, [
+          { textContent: 'B', stroke: '#ccc', fill: 'none' },
+          { textContent: 'A', stroke: '#ccc', fill: 'none' },
+        ]);
+      });
+
+      it('should show the clicked item again and keep the order', () => {
+        const { container, getByText } = renderTestCase();
+
+        act(() => {
+          getByText('A').click();
+          getByText('B').click();
+        });
+        expectLegendLabels(container, [
+          { textContent: 'B', stroke: '#ccc', fill: 'none' },
+          { textContent: 'A', stroke: '#ccc', fill: 'none' },
+        ]);
+
+        act(() => {
+          getByText('B').click();
+        });
+        expectLegendLabels(container, [
+          { textContent: 'B', stroke: 'red', fill: 'none' },
+          { textContent: 'A', stroke: '#ccc', fill: 'none' },
+        ]);
+
+        act(() => {
+          getByText('A').click();
+        });
+        expectLegendLabels(container, [
+          { textContent: 'B', stroke: 'red', fill: 'none' },
+          { textContent: 'A', stroke: 'blue', fill: 'none' },
+        ]);
+      });
+    });
+  });
+
+  describe('when Legend content hides and shows items on click and also it has a custom content', () => {
+    const spy = vi.fn();
+
+    /*
+     * I thought this will reproduce the Legend jumping bug, but it does not! Interesting.
+     * Perhaps it only applies to stacked charts?
+     * https://github.com/recharts/recharts/issues/5992
+     */
+    function MyLegendHidingComponent({ children }: { children: ReactNode }) {
+      const [hiddenItems, setHiddenItems] = React.useState<ReadonlyArray<string>>([]);
+
+      const handleClick = ({ dataKey }: LegendPayload) => {
+        if (typeof dataKey !== 'string') {
+          return;
+        }
+        setHiddenItems(prev => (prev.includes(dataKey) ? prev.filter(key => key !== dataKey) : [...prev, dataKey]));
+      };
+
+      // eslint-disable-next-line react/no-unstable-nested-components
+      const MyCustomLegendContent = (props: DefaultLegendContentProps) => {
+        spy(props);
+        return (
+          <ul>
+            {props.payload.map((entry, index) => (
+              // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
+              <li key={`item-${index}`} style={{ color: entry.color }} onClick={() => handleClick(entry)}>
+                {entry.value}
+              </li>
+            ))}
+            {props.children}
+          </ul>
+        );
+      };
+
+      return (
+        <LineChart width={500} height={500} data={numericalData}>
+          <Legend itemSorter="dataKey" onClick={handleClick} content={MyCustomLegendContent} />
+          <Line
+            dataKey="percent"
+            name="B"
+            stroke={hiddenItems.includes('percent') ? 'gold' : 'red'}
+            hide={hiddenItems.includes('percent')}
+          />
+          <Line
+            dataKey="value"
+            name="A"
+            stroke={hiddenItems.includes('percent') ? 'silver' : 'blue'}
+            hide={hiddenItems.includes('value')}
+          />
+          {children}
+        </LineChart>
+      );
+    }
+
+    beforeEach(() => {
+      spy.mockClear();
+    });
+
+    const renderTestCase = createSelectorTestCase(MyLegendHidingComponent);
+
+    describe('on initial render', () => {
+      it('should render all items sorted by dataKey', () => {
+        renderTestCase();
+
+        expect(spy).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            payload: [
+              expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'red', inactive: false }),
+              expect.objectContaining({ value: 'A', dataKey: 'value', color: 'blue', inactive: false }),
+            ],
+          }),
+        );
+      });
+    });
+
+    describe('after clicking on legend items', () => {
+      it('should hide the clicked item and keep the order', () => {
+        const { getByText } = renderTestCase();
+
+        act(() => {
+          getByText('A').click();
+        });
+        expect(spy).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            payload: [
+              expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'red', inactive: false }),
+              expect.objectContaining({ value: 'A', dataKey: 'value', color: 'blue', inactive: true }),
+            ],
+          }),
+        );
+
+        act(() => {
+          getByText('B').click();
+        });
+        expect(spy).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            payload: [
+              expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'gold', inactive: true }),
+              expect.objectContaining({ value: 'A', dataKey: 'value', color: 'silver', inactive: true }),
+            ],
+          }),
+        );
+      });
+    });
+  });
+});

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -31,33 +31,10 @@ import { useAppSelector } from '../../src/state/hooks';
 import { selectAxisRangeWithReverse } from '../../src/state/selectors/axisSelectors';
 import { selectLegendPayload, selectLegendSize } from '../../src/state/selectors/legendSelectors';
 import { LegendPortalContext } from '../../src/context/legendPortalContext';
-import { dataWithSpecialNameAndFillProperties } from '../_data';
+import { dataWithSpecialNameAndFillProperties, numericalData } from '../_data';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { Size } from '../../src/util/types';
-
-function assertHasLegend(container: Element): ReadonlyArray<Element> {
-  expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(1);
-  return Array.from(container.querySelectorAll('.recharts-default-legend .recharts-legend-item'));
-}
-
-function expectLegendLabels(
-  container: Element,
-  expectedLabels: undefined | ReadonlyArray<{ textContent: string; fill: string }>,
-) {
-  assertNotNull(container);
-
-  if (expectedLabels == null) {
-    expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(0);
-    return;
-  }
-
-  const actualLabels = assertHasLegend(container).map(legend => ({
-    textContent: legend.textContent,
-    fill: legend.querySelector('.recharts-legend-icon')?.getAttribute('fill'),
-  }));
-
-  expect(actualLabels).toEqual(expectedLabels);
-}
+import { assertHasLegend, expectLegendLabels } from '../helper/expectLegendLabels';
 
 type LegendTypeTestCases = ReadonlyArray<{
   legendType: LegendType;
@@ -342,15 +319,6 @@ describe('<Legend />', () => {
     { value: 'Sony', color: '#667300' },
   ];
 
-  const numericalData = [
-    { value: 'Luck', percent: 10 },
-    { value: 'Skill', percent: 20 },
-    { value: 'Concentrated power of will', percent: 15 },
-    { value: 'Pleasure', percent: 50 },
-    { value: 'Pain', percent: 50 },
-    { value: 'Reason to remember the name', percent: 100 },
-  ];
-
   const numericalData2 = [
     { title: 'Luftbaloons', value: 99 },
     { title: 'Miles I would walk', value: 500 },
@@ -602,36 +570,6 @@ describe('<Legend />', () => {
       expectLegendLabels(container, [
         { textContent: 'My Line Data', fill: 'none' },
         { textContent: 'My Other Line Data', fill: 'none' },
-      ]);
-    });
-
-    test('sorts legend items by name by default', () => {
-      const { container } = render(
-        <LineChart width={500} height={500} data={numericalData}>
-          <Legend />
-          <Line dataKey="percent" name="B" />
-          <Line dataKey="value" name="A" />
-        </LineChart>,
-      );
-
-      expectLegendLabels(container, [
-        { textContent: 'A', fill: 'none' },
-        { textContent: 'B', fill: 'none' },
-      ]);
-    });
-
-    test('sorts legend items when itemSorter=dataKey', () => {
-      const { container } = render(
-        <LineChart width={500} height={500} data={numericalData}>
-          <Legend itemSorter="dataKey" />
-          <Line dataKey="percent" name="B" />
-          <Line dataKey="value" name="A" />
-        </LineChart>,
-      );
-
-      expectLegendLabels(container, [
-        { textContent: 'B', fill: 'none' },
-        { textContent: 'A', fill: 'none' },
       ]);
     });
 

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -436,6 +436,7 @@ describe('<Legend />', () => {
         chartWidth: 600,
         content: customContent,
         iconSize: 14,
+        itemSorter: 'value',
         layout: 'horizontal',
         margin: {
           bottom: 5,
@@ -778,6 +779,7 @@ describe('<Legend />', () => {
         chartWidth: 600,
         content: expect.any(Function),
         iconSize: 14,
+        itemSorter: 'value',
         layout: 'horizontal',
         margin: {
           bottom: 5,

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -86,6 +86,7 @@ import {
   selectLegendSize,
 } from '../../../src/state/selectors/legendSelectors';
 import { mockTouchingElement } from '../../helper/mockTouchingElement';
+import { LegendSettings } from '../../../src/state/legendSlice';
 
 type TooltipVisibilityTestCase = {
   // For identifying which test is running
@@ -740,11 +741,13 @@ describe('Tooltip visibility', () => {
 
     it('should select legend settings', () => {
       const { spy } = renderTestCase(selectLegendSettings);
-      expect(spy).toHaveBeenLastCalledWith({
+      const expected: LegendSettings = {
         align: 'center',
+        itemSorter: 'value',
         layout: 'horizontal',
         verticalAlign: 'bottom',
-      });
+      };
+      expect(spy).toHaveBeenLastCalledWith(expected);
     });
 
     it('should select legend size', () => {

--- a/test/helper/createSelectorTestCase.tsx
+++ b/test/helper/createSelectorTestCase.tsx
@@ -16,6 +16,7 @@ export function createSelectorTestCase(Component: ComponentType<{ children: Reac
     debug: () => void;
     rerender: (ui: ReactNode) => void;
     animationManager: MockProgressAnimationManager;
+    getByText: (text: string) => HTMLElement;
   } {
     const spy: Mock<(selectorResult: T) => void> = vi.fn();
     const animationManager = new MockProgressAnimationManager();
@@ -25,14 +26,14 @@ export function createSelectorTestCase(Component: ComponentType<{ children: Reac
       return null;
     };
 
-    const { container, debug, rerender } = render(
+    const { container, debug, rerender, getByText } = render(
       <AnimationManagerContext.Provider value={animationManager}>
         <Component>
           <Comp />
         </Component>
       </AnimationManagerContext.Provider>,
     );
-    return { container, spy, debug, rerender, animationManager };
+    return { container, spy, debug, rerender, animationManager, getByText };
   };
 }
 

--- a/test/helper/expectLegendLabels.tsx
+++ b/test/helper/expectLegendLabels.tsx
@@ -1,0 +1,29 @@
+import { expect } from 'vitest';
+import { assertNotNull } from './assertNotNull';
+
+export function assertHasLegend(container: Element): ReadonlyArray<Element> {
+  expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(1);
+  return Array.from(container.querySelectorAll('.recharts-default-legend .recharts-legend-item'));
+}
+
+export function expectLegendLabels(
+  container: Element,
+  expectedLabels: undefined | ReadonlyArray<{ textContent: string; fill: string; stroke?: string }>,
+) {
+  assertNotNull(container);
+
+  if (expectedLabels == null) {
+    expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(0);
+    return;
+  }
+
+  const expectsStroke = expectedLabels.some(label => label.stroke != null);
+
+  const actualLabels = assertHasLegend(container).map(legend => ({
+    textContent: legend.textContent,
+    fill: legend.querySelector('.recharts-legend-icon')?.getAttribute('fill'),
+    stroke: expectsStroke ? legend.querySelector('.recharts-legend-icon')?.getAttribute('stroke') : undefined,
+  }));
+
+  expect(actualLabels).toEqual(expectedLabels);
+}

--- a/test/state/selectors/legendSelectors.spec.tsx
+++ b/test/state/selectors/legendSelectors.spec.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
 import { LegendSettings } from '../../../src/state/legendSlice';
-import { BarChart, Customized, Legend, LegendPayload } from '../../../src';
+import { BarChart, Legend, LegendPayload } from '../../../src';
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
 import {
   shouldReturnFromInitialState,
@@ -23,6 +23,7 @@ describe('selectLegendSettings', () => {
     layout: 'horizontal',
     align: 'center',
     verticalAlign: 'middle',
+    itemSorter: 'value',
   });
 
   it('should return Legend settings', () => {
@@ -36,13 +37,14 @@ describe('selectLegendSettings', () => {
     render(
       <BarChart width={100} height={100}>
         <Legend align="left" layout="vertical" verticalAlign="top" />
-        <Customized component={<Comp />} />
+        <Comp />
       </BarChart>,
     );
     const expected: LegendSettings = {
       align: 'left',
       layout: 'vertical',
       verticalAlign: 'top',
+      itemSorter: 'value',
     };
     expect(legendSettingsSpy).toHaveBeenLastCalledWith(expected);
     expect(legendSettingsSpy).toHaveBeenCalledTimes(3);
@@ -67,7 +69,7 @@ describe('selectLegendSize', () => {
     render(
       <BarChart width={100} height={100}>
         <Legend align="left" layout="vertical" verticalAlign="top" />
-        <Customized component={<Comp />} />
+        <Comp />
       </BarChart>,
     );
     const expected: Size = { width: 17, height: 71 };
@@ -81,21 +83,21 @@ describe('selectLegendPayload', () => {
   shouldReturnFromInitialState(selectLegendPayload, []);
 
   it('should return Legend payload', () => {
-    const legendSettingsSpy = vi.fn();
+    const legendPayloadSpy = vi.fn();
     const Comp = (): null => {
       const legend = useAppSelectorWithStableTest(selectLegendPayload);
-      legendSettingsSpy(legend);
+      legendPayloadSpy(legend);
       return null;
     };
     mockGetBoundingClientRect({ width: 17, height: 71 });
     render(
       <BarChart width={100} height={100}>
         <Legend align="left" layout="vertical" verticalAlign="top" />
-        <Customized component={<Comp />} />
+        <Comp />
       </BarChart>,
     );
     const expected: ReadonlyArray<LegendPayload> = [];
-    expect(legendSettingsSpy).toHaveBeenLastCalledWith(expected);
-    expect(legendSettingsSpy).toHaveBeenCalledTimes(1);
+    expect(legendPayloadSpy).toHaveBeenLastCalledWith(expected);
+    expect(legendPayloadSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/test/util/ChartUtils/appendOffsetOfLegend.spec.tsx
+++ b/test/util/ChartUtils/appendOffsetOfLegend.spec.tsx
@@ -23,6 +23,7 @@ describe('appendOffsetOfLegend', () => {
       verticalAlign: 'bottom',
       layout: 'vertical',
       align: 'left',
+      itemSorter: 'value',
     };
     const size: Size = {
       width: 100,
@@ -40,6 +41,7 @@ describe('appendOffsetOfLegend', () => {
       layout: 'horizontal',
       verticalAlign: 'middle',
       align: 'left',
+      itemSorter: 'value',
     };
     const size: Size = {
       width: 100,
@@ -58,6 +60,7 @@ describe('appendOffsetOfLegend', () => {
       layout: 'horizontal',
       verticalAlign: 'middle',
       align: 'left',
+      itemSorter: 'value',
     };
     const size: Size = {
       width: 100,
@@ -73,6 +76,7 @@ describe('appendOffsetOfLegend', () => {
       align: 'left',
       layout: 'horizontal',
       verticalAlign: 'bottom',
+      itemSorter: 'value',
     };
     const size: Size = {
       width: 100,
@@ -87,6 +91,7 @@ describe('appendOffsetOfLegend', () => {
       align: 'center',
       layout: 'vertical',
       verticalAlign: 'bottom',
+      itemSorter: 'value',
     };
     const size: Size = {
       width: 100,
@@ -101,6 +106,7 @@ describe('appendOffsetOfLegend', () => {
       align: 'center',
       layout: 'vertical',
       verticalAlign: 'middle',
+      itemSorter: 'value',
     };
     const size: Size = {
       width: 100,
@@ -115,6 +121,7 @@ describe('appendOffsetOfLegend', () => {
       align: 'left',
       layout: 'horizontal',
       verticalAlign: 'middle',
+      itemSorter: 'value',
     };
     const size: Size = {
       width: 100,


### PR DESCRIPTION
## Description

This was a journey to reproduce.

## Related Issue

Reported in https://github.com/recharts/recharts/issues/5992.

This PR solves only the Legend part. I do realize @noxify you also asked for consistent stacked item order, I have an idea how to fix that but that will come in next PR.


https://github.com/user-attachments/assets/3b66de52-367b-4cba-81c7-4efe8566e867

