### PR TITLE
fix: add payload as a valid property on Bar

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -71,6 +71,7 @@ export interface BarRectangleItem extends RectangleProps {
     height?: number;
   };
   tooltipPosition: Coordinate;
+  readonly payload?: any;
 }
 
 export interface BarProps {
@@ -698,7 +699,7 @@ export function computeBarRectangles({
       }
     }
 
-    return {
+    const barRectangleItem = {
       ...entry,
       x,
       y,
@@ -709,7 +710,9 @@ export function computeBarRectangles({
       background,
       tooltipPosition: { x: x + width / 2, y: y + height / 2 },
       ...(cells && cells[index] && cells[index].props),
-    };
+    } satisfies BarRectangleItem;
+
+    return barRectangleItem;
   });
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
we missed that `payload` exists in bar event data payload

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/6025

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
3.x bug

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
payload is now in the types

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
