### PR TITLE
Fix active tooltip and dots when there are multiple graphical items each with their own data

### DIFF
--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -4,10 +4,10 @@ import { ActiveDotProps, ActiveDotType, adaptEventHandlers, DataKey } from '../u
 import { filterProps } from '../util/ReactUtils';
 import { Dot } from '../shape/Dot';
 import { Layer } from '../container/Layer';
-import { useTooltipAxis } from '../context/useTooltipAxis';
-import { findEntryInArray, isNullish } from '../util/DataUtils';
+import { isNullish } from '../util/DataUtils';
 import { useAppSelector } from '../state/hooks';
-import { selectActiveLabel, selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
+import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
+import { useActiveTooltipDataPoints } from '../hooks';
 
 export interface PointType {
   readonly x: number | null;
@@ -78,25 +78,13 @@ type ActivePointsProps = {
 };
 
 export function ActivePoints({ points, mainColor, activeDot, itemDataKey }: ActivePointsProps) {
-  const tooltipAxis = useTooltipAxis();
   const activeTooltipIndex = useAppSelector(selectActiveTooltipIndex);
-  const activeLabel = useAppSelector(selectActiveLabel);
-  if (!activeTooltipIndex) {
+  const activeDataPoints = useActiveTooltipDataPoints();
+  if (points == null || activeDataPoints == null) {
     return null;
   }
 
-  let activePoint: PointType | undefined;
-
-  const tooltipAxisDataKey = tooltipAxis.dataKey;
-  if (tooltipAxisDataKey && !tooltipAxis.allowDuplicatedCategory) {
-    const specifiedKey =
-      typeof tooltipAxisDataKey === 'function'
-        ? (point: PointType) => tooltipAxisDataKey(point.payload)
-        : `payload.${tooltipAxisDataKey}`;
-    activePoint = findEntryInArray(points, specifiedKey, activeLabel);
-  } else {
-    activePoint = points?.[Number(activeTooltipIndex)];
-  }
+  const activePoint: PointType | undefined = points.find(p => activeDataPoints.includes(p.payload));
 
   if (isNullish(activePoint)) {
     return null;

--- a/src/state/selectors/tooltipSelectors.ts
+++ b/src/state/selectors/tooltipSelectors.ts
@@ -434,6 +434,6 @@ export const selectActiveTooltipDataPoints = createSelector([selectActiveTooltip
   if (payload == null) {
     return undefined;
   }
-  const dataPoints = payload.map(p => p.payload);
+  const dataPoints = payload.map(p => p.payload).filter(p => p != null);
   return Array.from(new Set(dataPoints));
 });

--- a/storybook/stories/API/cartesian/Bar.stories.tsx
+++ b/storybook/stories/API/cartesian/Bar.stories.tsx
@@ -589,11 +589,11 @@ export const WithMinHeight = {
           <XAxis dataKey="name" />
           <YAxis />
           <Legend />
+          <Tooltip />
           <Bar {...args}>
             <LabelList dataKey="name" content={renderCustomizedLabel} />
           </Bar>
           <Bar dataKey="uv" fill="#82ca9d" minPointSize={10} />
-          <Tooltip />
           <RechartsHookInspector
             position={context.rechartsInspectorPosition}
             setPosition={context.rechartsSetInspectorPosition}

--- a/storybook/stories/Examples/LineChart/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart/LineChart.stories.tsx
@@ -292,10 +292,6 @@ export const ConnectNulls = {
             <YAxis />
             <Line connectNulls type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
             <Tooltip />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
           </LineChart>
         </ResponsiveContainer>
       </>

--- a/storybook/storybook-addon-recharts/RechartsHookInspector.tsx
+++ b/storybook/storybook-addon-recharts/RechartsHookInspector.tsx
@@ -49,6 +49,8 @@ function Blanket() {
   );
 }
 
+const overlaysThatNeedBlanket = ['useChartWidth, useChartHeight', 'useOffset', 'usePlotArea'];
+
 export function RechartsHookInspector({
   defaultOpened,
   position,
@@ -93,7 +95,7 @@ export function RechartsHookInspector({
         Component={Component}
         setEnabledOverlays={setEnabledOverlays}
       />
-      {enabledOverlays.length >= 1 && <Blanket />}
+      {overlaysThatNeedBlanket.some(overlay => enabledOverlays.includes(overlay)) && <Blanket />}
       {enabledOverlays.includes('useChartWidth, useChartHeight') && <ChartSizeDimensions />}
       {enabledOverlays.includes('useOffset') && <OffsetShower />}
       {enabledOverlays.includes('usePlotArea') && <PlotAreaShower />}

--- a/storybook/storybook-addon-recharts/inspectors/generic/ArrayInspector.tsx
+++ b/storybook/storybook-addon-recharts/inspectors/generic/ArrayInspector.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { PrimitiveInspector } from './PrimitiveInspector';
+import { PrimitiveInspector, serializePrimitive } from './PrimitiveInspector';
 
 function ArrayOfObjectsInspector({ arr, expand }: { arr: ReadonlyArray<unknown>; expand: boolean }) {
   if (!expand) {
@@ -7,16 +7,9 @@ function ArrayOfObjectsInspector({ arr, expand }: { arr: ReadonlyArray<unknown>;
   }
   return (
     <pre>
-      <code>[{arr.map(i => JSON.stringify(i, null, 2)).join(',\n')}]</code>
+      <code>[{arr.map(serializePrimitive).join(',\n')}]</code>
     </pre>
   );
-}
-
-function ArrayOfPrimitivesInspector({ arr, expand }: { arr: ReadonlyArray<unknown>; expand: boolean }) {
-  if (!expand) {
-    return <code>Array({arr.length})</code>;
-  }
-  return <code>[{arr.map(i => JSON.stringify(i)).join(', ')}]</code>;
 }
 
 export function ArrayInspector({
@@ -50,11 +43,7 @@ export function ArrayInspector({
       <button type="button" onClick={copyToClipboard}>
         Copy to clipboard
       </button>
-      {typeofArr === 'object' ? (
-        <ArrayOfObjectsInspector arr={arr} expand={expand} />
-      ) : (
-        <ArrayOfPrimitivesInspector arr={arr} expand={expand} />
-      )}
+      <ArrayOfObjectsInspector arr={arr} expand={expand} />
     </>
   );
 }

--- a/storybook/storybook-addon-recharts/inspectors/generic/PrimitiveInspector.tsx
+++ b/storybook/storybook-addon-recharts/inspectors/generic/PrimitiveInspector.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
+export function serializePrimitive(value: unknown): string {
+  return value === undefined ? 'undefined' : JSON.stringify(value, null, 2);
+}
+
 export function PrimitiveInspector({ value }: { value: unknown }) {
-  const str = value === undefined ? 'undefined' : JSON.stringify(value);
+  const str = serializePrimitive(value);
   return <code>{str}</code>;
 }

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -1551,7 +1551,8 @@ describe('Tooltip integration', () => {
     ));
 
     it('should return tooltip payload', () => {
-      const { spy } = renderTestCase(state => selectTooltipPayload(state, 'axis', 'hover', '0'));
+      // ScatterChart only allows item interaction
+      const { spy } = renderTestCase(state => selectTooltipPayload(state, 'item', 'hover', '0'));
       expect(spy).toHaveBeenLastCalledWith([
         {
           color: undefined,

--- a/test/component/Tooltip/Tooltip.multipleDataArrays.spec.tsx
+++ b/test/component/Tooltip/Tooltip.multipleDataArrays.spec.tsx
@@ -1,0 +1,176 @@
+/*
+ * Reproducing https://github.com/recharts/recharts/issues/3044
+ * https://codesandbox.io/p/sandbox/recharts-issue-template-forked-yhhnky
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
+import { ComposedChart, Legend, Line, Tooltip, useActiveTooltipDataPoints, XAxis, YAxis } from '../../../src';
+import { expectLines } from '../../helper/expectLine';
+import {
+  selectAxisScale,
+  selectCartesianGraphicalItemsData,
+  selectDisplayedData,
+} from '../../../src/state/selectors/axisSelectors';
+import { selectActiveTooltipIndex } from '../../../src/state/selectors/tooltipSelectors';
+import { showTooltipOnCoordinate } from './tooltipTestHelpers';
+import { composedChartMouseHoverTooltipSelector } from './tooltipMouseHoverSelectors';
+import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
+
+describe('Tooltip in chart with multiple data arrays', () => {
+  beforeEach(() => {
+    mockGetBoundingClientRect({ width: 100, height: 100 });
+  });
+
+  const data1 = [
+    { xAxis: 10, y1: 4 },
+    { xAxis: 20, y1: 10 },
+    { xAxis: 30, y1: 6 },
+    { xAxis: 40, y1: 8 },
+  ];
+
+  const data2 = [
+    { xAxis: 5, y2: 9 },
+    { xAxis: 12, y2: 7 },
+    { xAxis: 13, y2: 8 },
+    { xAxis: 18, y2: 12 },
+    { xAxis: 25, y2: 12 },
+    { xAxis: 30, y2: 12 },
+  ];
+
+  describe('with default props', () => {
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <ComposedChart width={500} height={300}>
+        <XAxis dataKey="xAxis" type="number" />
+        <YAxis />
+        <Tooltip />
+        <Legend />
+        <Line dataKey="y1" data={data1} />
+        <Line dataKey="y2" data={data2} />
+        {children}
+      </ComposedChart>
+    ));
+
+    it('should select activeTooltipDataPoints', () => {
+      const { container, spy } = renderTestCase(useActiveTooltipDataPoints);
+
+      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expect(spy).toHaveBeenCalledTimes(3);
+
+      showTooltipOnCoordinate(container, composedChartMouseHoverTooltipSelector, { clientX: 387.5, clientY: 100 });
+
+      expect(spy).toHaveBeenLastCalledWith([
+        { xAxis: 30, y1: 6 },
+        { xAxis: 30, y2: 12 },
+      ]);
+      expect(spy).toHaveBeenCalledTimes(4);
+
+      // it is important that the data points are equal by reference because ActivePoints uses strict equality to compare them
+      const activePoints = spy.mock.calls[3][0];
+      expect(activePoints[0]).toBe(data1[2]);
+      expect(activePoints[1]).toBe(data2[5]);
+    });
+
+    it('should render two lines', () => {
+      const { container } = renderTestCase();
+      expectLines(container, [
+        { d: 'M172.5,111.667L280,31.667L387.5,85L495,58.333' },
+        { d: 'M118.75,45L194,71.667L204.75,58.333L258.5,5L333.75,5L387.5,5' },
+      ]);
+    });
+
+    it('should select individual items data', () => {
+      const { spy } = renderTestCase(state => selectCartesianGraphicalItemsData(state, 'xAxis', 0));
+
+      expect(spy).toHaveBeenLastCalledWith([
+        { xAxis: 10, y1: 4 },
+        { xAxis: 20, y1: 10 },
+        { xAxis: 30, y1: 6 },
+        { xAxis: 40, y1: 8 },
+        { xAxis: 5, y2: 9 },
+        { xAxis: 12, y2: 7 },
+        { xAxis: 13, y2: 8 },
+        { xAxis: 18, y2: 12 },
+        { xAxis: 25, y2: 12 },
+        { xAxis: 30, y2: 12 },
+      ]);
+      expect(spy).toHaveBeenCalledTimes(3);
+    });
+
+    it('should select displayed data', () => {
+      const { spy } = renderTestCase(state => selectDisplayedData(state, 'xAxis', 0, false));
+
+      expect(spy).toHaveBeenLastCalledWith([
+        { xAxis: 10, y1: 4 },
+        { xAxis: 20, y1: 10 },
+        { xAxis: 30, y1: 6 },
+        { xAxis: 40, y1: 8 },
+        { xAxis: 5, y2: 9 },
+        { xAxis: 12, y2: 7 },
+        { xAxis: 13, y2: 8 },
+        { xAxis: 18, y2: 12 },
+        { xAxis: 25, y2: 12 },
+        { xAxis: 30, y2: 12 },
+      ]);
+      expect(spy).toHaveBeenCalledTimes(3);
+    });
+
+    it('should select scale', () => {
+      const { spy } = renderTestCase(state => selectAxisScale(state, 'xAxis', 0, false));
+
+      expect(spy).toHaveBeenLastCalledWith(
+        expect.toBeRechartsScale({
+          domain: [0, 40],
+          range: [65, 495],
+        }),
+      );
+      expect(spy).toHaveBeenCalledTimes(3);
+      const scale = spy.mock.calls[2][0];
+      const chartX1 = scale(5);
+      expect(chartX1).toBe(118.75);
+
+      const chartX2 = scale(30);
+      expect(chartX2).toBe(387.5);
+
+      const chartX3 = scale(40);
+      expect(chartX3).toBe(495);
+    });
+
+    it('should highlight the first dot when hovering the first xaxis tick', () => {
+      const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+      expect(spy).toHaveBeenLastCalledWith(null);
+
+      showTooltipOnCoordinate(container, composedChartMouseHoverTooltipSelector, { clientX: 118.75, clientY: 100 });
+      // this is 4 because the tick is at xAxis=5 which is the fifth point in the displayedData array
+      expect(spy).toHaveBeenLastCalledWith('4');
+    });
+
+    it('should highlight the last dot when hovering the last xaxis tick', () => {
+      const { container, spy } = renderTestCase(selectActiveTooltipIndex);
+      expect(spy).toHaveBeenLastCalledWith(null);
+
+      showTooltipOnCoordinate(container, composedChartMouseHoverTooltipSelector, { clientX: 495, clientY: 100 });
+      // this is 3 because the tick is at xAxis=40 which is the fourth point in the displayedData array
+      expect(spy).toHaveBeenLastCalledWith('3');
+    });
+  });
+
+  describe('with defaultIndex=0', () => {
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <ComposedChart width={500} height={300}>
+        <XAxis dataKey="xAxis" type="number" />
+        <YAxis />
+        <Tooltip defaultIndex={0} />
+        <Legend />
+        <Line dataKey="y1" data={data1} />
+        <Line dataKey="y2" data={data2} />
+        {children}
+      </ComposedChart>
+    ));
+
+    it('should highlight the first dot', () => {
+      const { spy } = renderTestCase(selectActiveTooltipIndex);
+      expect(spy).toHaveBeenLastCalledWith('0');
+    });
+  });
+});

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -1686,19 +1686,19 @@ describe('Tooltip payload', () => {
     const lineData1 = [
       { category: 'A', value: 0.2 },
       { category: 'B', value: 0.3 },
-      { category: 'B', value: 0.5 },
-      { category: 'C', value: 0.6 },
-      { category: 'C', value: 0.7 },
-      { category: 'D', value: 0.4 },
+      { category: 'C', value: 0.5 },
+      { category: 'D', value: 0.6 },
+      { category: 'E', value: 0.7 },
+      { category: 'F', value: 0.4 },
     ];
 
     const lineData2 = [
       { category: 'A', value: null },
       { category: 'B', value: null },
-      { category: 'B', value: null },
-      { category: 'C', value: 0.2 },
-      { category: 'C', value: 0.4 },
-      { category: 'D', value: 0.6 },
+      { category: 'C', value: null },
+      { category: 'D', value: 0.2 },
+      { category: 'E', value: 0.4 },
+      { category: 'F', value: 0.6 },
     ];
 
     const { container, debug } = render(
@@ -1716,7 +1716,7 @@ describe('Tooltip payload', () => {
 
     showTooltip(container, ComposedChartTestCase.mouseHoverSelector, debug);
 
-    expectTooltipPayload(container, 'C', ['value : 0.7', 'value : 0.4']);
+    expectTooltipPayload(container, 'E', ['value : 0.7', 'value : 0.4']);
   });
 
   describe('shared prop', () => {

--- a/test/component/Tooltip/itemSorter.spec.tsx
+++ b/test/component/Tooltip/itemSorter.spec.tsx
@@ -33,7 +33,7 @@ import {
   radarChartMouseHoverTooltipSelector,
   radialBarChartMouseHoverTooltipSelector,
 } from './tooltipMouseHoverSelectors';
-import { selectTooltipPayload } from '../../../src/state/selectors/selectors';
+import { selectTooltipPayload, selectTooltipPayloadConfigurations } from '../../../src/state/selectors/selectors';
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
 
 describe('itemSorter in ComposedChart', () => {
@@ -48,10 +48,11 @@ describe('itemSorter in ComposedChart', () => {
     ) {
       return createSelectorTestCase(({ children }) => (
         <ComposedChart width={300} height={300} data={PageData}>
-          <Area dataKey="uv" />
-          <Bar dataKey="pv" />
-          <Line dataKey="amt" />
-          <Scatter dataKey="uv" />
+          <Area dataKey="uv" name="area" />
+          <Bar dataKey="pv" name="bar" />
+          <Line dataKey="amt" name="line" />
+          {/* name prop on Scatter doesn't do anything, not sure why */}
+          <Scatter dataKey="uv" name="scatter" />
           <YAxis dataKey="pv" />
           <XAxis dataKey="name" />
           <Tooltip itemSorter={itemSorter} />
@@ -65,11 +66,259 @@ describe('itemSorter in ComposedChart', () => {
         const { container } = renderTestCase(undefined);
         showTooltip(container, composedChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', [
-          'amt : 2400',
+          'area : 200',
+          'bar : 9800',
+          'line : 2400',
           'name : Page D',
           'pv : 9800',
-          'pv : 9800',
-          'uv : 200',
+        ]);
+      });
+
+      it('should select tooltipPayloadConfigurations', () => {
+        const { spy } = renderTestCase(undefined, state =>
+          selectTooltipPayloadConfigurations(state, 'axis', 'hover', '0'),
+        );
+        expect(spy).toHaveBeenLastCalledWith([
+          {
+            dataDefinedOnItem: undefined,
+            positions: undefined,
+            settings: {
+              color: '#3182bd',
+              dataKey: 'uv',
+              fill: '#3182bd',
+              hide: false,
+              name: 'area',
+              nameKey: undefined,
+              stroke: '#3182bd',
+              strokeWidth: undefined,
+              type: undefined,
+              unit: undefined,
+            },
+          },
+          {
+            dataDefinedOnItem: undefined,
+            positions: undefined,
+            settings: {
+              color: undefined,
+              dataKey: 'pv',
+              fill: undefined,
+              hide: false,
+              name: 'bar',
+              nameKey: undefined,
+              stroke: undefined,
+              strokeWidth: undefined,
+              type: undefined,
+              unit: undefined,
+            },
+          },
+          {
+            dataDefinedOnItem: undefined,
+            positions: undefined,
+            settings: {
+              color: '#3182bd',
+              dataKey: 'amt',
+              fill: '#fff',
+              hide: false,
+              name: 'line',
+              nameKey: undefined,
+              stroke: '#3182bd',
+              strokeWidth: 1,
+              type: undefined,
+              unit: undefined,
+            },
+          },
+          {
+            dataDefinedOnItem: [
+              [
+                {
+                  dataKey: 'name',
+                  name: 'name',
+                  payload: {
+                    amt: 2400,
+                    name: 'Page A',
+                    pv: 2400,
+                    uv: 400,
+                  },
+                  type: undefined,
+                  unit: '',
+                  value: 'Page A',
+                },
+                {
+                  dataKey: 'pv',
+                  name: 'pv',
+                  payload: {
+                    amt: 2400,
+                    name: 'Page A',
+                    pv: 2400,
+                    uv: 400,
+                  },
+                  type: undefined,
+                  unit: '',
+                  value: 2400,
+                },
+              ],
+              [
+                {
+                  dataKey: 'name',
+                  name: 'name',
+                  payload: {
+                    amt: 2400,
+                    name: 'Page B',
+                    pv: 4567,
+                    uv: 300,
+                  },
+                  type: undefined,
+                  unit: '',
+                  value: 'Page B',
+                },
+                {
+                  dataKey: 'pv',
+                  name: 'pv',
+                  payload: {
+                    amt: 2400,
+                    name: 'Page B',
+                    pv: 4567,
+                    uv: 300,
+                  },
+                  type: undefined,
+                  unit: '',
+                  value: 4567,
+                },
+              ],
+              [
+                {
+                  dataKey: 'name',
+                  name: 'name',
+                  payload: {
+                    amt: 2400,
+                    name: 'Page C',
+                    pv: 1398,
+                    uv: 300,
+                  },
+                  type: undefined,
+                  unit: '',
+                  value: 'Page C',
+                },
+                {
+                  dataKey: 'pv',
+                  name: 'pv',
+                  payload: {
+                    amt: 2400,
+                    name: 'Page C',
+                    pv: 1398,
+                    uv: 300,
+                  },
+                  type: undefined,
+                  unit: '',
+                  value: 1398,
+                },
+              ],
+              [
+                {
+                  dataKey: 'name',
+                  name: 'name',
+                  payload: {
+                    amt: 2400,
+                    name: 'Page D',
+                    pv: 9800,
+                    uv: 200,
+                  },
+                  type: undefined,
+                  unit: '',
+                  value: 'Page D',
+                },
+                {
+                  dataKey: 'pv',
+                  name: 'pv',
+                  payload: {
+                    amt: 2400,
+                    name: 'Page D',
+                    pv: 9800,
+                    uv: 200,
+                  },
+                  type: undefined,
+                  unit: '',
+                  value: 9800,
+                },
+              ],
+              [
+                {
+                  dataKey: 'name',
+                  name: 'name',
+                  payload: {
+                    amt: 2400,
+                    name: 'Page E',
+                    pv: 3908,
+                    uv: 278,
+                  },
+                  type: undefined,
+                  unit: '',
+                  value: 'Page E',
+                },
+                {
+                  dataKey: 'pv',
+                  name: 'pv',
+                  payload: {
+                    amt: 2400,
+                    name: 'Page E',
+                    pv: 3908,
+                    uv: 278,
+                  },
+                  type: undefined,
+                  unit: '',
+                  value: 3908,
+                },
+              ],
+              [
+                {
+                  dataKey: 'name',
+                  name: 'name',
+                  payload: {
+                    amt: 2400,
+                    name: 'Page F',
+                    pv: 4800,
+                    uv: 189,
+                  },
+                  type: undefined,
+                  unit: '',
+                  value: 'Page F',
+                },
+                {
+                  dataKey: 'pv',
+                  name: 'pv',
+                  payload: {
+                    amt: 2400,
+                    name: 'Page F',
+                    pv: 4800,
+                    uv: 189,
+                  },
+                  type: undefined,
+                  unit: '',
+                  value: 4800,
+                },
+              ],
+            ],
+            positions: [
+              { x: 84.16666666666667, y: 202.6 },
+              { x: 122.50000000000001, y: 146.258 },
+              { x: 160.83333333333334, y: 228.65200000000002 },
+              { x: 199.16666666666666, y: 10.200000000000005 },
+              { x: 237.5, y: 163.392 },
+              { x: 275.83333333333337, y: 140.20000000000002 },
+            ],
+            settings: {
+              color: undefined,
+              dataKey: 'uv',
+              fill: undefined,
+              hide: false,
+              name: 'scatter',
+              nameKey: undefined,
+              stroke: undefined,
+              strokeWidth: undefined,
+              type: undefined,
+              unit: '',
+            },
+          },
         ]);
       });
 
@@ -81,7 +330,7 @@ describe('itemSorter in ComposedChart', () => {
             dataKey: 'uv',
             fill: '#3182bd',
             hide: false,
-            name: 'uv',
+            name: 'area',
             nameKey: undefined,
             payload: {
               amt: 2400,
@@ -100,7 +349,7 @@ describe('itemSorter in ComposedChart', () => {
             dataKey: 'pv',
             fill: undefined,
             hide: false,
-            name: 'pv',
+            name: 'bar',
             nameKey: undefined,
             payload: {
               amt: 2400,
@@ -119,7 +368,7 @@ describe('itemSorter in ComposedChart', () => {
             dataKey: 'amt',
             fill: '#fff',
             hide: false,
-            name: 'amt',
+            name: 'line',
             nameKey: undefined,
             payload: {
               amt: 2400,
@@ -181,11 +430,11 @@ describe('itemSorter in ComposedChart', () => {
         const { container } = renderTestCase('dataKey');
         showTooltip(container, composedChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', [
-          'amt : 2400',
+          'line : 2400',
           'name : Page D',
+          'bar : 9800',
           'pv : 9800',
-          'pv : 9800',
-          'uv : 200',
+          'area : 200',
         ]);
       });
     });
@@ -195,9 +444,9 @@ describe('itemSorter in ComposedChart', () => {
         const { container } = renderTestCase('value');
         showTooltip(container, composedChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', [
-          'uv : 200',
-          'amt : 2400',
-          'pv : 9800',
+          'area : 200',
+          'line : 2400',
+          'bar : 9800',
           'name : Page D',
           'pv : 9800',
         ]);
@@ -209,11 +458,11 @@ describe('itemSorter in ComposedChart', () => {
         const { container } = renderTestCase('name');
         showTooltip(container, composedChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', [
-          'amt : 2400',
+          'area : 200',
+          'bar : 9800',
+          'line : 2400',
           'name : Page D',
           'pv : 9800',
-          'pv : 9800',
-          'uv : 200',
         ]);
       });
     });
@@ -223,9 +472,9 @@ describe('itemSorter in ComposedChart', () => {
         const { container } = renderTestCase(item => item.value);
         showTooltip(container, composedChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', [
-          'uv : 200',
-          'amt : 2400',
-          'pv : 9800',
+          'area : 200',
+          'line : 2400',
+          'bar : 9800',
           'name : Page D',
           'pv : 9800',
         ]);
@@ -242,7 +491,7 @@ describe('itemSorter in ComposedChart', () => {
           dataKey: 'uv',
           fill: '#3182bd',
           hide: false,
-          name: 'uv',
+          name: 'area',
           nameKey: undefined,
           payload: {
             amt: 2400,
@@ -261,7 +510,7 @@ describe('itemSorter in ComposedChart', () => {
           dataKey: 'pv',
           fill: undefined,
           hide: false,
-          name: 'pv',
+          name: 'bar',
           nameKey: undefined,
           payload: {
             amt: 2400,
@@ -280,7 +529,7 @@ describe('itemSorter in ComposedChart', () => {
           dataKey: 'amt',
           fill: '#fff',
           hide: false,
-          name: 'amt',
+          name: 'line',
           nameKey: undefined,
           payload: {
             amt: 2400,


### PR DESCRIPTION
## Description

1. ActivePoints does not need to do its own search in the data because that's what selectActiveTooltipDataPoints is doing already so let's reuse
2. If there are multiple graphical items then searching by array index won't work so let's use findEntryInArray which is smart enough to search by the dataKey label

## Related Issue

Fixes https://github.com/recharts/recharts/issues/3044

## Screenshots (if appropriate):

### Before

https://github.com/user-attachments/assets/652af24e-5bf7-4684-8636-bc35b062611e

### After

https://github.com/user-attachments/assets/2384495f-0527-4e33-a63a-ce7bf48cec3d

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
