### PR TITLE
Cartesian items use their state ID instead of generating a new one

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -11,7 +11,7 @@ import { Layer } from '../container/Layer';
 import { ErrorBarDataItem, ErrorBarDataPointFormatter, SetErrorBarPreferredDirection } from './ErrorBar';
 import { Cell } from '../component/Cell';
 import { LabelList } from '../component/LabelList';
-import { interpolateNumber, isNan, isNullish, mathSign, uniqueId } from '../util/DataUtils';
+import { interpolateNumber, isNan, mathSign } from '../util/DataUtils';
 import { filterProps, findAllByType } from '../util/ReactUtils';
 import { Global } from '../util/Global';
 import {
@@ -491,8 +491,6 @@ const errorBarDataPointFormatter: ErrorBarDataPointFormatter = (
 };
 
 class BarWithState extends PureComponent<InternalProps> {
-  id = uniqueId('recharts-bar-');
-
   render() {
     const { hide, data, dataKey, className, xAxisId, yAxisId, needClip, background, id, layout } = this.props;
     if (hide) {
@@ -500,7 +498,7 @@ class BarWithState extends PureComponent<InternalProps> {
     }
 
     const layerClass = clsx('recharts-bar', className);
-    const clipPathId = isNullish(id) ? this.id : id;
+    const clipPathId = id;
 
     return (
       <Layer className={layerClass} id={id}>
@@ -726,23 +724,25 @@ export class Bar extends PureComponent<Props> {
   render() {
     // Report all props to Redux store first, before calling any hooks, to avoid circular dependencies.
     return (
-      <CartesianGraphicalItemContext
-        id={this.props.id}
-        type="bar"
-        // Bar does not allow setting data directly on the graphical item (why?)
-        data={null}
-        xAxisId={this.props.xAxisId}
-        yAxisId={this.props.yAxisId}
-        zAxisId={0}
-        dataKey={this.props.dataKey}
-        stackId={this.props.stackId}
-        hide={this.props.hide}
-        barSize={this.props.barSize}
-      >
+      <>
         <SetLegendPayload legendPayload={computeLegendPayloadFromBarData(this.props)} />
         <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={this.props} />
-        <BarImpl {...this.props} />
-      </CartesianGraphicalItemContext>
+        <CartesianGraphicalItemContext
+          id={this.props.id}
+          type="bar"
+          // Bar does not allow setting data directly on the graphical item (why?)
+          data={null}
+          xAxisId={this.props.xAxisId}
+          yAxisId={this.props.yAxisId}
+          zAxisId={0}
+          dataKey={this.props.dataKey}
+          stackId={this.props.stackId}
+          hide={this.props.hide}
+          barSize={this.props.barSize}
+        >
+          {id => <BarImpl {...this.props} id={id} />}
+        </CartesianGraphicalItemContext>
+      </>
     );
   }
 }

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -10,7 +10,7 @@ import { ZAxis } from './ZAxis';
 import { Curve, CurveType, Props as CurveProps } from '../shape/Curve';
 import type { ErrorBarDataItem, ErrorBarDirection } from './ErrorBar';
 import { Cell } from '../component/Cell';
-import { getLinearRegression, interpolateNumber, isNullish, uniqueId } from '../util/DataUtils';
+import { getLinearRegression, interpolateNumber, isNullish } from '../util/DataUtils';
 import { getCateCoordinateOfLine, getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
 import {
   ActiveShape,
@@ -227,7 +227,7 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
 
   return (
     <>
-      <ScatterLine points={points} props={allOtherScatterProps} />
+      <ScatterLine points={points} props={allOtherPropsWithoutId} />
       {points.map((entry, i) => {
         const isActive = activeShape && activeIndex === String(i);
         const option = isActive ? activeShape : shape;
@@ -256,7 +256,7 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
           </Layer>
         );
       })}
-      {showLabels && LabelList.renderCallByParent(allOtherScatterProps, points)}
+      {showLabels && LabelList.renderCallByParent(allOtherPropsWithoutId, points)}
     </>
   );
 }
@@ -503,14 +503,12 @@ const errorBarDataPointFormatter = (
 };
 
 function ScatterWithId(props: InternalProps) {
-  const idRef = useRef(uniqueId('recharts-scatter-'));
-
   const { hide, points, className, needClip, xAxisId, yAxisId, id, children } = props;
   if (hide) {
     return null;
   }
   const layerClass = clsx('recharts-scatter', className);
-  const clipPathId = isNullish(id) ? idRef.current : id;
+  const clipPathId = id;
 
   return (
     <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null} id={id}>
@@ -628,22 +626,24 @@ export class Scatter extends Component<Props> {
   render() {
     // Report all props to Redux store first, before calling any hooks, to avoid circular dependencies.
     return (
-      <CartesianGraphicalItemContext
-        id={this.props.id}
-        type="scatter"
-        data={this.props.data}
-        xAxisId={this.props.xAxisId}
-        yAxisId={this.props.yAxisId}
-        zAxisId={this.props.zAxisId}
-        dataKey={this.props.dataKey}
-        // scatter doesn't stack
-        stackId={undefined}
-        hide={this.props.hide}
-        barSize={undefined}
-      >
+      <>
         <SetLegendPayload legendPayload={computeLegendPayloadFromScatterProps(this.props)} />
-        <ScatterImpl {...this.props} />
-      </CartesianGraphicalItemContext>
+        <CartesianGraphicalItemContext
+          id={this.props.id}
+          type="scatter"
+          data={this.props.data}
+          xAxisId={this.props.xAxisId}
+          yAxisId={this.props.yAxisId}
+          zAxisId={this.props.zAxisId}
+          dataKey={this.props.dataKey}
+          // scatter doesn't stack
+          stackId={undefined}
+          hide={this.props.hide}
+          barSize={undefined}
+        >
+          {id => <ScatterImpl {...this.props} id={id} />}
+        </CartesianGraphicalItemContext>
+      </>
     );
   }
 }

--- a/src/context/CartesianGraphicalItemContext.tsx
+++ b/src/context/CartesianGraphicalItemContext.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createContext, useCallback, useContext, useEffect } from 'react';
-import { CartesianGraphicalItemType, ErrorBarsSettings } from '../state/graphicalItemsSlice';
+import { CartesianGraphicalItemType, ErrorBarsSettings, GraphicalItemId } from '../state/graphicalItemsSlice';
 import { SetCartesianGraphicalItem } from '../state/SetGraphicalItem';
 import { ChartData } from '../state/chartDataSlice';
 import { AxisId } from '../state/cartesianAxisSlice';
@@ -55,10 +55,14 @@ type GraphicalItemContextProps = {
   yAxisId: AxisId;
   zAxisId: AxisId;
   dataKey: DataKey<any>;
-  children: React.ReactNode;
   stackId: StackId | undefined;
   hide: boolean;
   barSize: string | number | undefined;
+  /**
+   * Children must be a function that receives the resolved ID of the graphical item.
+   * This ID will either be the one provided via props.id or generated automatically.
+   */
+  children: (id: GraphicalItemId) => React.ReactNode;
 };
 
 export const CartesianGraphicalItemContext = ({
@@ -90,7 +94,7 @@ export const CartesianGraphicalItemContext = ({
   );
   const isPanorama = useIsPanorama();
 
-  const resolvedId = useUniqueId(type, id);
+  const resolvedId = useUniqueId(`recharts-${type}`, id);
 
   return (
     <ErrorBarDirectionDispatchContext.Provider value={{ addErrorBar, removeErrorBar }}>
@@ -108,7 +112,7 @@ export const CartesianGraphicalItemContext = ({
         barSize={barSize}
         isPanorama={isPanorama}
       />
-      {children}
+      {children(resolvedId)}
     </ErrorBarDirectionDispatchContext.Provider>
   );
 };

--- a/src/state/graphicalItemsSlice.ts
+++ b/src/state/graphicalItemsSlice.ts
@@ -29,6 +29,13 @@ export type ErrorBarsSettings = {
    */
 };
 
+/**
+ * Unique ID of the graphical item.
+ * This is used to identify the graphical item in the state and in the React tree.
+ * This is required for every graphical item - it's either provided by the user or generated automatically.
+ */
+export type GraphicalItemId = string;
+
 export type CartesianGraphicalItemType = 'area' | 'bar' | 'line' | 'scatter';
 export type PolarGraphicalItemType = 'pie' | 'radar' | 'radialBar';
 

--- a/src/state/selectors/areaSelectors.ts
+++ b/src/state/selectors/areaSelectors.ts
@@ -17,6 +17,7 @@ import { selectChartDataWithIndexesIfNotInPanorama } from './dataSelectors';
 import { getBandSizeOfAxis, getNormalizedStackId, isCategoricalAxis, StackId } from '../../util/ChartUtils';
 import { ChartData } from '../chartDataSlice';
 import { NullablePoint } from '../../shape/Curve';
+import { MaybeStackedGraphicalItem } from './barSelectors';
 
 export interface AreaPointItem extends NullablePoint {
   x: number | null;
@@ -24,7 +25,7 @@ export interface AreaPointItem extends NullablePoint {
   value?: number | number[];
   payload?: any;
 }
-export type AreaSettings = {
+export type AreaSettings = MaybeStackedGraphicalItem & {
   connectNulls: boolean;
   baseValue: BaseValue | undefined;
   dataKey: DataKey<any>;

--- a/src/state/selectors/barSelectors.ts
+++ b/src/state/selectors/barSelectors.ts
@@ -14,7 +14,7 @@ import {
 } from './axisSelectors';
 import { AxisId } from '../cartesianAxisSlice';
 import { getPercentValue, isNullish } from '../../util/DataUtils';
-import { CartesianGraphicalItemSettings } from '../graphicalItemsSlice';
+import { CartesianGraphicalItemSettings, GraphicalItemId } from '../graphicalItemsSlice';
 import { BarPositionPosition, getBandSizeOfAxis, NormalizedStackId, StackId } from '../../util/ChartUtils';
 import { ChartOffsetInternal, DataKey, LayoutType, TickItem } from '../../util/types';
 import { BarRectangleItem, computeBarRectangles } from '../../cartesian/Bar';
@@ -151,7 +151,7 @@ export interface MaybeStackedGraphicalItem {
    * This is used to identify the graphical item in the state and in the React tree.
    * This is required for every graphical item - it's either provided by the user or generated automatically.
    */
-  id: string;
+  id: GraphicalItemId;
   stackId: StackId | undefined;
   dataKey: DataKey<any> | undefined;
   barSize: number | string | undefined;

--- a/src/util/useUniqueId.ts
+++ b/src/util/useUniqueId.ts
@@ -25,3 +25,13 @@ export function useUniqueId(prefix?: string, customId?: string): string {
   // Apply the prefix if one was provided.
   return prefix ? `${prefix}-${generatedId}` : generatedId;
 }
+
+/**
+ * The useUniqueId hook returns a unique ID that is either reused from external props or generated internally.
+ * Either way the ID is now guaranteed to be present so no more nulls or undefined.
+ */
+export type WithIdRequired<T> = T & {
+  id: string;
+};
+
+export type WithoutId<T> = Omit<T, 'id'>;

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -1011,6 +1011,8 @@ describe('computeArea', () => {
   it('should return empty points if displayedData is empty array', () => {
     const { points } = computeArea({
       areaSettings: {
+        id: 'area-0',
+        barSize: undefined,
         connectNulls: false,
         baseValue: 0,
         dataKey: '',
@@ -1029,6 +1031,8 @@ describe('computeArea', () => {
     const { points } = computeArea({
       displayedData: [{ v: 1 }, { v: 2 }, { v: 3 }],
       areaSettings: {
+        id: 'area-0',
+        barSize: undefined,
         connectNulls: false,
         baseValue: 0,
         dataKey: 'v',
@@ -1073,6 +1077,8 @@ describe('computeArea', () => {
     const { points } = computeArea({
       displayedData: [{ v: 1 }, { v: 2 }, { v: 3 }],
       areaSettings: {
+        id: 'area-0',
+        barSize: undefined,
         connectNulls: false,
         baseValue: 0,
         dataKey: 'v',
@@ -1126,6 +1132,8 @@ describe('computeArea', () => {
       ],
       dataStartIndex: 0,
       areaSettings: {
+        id: 'area-0',
+        barSize: undefined,
         connectNulls: false,
         baseValue: 0,
         dataKey: 'v',
@@ -1179,6 +1187,8 @@ describe('computeArea', () => {
       ],
       dataStartIndex: 0,
       areaSettings: {
+        id: 'area-0',
+        barSize: undefined,
         connectNulls: false,
         baseValue: 0,
         dataKey: 'v',
@@ -1232,6 +1242,8 @@ describe('computeArea', () => {
       ],
       dataStartIndex: 0,
       areaSettings: {
+        id: 'area-0',
+        barSize: undefined,
         connectNulls: false,
         baseValue: 0,
         dataKey: 'v',

--- a/test/chart/AreaChart.spec.tsx
+++ b/test/chart/AreaChart.spec.tsx
@@ -164,6 +164,8 @@ describe('AreaChart', () => {
     const xAxisTicksSpy = vi.fn();
     const Comp = (): null => {
       const areaSettings: AreaSettings = {
+        id: 'area-0',
+        barSize: undefined,
         baseValue: undefined,
         stackId: '1',
         dataKey: 'uv',
@@ -372,6 +374,8 @@ describe('AreaChart', () => {
 
   test('renders a stacked chart when stackId is a number', () => {
     const areaSettings: AreaSettings = {
+      id: 'area-0',
+      barSize: undefined,
       baseValue: undefined,
       stackId: 1,
       dataKey: 'uv',

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -53,6 +53,7 @@ describe('<LineChart />', () => {
       'd',
       'fill',
       'height',
+      'id',
       'stroke',
       'stroke-dasharray',
       'stroke-width',
@@ -63,6 +64,7 @@ describe('<LineChart />', () => {
     expect(line).toHaveAttribute('fill', 'none');
     expect(line).toHaveAttribute('width', '360');
     expect(line).toHaveAttribute('height', '360');
+    expect(line).toHaveAttribute('id', expect.stringMatching('recharts-line-[:a-z0-9]+'));
     expect(line).toHaveAttribute('class', 'recharts-curve recharts-line-curve');
     expect(line).toHaveAttribute('stroke-dasharray', '0px 0px');
     expect(line).toHaveAttribute(
@@ -89,6 +91,7 @@ describe('<LineChart />', () => {
       'd',
       'fill',
       'height',
+      'id',
       'stroke',
       'stroke-dasharray',
       'stroke-width',
@@ -99,6 +102,7 @@ describe('<LineChart />', () => {
     expect(line).toHaveAttribute('fill', 'none');
     expect(line).toHaveAttribute('width', '300');
     expect(line).toHaveAttribute('height', '330');
+    expect(line).toHaveAttribute('id', expect.stringMatching('recharts-line-[:a-z0-9]+'));
     expect(line).toHaveAttribute('class', 'recharts-curve recharts-line-curve');
     expect(line).toHaveAttribute('stroke-dasharray', '0px 0px');
     expect(line).toHaveAttribute(
@@ -194,6 +198,7 @@ describe('<LineChart />', () => {
       'd',
       'fill',
       'height',
+      'id',
       'stroke',
       'stroke-dasharray',
       'stroke-width',
@@ -204,6 +209,7 @@ describe('<LineChart />', () => {
     expect(line1).toHaveAttribute('fill', 'none');
     expect(line1).toHaveAttribute('width', '330');
     expect(line1).toHaveAttribute('height', '160');
+    expect(line1).toHaveAttribute('id', expect.stringMatching('recharts-line-[:a-z0-9]+'));
     expect(line1).toHaveAttribute('class', 'recharts-curve recharts-line-curve');
     expect(line1).toHaveAttribute('stroke-dasharray', '0px 0px');
     expect(line1).toHaveAttribute('d', 'M80,58.333L135,58.333L190,36.067L245,18.6L300,5L355,17.267L410,74.333');
@@ -215,6 +221,7 @@ describe('<LineChart />', () => {
       'd',
       'fill',
       'height',
+      'id',
       'stroke',
       'stroke-dasharray',
       'stroke-width',
@@ -225,9 +232,12 @@ describe('<LineChart />', () => {
     expect(line2).toHaveAttribute('fill', 'none');
     expect(line2).toHaveAttribute('width', '330');
     expect(line2).toHaveAttribute('height', '160');
+    expect(line2).toHaveAttribute('id', expect.stringMatching('recharts-line-[:a-z0-9]+'));
     expect(line2).toHaveAttribute('class', 'recharts-curve recharts-line-curve');
     expect(line2).toHaveAttribute('stroke-dasharray', '0px 0px');
     expect(line2).toHaveAttribute('d', 'M80,106L135,106L190,78.2L245,25.3L300,17L355,13L410,25');
+
+    expect(line1.getAttribute('id')).not.toEqual(line2.getAttribute('id'));
   });
 
   test('Sets title and description correctly', () => {
@@ -1865,7 +1875,7 @@ describe('<LineChart /> with dataKey as a function', () => {
     fireEvent.click(screen.getByText('Use data2'));
 
     expectLines(container, [{ d: 'M5,5L150,101.667L295,198.333' }]);
-    expect(dataKey1Spy).toHaveBeenCalledTimes(data1.length * 9);
+    expect(dataKey1Spy).toHaveBeenCalledTimes(data1.length * 11);
 
     expect(dataKey2Spy).toHaveBeenCalledTimes(data2.length * 7);
     expect(dataKey2Spy).toHaveBeenNthCalledWith(1, data2[0]);

--- a/test/container/ClipPath.spec.tsx
+++ b/test/container/ClipPath.spec.tsx
@@ -78,7 +78,7 @@ describe('clip paths', () => {
       });
       const clipPath = line.querySelector('clipPath');
       const clipPathId = clipPath.getAttribute('id');
-      expect(clipPathId).toEqual(expect.stringMatching(/clipPath-recharts-line-\d+/));
+      expect(clipPathId).toEqual(expect.stringMatching(/clipPath-recharts-line-[:a-z]+/));
       const curve = container.querySelector('.recharts-line-curve');
       expect(curve.getAttribute('clip-path')).toEqual(`url(#${clipPathId})`);
     });
@@ -200,7 +200,7 @@ describe('clip paths', () => {
       });
       const clipPath = bar.querySelector('clipPath');
       const clipPathId = clipPath.getAttribute('id');
-      expect(clipPathId).toEqual(expect.stringMatching(/clipPath-recharts-bar-\d+/));
+      expect(clipPathId).toEqual(expect.stringMatching(/clipPath-recharts-bar-[:a-z]+/));
       const layer = bar.querySelector('.recharts-bar-rectangles');
       expect(layer.getAttribute('clip-path')).toEqual(`url(#${clipPathId})`);
     });
@@ -267,7 +267,7 @@ describe('clip paths', () => {
       });
       const clipPath = scatter.querySelector('clipPath');
       const clipPathId = clipPath.getAttribute('id');
-      expect(clipPathId).toEqual(expect.stringMatching(/clipPath-recharts-scatter-\d+/));
+      expect(clipPathId).toEqual(expect.stringMatching(/clipPath-recharts-scatter-[:a-z]+/));
       expect(scatter.getAttribute('clip-path')).toEqual(`url(#${clipPathId})`);
     });
 

--- a/test/state/selectors/areaSelectors.spec.tsx
+++ b/test/state/selectors/areaSelectors.spec.tsx
@@ -13,6 +13,8 @@ import { PageData } from '../../_data';
 import { assertNotNull } from '../../helper/assertNotNull';
 
 const areaSettings: AreaSettings = {
+  id: 'area-0',
+  barSize: undefined,
   connectNulls: true,
   baseValue: undefined,
   dataKey: 'uv',


### PR DESCRIPTION
## Description

I will use this ID to fetch data later so first it has to be available inside of the component.

And since it's there and it's available, there is no point generating another one for the clip path.

## Related Issue

https://github.com/recharts/recharts/issues/6073
