### PR TITLE
Allow falsy values in Responsive container

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -162,19 +162,21 @@ export const ResponsiveContainer = forwardRef<HTMLDivElement, Props>(
       );
 
       return React.Children.map(children, child => {
-        return cloneElement(child, {
-          width: calculatedWidth,
-          height: calculatedHeight,
-          // calculate the actual size and override it.
-          style: {
-            height: '100%',
-            width: '100%',
-            maxHeight: calculatedHeight,
-            maxWidth: calculatedWidth,
-            // keep components style
-            ...child.props.style,
-          },
-        });
+        if (React.isValidElement<any>(child)) {
+          return cloneElement(child, {
+            width: calculatedWidth,
+            height: calculatedHeight,
+            // calculate the actual size and override it.
+            style: {
+              height: '100%',
+              width: '100%',
+              maxHeight: calculatedHeight,
+              maxWidth: calculatedWidth,
+              // keep components style
+              ...child.props.style,
+            },
+          });
+        }
       });
     }, [aspect, children, height, maxHeight, minHeight, minWidth, sizes, width]);
 

--- a/test/component/ResponsiveContainer.spec.tsx
+++ b/test/component/ResponsiveContainer.spec.tsx
@@ -83,6 +83,20 @@ describe('<ResponsiveContainer />', () => {
     expect(screen.getByTestId('inside')).toBeTruthy();
   });
 
+  it('Renders omponent when part of the children are falsy inside', () => {
+    const condition = false;
+
+    render(
+      <ResponsiveContainer minWidth={200} minHeight={100}>
+        {condition && <div />}
+        {condition ? <div /> : null}
+        <div data-testid="inside" />
+      </ResponsiveContainer>,
+    );
+
+    expect(screen.getByTestId('inside')).toBeTruthy();
+  });
+
   it('Handles zero height correctly', () => {
     render(
       <ResponsiveContainer height={0} aspect={2} width={300}>


### PR DESCRIPTION
This PR partially reverts #5217 to allow users to render `null` or `false` children inside the `<ResponsiveContainer />` component.

It allows code like
```
  <ResponsiveContainer minWidth={200} minHeight={100}>
    {displayLimits && <Line ... />}

    <OtherComponent />
  </ResponsiveContainer>,
```

## Description

This reintroduces the check on `React.isValidElement(child)` before cloning the children

## Related Issue

#6037

## Motivation and Context

Allows user to render conditionnaly some components

## How Has This Been Tested?

Test added

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
