### PR TITLE
Don't apply duplicate IDs in DOM

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -255,14 +255,17 @@ function StaticArea({
   props: InternalProps;
   showLabels: boolean;
 }) {
-  const { layout, type, stroke, connectNulls, isRange, ...others } = props;
+  const { layout, type, stroke, connectNulls, isRange } = props;
+
+  const { id, ...propsWithoutId } = props;
+  const allOtherProps = filterProps(propsWithoutId, false);
 
   return (
     <>
       {points?.length > 1 && (
-        <Layer clipPath={needClip ? `url(#clipPath-${clipPathId})` : undefined}>
+        <Layer clipPath={needClip ? `url(#clipPath-${clipPathId})` : undefined} id={id}>
           <Curve
-            {...filterProps(others, true)}
+            {...allOtherProps}
             points={points}
             connectNulls={connectNulls}
             type={type}
@@ -273,7 +276,7 @@ function StaticArea({
           />
           {stroke !== 'none' && (
             <Curve
-              {...filterProps(props, false)}
+              {...allOtherProps}
               className="recharts-area-curve"
               layout={layout}
               type={type}
@@ -284,7 +287,7 @@ function StaticArea({
           )}
           {stroke !== 'none' && isRange && (
             <Curve
-              {...filterProps(props, false)}
+              {...allOtherProps}
               className="recharts-area-curve"
               layout={layout}
               type={type}
@@ -295,8 +298,8 @@ function StaticArea({
           )}
         </Layer>
       )}
-      <Dots points={points} props={props} clipPathId={clipPathId} />
-      {showLabels && LabelList.renderCallByParent(props, points)}
+      <Dots points={points} props={propsWithoutId} clipPathId={clipPathId} />
+      {showLabels && LabelList.renderCallByParent(propsWithoutId, points)}
     </>
   );
 }

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -263,9 +263,10 @@ function StaticArea({
   return (
     <>
       {points?.length > 1 && (
-        <Layer clipPath={needClip ? `url(#clipPath-${clipPathId})` : undefined} id={id}>
+        <Layer clipPath={needClip ? `url(#clipPath-${clipPathId})` : undefined}>
           <Curve
             {...allOtherProps}
+            id={id}
             points={points}
             connectNulls={connectNulls}
             type={type}

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -287,7 +287,7 @@ function BarRectangles({
   props: BarRectanglesProps;
   showLabels: boolean;
 }) {
-  const baseProps = filterProps(props, false);
+  const { id, ...baseProps } = filterProps(props, false);
   const { shape, dataKey, activeBar } = props;
 
   const activeIndex = useAppSelector(selectActiveTooltipIndex);
@@ -503,7 +503,7 @@ class BarWithState extends PureComponent<InternalProps> {
     const clipPathId = isNullish(id) ? this.id : id;
 
     return (
-      <Layer className={layerClass}>
+      <Layer className={layerClass} id={id}>
         {needClip && (
           <defs>
             <GraphicalItemClipPath clipPathId={clipPathId} xAxisId={xAxisId} yAxisId={yAxisId} />

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -241,8 +241,14 @@ function Dots({
     return null;
   }
 
+  /*
+   * Exclude ID from the props passed to the Dots component
+   * because then the ID would be applied to multiple dots and it would no longer be unique.
+   */
+  const { id, ...propsWithoutId } = props;
+
   const clipDot = isClipDot(dot);
-  const lineProps = filterProps(props, false);
+  const lineProps = filterProps(propsWithoutId, false);
   const customDotProps = filterProps(dot, true);
 
   const dots = points.map((entry, i) => {

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -206,7 +206,6 @@ function ScatterLine({ points, props }: { points: ReadonlyArray<ScatterPointItem
 function ScatterSymbols(props: ScatterSymbolsProps) {
   const { points, showLabels, allOtherScatterProps } = props;
   const { shape, activeShape, dataKey } = allOtherScatterProps;
-  const baseProps = filterProps(allOtherScatterProps, false);
 
   const activeIndex = useAppSelector(selectActiveTooltipIndex);
   const {
@@ -222,6 +221,10 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
   if (points == null) {
     return null;
   }
+
+  const { id, ...allOtherPropsWithoutId } = allOtherScatterProps;
+  const baseProps = filterProps(allOtherPropsWithoutId, false);
+
   return (
     <>
       <ScatterLine points={points} props={allOtherScatterProps} />
@@ -510,7 +513,7 @@ function ScatterWithId(props: InternalProps) {
   const clipPathId = isNullish(id) ? idRef.current : id;
 
   return (
-    <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null}>
+    <Layer className={layerClass} clipPath={needClip ? `url(#clipPath-${clipPathId})` : null} id={id}>
       {needClip && (
         <defs>
           <GraphicalItemClipPath clipPathId={clipPathId} xAxisId={xAxisId} yAxisId={yAxisId} />

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -17,6 +17,7 @@ import { mockXAxisWithScale, mockYAxisWithScale } from '../helper/mockAxes';
 import { useLegendPayload } from '../../src/context/legendPayloadContext';
 import { selectTooltipPayloadConfigurations } from '../../src/state/selectors/selectors';
 import { assertNotNull } from '../helper/assertNotNull';
+import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 
 type TestCase = CartesianChartTestCase;
 
@@ -428,18 +429,31 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
       });
     });
   });
-
-  it('should pass id prop to an element in the DOM', () => {
-    const { container } = render(
+  describe('with explicit ID prop', () => {
+    const renderTestCase = createSelectorTestCase(({ children }) => (
       <ChartElement data={data}>
         <Area dataKey="value" id="my-custom-area-id" />
-      </ChartElement>,
-    );
+        <XAxis allowDataOverflow />
+        {children}
+      </ChartElement>
+    ));
 
-    const area = container.querySelector('#my-custom-area-id');
-    assertNotNull(area);
-    expect(area.tagName).toBe('path');
-    expect(area.classList.value).toBe('recharts-curve recharts-area-area');
+    it('should pass id prop to an element in the DOM', () => {
+      const { container } = renderTestCase();
+
+      const area = container.querySelector('#my-custom-area-id');
+      assertNotNull(area);
+      expect(area.tagName).toBe('g');
+      expect(area.classList.value).toBe('recharts-layer');
+    });
+
+    it('should set the ID on the clipPath, if it needs clipping', () => {
+      const { container } = renderTestCase();
+
+      const clipPath = container.querySelector('#clipPath-my-custom-area-id');
+      assertNotNull(clipPath);
+      expect(clipPath.tagName).toBe('clipPath');
+    });
   });
 
   describe('state integration', () => {

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -438,13 +438,18 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
       </ChartElement>
     ));
 
-    it('should pass id prop to an element in the DOM', () => {
+    it('should pass id prop to the path element', () => {
       const { container } = renderTestCase();
 
       const area = container.querySelector('#my-custom-area-id');
       assertNotNull(area);
-      expect(area.tagName).toBe('g');
-      expect(area.classList.value).toBe('recharts-layer');
+      /*
+       * This behaviour is useful for setting a clipPath based on the area path:
+       * See https://github.com/recharts/recharts/issues/6098
+       * and https://github.com/recharts/recharts/pull/6111#issuecomment-3078857263
+       */
+      expect(area.tagName).toBe('path');
+      expect(area.classList.value).toBe('recharts-curve recharts-area-area');
     });
 
     it('should set the ID on the clipPath, if it needs clipping', () => {

--- a/test/cartesian/Bar.spec.tsx
+++ b/test/cartesian/Bar.spec.tsx
@@ -213,17 +213,31 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
     expectBars(container, []);
   });
 
-  it('should pass id prop to an element in the DOM', () => {
-    const { container } = renderWithStrictMode(
+  describe('with explicit ID prop', () => {
+    const renderTestCase = createSelectorTestCase(({ children }) => (
       <ChartElement layout="horizontal" data={data}>
         <Bar isAnimationActive={false} dataKey="value" id="test-bar-id" />
-      </ChartElement>,
-    );
+        <XAxis allowDataOverflow />
+        {children}
+      </ChartElement>
+    ));
 
-    const bar = container.querySelector('#test-bar-id');
-    assertNotNull(bar);
-    expect(bar.tagName).toBe('path');
-    expect(bar.classList.value).toBe('recharts-rectangle');
+    it('should pass id prop to an element in the DOM', () => {
+      const { container } = renderTestCase();
+
+      const bar = container.querySelector('#test-bar-id');
+      assertNotNull(bar);
+      expect(bar.tagName).toBe('g');
+      expect(bar.classList.value).toBe('recharts-layer recharts-bar');
+    });
+
+    it('should set the ID on the clipPath, if it needs clipping', () => {
+      const { container } = renderTestCase();
+
+      const clipPath = container.querySelector('#clipPath-test-bar-id');
+      assertNotNull(clipPath);
+      expect(clipPath.tagName).toBe('clipPath');
+    });
   });
 
   describe('barSize', () => {

--- a/test/cartesian/Line.spec.tsx
+++ b/test/cartesian/Line.spec.tsx
@@ -114,17 +114,31 @@ describe('<Line />', () => {
     expect(dotsWrapper.getAttribute('clip-path')).toContain('url(#clipPath-recharts-line');
   });
 
-  it('should pass id prop to an element in the DOM', () => {
-    const { container } = render(
+  describe('with explicit ID prop', () => {
+    const renderTestCase = createSelectorTestCase(({ children }) => (
       <LineChart width={500} height={500}>
         <Line isAnimationActive={false} data={data} dataKey="y" id="test-line-id" />
-      </LineChart>,
-    );
+        <XAxis allowDataOverflow />
+        {children}
+      </LineChart>
+    ));
 
-    const line = container.querySelector('#test-line-id');
-    assertNotNull(line);
-    expect(line.tagName).toBe('path');
-    expect(line.classList.value).toBe('recharts-curve recharts-line-curve');
+    it('should pass id prop to an element in the DOM', () => {
+      const { container } = renderTestCase();
+
+      const line = container.querySelector('#test-line-id');
+      assertNotNull(line);
+      expect(line.tagName).toBe('path');
+      expect(line.classList.value).toBe('recharts-curve recharts-line-curve');
+    });
+
+    it('should set the ID on the clipPath, if it needs clipping', () => {
+      const { container } = renderTestCase();
+
+      const clipPath = container.querySelector('#clipPath-test-line-id');
+      assertNotNull(clipPath);
+      expect(clipPath.tagName).toBe('clipPath');
+    });
   });
 
   it("Don't render any path when data is empty", () => {

--- a/test/cartesian/Scatter.spec.tsx
+++ b/test/cartesian/Scatter.spec.tsx
@@ -186,17 +186,31 @@ describe('<Scatter />', () => {
     expect.soft(container.querySelector('[fill="fill4"]')).toBeInTheDocument();
   });
 
-  it('should pass id prop to an element in the DOM', () => {
-    const { container } = render(
+  describe('with explicit ID prop', () => {
+    const renderTestCase = createSelectorTestCase(({ children }) => (
       <ScatterChart width={500} height={500}>
         <Scatter isAnimationActive={false} data={data} dataKey="cx" id="test-scatter-id" />
-      </ScatterChart>,
-    );
+        <XAxis allowDataOverflow />
+        {children}
+      </ScatterChart>
+    ));
 
-    const scatter = container.querySelector('#test-scatter-id');
-    assertNotNull(scatter);
-    expect(scatter.tagName).toBe('path');
-    expect(scatter.classList.value).toBe('recharts-symbols');
+    it('should pass id prop to an element in the DOM', () => {
+      const { container } = renderTestCase();
+
+      const scatter = container.querySelector('#test-scatter-id');
+      assertNotNull(scatter);
+      expect(scatter.tagName).toBe('g');
+      expect(scatter.classList.value).toBe('recharts-layer recharts-scatter');
+    });
+
+    it('should set the ID on the clipPath, if it needs clipping', () => {
+      const { container } = renderTestCase();
+
+      const clipPath = container.querySelector('#clipPath-test-scatter-id');
+      assertNotNull(clipPath);
+      expect(clipPath.tagName).toBe('clipPath');
+    });
   });
 
   describe('state integration', () => {

--- a/test/util/assertUniqueHtmlIds.ts
+++ b/test/util/assertUniqueHtmlIds.ts
@@ -9,15 +9,15 @@ type ReturnsContainer = () => { container: Element };
  * @throws {Error} If a duplicate ID is found.
  */
 export function assertUniqueHtmlIds(root: Element | ReturnsContainer) {
-  let el;
+  let container;
   if (typeof root === 'function') {
-    el = root().container;
+    container = root().container;
   } else {
-    el = root;
+    container = root;
   }
 
   const idMap = new Map<string, number>();
-  const elementsWithIds = el.querySelectorAll('[id]');
+  const elementsWithIds = container.querySelectorAll('[id]');
 
   elementsWithIds.forEach(element => {
     const { id } = element;
@@ -29,7 +29,10 @@ export function assertUniqueHtmlIds(root: Element | ReturnsContainer) {
 
   idMap.forEach((count, id) => {
     if (count > 1) {
-      throw new Error(`Duplicate HTML ID found: "${id}", with ${count} occurrences.`);
+      const duplicateElements = Array.from(container.querySelectorAll(`[id="${id}"]`));
+      const elementList = duplicateElements.map(el => `${el.tagName}.${el.classList.value}`).join(', ');
+      const errorMessage = `Duplicate HTML ID found: "${id}", with ${count} occurrences: ${elementList}.`;
+      throw new Error(errorMessage);
     }
   });
 }


### PR DESCRIPTION
## Description

Apply ID to element that is only rendered once instead of element that is rendered multiple times because IDs should be unique.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/6110

Adds tests that cover https://github.com/recharts/recharts/issues/6098
