### PR TITLE
Remove duplicate 'square' from Pie component’s legendType summary

### DIFF
--- a/storybook/stories/API/polar/Pie.stories.tsx
+++ b/storybook/stories/API/polar/Pie.stories.tsx
@@ -80,8 +80,7 @@ const GeneralProps: Args = {
     description: 'The type of icon in legend. If set to "none", no legend item will be rendered.',
     table: {
       type: {
-        summary: `'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square'
-          | 'star' | 'triangle' | 'wye' | 'none'`,
+        summary: `'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'star' | 'triangle' | 'wye' | 'none'`,
         defaultValue: 'rect',
       },
       category: 'General',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes an issue where the `legendType` option summary for the Pie component listed `'square'` twice. The duplicate entry has been removed so that the documentation accurately reflects the available options.

## Related Issue
- Docs: https://recharts.org/en-US/api/Pie#legendType

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The `legendType` union summary in the Pie chart docs included `'square'` twice, which could confuse users selecting a legend icon. This change cleans up the summary for clarity and accuracy.

## How Has This Been Tested?
1. Start Storybook locally:  
   `npm run storybook`
2. Open the Pie API docs page in your browser:
   `http://localhost:6006/?path=/docs/api-polar-pie--docs`
3. Verify that legendType now only shows 'square' once in the type summary.
4. Run existing tests and lint checks:
   ```bash
   npm test
   npm run lint
5. Build the static docs to ensure no build errors:
   `npm run build-storybook`
## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
