### PR TITLE
Add overflow: visible zero-size wrapper so that ResponsiveContainer can shrink

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -167,10 +167,8 @@ export const ResponsiveContainer = forwardRef<HTMLDivElement, Props>(
           height: calculatedHeight,
           // calculate the actual size and override it.
           style: {
-            height: '100%',
-            width: '100%',
-            maxHeight: calculatedHeight,
-            maxWidth: calculatedWidth,
+            width: calculatedWidth,
+            height: calculatedHeight,
             // keep components style
             ...child.props.style,
           },
@@ -185,7 +183,17 @@ export const ResponsiveContainer = forwardRef<HTMLDivElement, Props>(
         style={{ ...style, width, height, minWidth, minHeight, maxHeight }}
         ref={containerRef}
       >
-        {chartContent}
+        {/*
+         * This zero-size, overflow-visible is required to allow the chart to shrink.
+         * Without it, the chart itself will fill the ResponsiveContainer, and while it allows the chart to grow,
+         * it would always keep the container at the size of the chart,
+         * and ResizeObserver would never fire.
+         * With this zero-size element, the chart itself never actually fills the container,
+         * it just so happens that it is visible because it overflows.
+         * I learned this trick from the `react-virtualized` library: https://github.com/bvaughn/react-virtualized-auto-sizer/blob/master/src/AutoSizer.ts
+         * See https://github.com/recharts/recharts/issues/172 and also https://github.com/bvaughn/react-virtualized/issues/68
+         */}
+        <div style={{ width: 0, height: 0, overflow: 'visible' }}>{chartContent}</div>
       </div>
     );
   },

--- a/storybook/stories/API/ResponsiveContainer.stories.tsx
+++ b/storybook/stories/API/ResponsiveContainer.stories.tsx
@@ -13,35 +13,48 @@ export default {
 };
 
 export const API: StoryObj<Props> = {
+  // https://github.com/recharts/recharts/issues/172
   render: (args: Args, context: RechartsStoryContext<Props>) => {
     return (
-      <ResponsiveContainer {...args}>
-        <AreaChart
-          width={500}
-          height={400}
-          data={pageData}
-          margin={{
-            top: 10,
-            right: 30,
-            left: 0,
-            bottom: 0,
-          }}
-        >
-          <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="name" />
-          <YAxis />
-          <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
-          <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
-        </AreaChart>
-      </ResponsiveContainer>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          width: '100%',
+          flexGrow: 1,
+        }}
+      >
+        <h6>Flexbox sibling</h6>
+        <div style={{ flexGrow: 1 }}>
+          <ResponsiveContainer {...args}>
+            <AreaChart
+              width={500}
+              height={400}
+              data={pageData}
+              margin={{
+                top: 10,
+                right: 30,
+                left: 0,
+                bottom: 0,
+              }}
+            >
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
+              <Tooltip />
+              <RechartsHookInspector
+                position={context.rechartsInspectorPosition}
+                setPosition={context.rechartsSetInspectorPosition}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
     );
   },
   args: {
-    width: '100%',
-    height: 400,
+    width: '80%',
+    height: '80%',
   },
 };

--- a/test/component/ResponsiveContainer.spec.tsx
+++ b/test/component/ResponsiveContainer.spec.tsx
@@ -165,8 +165,10 @@ describe('<ResponsiveContainer />', () => {
       notifyResizeObserverChange([{ contentRect: { width: 100, height: 100 } }]);
     });
 
-    expect(element.firstElementChild).toHaveAttribute('width', '100');
-    expect(element.firstElementChild).toHaveAttribute('height', '200');
+    const testDiv = screen.getByTestId('inside');
+
+    expect(testDiv).toHaveAttribute('width', '100');
+    expect(testDiv).toHaveAttribute('height', '200');
   });
 
   it('should resize when debounced', () => {
@@ -189,8 +191,10 @@ describe('<ResponsiveContainer />', () => {
       notifyResizeObserverChange([{ contentRect: { width: 100, height: 100 } }]);
       vi.advanceTimersByTime(200);
     });
-    expect(element.firstElementChild).toHaveAttribute('width', '100');
-    expect(element.firstElementChild).toHaveAttribute('height', '200');
+    const testDiv = screen.getByTestId('inside');
+
+    expect(testDiv).toHaveAttribute('width', '100');
+    expect(testDiv).toHaveAttribute('height', '200');
   });
 
   it('should call onResize when ResizeObserver notifies one or many changes', () => {
@@ -210,8 +214,10 @@ describe('<ResponsiveContainer />', () => {
       notifyResizeObserverChange([{ contentRect: { width: 100, height: 100 } }]);
     });
 
-    expect(element.firstElementChild).toHaveAttribute('width', '100');
-    expect(element.firstElementChild).toHaveAttribute('height', '200');
+    const testDiv = screen.getByTestId('inside');
+
+    expect(testDiv).toHaveAttribute('width', '100');
+    expect(testDiv).toHaveAttribute('height', '200');
 
     expect(onResize).toHaveBeenCalledTimes(1);
 
@@ -303,10 +309,8 @@ describe('<ResponsiveContainer />', () => {
 
     expect(elementsInside).toHaveLength(4);
     expect(elementsInside[0]).toHaveStyle({
-      width: '100%',
-      height: '100%',
-      'max-width': '400px',
-      'max-height': '200px',
+      width: '400px',
+      height: '200px',
       'background-color': 'rgb(0, 0, 255)',
     });
     expect(elementsInside[0]).toHaveAttribute('height', '200');
@@ -314,10 +318,8 @@ describe('<ResponsiveContainer />', () => {
 
     // all elements are cloned with the same style props besides their own style
     expect(elementsInside[1]).toHaveStyle({
-      width: '100%',
-      height: '100%',
-      'max-width': '400px',
-      'max-height': '200px',
+      width: '400px',
+      height: '200px',
       'background-color': 'rgba(0, 0, 0, 0)',
     });
     expect(elementsInside[1]).toHaveAttribute('height', '200');


### PR DESCRIPTION
## Description

The chart was filling the responsive container and didn't allow it to get any smaller. I copied what I found in react-virtualized, thanks @bvaughn!

## Related Issue

Fixes https://github.com/recharts/recharts/issues/172

Reported in https://github.com/bvaughn/react-virtualized/issues/68

## Screenshots (if appropriate):


https://github.com/user-attachments/assets/163839a5-6c13-4849-94c7-f2130836286b

