### PR TITLE
Update and rename offset types and selectors

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -151,7 +151,7 @@
   "es6/state/selectors/scatterSelectors.js",
   "es6/state/selectors/selectActivePropsFromChartPointer.js",
   "es6/state/selectors/selectAllAxes.js",
-  "es6/state/selectors/selectChartOffset.js",
+  "es6/state/selectors/selectChartOffsetInternal.js",
   "es6/state/selectors/selectTooltipEventType.js",
   "es6/state/selectors/selectTooltipPayloadSearcher.js",
   "es6/state/selectors/selectTooltipSettings.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -151,7 +151,7 @@
   "lib/state/selectors/scatterSelectors.js",
   "lib/state/selectors/selectActivePropsFromChartPointer.js",
   "lib/state/selectors/selectAllAxes.js",
-  "lib/state/selectors/selectChartOffset.js",
+  "lib/state/selectors/selectChartOffsetInternal.js",
   "lib/state/selectors/selectTooltipEventType.js",
   "lib/state/selectors/selectTooltipPayloadSearcher.js",
   "lib/state/selectors/selectTooltipSettings.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -151,7 +151,7 @@
   "types/state/selectors/scatterSelectors.d.ts",
   "types/state/selectors/selectActivePropsFromChartPointer.d.ts",
   "types/state/selectors/selectAllAxes.d.ts",
-  "types/state/selectors/selectChartOffset.d.ts",
+  "types/state/selectors/selectChartOffsetInternal.d.ts",
   "types/state/selectors/selectTooltipEventType.d.ts",
   "types/state/selectors/selectTooltipPayloadSearcher.d.ts",
   "types/state/selectors/selectTooltipSettings.d.ts",

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -30,7 +30,7 @@ import { BaseAxisWithScale } from '../state/selectors/axisSelectors';
 import { ChartData } from '../state/chartDataSlice';
 import { AreaPointItem, AreaSettings, ComputedArea, selectArea } from '../state/selectors/areaSelectors';
 import { useIsPanorama } from '../context/PanoramaContext';
-import { useChartLayout, useOffset } from '../context/chartLayoutContext';
+import { useChartLayout, useOffsetInternal } from '../context/chartLayoutContext';
 import { useChartName } from '../state/selectors/selectors';
 import { SetLegendPayload } from '../state/SetLegendPayload';
 import { useAppSelector } from '../state/hooks';
@@ -719,7 +719,7 @@ function AreaImpl(props: Props) {
   );
   const { points, isRange, baseLine } =
     useAppSelector(state => selectArea(state, xAxisId, yAxisId, isPanorama, areaSettings)) ?? {};
-  const { height, width, left, top } = useOffset();
+  const { height, width, left, top } = useOffsetInternal();
 
   if (layout !== 'horizontal' && layout !== 'vertical') {
     // Can't render Area in an unsupported layout

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -29,7 +29,7 @@ import {
   adaptEventsOfChild,
   AnimationDuration,
   AnimationTiming,
-  ChartOffset,
+  ChartOffsetRequired,
   Coordinate,
   DataKey,
   LegendType,
@@ -61,15 +61,17 @@ import { useAnimationId } from '../util/useAnimationId';
 import { resolveDefaultProps } from '../util/resolveDefaultProps';
 import { Animate } from '../animation/Animate';
 
+type Rectangle = {
+  x: number | null;
+  y: number | null;
+  width: number;
+  height: number;
+};
+
 export interface BarRectangleItem extends RectangleProps {
   value?: number | [number, number];
   /** the coordinate of background rectangle */
-  background?: {
-    x?: number;
-    y?: number;
-    width?: number;
-    height?: number;
-  };
+  background?: Rectangle;
   tooltipPosition: Coordinate;
   readonly payload?: any;
 }
@@ -631,7 +633,7 @@ export function computeBarRectangles({
   xAxisTicks: TickItem[];
   yAxisTicks: TickItem[];
   stackedData: Series<Record<number, number>, DataKey<any>> | undefined;
-  offset: ChartOffset;
+  offset: ChartOffsetRequired;
   displayedData: any[];
   cells: ReadonlyArray<ReactElement> | undefined;
 }): ReadonlyArray<BarRectangleItem> | undefined {
@@ -641,7 +643,7 @@ export function computeBarRectangles({
   const baseValue = getBaseValueOfBar({ numericAxis });
 
   return displayedData.map((entry, index): BarRectangleItem => {
-    let value, x, y, width, height, background;
+    let value, x, y, width, height, background: Rectangle;
 
     if (stackedData) {
       // we don't need to use dataStartIndex here, because stackedData is already sliced from the selector
@@ -699,7 +701,7 @@ export function computeBarRectangles({
       }
     }
 
-    const barRectangleItem = {
+    const barRectangleItem: BarRectangleItem = {
       ...entry,
       x,
       y,

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -29,7 +29,7 @@ import {
   adaptEventsOfChild,
   AnimationDuration,
   AnimationTiming,
-  ChartOffsetRequired,
+  ChartOffsetInternal,
   Coordinate,
   DataKey,
   LegendType,
@@ -633,7 +633,7 @@ export function computeBarRectangles({
   xAxisTicks: TickItem[];
   yAxisTicks: TickItem[];
   stackedData: Series<Record<number, number>, DataKey<any>> | undefined;
-  offset: ChartOffsetRequired;
+  offset: ChartOffsetInternal;
   displayedData: any[];
   cells: ReadonlyArray<ReactElement> | undefined;
 }): ReadonlyArray<BarRectangleItem> | undefined {

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -6,7 +6,7 @@ import { ReactElement, SVGProps } from 'react';
 
 import { warn } from '../util/LogUtils';
 import { isNumber } from '../util/DataUtils';
-import { ChartOffset } from '../util/types';
+import { ChartOffsetRequired } from '../util/types';
 
 import { filterProps } from '../util/ReactUtils';
 import { AxisPropsNeededForTicksGenerator, getCoordinatesOfGrid, getTicksOfAxis } from '../util/ChartUtils';
@@ -26,7 +26,7 @@ export type GridLineTypeFunctionProps = Omit<LineItemProps, 'key'> & {
   // React does not pass the key through when calling cloneElement - so it might be undefined when cloning
   key: LineItemProps['key'] | undefined;
   // offset is not present in LineItemProps, but it is read from context and then passed to the GridLineType function and element
-  offset: ChartOffset;
+  offset: ChartOffsetRequired;
 };
 
 export type AxisPropsForCartesianGridTicksGeneration = AxisPropsNeededForTicksGenerator &
@@ -43,7 +43,7 @@ export type HorizontalCoordinatesGenerator = (
     yAxis: AxisPropsForCartesianGridTicksGeneration;
     width: number;
     height: number;
-    offset: ChartOffset;
+    offset: ChartOffsetRequired;
   },
   syncWithTicks: boolean,
 ) => number[];
@@ -53,7 +53,7 @@ export type VerticalCoordinatesGenerator = (
     xAxis: AxisPropsForCartesianGridTicksGeneration;
     width: number;
     height: number;
-    offset: ChartOffset;
+    offset: ChartOffsetRequired;
   },
   syncWithTicks: boolean,
 ) => number[];
@@ -163,7 +163,7 @@ const Background = (props: Pick<AcceptedSvgProps, 'fill' | 'fillOpacity' | 'x' |
 };
 
 type LineItemProps = Props & {
-  offset: ChartOffset;
+  offset: ChartOffsetRequired;
   xAxis: null | AxisPropsForCartesianGridTicksGeneration;
   yAxis: null | AxisPropsForCartesianGridTicksGeneration;
   x1: number;

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -6,7 +6,7 @@ import { ReactElement, SVGProps } from 'react';
 
 import { warn } from '../util/LogUtils';
 import { isNumber } from '../util/DataUtils';
-import { ChartOffsetRequired } from '../util/types';
+import { ChartOffsetInternal } from '../util/types';
 
 import { filterProps } from '../util/ReactUtils';
 import { AxisPropsNeededForTicksGenerator, getCoordinatesOfGrid, getTicksOfAxis } from '../util/ChartUtils';
@@ -26,7 +26,7 @@ export type GridLineTypeFunctionProps = Omit<LineItemProps, 'key'> & {
   // React does not pass the key through when calling cloneElement - so it might be undefined when cloning
   key: LineItemProps['key'] | undefined;
   // offset is not present in LineItemProps, but it is read from context and then passed to the GridLineType function and element
-  offset: ChartOffsetRequired;
+  offset: ChartOffsetInternal;
 };
 
 export type AxisPropsForCartesianGridTicksGeneration = AxisPropsNeededForTicksGenerator &
@@ -43,7 +43,7 @@ export type HorizontalCoordinatesGenerator = (
     yAxis: AxisPropsForCartesianGridTicksGeneration;
     width: number;
     height: number;
-    offset: ChartOffsetRequired;
+    offset: ChartOffsetInternal;
   },
   syncWithTicks: boolean,
 ) => number[];
@@ -53,7 +53,7 @@ export type VerticalCoordinatesGenerator = (
     xAxis: AxisPropsForCartesianGridTicksGeneration;
     width: number;
     height: number;
-    offset: ChartOffsetRequired;
+    offset: ChartOffsetInternal;
   },
   syncWithTicks: boolean,
 ) => number[];
@@ -163,7 +163,7 @@ const Background = (props: Pick<AcceptedSvgProps, 'fill' | 'fillOpacity' | 'x' |
 };
 
 type LineItemProps = Props & {
-  offset: ChartOffsetRequired;
+  offset: ChartOffsetInternal;
   xAxis: null | AxisPropsForCartesianGridTicksGeneration;
   yAxis: null | AxisPropsForCartesianGridTicksGeneration;
   x1: number;

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -12,7 +12,7 @@ import { filterProps } from '../util/ReactUtils';
 import { AxisPropsNeededForTicksGenerator, getCoordinatesOfGrid, getTicksOfAxis } from '../util/ChartUtils';
 import { getTicks, GetTicksInput } from './getTicks';
 import { CartesianAxis } from './CartesianAxis';
-import { useChartHeight, useChartWidth, useOffset } from '../context/chartLayoutContext';
+import { useChartHeight, useChartWidth, useOffsetInternal } from '../context/chartLayoutContext';
 import { AxisId } from '../state/cartesianAxisSlice';
 import { selectAxisPropsNeededForCartesianGridTicksGenerator } from '../state/selectors/axisSelectors';
 import { useAppSelector } from '../state/hooks';
@@ -378,7 +378,7 @@ const defaultProps = {
 export function CartesianGrid(props: Props) {
   const chartWidth = useChartWidth();
   const chartHeight = useChartHeight();
-  const offset = useOffset();
+  const offset = useOffsetInternal();
   const propsIncludingDefaults = {
     ...resolveDefaultProps(props, defaultProps),
     x: isNumber(props.x) ? props.x : offset.left,

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -17,7 +17,7 @@ import {
   adaptEventsOfChild,
   AnimationDuration,
   AnimationTiming,
-  ChartOffset,
+  ChartOffsetRequired,
   Coordinate,
   DataKey,
   LegendType,
@@ -323,7 +323,7 @@ function RenderTrapezoids(props: InternalProps) {
   return <FunnelTrapezoids trapezoids={trapezoids} allOtherFunnelProps={props} showLabels />;
 }
 
-const getRealWidthHeight = ({ customWidth }: { customWidth: number | string }, offset: ChartOffset) => {
+const getRealWidthHeight = (customWidth: number | string | undefined, offset: ChartOffsetRequired) => {
   const { width, height, left, right, top, bottom } = offset;
   const realHeight = height;
   let realWidth = width;
@@ -453,15 +453,15 @@ export function computeFunnelTrapezoids({
 }: {
   dataKey: Props['dataKey'];
   nameKey: Props['nameKey'];
-  offset: ChartOffset;
+  offset: ChartOffsetRequired;
   displayedData: RealFunnelData[];
   tooltipType?: TooltipType;
   lastShapeType?: Props['lastShapeType'];
   reversed?: boolean;
-  customWidth?: number | string;
+  customWidth: number | string | undefined;
 }): FunnelComposedData {
   const { left, top } = offset;
-  const { realHeight, realWidth, offsetX, offsetY } = getRealWidthHeight({ customWidth }, offset);
+  const { realHeight, realWidth, offsetX, offsetY } = getRealWidthHeight(customWidth, offset);
   const maxValue = Math.max.apply(
     null,
     displayedData.map((entry: any) => getValueByDataKey(entry, dataKey, 0)),

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -32,7 +32,7 @@ import {
 } from '../context/tooltipContext';
 import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
-import { useOffset } from '../context/chartLayoutContext';
+import { useOffsetInternal } from '../context/chartLayoutContext';
 import { ResolvedFunnelSettings, selectFunnelTrapezoids } from '../state/selectors/funnelSelectors';
 import { filterProps, findAllByType } from '../util/ReactUtils';
 import { Cell } from '../component/Cell';
@@ -370,7 +370,7 @@ const defaultFunnelProps = {
 } as const satisfies Partial<Props>;
 
 function FunnelImpl(props: Props) {
-  const { height, width } = useOffset();
+  const { height, width } = useOffsetInternal();
 
   const {
     stroke,

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -17,7 +17,7 @@ import {
   adaptEventsOfChild,
   AnimationDuration,
   AnimationTiming,
-  ChartOffsetRequired,
+  ChartOffsetInternal,
   Coordinate,
   DataKey,
   LegendType,
@@ -323,7 +323,7 @@ function RenderTrapezoids(props: InternalProps) {
   return <FunnelTrapezoids trapezoids={trapezoids} allOtherFunnelProps={props} showLabels />;
 }
 
-const getRealWidthHeight = (customWidth: number | string | undefined, offset: ChartOffsetRequired) => {
+const getRealWidthHeight = (customWidth: number | string | undefined, offset: ChartOffsetInternal) => {
   const { width, height, left, right, top, bottom } = offset;
   const realHeight = height;
   let realWidth = width;
@@ -453,7 +453,7 @@ export function computeFunnelTrapezoids({
 }: {
   dataKey: Props['dataKey'];
   nameKey: Props['nameKey'];
-  offset: ChartOffsetRequired;
+  offset: ChartOffsetInternal;
   displayedData: RealFunnelData[];
   tooltipType?: TooltipType;
   lastShapeType?: Props['lastShapeType'];

--- a/src/cartesian/GraphicalItemClipPath.tsx
+++ b/src/cartesian/GraphicalItemClipPath.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AxisId } from '../state/cartesianAxisSlice';
-import { useOffset } from '../context/chartLayoutContext';
+import { useOffsetInternal } from '../context/chartLayoutContext';
 import { useAppSelector } from '../state/hooks';
 import {
   implicitXAxis,
@@ -27,7 +27,7 @@ export function useNeedsClip(xAxisId: AxisId, yAxisId: AxisId) {
 }
 
 export function GraphicalItemClipPath({ xAxisId, yAxisId, clipPathId }: GraphicalItemClipPathProps) {
-  const offset = useOffset();
+  const offset = useOffsetInternal();
 
   const { needClipX, needClipY, needClip } = useNeedsClip(xAxisId, yAxisId);
 

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -28,7 +28,7 @@ import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 import { CartesianGraphicalItemContext, SetErrorBarContext } from '../context/CartesianGraphicalItemContext';
 import { GraphicalItemClipPath, useNeedsClip } from './GraphicalItemClipPath';
-import { useChartLayout, useOffset } from '../context/chartLayoutContext';
+import { useChartLayout, useOffsetInternal } from '../context/chartLayoutContext';
 import { BaseAxisWithScale } from '../state/selectors/axisSelectors';
 import { useIsPanorama } from '../context/PanoramaContext';
 import { ResolvedLineSettings, selectLinePoints } from '../state/selectors/lineSelectors';
@@ -623,7 +623,7 @@ function LineImpl(props: Props) {
   } = resolveDefaultProps(props, defaultLineProps);
 
   const { needClip } = useNeedsClip(xAxisId, yAxisId);
-  const { height, width, left, top } = useOffset();
+  const { height, width, left, top } = useOffsetInternal();
   const layout = useChartLayout();
   const isPanorama = useIsPanorama();
   const lineSettings: ResolvedLineSettings = useMemo(

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -16,7 +16,7 @@ import {
   selectXAxisSettings,
   selectXAxisSize,
 } from '../state/selectors/axisSelectors';
-import { selectAxisViewBox } from '../state/selectors/selectChartOffset';
+import { selectAxisViewBox } from '../state/selectors/selectChartOffsetInternal';
 import { useIsPanorama } from '../context/PanoramaContext';
 
 interface XAxisProps extends BaseAxisProps {

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -20,7 +20,7 @@ import {
   selectYAxisPosition,
   selectYAxisSize,
 } from '../state/selectors/axisSelectors';
-import { selectAxisViewBox } from '../state/selectors/selectChartOffset';
+import { selectAxisViewBox } from '../state/selectors/selectChartOffsetInternal';
 import { useIsPanorama } from '../context/PanoramaContext';
 import { getCalculatedYAxisWidth } from '../util/YAxisUtils';
 import { isLabelContentAFunction } from '../component/Label';

--- a/src/component/Cursor.tsx
+++ b/src/component/Cursor.tsx
@@ -10,7 +10,7 @@ import { getRadialCursorPoints } from '../util/cursor/getRadialCursorPoints';
 import { Sector } from '../shape/Sector';
 import { getCursorPoints } from '../util/cursor/getCursorPoints';
 import { filterProps } from '../util/ReactUtils';
-import { useChartLayout, useOffset } from '../context/chartLayoutContext';
+import { useChartLayout, useOffsetInternal } from '../context/chartLayoutContext';
 import { useTooltipAxisBandSize } from '../context/useTooltipAxis';
 import { useChartName } from '../state/selectors/selectors';
 import { TooltipPayload } from '../state/tooltipSlice';
@@ -103,7 +103,7 @@ export function CursorInternal(props: CursorConnectedProps) {
  */
 export function Cursor(props: CursorProps) {
   const tooltipAxisBandSize = useTooltipAxisBandSize();
-  const offset = useOffset();
+  const offset = useOffsetInternal();
   const layout = useChartLayout();
   const chartName = useChartName();
   return (

--- a/src/component/Cursor.tsx
+++ b/src/component/Cursor.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ReactElement, cloneElement, createElement, isValidElement, SVGProps } from 'react';
 import { clsx } from 'clsx';
-import { ChartCoordinate, ChartOffsetRequired, LayoutType, TooltipEventType } from '../util/types';
+import { ChartCoordinate, ChartOffsetInternal, LayoutType, TooltipEventType } from '../util/types';
 import { Curve } from '../shape/Curve';
 import { Cross } from '../shape/Cross';
 import { getCursorRectangle } from '../util/cursor/getCursorRectangle';
@@ -33,7 +33,7 @@ export type CursorProps = {
 export type CursorConnectedProps = CursorProps & {
   tooltipAxisBandSize: number;
   layout: LayoutType;
-  offset: ChartOffsetRequired;
+  offset: ChartOffsetInternal;
   coordinate: ChartCoordinate;
   payload: TooltipPayload;
   index: string;

--- a/src/container/ClipPathProvider.tsx
+++ b/src/container/ClipPathProvider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createContext, ReactNode, useContext, useState } from 'react';
-import { useOffset } from '../context/chartLayoutContext';
+import { useOffsetInternal } from '../context/chartLayoutContext';
 import { uniqueId } from '../util/DataUtils';
 
 const ClipPathIdContext = createContext<string | undefined>(undefined);
@@ -18,7 +18,7 @@ const ClipPathIdContext = createContext<string | undefined>(undefined);
 export const ClipPathProvider = ({ children }: { children: ReactNode }) => {
   const [clipPathId] = useState<string>(`${uniqueId('recharts')}-clip`);
 
-  const offset = useOffset();
+  const offset = useOffsetInternal();
 
   if (offset == null) {
     return null;

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { CartesianViewBoxRequired, ChartOffsetRequired, LayoutType, Margin, Size } from '../util/types';
+import { CartesianViewBoxRequired, ChartOffsetInternal, LayoutType, Margin, Size } from '../util/types';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { RechartsRootState } from '../state/store';
 import { setChartSize, setMargin } from '../state/layoutSlice';
@@ -24,7 +24,7 @@ export const useViewBox = (): CartesianViewBoxRequired | undefined => {
   };
 };
 
-const manyComponentsThrowErrorsIfOffsetIsUndefined: ChartOffsetRequired = {
+const manyComponentsThrowErrorsIfOffsetIsUndefined: ChartOffsetInternal = {
   top: 0,
   bottom: 0,
   left: 0,
@@ -33,7 +33,7 @@ const manyComponentsThrowErrorsIfOffsetIsUndefined: ChartOffsetRequired = {
   height: 0,
   brushBottom: 0,
 };
-export const useOffset = (): ChartOffsetRequired => {
+export const useOffset = (): ChartOffsetInternal => {
   return useAppSelector(selectChartOffset) ?? manyComponentsThrowErrorsIfOffsetIsUndefined;
 };
 

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -33,7 +33,14 @@ const manyComponentsThrowErrorsIfOffsetIsUndefined: ChartOffsetInternal = {
   height: 0,
   brushBottom: 0,
 };
-export const useOffset = (): ChartOffsetInternal => {
+/**
+ * For internal use only. If you want this information, `import { useOffset } from 'recharts'` instead.
+ *
+ * Returns the offset of the chart in pixels.
+ *
+ * @returns {ChartOffsetInternal} The offset of the chart in pixels, or a default value if not in a chart context.
+ */
+export const useOffsetInternal = (): ChartOffsetInternal => {
   return useAppSelector(selectChartOffset) ?? manyComponentsThrowErrorsIfOffsetIsUndefined;
 };
 

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -3,7 +3,7 @@ import { CartesianViewBoxRequired, ChartOffsetInternal, LayoutType, Margin, Size
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { RechartsRootState } from '../state/store';
 import { setChartSize, setMargin } from '../state/layoutSlice';
-import { selectChartOffset, selectChartViewBox } from '../state/selectors/selectChartOffset';
+import { selectChartOffsetInternal, selectChartViewBox } from '../state/selectors/selectChartOffsetInternal';
 import { selectChartHeight, selectChartWidth } from '../state/selectors/containerSelectors';
 import { useIsPanorama } from './PanoramaContext';
 import { selectBrushDimensions, selectBrushSettings } from '../state/selectors/brushSelectors';
@@ -41,7 +41,7 @@ const manyComponentsThrowErrorsIfOffsetIsUndefined: ChartOffsetInternal = {
  * @returns {ChartOffsetInternal} The offset of the chart in pixels, or a default value if not in a chart context.
  */
 export const useOffsetInternal = (): ChartOffsetInternal => {
-  return useAppSelector(selectChartOffset) ?? manyComponentsThrowErrorsIfOffsetIsUndefined;
+  return useAppSelector(selectChartOffsetInternal) ?? manyComponentsThrowErrorsIfOffsetIsUndefined;
 };
 
 /**

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -31,7 +31,7 @@ import {
   adaptEventsOfChild,
   AnimationDuration,
   AnimationTiming,
-  ChartOffsetRequired,
+  ChartOffsetInternal,
   Coordinate,
   DataKey,
   GeometrySector,
@@ -311,7 +311,7 @@ const parseCoordinateOfPie = (
     outerRadius?: number | string | ((dataPoint: any) => number);
     maxRadius?: number;
   },
-  offset: ChartOffsetRequired,
+  offset: ChartOffsetInternal,
   dataPoint: any,
 ): PieCoordinate => {
   const { top, left, width, height } = offset;
@@ -503,7 +503,7 @@ export function computePieSectors({
     cornerRadius?: number | string;
     presentationProps?: Record<string, string>;
   };
-  offset: ChartOffsetRequired;
+  offset: ChartOffsetInternal;
 }): ReadonlyArray<PieSectorDataItem> {
   const { cornerRadius, startAngle, endAngle, dataKey, nameKey, tooltipType } = pieSettings;
   const minAngle = Math.abs(pieSettings.minAngle);

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -31,7 +31,7 @@ import {
   adaptEventsOfChild,
   AnimationDuration,
   AnimationTiming,
-  ChartOffset,
+  ChartOffsetRequired,
   Coordinate,
   DataKey,
   GeometrySector,
@@ -311,7 +311,7 @@ const parseCoordinateOfPie = (
     outerRadius?: number | string | ((dataPoint: any) => number);
     maxRadius?: number;
   },
-  offset: ChartOffset,
+  offset: ChartOffsetRequired,
   dataPoint: any,
 ): PieCoordinate => {
   const { top, left, width, height } = offset;
@@ -503,7 +503,7 @@ export function computePieSectors({
     cornerRadius?: number | string;
     presentationProps?: Record<string, string>;
   };
-  offset: ChartOffset;
+  offset: ChartOffsetRequired;
 }): ReadonlyArray<PieSectorDataItem> {
   const { cornerRadius, startAngle, endAngle, dataKey, nameKey, tooltipType } = pieSettings;
   const minAngle = Math.abs(pieSettings.minAngle);

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -62,7 +62,7 @@ import {
 } from '../referenceElementsSlice';
 import { selectChartHeight, selectChartWidth } from './containerSelectors';
 import { selectAllXAxes, selectAllYAxes } from './selectAllAxes';
-import { selectChartOffset } from './selectChartOffset';
+import { selectChartOffsetInternal } from './selectChartOffsetInternal';
 import { AxisPropsForCartesianGridTicksGeneration } from '../../cartesian/CartesianGrid';
 import { BrushDimensions, selectBrushDimensions, selectBrushSettings } from './brushSelectors';
 import { selectBarCategoryGap, selectChartName, selectStackOffsetType } from './rootPropsSelectors';
@@ -1138,7 +1138,7 @@ const selectCalculatedPadding: (
   selectSmallestDistanceBetweenValues,
   selectChartLayout,
   selectBarCategoryGap,
-  selectChartOffset,
+  selectChartOffsetInternal,
   (_1, _2, _3, padding) => padding,
   (
     smallestDistanceInPercent: number | undefined,
@@ -1226,7 +1226,7 @@ export const combineXAxisRange: (
   isPanorama: boolean,
 ) => AxisRange | undefined = createSelector(
   [
-    selectChartOffset,
+    selectChartOffsetInternal,
     selectXAxisPadding,
     selectBrushDimensions,
     selectBrushSettings,
@@ -1254,7 +1254,7 @@ export const combineYAxisRange: (
   isPanorama: boolean,
 ) => AxisRange | undefined = createSelector(
   [
-    selectChartOffset,
+    selectChartOffsetInternal,
     selectChartLayout,
     selectYAxisPadding,
     selectBrushDimensions,
@@ -1395,7 +1395,7 @@ const getYAxisSize = (offset: ChartOffsetInternal, axisSettings: YAxisSettings):
 };
 
 export const selectXAxisSize: (state: RechartsRootState, xAxisId: AxisId) => Size = createSelector(
-  selectChartOffset,
+  selectChartOffsetInternal,
   selectXAxisSettings,
   getXAxisSize,
 );
@@ -1438,7 +1438,7 @@ export const selectAllXAxesOffsetSteps: (
   mirror: boolean,
 ) => AxisOffsetSteps = createSelector(
   selectChartHeight,
-  selectChartOffset,
+  selectChartOffsetInternal,
   selectAllXAxesWithOffsetType,
   pickAxisOrientation,
   pickMirror,
@@ -1464,7 +1464,7 @@ export const selectAllYAxesOffsetSteps: (
   mirror: boolean,
 ) => AxisOffsetSteps = createSelector(
   selectChartWidth,
-  selectChartOffset,
+  selectChartOffsetInternal,
   selectAllYAxesWithOffsetType,
   pickAxisOrientation,
   pickMirror,
@@ -1485,7 +1485,7 @@ export const selectAllYAxesOffsetSteps: (
 );
 
 export const selectXAxisPosition = (state: RechartsRootState, axisId: AxisId): Coordinate | undefined => {
-  const offset = selectChartOffset(state);
+  const offset = selectChartOffsetInternal(state);
   const axisSettings = selectXAxisSettings(state, axisId);
   if (axisSettings == null) {
     return undefined;
@@ -1499,7 +1499,7 @@ export const selectXAxisPosition = (state: RechartsRootState, axisId: AxisId): C
 };
 
 export const selectYAxisPosition = (state: RechartsRootState, axisId: AxisId): Coordinate | undefined => {
-  const offset = selectChartOffset(state);
+  const offset = selectChartOffsetInternal(state);
   const axisSettings: YAxisSettings = selectYAxisSettings(state, axisId);
   if (axisSettings == null) {
     return undefined;
@@ -1513,7 +1513,7 @@ export const selectYAxisPosition = (state: RechartsRootState, axisId: AxisId): C
 };
 
 export const selectYAxisSize: (state: RechartsRootState, yAxisId: AxisId) => Size = createSelector(
-  selectChartOffset,
+  selectChartOffsetInternal,
   selectYAxisSettings,
   (offset: ChartOffsetInternal, axisSettings: YAxisSettings): Size => {
     const width = typeof axisSettings.width === 'number' ? axisSettings.width : DEFAULT_Y_AXIS_WIDTH;

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -18,7 +18,7 @@ import {
   AxisType,
   CartesianTickItem,
   CategoricalDomain,
-  ChartOffsetRequired,
+  ChartOffsetInternal,
   Coordinate,
   DataKey,
   LayoutType,
@@ -1144,7 +1144,7 @@ const selectCalculatedPadding: (
     smallestDistanceInPercent: number | undefined,
     layout: LayoutType,
     barCategoryGap: number | string,
-    offset: ChartOffsetRequired,
+    offset: ChartOffsetInternal,
     padding: string,
   ) => {
     if (!isWellBehavedNumber(smallestDistanceInPercent)) {
@@ -1233,7 +1233,7 @@ export const combineXAxisRange: (
     (_state: RechartsRootState, _axisId: AxisId, isPanorama) => isPanorama,
   ],
   (
-    offset: ChartOffsetRequired,
+    offset: ChartOffsetInternal,
     padding,
     brushDimensions: BrushDimensions,
     { padding: brushPadding },
@@ -1262,7 +1262,7 @@ export const combineYAxisRange: (
     (_state: RechartsRootState, _axisId: AxisId, isPanorama) => isPanorama,
   ],
   (
-    offset: ChartOffsetRequired,
+    offset: ChartOffsetInternal,
     layout: LayoutType,
     padding: { top: number; bottom: number },
     brushDimensions: BrushDimensions,
@@ -1379,14 +1379,14 @@ const selectAllYAxesWithOffsetType: (
       .sort(compareIds),
 );
 
-const getXAxisSize = (offset: ChartOffsetRequired, axisSettings: XAxisSettings): Size => {
+const getXAxisSize = (offset: ChartOffsetInternal, axisSettings: XAxisSettings): Size => {
   return {
     width: offset.width,
     height: axisSettings.height,
   };
 };
 
-const getYAxisSize = (offset: ChartOffsetRequired, axisSettings: YAxisSettings): Size => {
+const getYAxisSize = (offset: ChartOffsetInternal, axisSettings: YAxisSettings): Size => {
   const width = typeof axisSettings.width === 'number' ? axisSettings.width : DEFAULT_Y_AXIS_WIDTH;
   return {
     width,
@@ -1403,7 +1403,7 @@ export const selectXAxisSize: (state: RechartsRootState, xAxisId: AxisId) => Siz
 type AxisOffsetSteps = Record<AxisId, number>;
 
 const combineXAxisPositionStartingPoint = (
-  offset: ChartOffsetRequired,
+  offset: ChartOffsetInternal,
   orientation: XAxisOrientation,
   chartHeight: number,
 ) => {
@@ -1418,7 +1418,7 @@ const combineXAxisPositionStartingPoint = (
 };
 
 const combineYAxisPositionStartingPoint = (
-  offset: ChartOffsetRequired,
+  offset: ChartOffsetInternal,
   orientation: YAxisOrientation,
   chartWidth: number,
 ) => {
@@ -1468,7 +1468,7 @@ export const selectAllYAxesOffsetSteps: (
   selectAllYAxesWithOffsetType,
   pickAxisOrientation,
   pickMirror,
-  (chartWidth, offset: ChartOffsetRequired, allAxesWithSameOffsetType, orientation: YAxisOrientation, mirror) => {
+  (chartWidth, offset: ChartOffsetInternal, allAxesWithSameOffsetType, orientation: YAxisOrientation, mirror) => {
     const steps: AxisOffsetSteps = {};
     let position: number;
     allAxesWithSameOffsetType.forEach(axis => {
@@ -1515,7 +1515,7 @@ export const selectYAxisPosition = (state: RechartsRootState, axisId: AxisId): C
 export const selectYAxisSize: (state: RechartsRootState, yAxisId: AxisId) => Size = createSelector(
   selectChartOffset,
   selectYAxisSettings,
-  (offset: ChartOffsetRequired, axisSettings: YAxisSettings): Size => {
+  (offset: ChartOffsetInternal, axisSettings: YAxisSettings): Size => {
     const width = typeof axisSettings.width === 'number' ? axisSettings.width : DEFAULT_Y_AXIS_WIDTH;
 
     return {

--- a/src/state/selectors/barSelectors.ts
+++ b/src/state/selectors/barSelectors.ts
@@ -22,7 +22,7 @@ import { selectChartLayout } from '../../context/chartLayoutContext';
 import { ChartData } from '../chartDataSlice';
 import { selectChartDataWithIndexesIfNotInPanorama } from './dataSelectors';
 import { MinPointSize } from '../../util/BarUtils';
-import { selectChartOffset } from './selectChartOffset';
+import { selectChartOffsetInternal } from './selectChartOffsetInternal';
 import { selectBarCategoryGap, selectBarGap, selectRootBarSize, selectRootMaxBarSize } from './rootPropsSelectors';
 import { isWellBehavedNumber } from '../../util/isWellBehavedNumber';
 
@@ -508,7 +508,7 @@ export const selectBarRectangles: (
   cells: ReadonlyArray<ReactElement> | undefined,
 ) => ReadonlyArray<BarRectangleItem> | undefined = createSelector(
   [
-    selectChartOffset,
+    selectChartOffsetInternal,
     selectXAxisWithScale,
     selectYAxisWithScale,
     selectXAxisTicks,

--- a/src/state/selectors/barSelectors.ts
+++ b/src/state/selectors/barSelectors.ts
@@ -16,7 +16,7 @@ import { AxisId } from '../cartesianAxisSlice';
 import { getPercentValue, isNullish } from '../../util/DataUtils';
 import { CartesianGraphicalItemSettings } from '../graphicalItemsSlice';
 import { BarPositionPosition, getBandSizeOfAxis, NormalizedStackId, StackId } from '../../util/ChartUtils';
-import { ChartOffset, DataKey, LayoutType, TickItem } from '../../util/types';
+import { ChartOffsetRequired, DataKey, LayoutType, TickItem } from '../../util/types';
 import { BarRectangleItem, computeBarRectangles } from '../../cartesian/Bar';
 import { selectChartLayout } from '../../context/chartLayoutContext';
 import { ChartData } from '../chartDataSlice';
@@ -522,7 +522,7 @@ export const selectBarRectangles: (
     pickCells,
   ],
   (
-    offset: ChartOffset,
+    offset: ChartOffsetRequired,
     xAxis: BaseAxisWithScale,
     yAxis: BaseAxisWithScale,
     xAxisTicks,

--- a/src/state/selectors/barSelectors.ts
+++ b/src/state/selectors/barSelectors.ts
@@ -16,7 +16,7 @@ import { AxisId } from '../cartesianAxisSlice';
 import { getPercentValue, isNullish } from '../../util/DataUtils';
 import { CartesianGraphicalItemSettings } from '../graphicalItemsSlice';
 import { BarPositionPosition, getBandSizeOfAxis, NormalizedStackId, StackId } from '../../util/ChartUtils';
-import { ChartOffsetRequired, DataKey, LayoutType, TickItem } from '../../util/types';
+import { ChartOffsetInternal, DataKey, LayoutType, TickItem } from '../../util/types';
 import { BarRectangleItem, computeBarRectangles } from '../../cartesian/Bar';
 import { selectChartLayout } from '../../context/chartLayoutContext';
 import { ChartData } from '../chartDataSlice';
@@ -522,7 +522,7 @@ export const selectBarRectangles: (
     pickCells,
   ],
   (
-    offset: ChartOffsetRequired,
+    offset: ChartOffsetInternal,
     xAxis: BaseAxisWithScale,
     yAxis: BaseAxisWithScale,
     xAxisTicks,

--- a/src/state/selectors/brushSelectors.ts
+++ b/src/state/selectors/brushSelectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { RechartsRootState } from '../store';
-import { selectChartOffset } from './selectChartOffset';
+import { selectChartOffsetInternal } from './selectChartOffsetInternal';
 import { selectMargin } from './containerSelectors';
 import { isNumber } from '../../util/DataUtils';
 import { BrushSettings } from '../brushSlice';
@@ -15,7 +15,7 @@ export type BrushDimensions = {
 };
 
 export const selectBrushDimensions: (state: RechartsRootState) => BrushDimensions = createSelector(
-  [selectBrushSettings, selectChartOffset, selectMargin],
+  [selectBrushSettings, selectChartOffsetInternal, selectMargin],
   (brushSettings, offset, margin): BrushDimensions => ({
     height: brushSettings.height,
     x: isNumber(brushSettings.x) ? brushSettings.x : offset.left,

--- a/src/state/selectors/combiners/combineCoordinateForDefaultIndex.ts
+++ b/src/state/selectors/combiners/combineCoordinateForDefaultIndex.ts
@@ -1,11 +1,11 @@
-import { ChartOffsetRequired, Coordinate, LayoutType, TickItem } from '../../../util/types';
+import { ChartOffsetInternal, Coordinate, LayoutType, TickItem } from '../../../util/types';
 import { TooltipIndex, TooltipPayloadConfiguration, TooltipPayloadSearcher } from '../../tooltipSlice';
 
 export const combineCoordinateForDefaultIndex = (
   width: number,
   height: number,
   layout: LayoutType,
-  offset: ChartOffsetRequired,
+  offset: ChartOffsetInternal,
   tooltipTicks: ReadonlyArray<TickItem>,
   defaultIndex: TooltipIndex | undefined,
   tooltipConfigurations: ReadonlyArray<TooltipPayloadConfiguration>,

--- a/src/state/selectors/funnelSelectors.ts
+++ b/src/state/selectors/funnelSelectors.ts
@@ -5,7 +5,7 @@ import { ChartData } from '../chartDataSlice';
 import { RechartsRootState } from '../store';
 import { selectChartOffset } from './selectChartOffset';
 import { selectChartDataAndAlwaysIgnoreIndexes } from './dataSelectors';
-import { ChartOffsetRequired, DataKey, TooltipType } from '../../util/types';
+import { ChartOffsetInternal, DataKey, TooltipType } from '../../util/types';
 import { CellProps } from '../..';
 
 type FunnelComposedData = {
@@ -45,7 +45,7 @@ export const selectFunnelTrapezoids: (
 ) => FunnelComposedData = createSelector(
   [selectChartOffset, pickFunnelSettings, selectChartDataAndAlwaysIgnoreIndexes],
   (
-    offset: ChartOffsetRequired,
+    offset: ChartOffsetInternal,
     { data, dataKey, nameKey, tooltipType, lastShapeType, reversed, customWidth, cells, presentationProps },
     { chartData },
   ): FunnelComposedData => {

--- a/src/state/selectors/funnelSelectors.ts
+++ b/src/state/selectors/funnelSelectors.ts
@@ -5,7 +5,7 @@ import { ChartData } from '../chartDataSlice';
 import { RechartsRootState } from '../store';
 import { selectChartOffset } from './selectChartOffset';
 import { selectChartDataAndAlwaysIgnoreIndexes } from './dataSelectors';
-import { DataKey, TooltipType } from '../../util/types';
+import { ChartOffsetRequired, DataKey, TooltipType } from '../../util/types';
 import { CellProps } from '../..';
 
 type FunnelComposedData = {
@@ -45,7 +45,7 @@ export const selectFunnelTrapezoids: (
 ) => FunnelComposedData = createSelector(
   [selectChartOffset, pickFunnelSettings, selectChartDataAndAlwaysIgnoreIndexes],
   (
-    offset,
+    offset: ChartOffsetRequired,
     { data, dataKey, nameKey, tooltipType, lastShapeType, reversed, customWidth, cells, presentationProps },
     { chartData },
   ): FunnelComposedData => {

--- a/src/state/selectors/funnelSelectors.ts
+++ b/src/state/selectors/funnelSelectors.ts
@@ -3,7 +3,7 @@ import { ReactElement } from 'react';
 import { computeFunnelTrapezoids, FunnelTrapezoidItem } from '../../cartesian/Funnel';
 import { ChartData } from '../chartDataSlice';
 import { RechartsRootState } from '../store';
-import { selectChartOffset } from './selectChartOffset';
+import { selectChartOffsetInternal } from './selectChartOffsetInternal';
 import { selectChartDataAndAlwaysIgnoreIndexes } from './dataSelectors';
 import { ChartOffsetInternal, DataKey, TooltipType } from '../../util/types';
 import { CellProps } from '../..';
@@ -43,7 +43,7 @@ export const selectFunnelTrapezoids: (
     presentationProps,
   }: ResolvedFunnelSettings,
 ) => FunnelComposedData = createSelector(
-  [selectChartOffset, pickFunnelSettings, selectChartDataAndAlwaysIgnoreIndexes],
+  [selectChartOffsetInternal, pickFunnelSettings, selectChartDataAndAlwaysIgnoreIndexes],
   (
     offset: ChartOffsetInternal,
     { data, dataKey, nameKey, tooltipType, lastShapeType, reversed, customWidth, cells, presentationProps },

--- a/src/state/selectors/pieSelectors.ts
+++ b/src/state/selectors/pieSelectors.ts
@@ -7,7 +7,7 @@ import { selectChartDataAndAlwaysIgnoreIndexes } from './dataSelectors';
 import { ChartData, ChartDataState } from '../chartDataSlice';
 import { ChartOffsetInternal, DataKey } from '../../util/types';
 import { TooltipType } from '../../component/DefaultTooltipContent';
-import { selectChartOffset } from './selectChartOffset';
+import { selectChartOffsetInternal } from './selectChartOffsetInternal';
 import type { LegendPayload } from '../../component/DefaultLegendContent';
 import { getTooltipNameProp, getValueByDataKey } from '../../util/ChartUtils';
 import { selectUnfilteredPolarItems } from './polarSelectors';
@@ -137,7 +137,7 @@ export const selectPieSectors: (
   pieSettings: ResolvedPieSettings,
   cells: ReadonlyArray<ReactElement> | undefined,
 ) => Readonly<PieSectorDataItem[]> | undefined = createSelector(
-  [selectDisplayedData, selectSynchronisedPieSettings, pickCells, selectChartOffset],
+  [selectDisplayedData, selectSynchronisedPieSettings, pickCells, selectChartOffsetInternal],
   (
     displayedData: ChartData | undefined,
     pieSettings: ResolvedPieSettings,

--- a/src/state/selectors/pieSelectors.ts
+++ b/src/state/selectors/pieSelectors.ts
@@ -5,7 +5,7 @@ import { computePieSectors, PieSectorDataItem } from '../../polar/Pie';
 import { RechartsRootState } from '../store';
 import { selectChartDataAndAlwaysIgnoreIndexes } from './dataSelectors';
 import { ChartData, ChartDataState } from '../chartDataSlice';
-import { ChartOffsetRequired, DataKey } from '../../util/types';
+import { ChartOffsetInternal, DataKey } from '../../util/types';
 import { TooltipType } from '../../component/DefaultTooltipContent';
 import { selectChartOffset } from './selectChartOffset';
 import type { LegendPayload } from '../../component/DefaultLegendContent';
@@ -142,7 +142,7 @@ export const selectPieSectors: (
     displayedData: ChartData | undefined,
     pieSettings: ResolvedPieSettings,
     cells,
-    offset: ChartOffsetRequired,
+    offset: ChartOffsetInternal,
   ): Readonly<PieSectorDataItem[]> | undefined => {
     if (pieSettings == null || displayedData == null) {
       return undefined;

--- a/src/state/selectors/pieSelectors.ts
+++ b/src/state/selectors/pieSelectors.ts
@@ -5,7 +5,7 @@ import { computePieSectors, PieSectorDataItem } from '../../polar/Pie';
 import { RechartsRootState } from '../store';
 import { selectChartDataAndAlwaysIgnoreIndexes } from './dataSelectors';
 import { ChartData, ChartDataState } from '../chartDataSlice';
-import { ChartOffset, DataKey } from '../../util/types';
+import { ChartOffsetRequired, DataKey } from '../../util/types';
 import { TooltipType } from '../../component/DefaultTooltipContent';
 import { selectChartOffset } from './selectChartOffset';
 import type { LegendPayload } from '../../component/DefaultLegendContent';
@@ -142,7 +142,7 @@ export const selectPieSectors: (
     displayedData: ChartData | undefined,
     pieSettings: ResolvedPieSettings,
     cells,
-    offset: ChartOffset,
+    offset: ChartOffsetRequired,
   ): Readonly<PieSectorDataItem[]> | undefined => {
     if (pieSettings == null || displayedData == null) {
       return undefined;

--- a/src/state/selectors/polarAxisSelectors.ts
+++ b/src/state/selectors/polarAxisSelectors.ts
@@ -4,7 +4,7 @@ import { AxisId } from '../cartesianAxisSlice';
 import { AngleAxisSettings, RadiusAxisSettings } from '../polarAxisSlice';
 import { PolarChartOptions } from '../polarOptionsSlice';
 import { selectChartHeight, selectChartWidth } from './containerSelectors';
-import { selectChartOffset } from './selectChartOffset';
+import { selectChartOffsetInternal } from './selectChartOffsetInternal';
 import { getMaxRadius } from '../../util/PolarUtils';
 import { getPercentValue } from '../../util/DataUtils';
 import { LayoutType, PolarViewBoxRequired } from '../../util/types';
@@ -109,7 +109,7 @@ export const selectRadiusAxis = (state: RechartsRootState, radiusAxisId: AxisId)
 export const selectPolarOptions = (state: RechartsRootState): PolarChartOptions | null => state.polarOptions;
 
 export const selectMaxRadius: (state: RechartsRootState) => number = createSelector(
-  [selectChartWidth, selectChartHeight, selectChartOffset],
+  [selectChartWidth, selectChartHeight, selectChartOffsetInternal],
   getMaxRadius,
 );
 

--- a/src/state/selectors/selectActivePropsFromChartPointer.ts
+++ b/src/state/selectors/selectActivePropsFromChartPointer.ts
@@ -3,7 +3,7 @@ import { RechartsRootState } from '../store';
 import { ActiveTooltipProps } from '../tooltipSlice';
 import { selectChartLayout } from '../../context/chartLayoutContext';
 import { selectTooltipAxisRangeWithReverse, selectTooltipAxisTicks, selectTooltipAxisType } from './tooltipSelectors';
-import { selectChartOffset } from './selectChartOffset';
+import { selectChartOffsetInternal } from './selectChartOffsetInternal';
 import { combineActiveProps, selectOrderedTooltipTicks } from './selectors';
 import { selectPolarViewBox } from './polarAxisSelectors';
 import { ChartPointer } from '../../util/types';
@@ -22,7 +22,7 @@ export const selectActivePropsFromChartPointer: (
     selectTooltipAxisRangeWithReverse,
     selectTooltipAxisTicks,
     selectOrderedTooltipTicks,
-    selectChartOffset,
+    selectChartOffsetInternal,
   ],
   combineActiveProps,
 );

--- a/src/state/selectors/selectChartOffset.ts
+++ b/src/state/selectors/selectChartOffset.ts
@@ -4,7 +4,7 @@ import get from 'es-toolkit/compat/get';
 import { selectLegendSettings, selectLegendSize } from './legendSelectors';
 import {
   CartesianViewBoxRequired,
-  ChartOffsetRequired,
+  ChartOffsetInternal,
   Margin,
   OffsetHorizontal,
   OffsetVertical,
@@ -20,7 +20,7 @@ import { RechartsRootState } from '../store';
 
 export const selectBrushHeight = (state: RechartsRootState) => state.brush.height;
 
-export const selectChartOffset: (state: RechartsRootState) => ChartOffsetRequired = createSelector(
+export const selectChartOffset: (state: RechartsRootState) => ChartOffsetInternal = createSelector(
   [
     selectChartWidth,
     selectChartHeight,
@@ -40,7 +40,7 @@ export const selectChartOffset: (state: RechartsRootState) => ChartOffsetRequire
     yAxes: YAxisSettings[],
     legendSettings: LegendSettings,
     legendSize: Size,
-  ): ChartOffsetRequired => {
+  ): ChartOffsetInternal => {
     const offsetH: OffsetHorizontal = yAxes.reduce(
       (result: OffsetHorizontal, entry: YAxisSettings): OffsetHorizontal => {
         const { orientation } = entry;
@@ -91,7 +91,7 @@ export const selectChartOffset: (state: RechartsRootState) => ChartOffsetRequire
 
 export const selectChartViewBox = createSelector(
   selectChartOffset,
-  (offset: ChartOffsetRequired): CartesianViewBoxRequired => ({
+  (offset: ChartOffsetInternal): CartesianViewBoxRequired => ({
     x: offset.left,
     y: offset.top,
     width: offset.width,

--- a/src/state/selectors/selectChartOffsetInternal.ts
+++ b/src/state/selectors/selectChartOffsetInternal.ts
@@ -20,7 +20,13 @@ import { RechartsRootState } from '../store';
 
 export const selectBrushHeight = (state: RechartsRootState) => state.brush.height;
 
-export const selectChartOffset: (state: RechartsRootState) => ChartOffsetInternal = createSelector(
+/**
+ * For internal use only.
+ *
+ * @param root state
+ * @return ChartOffsetInternal
+ */
+export const selectChartOffsetInternal: (state: RechartsRootState) => ChartOffsetInternal = createSelector(
   [
     selectChartWidth,
     selectChartHeight,
@@ -90,7 +96,7 @@ export const selectChartOffset: (state: RechartsRootState) => ChartOffsetInterna
 );
 
 export const selectChartViewBox = createSelector(
-  selectChartOffset,
+  selectChartOffsetInternal,
   (offset: ChartOffsetInternal): CartesianViewBoxRequired => ({
     x: offset.left,
     y: offset.top,

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -40,7 +40,7 @@ import { selectTooltipAxis, selectTooltipAxisTicks, selectTooltipDisplayedData }
 import { AxisRange } from './axisSelectors';
 import { selectChartName } from './rootPropsSelectors';
 import { selectChartLayout } from '../../context/chartLayoutContext';
-import { selectChartOffset } from './selectChartOffset';
+import { selectChartOffsetInternal } from './selectChartOffsetInternal';
 import { selectChartHeight, selectChartWidth } from './containerSelectors';
 import { combineActiveLabel } from './combiners/combineActiveLabel';
 import { combineTooltipInteractionState } from './combiners/combineTooltipInteractionState';
@@ -149,7 +149,7 @@ export const selectCoordinateForDefaultIndex: (
     selectChartWidth,
     selectChartHeight,
     selectChartLayout,
-    selectChartOffset,
+    selectChartOffsetInternal,
     selectTooltipAxisTicks,
     pickDefaultIndex,
     selectTooltipPayloadConfigurations,

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -24,7 +24,7 @@ import { ChartDataState } from '../chartDataSlice';
 import {
   AxisType,
   BaseAxisProps,
-  ChartOffsetRequired,
+  ChartOffsetInternal,
   ChartPointer,
   Coordinate,
   DataKey,
@@ -313,7 +313,7 @@ export const combineActiveProps = (
   tooltipAxisRange: AxisRange | undefined,
   tooltipTicks: ReadonlyArray<TickItem> | undefined,
   orderedTooltipTicks: ReadonlyArray<TickItem> | undefined,
-  offset: ChartOffsetRequired,
+  offset: ChartOffsetInternal,
 ): ActiveTooltipProps | undefined => {
   if (!chartEvent || !layout || !tooltipAxisType || !tooltipAxisRange || !tooltipTicks) {
     return undefined;

--- a/src/state/selectors/tooltipSelectors.ts
+++ b/src/state/selectors/tooltipSelectors.ts
@@ -72,7 +72,7 @@ import { combineTooltipInteractionState } from './combiners/combineTooltipIntera
 import { combineActiveTooltipIndex } from './combiners/combineActiveTooltipIndex';
 import { combineCoordinateForDefaultIndex } from './combiners/combineCoordinateForDefaultIndex';
 import { selectChartHeight, selectChartWidth } from './containerSelectors';
-import { selectChartOffset } from './selectChartOffset';
+import { selectChartOffsetInternal } from './selectChartOffsetInternal';
 import { combineTooltipPayloadConfigurations } from './combiners/combineTooltipPayloadConfigurations';
 import { selectTooltipPayloadSearcher } from './selectTooltipPayloadSearcher';
 import { selectTooltipState } from './selectTooltipState';
@@ -390,7 +390,7 @@ const selectTooltipCoordinateForDefaultIndex: (state: RechartsRootState) => Coor
     selectChartWidth,
     selectChartHeight,
     selectChartLayout,
-    selectChartOffset,
+    selectChartOffsetInternal,
     selectTooltipAxisTicks,
     selectDefaultIndex,
     selectTooltipPayloadConfigurations,

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -20,7 +20,7 @@ import {
   AxisType,
   BaseAxisProps,
   ChartCoordinate,
-  ChartOffsetRequired,
+  ChartOffsetInternal,
   DataKey,
   LayoutType,
   NumberDomain,
@@ -738,7 +738,7 @@ export function inRange(
   y: number,
   layout: LayoutType,
   polarViewBox: PolarViewBoxRequired | undefined,
-  offset: ChartOffsetRequired,
+  offset: ChartOffsetInternal,
 ): RangeObj | null {
   if (layout === 'horizontal' || layout === 'vertical') {
     const isInRange =

--- a/src/util/PolarUtils.ts
+++ b/src/util/PolarUtils.ts
@@ -1,5 +1,5 @@
 import { ReactElement, SVGProps, isValidElement } from 'react';
-import { Coordinate, ChartOffset, RangeObj, PolarViewBoxRequired } from './types';
+import { Coordinate, RangeObj, PolarViewBoxRequired, ChartOffsetRequired } from './types';
 
 export const RADIAN = Math.PI / 180;
 
@@ -15,11 +15,14 @@ export const polarToCartesian = (cx: number, cy: number, radius: number, angle: 
 export const getMaxRadius = (
   width: number,
   height: number,
-  offset: ChartOffset = {
+  offset: ChartOffsetRequired = {
     top: 0,
     right: 0,
     bottom: 0,
     left: 0,
+    width: 0,
+    height: 0,
+    brushBottom: 0,
   },
 ) =>
   Math.min(

--- a/src/util/PolarUtils.ts
+++ b/src/util/PolarUtils.ts
@@ -1,5 +1,5 @@
 import { ReactElement, SVGProps, isValidElement } from 'react';
-import { Coordinate, RangeObj, PolarViewBoxRequired, ChartOffsetRequired } from './types';
+import { Coordinate, RangeObj, PolarViewBoxRequired, ChartOffsetInternal } from './types';
 
 export const RADIAN = Math.PI / 180;
 
@@ -15,7 +15,7 @@ export const polarToCartesian = (cx: number, cy: number, radius: number, angle: 
 export const getMaxRadius = (
   width: number,
   height: number,
-  offset: ChartOffsetRequired = {
+  offset: ChartOffsetInternal = {
     top: 0,
     right: 0,
     bottom: 0,

--- a/src/util/cursor/getCursorPoints.ts
+++ b/src/util/cursor/getCursorPoints.ts
@@ -1,11 +1,11 @@
 import { polarToCartesian } from '../PolarUtils';
-import { ChartCoordinate, Coordinate, LayoutType, ChartOffsetRequired } from '../types';
+import { ChartCoordinate, Coordinate, LayoutType, ChartOffsetInternal } from '../types';
 import { RadialCursorPoints, getRadialCursorPoints } from './getRadialCursorPoints';
 
 export function getCursorPoints(
   layout: LayoutType,
   activeCoordinate: ChartCoordinate,
-  offset: ChartOffsetRequired,
+  offset: ChartOffsetInternal,
 ): [Coordinate, Coordinate] | RadialCursorPoints {
   let x1, y1, x2, y2;
 

--- a/src/util/cursor/getCursorRectangle.ts
+++ b/src/util/cursor/getCursorRectangle.ts
@@ -1,4 +1,4 @@
-import { ChartCoordinate, ChartOffsetRequired, LayoutType } from '../types';
+import { ChartCoordinate, ChartOffsetInternal, LayoutType } from '../types';
 
 export type CursorRectangle = {
   stroke: string;
@@ -12,7 +12,7 @@ export type CursorRectangle = {
 export function getCursorRectangle(
   layout: LayoutType,
   activeCoordinate: ChartCoordinate,
-  offset: ChartOffsetRequired,
+  offset: ChartOffsetInternal,
   tooltipAxisBandSize: number,
 ): CursorRectangle {
   const halfSize = tooltipAxisBandSize / 2;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -98,7 +98,7 @@ export interface ChartCoordinate extends Coordinate {
   yAxis?: any;
   width?: any;
   height?: any;
-  offset?: ChartOffsetRequired;
+  offset?: ChartOffsetInternal;
   angle?: number;
   radius?: number;
   cx?: number;
@@ -1074,7 +1074,12 @@ export type OffsetHorizontal = {
   right: number;
 };
 
-export type ChartOffsetRequired = {
+/**
+ * This object defines the offset of the chart area and width and height and brush and ... it's a bit too much information all in one.
+ * We use it internally but let's not expose it to the outside world.
+ * If you are looking for this information, instead import `ChartOffset` or `PlotArea` from `recharts`.
+ */
+export type ChartOffsetInternal = {
   top: number;
   bottom: number;
   left: number;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1074,21 +1074,15 @@ export type OffsetHorizontal = {
   right: number;
 };
 
-/**
- * the offset of a chart, which define the blank space all around
- * @deprecated, has all properties optional. instead use `ChartOffsetRequired`
- * */
-export interface ChartOffset {
-  top?: number;
-  bottom?: number;
-  left?: number;
-  right?: number;
-  width?: number;
-  height?: number;
-  brushBottom?: number;
-}
-
-export type ChartOffsetRequired = Required<ChartOffset>;
+export type ChartOffsetRequired = {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+  width: number;
+  height: number;
+  brushBottom: number;
+};
 
 export interface Padding {
   top: number;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1071,7 +1071,10 @@ export type OffsetHorizontal = {
   right: number;
 };
 
-/** the offset of a chart, which define the blank space all around */
+/**
+ * the offset of a chart, which define the blank space all around
+ * @deprecated, has all properties optional. instead use `ChartOffsetRequired`
+ * */
 export interface ChartOffset {
   top?: number;
   bottom?: number;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -90,12 +90,15 @@ export interface NullableCoordinate {
   y: number | null;
 }
 
+/**
+ * @deprecated do not use: too many properties, mixing too many concepts, cartesian and polar together, everything optional.
+ */
 export interface ChartCoordinate extends Coordinate {
   xAxis?: any;
   yAxis?: any;
   width?: any;
   height?: any;
-  offset?: ChartOffset;
+  offset?: ChartOffsetRequired;
   angle?: number;
   radius?: number;
   cx?: number;

--- a/storybook/storybook-addon-recharts/inspectors/GraphicalAreaShower.tsx
+++ b/storybook/storybook-addon-recharts/inspectors/GraphicalAreaShower.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useOffset } from '../../../src/context/chartLayoutContext';
+import { useOffsetInternal } from '../../../src/context/chartLayoutContext';
 import { SvgDimensionShower } from '../../ChartSizeDimensions';
 
 export function GraphicalAreaShower() {
-  const offset = useOffset();
+  const offset = useOffsetInternal();
   return (
     <SvgDimensionShower
       x={offset.left}

--- a/storybook/storybook-addon-recharts/inspectors/OffsetInspector.tsx
+++ b/storybook/storybook-addon-recharts/inspectors/OffsetInspector.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useOffset } from '../../../src/context/chartLayoutContext';
+import { useOffsetInternal } from '../../../src/context/chartLayoutContext';
 import { ObjectInspector } from './generic/ObjectInspector';
 
 export function OffsetInspector() {
-  const offset = useOffset();
+  const offset = useOffsetInternal();
   return <ObjectInspector obj={offset} />;
 }

--- a/storybook/storybook-addon-recharts/inspectors/OffsetShower.tsx
+++ b/storybook/storybook-addon-recharts/inspectors/OffsetShower.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useChartHeight, useChartWidth, useOffset } from '../../../src/context/chartLayoutContext';
+import { useChartHeight, useChartWidth, useOffsetInternal } from '../../../src/context/chartLayoutContext';
 import { SvgDimensionShower } from '../../ChartSizeDimensions';
 
 export function OffsetShower() {
-  const offset = useOffset();
+  const offset = useOffsetInternal();
   const height = useChartHeight();
   const width = useChartWidth();
   return (

--- a/storybook/storybook-addon-recharts/inspectors/SelectChartViewBoxInspector.tsx
+++ b/storybook/storybook-addon-recharts/inspectors/SelectChartViewBoxInspector.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useAppSelector } from '../../../src/state/hooks';
-import { selectChartViewBox } from '../../../src/state/selectors/selectChartOffset';
+import { selectChartViewBox } from '../../../src/state/selectors/selectChartOffsetInternal';
 import { ObjectInspector } from './generic/ObjectInspector';
 
 export function SelectChartViewBoxInspector() {

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -23,7 +23,7 @@ import {
   HorizontalCoordinatesGenerator,
   VerticalCoordinatesGenerator,
 } from '../../src/cartesian/CartesianGrid';
-import { ChartOffsetRequired, Margin } from '../../src/util/types';
+import { ChartOffsetInternal, Margin } from '../../src/util/types';
 import { assertNotNull } from '../helper/assertNotNull';
 import { pageData } from '../../storybook/stories/data';
 import { selectAxisScale } from '../../src/state/selectors/axisSelectors';
@@ -320,7 +320,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
       top: 14,
     };
 
-    const expectedOffset: ChartOffsetRequired = {
+    const expectedOffset: ChartOffsetInternal = {
       bottom: 11,
       brushBottom: 11,
       height: 175,

--- a/test/cartesian/CartesianGrid.spec.tsx
+++ b/test/cartesian/CartesianGrid.spec.tsx
@@ -23,7 +23,7 @@ import {
   HorizontalCoordinatesGenerator,
   VerticalCoordinatesGenerator,
 } from '../../src/cartesian/CartesianGrid';
-import { ChartOffset, Margin } from '../../src/util/types';
+import { ChartOffsetRequired, Margin } from '../../src/util/types';
 import { assertNotNull } from '../helper/assertNotNull';
 import { pageData } from '../../storybook/stories/data';
 import { selectAxisScale } from '../../src/state/selectors/axisSelectors';
@@ -320,7 +320,7 @@ describe.each(allChartsThatSupportCartesianGrid)('<CartesianGrid /> when child o
       top: 14,
     };
 
-    const expectedOffset: ChartOffset = {
+    const expectedOffset: ChartOffsetRequired = {
       bottom: 11,
       brushBottom: 11,
       height: 175,

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -45,7 +45,7 @@ import {
   selectBarCartesianAxisSize,
   selectBarSizeList,
 } from '../../src/state/selectors/barSelectors';
-import { selectChartOffset } from '../../src/state/selectors/selectChartOffset';
+import { selectChartOffsetInternal } from '../../src/state/selectors/selectChartOffsetInternal';
 import { selectChartDataWithIndexes } from '../../src/state/selectors/dataSelectors';
 import { useIsPanorama } from '../../src/context/PanoramaContext';
 
@@ -483,7 +483,7 @@ describe('<XAxis />', () => {
       yAxisRangeSpy(useAppSelector(state => selectAxisRangeWithReverse(state, 'yAxis', 0, false)));
       barTicksSpy(useAppSelector(state => selectTicksOfGraphicalItem(state, 'xAxis', 0, false)));
       barBandSizeSpy(useAppSelector(state => selectBarBandSize(state, 0, 0, false, barSettings)));
-      offsetSpy(useAppSelector(selectChartOffset));
+      offsetSpy(useAppSelector(selectChartOffsetInternal));
       return null;
     };
 

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -79,7 +79,7 @@ import { expectLastCalledWithScale } from '../../helper/expectScale';
 import { selectChartLayout } from '../../../src/context/chartLayoutContext';
 import { TooltipIndex, TooltipState } from '../../../src/state/tooltipSlice';
 import { selectTooltipState } from '../../../src/state/selectors/selectTooltipState';
-import { selectChartOffset } from '../../../src/state/selectors/selectChartOffset';
+import { selectChartOffsetInternal } from '../../../src/state/selectors/selectChartOffsetInternal';
 import {
   selectLegendPayload,
   selectLegendSettings,
@@ -727,7 +727,7 @@ describe('Tooltip visibility', () => {
     });
 
     it('should select chart offset', () => {
-      const { spy } = renderTestCase(selectChartOffset);
+      const { spy } = renderTestCase(selectChartOffsetInternal);
       expect(spy).toHaveBeenLastCalledWith({
         bottom: 135,
         brushBottom: 35,

--- a/test/container/chartDimensions.spec.tsx
+++ b/test/container/chartDimensions.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { Line, LineChart, useChartWidth, useChartHeight, Brush } from '../../src';
 import { PageData } from '../_data';
-import { useOffset } from '../../src/context/chartLayoutContext';
+import { useOffsetInternal } from '../../src/context/chartLayoutContext';
 import { selectBrushDimensions } from '../../src/state/selectors/brushSelectors';
 import { useClipPathId } from '../../src/container/ClipPathProvider';
 import { useIsPanorama } from '../../src/context/PanoramaContext';
@@ -40,7 +40,7 @@ describe('Chart dimensions', () => {
     });
 
     it('should return chart offset', () => {
-      const { spy } = renderTestCase(useOffset);
+      const { spy } = renderTestCase(useOffsetInternal);
       expect(spy).toHaveBeenLastCalledWith({
         bottom: 13,
         brushBottom: 13,
@@ -165,7 +165,7 @@ describe('Chart dimensions', () => {
       });
 
       it('should return chart offset', () => {
-        const { spy } = renderTestCase(useOffset);
+        const { spy } = renderTestCase(useOffsetInternal);
         expect(spy).toHaveBeenLastCalledWith({
           bottom: 53,
           brushBottom: 13,
@@ -284,7 +284,7 @@ describe('Chart dimensions', () => {
       });
 
       it('should return chart offset from the main chart', () => {
-        const { spy } = renderTestCase(useOffset);
+        const { spy } = renderTestCase(useOffsetInternal);
         expect(spy).toHaveBeenLastCalledWith({
           bottom: 53,
           brushBottom: 13,

--- a/test/context/chartLayoutContext.spec.tsx
+++ b/test/context/chartLayoutContext.spec.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentType } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
-import { useOffset } from '../../src/context/chartLayoutContext';
+import { useOffsetInternal } from '../../src/context/chartLayoutContext';
 import { Brush, ComposedChart, Customized, Legend, XAxis, YAxis } from '../../src';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 import { emptyOffset } from '../helper/offsetHelpers';
@@ -37,7 +37,7 @@ describe('useOffset', () => {
   it('should return offset with all zeroes when used outside of chart', () => {
     expect.assertions(1);
     const Comp = (): null => {
-      const offset = useOffset();
+      const offset = useOffsetInternal();
       expect(offset).toEqual(emptyOffset);
       return null;
     };
@@ -47,7 +47,7 @@ describe('useOffset', () => {
   it('should return default offset in an empty chart', () => {
     const offsetSpy = vi.fn();
     const Comp = (): null => {
-      const offset = useOffset();
+      const offset = useOffsetInternal();
       offsetSpy(offset);
       return null;
     };
@@ -72,7 +72,7 @@ describe('useOffset', () => {
   it('should add chart margin', () => {
     const offsetSpy = vi.fn();
     const Comp = (): null => {
-      const offset = useOffset();
+      const offset = useOffsetInternal();
       offsetSpy(offset);
       return null;
     };
@@ -97,7 +97,7 @@ describe('useOffset', () => {
   it('should include default Brush height (40) in bottom property', () => {
     const offsetSpy = vi.fn();
     const Comp = (): null => {
-      offsetSpy(useOffset());
+      offsetSpy(useOffsetInternal());
       return null;
     };
     render(
@@ -121,7 +121,7 @@ describe('useOffset', () => {
   it('should include explicit brush height in bottom property', () => {
     const offsetSpy = vi.fn();
     const Comp = (): null => {
-      offsetSpy(useOffset());
+      offsetSpy(useOffsetInternal());
       return null;
     };
     render(
@@ -145,7 +145,7 @@ describe('useOffset', () => {
   it('should include default width of YAxis', () => {
     const offsetSpy = vi.fn();
     const Comp = (): null => {
-      offsetSpy(useOffset());
+      offsetSpy(useOffsetInternal());
       return null;
     };
     render(
@@ -170,7 +170,7 @@ describe('useOffset', () => {
   it('should include explicit width of YAxis', () => {
     const offsetSpy = vi.fn();
     const Comp = (): null => {
-      offsetSpy(useOffset());
+      offsetSpy(useOffsetInternal());
       return null;
     };
     render(
@@ -195,7 +195,7 @@ describe('useOffset', () => {
   it('should exclude hidden YAxis dimensions', () => {
     const offsetSpy = vi.fn();
     const Comp = (): null => {
-      offsetSpy(useOffset());
+      offsetSpy(useOffsetInternal());
       return null;
     };
     render(
@@ -220,7 +220,7 @@ describe('useOffset', () => {
   it('should include default height of XAxis', () => {
     const offsetSpy = vi.fn();
     const Comp = (): null => {
-      offsetSpy(useOffset());
+      offsetSpy(useOffsetInternal());
       return null;
     };
     render(
@@ -244,7 +244,7 @@ describe('useOffset', () => {
   it('should include explicit height of XAxis', () => {
     const offsetSpy = vi.fn();
     const Comp = (): null => {
-      offsetSpy(useOffset());
+      offsetSpy(useOffsetInternal());
       return null;
     };
     render(
@@ -268,7 +268,7 @@ describe('useOffset', () => {
   it('should exclude hidden XAxis height', () => {
     const offsetSpy = vi.fn();
     const Comp = (): null => {
-      offsetSpy(useOffset());
+      offsetSpy(useOffsetInternal());
       return null;
     };
     render(
@@ -297,7 +297,7 @@ describe('useOffset', () => {
   it('should include computed width and height on Legend - see appendOffsetOfLegend for detailed behaviour', () => {
     const offsetSpy = vi.fn();
     const Comp = (): null => {
-      offsetSpy(useOffset());
+      offsetSpy(useOffsetInternal());
       return null;
     };
     mockGetBoundingClientRect({ height: 29, width: 43 });

--- a/test/helper/offsetHelpers.ts
+++ b/test/helper/offsetHelpers.ts
@@ -1,4 +1,4 @@
-import { ChartOffset, ChartOffsetRequired } from '../../src/util/types';
+import { ChartOffsetRequired } from '../../src/util/types';
 
 export const emptyOffset: ChartOffsetRequired = {
   top: 0,
@@ -10,7 +10,7 @@ export const emptyOffset: ChartOffsetRequired = {
   brushBottom: 0,
 };
 
-export function makeChartOffset(partialOffset: ChartOffset): ChartOffsetRequired {
+export function makeChartOffset(partialOffset: Partial<ChartOffsetRequired>): ChartOffsetRequired {
   return {
     ...emptyOffset,
     ...partialOffset,

--- a/test/helper/offsetHelpers.ts
+++ b/test/helper/offsetHelpers.ts
@@ -1,6 +1,6 @@
-import { ChartOffsetRequired } from '../../src/util/types';
+import { ChartOffsetInternal } from '../../src/util/types';
 
-export const emptyOffset: ChartOffsetRequired = {
+export const emptyOffset: ChartOffsetInternal = {
   top: 0,
   bottom: 0,
   left: 0,
@@ -10,7 +10,7 @@ export const emptyOffset: ChartOffsetRequired = {
   brushBottom: 0,
 };
 
-export function makeChartOffset(partialOffset: Partial<ChartOffsetRequired>): ChartOffsetRequired {
+export function makeChartOffset(partialOffset: Partial<ChartOffsetInternal>): ChartOffsetInternal {
   return {
     ...emptyOffset,
     ...partialOffset,

--- a/test/state/selectors/brushSelectors.spec.tsx
+++ b/test/state/selectors/brushSelectors.spec.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { useAppSelector } from '../../../src/state/hooks';
 import { BarChart, Brush, Customized } from '../../../src';
-import { selectBrushHeight } from '../../../src/state/selectors/selectChartOffset';
+import { selectBrushHeight } from '../../../src/state/selectors/selectChartOffsetInternal';
 import { shouldReturnFromInitialState, shouldReturnUndefinedOutOfContext } from '../../helper/selectorTestHelpers';
 
 describe('selectBrushHeight', () => {

--- a/test/state/selectors/selectChartOffset.spec.tsx
+++ b/test/state/selectors/selectChartOffset.spec.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { selectChartOffset } from '../../../src/state/selectors/selectChartOffset';
+import { selectChartOffsetInternal } from '../../../src/state/selectors/selectChartOffsetInternal';
 import { useAppSelector } from '../../../src/state/hooks';
 import { Customized, LineChart } from '../../../src';
 import { shouldReturnFromInitialState, shouldReturnUndefinedOutOfContext } from '../../helper/selectorTestHelpers';
 
 describe('selectChartOffset', () => {
-  shouldReturnUndefinedOutOfContext(selectChartOffset);
-  shouldReturnFromInitialState(selectChartOffset, {
+  shouldReturnUndefinedOutOfContext(selectChartOffsetInternal);
+  shouldReturnFromInitialState(selectChartOffsetInternal, {
     bottom: 5,
     brushBottom: 5,
     height: 0,
@@ -21,8 +21,8 @@ describe('selectChartOffset', () => {
   it('should be stable', () => {
     expect.assertions(2);
     const Comp = (): null => {
-      const offset1 = useAppSelector(selectChartOffset);
-      const offset2 = useAppSelector(selectChartOffset);
+      const offset1 = useAppSelector(selectChartOffsetInternal);
+      const offset2 = useAppSelector(selectChartOffsetInternal);
       expect(offset1).not.toBe(undefined);
       expect(offset1).toBe(offset2);
       return null;

--- a/test/util/PolarUtils.spec.ts
+++ b/test/util/PolarUtils.spec.ts
@@ -45,6 +45,8 @@ describe('getMaxRadius', () => {
   });
 
   it('should include offset', () => {
-    expect(getMaxRadius(10, 8, { top: 2, right: 2, bottom: 2, left: 2 })).toEqual(2);
+    expect(getMaxRadius(10, 8, { top: 2, right: 2, bottom: 2, left: 2, width: 0, height: 0, brushBottom: 0 })).toEqual(
+      2,
+    );
   });
 });

--- a/test/util/context.tsx
+++ b/test/util/context.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentType, ReactNode } from 'react';
 import { render } from '@testing-library/react';
 import { useChartHeight, useChartWidth, useOffset, useViewBox } from '../../src/context/chartLayoutContext';
-import { CartesianViewBox, ChartOffsetRequired } from '../../src/util/types';
+import { CartesianViewBox, ChartOffsetInternal } from '../../src/util/types';
 
 import { useClipPathId } from '../../src/container/ClipPathProvider';
 
@@ -10,7 +10,7 @@ type AllContextPropertiesMixed = {
   viewBox: CartesianViewBox | undefined;
   width: number;
   height: number;
-  offset: ChartOffsetRequired | null;
+  offset: ChartOffsetInternal | null;
 };
 
 export function testChartLayoutContext(

--- a/test/util/context.tsx
+++ b/test/util/context.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentType, ReactNode } from 'react';
 import { render } from '@testing-library/react';
 import { useChartHeight, useChartWidth, useOffset, useViewBox } from '../../src/context/chartLayoutContext';
-import { CartesianViewBox, ChartOffset } from '../../src/util/types';
+import { CartesianViewBox, ChartOffsetRequired } from '../../src/util/types';
 
 import { useClipPathId } from '../../src/container/ClipPathProvider';
 
@@ -10,7 +10,7 @@ type AllContextPropertiesMixed = {
   viewBox: CartesianViewBox | undefined;
   width: number;
   height: number;
-  offset: ChartOffset | null;
+  offset: ChartOffsetRequired | null;
 };
 
 export function testChartLayoutContext(

--- a/test/util/context.tsx
+++ b/test/util/context.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentType, ReactNode } from 'react';
 import { render } from '@testing-library/react';
-import { useChartHeight, useChartWidth, useOffset, useViewBox } from '../../src/context/chartLayoutContext';
+import { useChartHeight, useChartWidth, useOffsetInternal, useViewBox } from '../../src/context/chartLayoutContext';
 import { CartesianViewBox, ChartOffsetInternal } from '../../src/util/types';
 
 import { useClipPathId } from '../../src/container/ClipPathProvider';
@@ -38,7 +38,7 @@ export function testChartLayoutContext(
       const viewBox = useViewBox();
       const width = useChartWidth();
       const height = useChartHeight();
-      const offset = useOffset();
+      const offset = useOffsetInternal();
       const context: AllContextPropertiesMixed = { clipPathId, viewBox, width, height, offset };
       assertions(context);
       return <></>;

--- a/test/util/cursor/getCursorPoints.spec.ts
+++ b/test/util/cursor/getCursorPoints.spec.ts
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 
 import { RADIAN } from '../../../src/util/PolarUtils';
 import { getCursorPoints } from '../../../src/util/cursor/getCursorPoints';
-import { ChartCoordinate, ChartOffsetRequired, Coordinate } from '../../../src/util/types';
+import { ChartCoordinate, ChartOffsetInternal, Coordinate } from '../../../src/util/types';
 import { getRadialCursorPoints } from '../../../src/util/cursor/getRadialCursorPoints';
 import { emptyOffset, makeChartOffset } from '../../helper/offsetHelpers';
 
@@ -17,7 +17,7 @@ describe('getCursorPoints', () => {
         x: 18,
         y: 0,
       };
-      const offset: ChartOffsetRequired = makeChartOffset({
+      const offset: ChartOffsetInternal = makeChartOffset({
         top: 12,
         height: 10,
       });
@@ -42,7 +42,7 @@ describe('getCursorPoints', () => {
         x: 18,
         y: 99,
       };
-      const offset: ChartOffsetRequired = makeChartOffset({
+      const offset: ChartOffsetInternal = makeChartOffset({
         left: 42,
         width: 60,
       });
@@ -66,7 +66,7 @@ describe('getCursorPoints', () => {
         x: 1,
         y: 1,
       };
-      const offset: ChartOffsetRequired = makeChartOffset({});
+      const offset: ChartOffsetInternal = makeChartOffset({});
       const result = getCursorPoints('centric', activeCoordinate, offset);
       const expected: object[] = [
         {
@@ -113,7 +113,7 @@ describe('getCursorPoints', () => {
         x: 0,
         y: 0,
       };
-      const fullOffset: ChartOffsetRequired = {
+      const fullOffset: ChartOffsetInternal = {
         bottom: 87,
         brushBottom: 23,
         height: 35,
@@ -157,7 +157,7 @@ describe('getCursorPoints', () => {
         x: 0,
         y: 0,
       };
-      const offset: ChartOffsetRequired = makeChartOffset({
+      const offset: ChartOffsetInternal = makeChartOffset({
         left: 42,
         width: 60,
       });

--- a/test/util/cursor/getCursorRectangle.spec.ts
+++ b/test/util/cursor/getCursorRectangle.spec.ts
@@ -1,12 +1,12 @@
 import { CursorRectangle, getCursorRectangle } from '../../../src/util/cursor/getCursorRectangle';
-import { ChartCoordinate, ChartOffsetRequired, LayoutType } from '../../../src/util/types';
+import { ChartCoordinate, ChartOffsetInternal, LayoutType } from '../../../src/util/types';
 import { makeChartOffset } from '../../helper/offsetHelpers';
 
 const activeCoordinate: ChartCoordinate = {
   x: 100,
   y: 170,
 };
-const offset: ChartOffsetRequired = makeChartOffset({
+const offset: ChartOffsetInternal = makeChartOffset({
   left: 10,
   top: 80,
   width: 13,


### PR DESCRIPTION
## Description

Only types and renames here. I want to distinguish between the offset type for internal use only, and the external one. I'll add the external types and hooks next.

## Related Issue

https://github.com/recharts/recharts/issues/6021

Also https://github.com/recharts/recharts/issues/5768

747 errors -> 719
