### PR TITLE
Delay rendering for one cycle so that tickFormatter is called with the correct values

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -2,7 +2,7 @@
  * @fileOverview X Axis
  */
 import * as React from 'react';
-import { Component, useEffect } from 'react';
+import { Component, ReactNode, useEffect, useMemo } from 'react';
 import { clsx } from 'clsx';
 import { CartesianAxis } from './CartesianAxis';
 import { AxisInterval, AxisTick, BaseAxisProps, PresentationAttributesAdaptChildEvent } from '../util/types';
@@ -13,6 +13,7 @@ import {
   selectAxisScale,
   selectTicksOfAxis,
   selectXAxisPosition,
+  selectXAxisSettings,
   selectXAxisSize,
 } from '../state/selectors/axisSelectors';
 import { selectAxisViewBox } from '../state/selectors/selectChartOffset';
@@ -41,14 +42,27 @@ interface XAxisProps extends BaseAxisProps {
 
 export type Props = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>, 'scale' | 'ref'> & XAxisProps;
 
-function SetXAxisSettings(settings: XAxisSettings): null {
+type SetXAxisSettingsProps = XAxisSettings & { children: ReactNode };
+
+function SetXAxisSettings(props: SetXAxisSettingsProps): ReactNode {
   const dispatch = useAppDispatch();
+  const settings = useMemo(() => {
+    const { children, ...rest } = props;
+    return rest;
+  }, [props]);
+  const synchronizedSettings = useAppSelector(state => selectXAxisSettings(state, settings.id));
+  const settingsAreSynchronized = settings === synchronizedSettings;
+
   useEffect(() => {
     dispatch(addXAxis(settings));
     return () => {
       dispatch(removeXAxis(settings));
     };
   }, [settings, dispatch]);
+
+  if (settingsAreSynchronized) {
+    return props.children;
+  }
   return null;
 }
 
@@ -85,35 +99,34 @@ const XAxisImpl = (props: Props) => {
 
 const XAxisSettingsDispatcher = (props: Props) => {
   return (
-    <>
-      <SetXAxisSettings
-        interval={props.interval ?? 'preserveEnd'}
-        id={props.xAxisId}
-        scale={props.scale}
-        type={props.type}
-        padding={props.padding}
-        allowDataOverflow={props.allowDataOverflow}
-        domain={props.domain}
-        dataKey={props.dataKey}
-        allowDuplicatedCategory={props.allowDuplicatedCategory}
-        allowDecimals={props.allowDecimals}
-        tickCount={props.tickCount}
-        includeHidden={props.includeHidden ?? false}
-        reversed={props.reversed}
-        ticks={props.ticks}
-        height={props.height}
-        orientation={props.orientation}
-        mirror={props.mirror}
-        hide={props.hide}
-        unit={props.unit}
-        name={props.name}
-        angle={props.angle ?? 0}
-        minTickGap={props.minTickGap ?? 5}
-        tick={props.tick ?? true}
-        tickFormatter={props.tickFormatter}
-      />
+    <SetXAxisSettings
+      interval={props.interval ?? 'preserveEnd'}
+      id={props.xAxisId}
+      scale={props.scale}
+      type={props.type}
+      padding={props.padding}
+      allowDataOverflow={props.allowDataOverflow}
+      domain={props.domain}
+      dataKey={props.dataKey}
+      allowDuplicatedCategory={props.allowDuplicatedCategory}
+      allowDecimals={props.allowDecimals}
+      tickCount={props.tickCount}
+      includeHidden={props.includeHidden ?? false}
+      reversed={props.reversed}
+      ticks={props.ticks}
+      height={props.height}
+      orientation={props.orientation}
+      mirror={props.mirror}
+      hide={props.hide}
+      unit={props.unit}
+      name={props.name}
+      angle={props.angle ?? 0}
+      minTickGap={props.minTickGap ?? 5}
+      tick={props.tick ?? true}
+      tickFormatter={props.tickFormatter}
+    >
       <XAxisImpl {...props} />
-    </>
+    </SetXAxisSettings>
   );
 };
 

--- a/src/polar/PolarAngleAxis.tsx
+++ b/src/polar/PolarAngleAxis.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FunctionComponent, PureComponent, ReactElement, SVGProps, useEffect } from 'react';
+import { FunctionComponent, PureComponent, ReactElement, ReactNode, SVGProps, useEffect, useMemo } from 'react';
 import { clsx } from 'clsx';
 import { Layer } from '../container/Layer';
 import { Dot } from '../shape/Dot';
@@ -19,7 +19,7 @@ import { RechartsScale } from '../util/ChartUtils';
 import { addAngleAxis, AngleAxisSettings, removeAngleAxis } from '../state/polarAxisSlice';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { selectPolarAxisScale, selectPolarAxisTicks } from '../state/selectors/polarScaleSelectors';
-import { selectPolarViewBox } from '../state/selectors/polarAxisSelectors';
+import { selectAngleAxis, selectPolarViewBox } from '../state/selectors/polarAxisSelectors';
 import { defaultPolarAngleAxisProps } from './defaultPolarAngleAxisProps';
 import { useIsPanorama } from '../context/PanoramaContext';
 
@@ -65,14 +65,26 @@ export type Props = AxisSvgProps & PolarAngleAxisProps;
 
 const AXIS_TYPE = 'angleAxis';
 
-function SetAngleAxisSettings(settings: AngleAxisSettings): null {
+type AngleAxisSettingsReporter = AngleAxisSettings & { children: React.ReactNode };
+
+function SetAngleAxisSettings(props: AngleAxisSettingsReporter): ReactNode {
   const dispatch = useAppDispatch();
+  const settings = useMemo(() => {
+    const { children, ...rest } = props;
+    return rest;
+  }, [props]);
+  const synchronizedSettings = useAppSelector(state => selectAngleAxis(state, settings.id));
+  const settingsAreSynchronized = settings === synchronizedSettings;
   useEffect(() => {
     dispatch(addAngleAxis(settings));
     return () => {
       dispatch(removeAngleAxis(settings));
     };
   });
+
+  if (settingsAreSynchronized) {
+    return props.children;
+  }
   return null;
 }
 
@@ -250,27 +262,26 @@ export class PolarAngleAxis extends PureComponent<Props> {
     if (this.props.radius <= 0) return null;
 
     return (
-      <>
-        <SetAngleAxisSettings
-          id={this.props.angleAxisId}
-          scale={this.props.scale}
-          type={this.props.type}
-          dataKey={this.props.dataKey}
-          unit={undefined}
-          name={this.props.name}
-          allowDuplicatedCategory={false} // Ignoring the prop on purpose because axis calculation behaves as if it was false and Tooltip requires it to be true.
-          allowDataOverflow={false}
-          reversed={this.props.reversed}
-          includeHidden={false}
-          allowDecimals={this.props.allowDecimals}
-          tickCount={this.props.tickCount}
-          // @ts-expect-error the type does not match. Is RadiusAxis really expecting what it says?
-          ticks={this.props.ticks}
-          tick={this.props.tick}
-          domain={this.props.domain}
-        />
+      <SetAngleAxisSettings
+        id={this.props.angleAxisId}
+        scale={this.props.scale}
+        type={this.props.type}
+        dataKey={this.props.dataKey}
+        unit={undefined}
+        name={this.props.name}
+        allowDuplicatedCategory={false} // Ignoring the prop on purpose because axis calculation behaves as if it was false and Tooltip requires it to be true.
+        allowDataOverflow={false}
+        reversed={this.props.reversed}
+        includeHidden={false}
+        allowDecimals={this.props.allowDecimals}
+        tickCount={this.props.tickCount}
+        // @ts-expect-error the type does not match. Is RadiusAxis really expecting what it says?
+        ticks={this.props.ticks}
+        tick={this.props.tick}
+        domain={this.props.domain}
+      >
         <PolarAngleAxisWrapper {...this.props} />
-      </>
+      </SetAngleAxisSettings>
     );
   }
 }

--- a/src/polar/PolarAngleAxis.tsx
+++ b/src/polar/PolarAngleAxis.tsx
@@ -65,7 +65,7 @@ export type Props = AxisSvgProps & PolarAngleAxisProps;
 
 const AXIS_TYPE = 'angleAxis';
 
-type AngleAxisSettingsReporter = AngleAxisSettings & { children: React.ReactNode };
+type AngleAxisSettingsReporter = AngleAxisSettings & { children: ReactNode };
 
 function SetAngleAxisSettings(props: AngleAxisSettingsReporter): ReactNode {
   const dispatch = useAppDispatch();

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -159,52 +159,6 @@ describe('<XAxis />', () => {
     expect(onClickFn).toHaveBeenCalledWith(eventData, eventIndex, eventExpect);
   });
 
-  it('Render ticks with tickFormatter', () => {
-    const spy = vi.fn();
-    const { container } = render(
-      <LineChart width={400} height={400} data={lineData} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
-        <XAxis dataKey="name" tickFormatter={(_, i) => `${i}`} />
-        <Line type="monotone" dataKey="uv" stroke="#ff7300" />
-        <Customized component={<ExpectAxisDomain assert={spy} axisType="xAxis" />} />
-      </LineChart>,
-    );
-
-    expect(container.querySelectorAll('.xAxis .recharts-cartesian-axis-tick')[0]).toHaveTextContent('0');
-    expectXAxisTicks(container, [
-      {
-        textContent: '0',
-        x: '20',
-        y: '358',
-      },
-      {
-        textContent: '1',
-        x: '92',
-        y: '358',
-      },
-      {
-        textContent: '2',
-        x: '164',
-        y: '358',
-      },
-      {
-        textContent: '3',
-        x: '236',
-        y: '358',
-      },
-      {
-        textContent: '4',
-        x: '308',
-        y: '358',
-      },
-      {
-        textContent: '5',
-        x: '380',
-        y: '358',
-      },
-    ]);
-    expect(spy).toHaveBeenLastCalledWith(['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
-  });
-
   it('should render array indexes when dataKey is not specified', () => {
     const axisDomainSpy = vi.fn();
     const { container } = render(
@@ -5016,5 +4970,4 @@ describe('<XAxis />', () => {
   });
 
   describe.todo('in vertical stacked BarChart');
-  describe.todo('with custom tickFormatter');
 });

--- a/test/cartesian/XAxis.tickFormatter.spec.tsx
+++ b/test/cartesian/XAxis.tickFormatter.spec.tsx
@@ -34,12 +34,13 @@ describe('XAxis with custom tickFormatter', () => {
     // https://github.com/recharts/recharts/issues/6010
     renderTestCase();
 
-    // expect(tickFormatterSpy).toHaveBeenCalledTimes(6);
-    expect(tickFormatterSpy.mock.calls[0]).toEqual(['Page A', 0]);
-    expect(tickFormatterSpy.mock.calls[1]).toEqual(['Page B', 1]);
-    expect(tickFormatterSpy.mock.calls[2]).toEqual(['Page C', 2]);
-    expect(tickFormatterSpy.mock.calls[3]).toEqual(['Page D', 3]);
-    expect(tickFormatterSpy.mock.calls[4]).toEqual(['Page E', 4]);
-    expect(tickFormatterSpy.mock.calls[5]).toEqual(['Page F', 5]);
+    expect(tickFormatterSpy).toHaveBeenCalledTimes(2 * PageData.length);
+    // interesting that they are called upside down but ... that doesn't really matter
+    expect(tickFormatterSpy).toHaveBeenNthCalledWith(1, 'Page F', 5);
+    expect(tickFormatterSpy).toHaveBeenNthCalledWith(2, 'Page E', 4);
+    expect(tickFormatterSpy).toHaveBeenNthCalledWith(3, 'Page D', 3);
+    expect(tickFormatterSpy).toHaveBeenNthCalledWith(4, 'Page C', 2);
+    expect(tickFormatterSpy).toHaveBeenNthCalledWith(5, 'Page B', 1);
+    expect(tickFormatterSpy).toHaveBeenNthCalledWith(6, 'Page A', 0);
   });
 });

--- a/test/cartesian/XAxis.tickFormatter.spec.tsx
+++ b/test/cartesian/XAxis.tickFormatter.spec.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { Line, LineChart, XAxis } from '../../src';
+import { expectXAxisTicks } from '../helper/expectAxisTicks';
+import { PageData } from '../_data';
+import { createSelectorTestCase } from '../helper/createSelectorTestCase';
+
+describe('XAxis with custom tickFormatter', () => {
+  const tickFormatterSpy = vi.fn((value, index) => `formatted: ${value}: ${index}`);
+
+  const renderTestCase = createSelectorTestCase(({ children }) => (
+    <LineChart width={400} height={400} data={PageData} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+      <XAxis dataKey="name" tickFormatter={tickFormatterSpy} />
+      <Line type="monotone" dataKey="uv" stroke="#ff7300" />
+      {children}
+    </LineChart>
+  ));
+
+  it('should render ticks formatted with tickFormatter', () => {
+    const { container } = renderTestCase();
+
+    expect(container.querySelectorAll('.xAxis .recharts-cartesian-axis-tick')[0]).toHaveTextContent('0');
+    expectXAxisTicks(container, [
+      { textContent: 'formatted: Page A: 0', x: '20', y: '358' },
+      { textContent: 'formatted: Page B: 1', x: '92', y: '358' },
+      { textContent: 'formatted: Page C: 2', x: '164', y: '358' },
+      { textContent: 'formatted: Page D: 3', x: '236', y: '358' },
+      { textContent: 'formatted: Page E: 4', x: '308', y: '358' },
+      { textContent: 'formatted: Page F: 5', x: '380', y: '358' },
+    ]);
+  });
+
+  it('should call the tickFormatter with the correct parameters', () => {
+    // https://github.com/recharts/recharts/issues/6010
+    renderTestCase();
+
+    // expect(tickFormatterSpy).toHaveBeenCalledTimes(6);
+    expect(tickFormatterSpy.mock.calls[0]).toEqual(['Page A', 0]);
+    expect(tickFormatterSpy.mock.calls[1]).toEqual(['Page B', 1]);
+    expect(tickFormatterSpy.mock.calls[2]).toEqual(['Page C', 2]);
+    expect(tickFormatterSpy.mock.calls[3]).toEqual(['Page D', 3]);
+    expect(tickFormatterSpy.mock.calls[4]).toEqual(['Page E', 4]);
+    expect(tickFormatterSpy.mock.calls[5]).toEqual(['Page F', 5]);
+  });
+});

--- a/test/cartesian/YAxis/YAxis.tickFormatter.spec.tsx
+++ b/test/cartesian/YAxis/YAxis.tickFormatter.spec.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
+import { Line, LineChart, YAxis } from '../../../src';
+import { PageData } from '../../_data';
+import { expectYAxisTicks } from '../../helper/expectAxisTicks';
+
+describe('YAxis with custom tickFormatter', () => {
+  const tickFormatterSpy = vi.fn((value, index) => `formatted: ${value}: ${index}`);
+
+  const renderTestCase = createSelectorTestCase(({ children }) => (
+    <LineChart width={400} height={400} data={PageData} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+      <YAxis type="category" dataKey="name" tickFormatter={tickFormatterSpy} />
+      <Line type="monotone" dataKey="uv" stroke="#ff7300" />
+      {children}
+    </LineChart>
+  ));
+
+  it('should render ticks formatted with tickFormatter', () => {
+    const { container } = renderTestCase();
+
+    expect(container.querySelectorAll('.yAxis .recharts-cartesian-axis-tick')[0]).toHaveTextContent('0');
+    expectYAxisTicks(container, [
+      { textContent: 'formatted: Page A: 0', x: '72', y: '380' },
+      { textContent: 'formatted: Page B: 1', x: '72', y: '308' },
+      { textContent: 'formatted: Page C: 2', x: '72', y: '236' },
+      { textContent: 'formatted: Page D: 3', x: '72', y: '164' },
+      { textContent: 'formatted: Page E: 4', x: '72', y: '92' },
+      { textContent: 'formatted: Page F: 5', x: '72', y: '20' },
+    ]);
+  });
+
+  it('should call the tickFormatter with the correct parameters', () => {
+    // https://github.com/recharts/recharts/issues/6010
+    renderTestCase();
+
+    expect(tickFormatterSpy).toHaveBeenCalledTimes(2 * PageData.length);
+    // interesting that they are called upside down but ... that doesn't really matter
+    expect(tickFormatterSpy).toHaveBeenNthCalledWith(1, 'Page F', 5);
+    expect(tickFormatterSpy).toHaveBeenNthCalledWith(2, 'Page E', 4);
+    expect(tickFormatterSpy).toHaveBeenNthCalledWith(3, 'Page D', 3);
+    expect(tickFormatterSpy).toHaveBeenNthCalledWith(4, 'Page C', 2);
+    expect(tickFormatterSpy).toHaveBeenNthCalledWith(5, 'Page B', 1);
+    expect(tickFormatterSpy).toHaveBeenNthCalledWith(6, 'Page A', 0);
+  });
+});

--- a/test/chart/AreaChart.spec.tsx
+++ b/test/chart/AreaChart.spec.tsx
@@ -453,14 +453,14 @@ describe('AreaChart', () => {
       const { container } = render(chart);
 
       spies.forEach(el => expect(el.mock.calls.length).toBe(1));
-      expect(axisSpy).toHaveBeenCalledTimes(4);
+      expect(axisSpy).toHaveBeenCalledTimes(3);
 
       fireEvent.mouseEnter(container, { clientX: 30, clientY: 200 });
       fireEvent.mouseMove(container, { clientX: 200, clientY: 200 });
       fireEvent.mouseLeave(container);
 
       spies.forEach(el => expect(el.mock.calls.length).toBe(1));
-      expect(axisSpy).toHaveBeenCalledTimes(4);
+      expect(axisSpy).toHaveBeenCalledTimes(3);
     });
 
     // protect against the future where someone might mess up our clean rendering
@@ -468,7 +468,7 @@ describe('AreaChart', () => {
       const { container } = render(chart);
 
       spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-      expect(axisSpy).toHaveBeenCalledTimes(4);
+      expect(axisSpy).toHaveBeenCalledTimes(3);
 
       const brushSlide = container.querySelector('.recharts-brush-slide');
       assertNotNull(brushSlide);
@@ -477,7 +477,7 @@ describe('AreaChart', () => {
       fireEvent.mouseUp(window);
 
       spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-      expect(axisSpy).toHaveBeenCalledTimes(4);
+      expect(axisSpy).toHaveBeenCalledTimes(3);
     });
 
     test('should only show the last data when the brush travelers all moved to the right', () => {

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -1392,14 +1392,14 @@ describe('<LineChart /> - Pure Rendering', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
 
     fireEvent.mouseEnter(container, { clientX: 30, clientY: 200, bubbles: true, cancelable: true });
     fireEvent.mouseMove(container, { clientX: 200, clientY: 200, bubbles: true, cancelable: true });
     fireEvent.mouseLeave(container);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
   });
 
   // protect against the future where someone might mess up our clean rendering
@@ -1407,7 +1407,7 @@ describe('<LineChart /> - Pure Rendering', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
 
     const leftCursor = container.querySelector('.recharts-brush-traveller');
     assertNotNull(leftCursor);
@@ -1418,7 +1418,7 @@ describe('<LineChart /> - Pure Rendering', () => {
     fireEvent.mouseUp(window);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -1452,7 +1452,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
 
     fireEvent.mouseEnter(container, { clientX: 30, clientY: 200, bubbles: true, cancelable: true });
 
@@ -1461,7 +1461,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     fireEvent.mouseLeave(container);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
   });
 
   // protect against the future where someone might mess up our clean rendering
@@ -1469,7 +1469,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     const { container } = render(chart);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
 
     const leftCursor = container.querySelector('.recharts-brush-traveller');
     assertNotNull(leftCursor);
@@ -1478,7 +1478,7 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
     fireEvent.mouseUp(window);
 
     spies.forEach(el => expect(el).toHaveBeenCalledTimes(1));
-    expect(axisSpy).toHaveBeenCalledTimes(4);
+    expect(axisSpy).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/test/polar/PolarAngleAxis.spec.tsx
+++ b/test/polar/PolarAngleAxis.spec.tsx
@@ -135,7 +135,7 @@ describe('<PolarAngleAxis />', () => {
           type: 'category',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select polar items', () => {
@@ -152,13 +152,13 @@ describe('<PolarAngleAxis />', () => {
             radiusAxisId: 0,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([420, 460, 999, 500, 864, 650, 765, 365]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select angle axis range', () => {
@@ -176,7 +176,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select scale', () => {
         const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
         expectLastCalledWithScale(spy, { domain: [420, 460, 999, 500, 864, 650, 765, 365], range: [90, -270] });
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select ticks', () => {
@@ -231,7 +231,7 @@ describe('<PolarAngleAxis />', () => {
             value: 365,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select nice ticks', () => {
@@ -252,7 +252,7 @@ describe('<PolarAngleAxis />', () => {
           { value: 765 },
           { value: 365 },
         ]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should render axis ticks', () => {
@@ -384,7 +384,7 @@ describe('<PolarAngleAxis />', () => {
           type: 'category',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select polar items', () => {
@@ -401,13 +401,13 @@ describe('<PolarAngleAxis />', () => {
             radiusAxisId: 0,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select angle axis range', () => {
@@ -424,7 +424,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select scale', () => {
         const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
         expectLastCalledWithScale(spy, { domain: [0, 1, 2, 3, 4, 5, 6, 7], range: [90, -270] });
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select applied data', () => {
@@ -439,7 +439,7 @@ describe('<PolarAngleAxis />', () => {
           { value: 765 },
           { value: 365 },
         ]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should render ticks', () => {
@@ -673,7 +673,7 @@ describe('<PolarAngleAxis />', () => {
           type: 'number',
           unit: undefined,
         });
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select polar items', () => {
@@ -690,13 +690,13 @@ describe('<PolarAngleAxis />', () => {
             radiusAxisId: 0,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([0, 360]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select angle axis range', () => {
@@ -708,13 +708,13 @@ describe('<PolarAngleAxis />', () => {
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith('linear');
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select scale', () => {
         const { spy } = renderTestCase(state => selectPolarAxisScale(state, 'angleAxis', 0));
         expectLastCalledWithScale(spy, { domain: [0, 360], range: [90, -270] });
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select ticks', () => {
@@ -745,7 +745,7 @@ describe('<PolarAngleAxis />', () => {
             value: 270,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select nice ticks', () => {
@@ -757,7 +757,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select applied data', () => {
         const { spy } = renderTestCase(state => selectPolarAppliedValues(state, 'angleAxis', 0));
         expect(spy).toHaveBeenLastCalledWith([{ value: 0 }, { value: 90 }, { value: 180 }, { value: 270 }]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should render axis ticks', () => {
@@ -1081,7 +1081,7 @@ describe('<PolarAngleAxis />', () => {
         </RadarChart>,
       );
 
-      expect(tick).toHaveBeenCalledTimes(2 * exampleRadarData.length);
+      expect(tick).toHaveBeenCalledTimes(exampleRadarData.length);
       expect(tick).toHaveBeenNthCalledWith(1, {
         cx: 250,
         cy: 250,
@@ -1550,7 +1550,7 @@ describe('<PolarAngleAxis />', () => {
       };
 
       render(
-        <RadarChart width={500} height={500} data={exampleRadarData}>
+        <RadarChart width={500} height={500} data={PageData}>
           <Radar dataKey="uv" />
           <PolarAngleAxis dataKey="uv" type={axisType} />
           <Customized component={<Comp />} />
@@ -2494,7 +2494,7 @@ describe('<PolarAngleAxis />', () => {
         </RadarChart>,
       );
       expect(angleAxisSpy).toHaveBeenLastCalledWith(implicitAngleAxis);
-      expect(angleAxisSpy).toHaveBeenCalledTimes(4);
+      expect(angleAxisSpy).toHaveBeenCalledTimes(5);
     });
 
     it('should select angle axis settings', () => {
@@ -2564,15 +2564,15 @@ describe('<PolarAngleAxis />', () => {
         unit: undefined,
       };
       expect(axisSettingsSpy).toHaveBeenLastCalledWith(expectedSettings);
-      expect(axisSettingsSpy).toHaveBeenCalledTimes(2);
+      expect(axisSettingsSpy).toHaveBeenCalledTimes(3);
 
       expect(angleAxisRangeSpy).toHaveBeenLastCalledWith([-270, 90]);
-      expect(angleAxisRangeSpy).toHaveBeenCalledTimes(2);
+      expect(angleAxisRangeSpy).toHaveBeenCalledTimes(3);
 
       expect(angleAxisDomainSpy).toHaveBeenLastCalledWith([420, 460, 999, 500, 864, 650, 765, 365]);
-      expect(angleAxisDomainSpy).toHaveBeenCalledTimes(2);
+      expect(angleAxisDomainSpy).toHaveBeenCalledTimes(3);
 
-      expect(angleAxisScaleSpy).toHaveBeenCalledTimes(2);
+      expect(angleAxisScaleSpy).toHaveBeenCalledTimes(3);
 
       expectLastCalledWithScale(angleAxisScaleSpy, { domain: [420, 365], range: [-270, 90] });
 
@@ -2638,10 +2638,156 @@ describe('<PolarAngleAxis />', () => {
           index: 9,
         },
       ]);
-      expect(angleAxisTicksSpy).toHaveBeenCalledTimes(2);
+      expect(angleAxisTicksSpy).toHaveBeenCalledTimes(3);
 
       expect(angleAxisNiceTicksSpy).toHaveBeenLastCalledWith(undefined);
-      expect(angleAxisNiceTicksSpy).toHaveBeenCalledTimes(2);
+      expect(angleAxisNiceTicksSpy).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('with custom tick formatter and numerical values', () => {
+    const formatter = vi.fn(value => `${value}°`);
+
+    beforeEach(() => {
+      formatter.mockClear();
+    });
+
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <RadialBarChart width={500} height={500} data={PageData}>
+        <RadialBar dataKey="uv" />
+        <PolarAngleAxis tickFormatter={formatter} />
+        {children}
+      </RadialBarChart>
+    ));
+
+    it('should render labels with custom formatter', () => {
+      const { container } = renderTestCase();
+      expectAngleAxisTickLabels(container, [
+        {
+          textContext: '400°',
+          x: '454',
+          y: '250',
+        },
+        {
+          textContext: '380°',
+          x: '418.8779385482782',
+          y: '135.56118721480914',
+        },
+        {
+          textContext: '360°',
+          x: '325.6054718462357',
+          y: '60.52754124435904',
+        },
+        {
+          textContext: '340°',
+          x: '206.2994754552723',
+          y: '50.7356927231682',
+        },
+        {
+          textContext: '320°',
+          x: '102.04105267737185',
+          y: '109.55730739130729',
+        },
+        {
+          textContext: '300°',
+          x: '48.72991656807338',
+          y: '216.73810715991496',
+        },
+        {
+          textContext: '280°',
+          x: '64.72290044592495',
+          y: '335.3721054023465',
+        },
+        {
+          textContext: '260°',
+          x: '144.51307722706076',
+          y: '424.6095905839537',
+        },
+        {
+          textContext: '240°',
+          x: '260.62598130215935',
+          y: '453.7230682111532',
+        },
+        {
+          textContext: '220°',
+          x: '373.07999941373566',
+          y: '412.68777994771096',
+        },
+        {
+          textContext: '200°',
+          x: '443.1533969087716',
+          y: '315.6335681081149',
+        },
+      ]);
+    });
+
+    it('should call the custom tick formatter function with the tick value, and index', () => {
+      renderTestCase();
+      expect(formatter).toHaveBeenCalledTimes(11);
+      expect(formatter).toHaveBeenNthCalledWith(1, 400, 0);
+      expect(formatter).toHaveBeenNthCalledWith(2, 380, 1);
+      expect(formatter).toHaveBeenNthCalledWith(3, 360, 2);
+      expect(formatter).toHaveBeenNthCalledWith(4, 340, 3);
+      expect(formatter).toHaveBeenLastCalledWith(200, 10);
+    });
+  });
+
+  describe('with custom tick formatter and category values', () => {
+    // https://github.com/recharts/recharts/issues/6010
+    const formatter = vi.fn(value => `Formatted: ${value}`);
+
+    beforeEach(() => {
+      formatter.mockClear();
+    });
+
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <RadarChart width={500} height={500} data={exampleRadarData}>
+        <Radar dataKey="value" />
+        <PolarAngleAxis dataKey="name" tickFormatter={formatter} />
+        {children}
+      </RadarChart>
+    ));
+
+    it('should select ticks', () => {
+      const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'angleAxis', 0, false));
+      expect(spy).toHaveBeenLastCalledWith([
+        { coordinate: 90, index: 0, offset: 45, value: 'iPhone 3GS' },
+        { coordinate: 45, index: 1, offset: 45, value: 'iPhone 4' },
+        { coordinate: 0, index: 2, offset: 45, value: 'iPhone 4s' },
+        { coordinate: -45, index: 3, offset: 45, value: 'iPhone 5' },
+        { coordinate: -90, index: 4, offset: 45, value: 'iPhone 5s' },
+        { coordinate: -135, index: 5, offset: 45, value: 'iPhone 6' },
+        { coordinate: -180, index: 6, offset: 45, value: 'iPhone 6s' },
+        { coordinate: -225, index: 7, offset: 45, value: 'iPhone 5se' },
+      ]);
+      expect(spy).toHaveBeenCalledTimes(3);
+    });
+
+    it('should render labels with custom formatter', () => {
+      const { container } = renderTestCase();
+      expectAngleAxisTickLabels(container, [
+        { textContext: 'Formatted: iPhone 3GS', x: '250', y: '46' },
+        { textContext: 'Formatted: iPhone 4', x: '394.2497833620557', y: '105.7502166379443' },
+        { textContext: 'Formatted: iPhone 4s', x: '454', y: '250' },
+        { textContext: 'Formatted: iPhone 5', x: '394.2497833620557', y: '394.2497833620557' },
+        { textContext: 'Formatted: iPhone 5s', x: '250', y: '454' },
+        { textContext: 'Formatted: iPhone 6', x: '105.7502166379443', y: '394.2497833620557' },
+        { textContext: 'Formatted: iPhone 6s', x: '46', y: '250.00000000000003' },
+        { textContext: 'Formatted: iPhone 5se', x: '105.75021663794428', y: '105.7502166379443' },
+      ]);
+    });
+
+    it('should call the custom tick formatter function with the tick value, and index', () => {
+      renderTestCase();
+      expect(formatter).toHaveBeenCalledTimes(exampleRadarData.length);
+      expect(formatter).toHaveBeenNthCalledWith(1, 'iPhone 3GS', 0);
+      expect(formatter).toHaveBeenNthCalledWith(2, 'iPhone 4', 1);
+      expect(formatter).toHaveBeenNthCalledWith(3, 'iPhone 4s', 2);
+      expect(formatter).toHaveBeenNthCalledWith(4, 'iPhone 5', 3);
+      expect(formatter).toHaveBeenNthCalledWith(5, 'iPhone 5s', 4);
+      expect(formatter).toHaveBeenNthCalledWith(6, 'iPhone 6', 5);
+      expect(formatter).toHaveBeenNthCalledWith(7, 'iPhone 6s', 6);
+      expect(formatter).toHaveBeenNthCalledWith(8, 'iPhone 5se', 7);
     });
   });
 });

--- a/test/polar/PolarRadiusAxis.spec.tsx
+++ b/test/polar/PolarRadiusAxis.spec.tsx
@@ -1216,4 +1216,89 @@ describe('<PolarRadiusAxis />', () => {
       expect(realScaleTypeSpy).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('with custom tick formatter and category values', () => {
+    // https://github.com/recharts/recharts/issues/6010
+    const formatter = vi.fn(value => `Formatted: ${value}`);
+
+    beforeEach(() => {
+      formatter.mockClear();
+    });
+
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <RadarChart width={500} height={500} data={exampleRadarData}>
+        <PolarRadiusAxis dataKey="name" type="category" tickFormatter={formatter} />
+        <Radar dataKey="value" />
+        {children}
+      </RadarChart>
+    ));
+
+    it('should render labels with custom formatter', () => {
+      const { container } = renderTestCase();
+
+      expectRadiusAxisTicks(container, [
+        {
+          textContent: 'Formatted: iPhone 3GS',
+          transform: 'rotate(90, 262.25, 250)',
+          x: '262.25',
+          y: '250',
+        },
+        {
+          textContent: 'Formatted: iPhone 4',
+          transform: 'rotate(90, 286.75, 250)',
+          x: '286.75',
+          y: '250',
+        },
+        {
+          textContent: 'Formatted: iPhone 4s',
+          transform: 'rotate(90, 311.25, 250)',
+          x: '311.25',
+          y: '250',
+        },
+        {
+          textContent: 'Formatted: iPhone 5',
+          transform: 'rotate(90, 335.75, 250)',
+          x: '335.75',
+          y: '250',
+        },
+        {
+          textContent: 'Formatted: iPhone 5s',
+          transform: 'rotate(90, 360.25, 250)',
+          x: '360.25',
+          y: '250',
+        },
+        {
+          textContent: 'Formatted: iPhone 6',
+          transform: 'rotate(90, 384.75, 250)',
+          x: '384.75',
+          y: '250',
+        },
+        {
+          textContent: 'Formatted: iPhone 6s',
+          transform: 'rotate(90, 409.25, 250)',
+          x: '409.25',
+          y: '250',
+        },
+        {
+          textContent: 'Formatted: iPhone 5se',
+          transform: 'rotate(90, 433.75, 250)',
+          x: '433.75',
+          y: '250',
+        },
+      ]);
+    });
+
+    it('should call the custom tick formatter function with the tick value, and index', () => {
+      renderTestCase();
+      expect(formatter).toHaveBeenCalledTimes(exampleRadarData.length);
+      expect(formatter).toHaveBeenNthCalledWith(1, 'iPhone 3GS', 0);
+      expect(formatter).toHaveBeenNthCalledWith(2, 'iPhone 4', 1);
+      expect(formatter).toHaveBeenNthCalledWith(3, 'iPhone 4s', 2);
+      expect(formatter).toHaveBeenNthCalledWith(4, 'iPhone 5', 3);
+      expect(formatter).toHaveBeenNthCalledWith(5, 'iPhone 5s', 4);
+      expect(formatter).toHaveBeenNthCalledWith(6, 'iPhone 6', 5);
+      expect(formatter).toHaveBeenNthCalledWith(7, 'iPhone 6s', 6);
+      expect(formatter).toHaveBeenNthCalledWith(8, 'iPhone 5se', 7);
+    });
+  });
 });

--- a/test/state/selectors/radarSelectors.spec.tsx
+++ b/test/state/selectors/radarSelectors.spec.tsx
@@ -163,7 +163,7 @@ describe('selectRadarPoints', () => {
         },
       ],
     });
-    expect(radarPointsSpy).toHaveBeenCalledTimes(2);
+    expect(radarPointsSpy).toHaveBeenCalledTimes(3);
   });
 
   it('should return new data after interaction', () => {


### PR DESCRIPTION
## Description

The tickFormatter was called while the chart state was being populated and that caused some trouble on the receiving side. Should be fixed now.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/6010
