### PR TITLE
Run test-vr in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
         if: steps.vr_test_step.outcome == 'failure' && github.event_name == 'pull_request'
         run: |
           REPORT_URL=${{ steps.deployment.outputs.page_url }}/vr-report/$SANITIZED_BRANCH_NAME
-          ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/github-pages"
+          ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload_vr_report.outputs.artifact_id }}"
           COMMENT_BODY=$(cat <<EOF
           Visual Regression tests failed.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Prepare VR report for publishing
         if: steps.vr_test_step.outcome == 'failure'
         run: |
-          REPORT_DIR=vr-report/$SANITIZED_BRANCH_NAME
+          REPORT_DIR=./vr-report/$SANITIZED_BRANCH_NAME
           mkdir -p $REPORT_DIR
           sudo mv ./test-vr/playwright-report/* $REPORT_DIR/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Prepare VR report for publishing
         if: steps.vr_test_step.outcome == 'failure'
         run: |
-          REPORT_DIR=./vr-report/$SANITIZED_BRANCH_NAME
+          REPORT_DIR=./gh-pages/vr-report/$SANITIZED_BRANCH_NAME
           mkdir -p $REPORT_DIR
           sudo mv ./test-vr/playwright-report/* $REPORT_DIR/
 
@@ -222,7 +222,7 @@ jobs:
         if: steps.vr_test_step.outcome == 'failure'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./vr-report
+          path: ./gh-pages
 
       - name: Deploy to GitHub Pages
         if: steps.vr_test_step.outcome == 'failure'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,6 @@ jobs:
 #        uses: actions/download-artifact@v4
 #        with:
 #          # name is not the filename, it's the "artifact name". The actual filename is the original of what was uploaded.
-#          # In this workflow we keep them the same but GitHub treats them differently.
 #          name: ${{ env.PACKED_ARTIFACT_NAME }}
 #          # path is the directory where the artifact will be downloaded
 #          # so the full path to the artifact will be ${{ runner.temp }}/${{ env.PACKED_ARTIFACT_NAME }}
@@ -197,6 +196,13 @@ jobs:
         with:
           repository: recharts/recharts # Checkout the main repo again but this time all directories and files
 
+      - name: Sanitize branch name
+        run: |
+          BRANCH_NAME=${{ github.head_ref || github.ref_name }}
+          # Sanitize branch name for URL
+          SANITIZED_BRANCH_NAME=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9]/-/g')
+          echo "SANITIZED_BRANCH_NAME=$SANITIZED_BRANCH_NAME" >> $GITHUB_ENV
+
       - name: Build Docker Image
         run: npm run test-vr:prepare
 
@@ -208,10 +214,7 @@ jobs:
       - name: Prepare VR report for publishing
         if: steps.vr_test_step.outcome == 'failure'
         run: |
-          BRANCH_NAME=${{ github.head_ref || github.ref_name }}
-          # Sanitize branch name for URL
-          BRANCH_NAME=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9]/-/g')
-          REPORT_DIR=vr-report/$BRANCH_NAME
+          REPORT_DIR=vr-report/$SANITIZED_BRANCH_NAME
           mkdir -p $REPORT_DIR
           sudo mv ./test-vr/playwright-report/* $REPORT_DIR/
 
@@ -229,10 +232,7 @@ jobs:
       - name: Add a comment with the VR report URL
         if: steps.vr_test_step.outcome == 'failure' && github.event_name == 'pull_request'
         run: |
-          BRANCH_NAME=${{ github.head_ref || github.ref_name }}
-          # Sanitize branch name for URL
-          BRANCH_NAME=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9]/-/g')
-          REPORT_URL=${{ steps.deployment.outputs.page_url }}/vr-report/$BRANCH_NAME
+          REPORT_URL=${{ steps.deployment.outputs.page_url }}/vr-report/$SANITIZED_BRANCH_NAME
           ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/github-pages"
           COMMENT_BODY=$(cat <<EOF
           Visual Regression tests failed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
           # Sanitize branch name for URL
           BRANCH_NAME=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9]/-/g')
           REPORT_URL=${{ steps.deployment.outputs.page_url }}vr-report/$BRANCH_NAME
-          ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.vr_test_step.outputs.artifact_id }}"
           COMMENT_BODY=$(cat <<EOF
           Visual Regression tests failed.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,9 +209,9 @@ jobs:
           BRANCH_NAME=${{ github.head_ref || github.ref_name }}
           # Sanitize branch name for URL
           BRANCH_NAME=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9]/-/g')
-          REPORT_DIR=vr-report/$BRANCH_NAME
+          REPORT_DIR=./vr-report/$BRANCH_NAME
           mkdir -p $REPORT_DIR
-          mv ./test-vr/playwright-report $REPORT_DIR/
+          sudo mv ./test-vr/playwright-report $REPORT_DIR/
 
       - name: Upload Visual Regression Report artifact
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,3 +218,10 @@ jobs:
       - name: Upload VR report to GitHub Pages
         if: ${{ !cancelled() }}
         uses: actions/deploy-pages@v4
+
+      - name: Add a comment with the VR report URL
+        if: ${{ !cancelled() }}
+        run: |
+          REPORT_URL=${{ steps.deployment.outputs.page_url }}
+          echo "Visual Regression Report URL: $REPORT_URL"
+          gh pr comment ${{ github.event.pull_request.number }} --body "Visual Regression Report: $REPORT_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,9 @@ jobs:
           repository: recharts/recharts # Checkout the main repo again but this time all directories and files
 
       - name: Sanitize branch name
+        # The branch name is used in the URL for the report.
+        # It needs to be sanitized to remove characters that are not URL-friendly.
+        # This step creates a GITHUB_ENV variable so it can be reused in later steps.
         run: |
           BRANCH_NAME=${{ github.head_ref || github.ref_name }}
           # Sanitize branch name for URL
@@ -204,34 +207,52 @@ jobs:
           echo "SANITIZED_BRANCH_NAME=$SANITIZED_BRANCH_NAME" >> $GITHUB_ENV
 
       - name: Build Docker Image
+        # The VR tests run inside a Docker container. This step builds the image.
         run: npm run test-vr:prepare
 
       - name: Run Visual Regression Tests
         id: vr_test_step
         run: npm run test-vr
+        # Continue even if this step fails. This allows us to upload the report
+        # and post a comment on the PR. The workflow will be failed in a later step.
         continue-on-error: true
 
       - name: Prepare VR report for publishing
+        # This step only runs if the VR tests have failed to prevent overwriting reports from other PRs.
         if: steps.vr_test_step.outcome == 'failure'
+        # The report is placed in a directory named after the sanitized branch name.
+        # This allows us to have separate reports for each branch on GitHub Pages.
+        # The test report is generated inside a Docker container by a root user.
+        # We need to use sudo to move the report files.
         run: |
           REPORT_DIR=./gh-pages/vr-report/$SANITIZED_BRANCH_NAME
           mkdir -p $REPORT_DIR
           sudo mv ./test-vr/playwright-report/* $REPORT_DIR/
 
       - name: Upload Visual Regression Report artifact for Pages
+        # This step only runs if the VR tests have failed to prevent overwriting reports from other PRs.
         if: steps.vr_test_step.outcome == 'failure'
         id: upload_vr_report
+        # This action uploads the report as an artifact that can be deployed to GitHub Pages.
         uses: actions/upload-pages-artifact@v3
         with:
+          # The root of the artifact will be the gh-pages directory so that the public URL can start with "vr-report".
+          # Note: This setup will overwrite reports from other PRs if they run in parallel,
+          # as we are not checking out the existing gh-pages branch content first.
           path: ./gh-pages
 
       - name: Deploy to GitHub Pages
+        # This step only runs if the VR tests have failed.
         if: steps.vr_test_step.outcome == 'failure'
         id: deployment
+        # This action deploys the artifact to GitHub Pages. This will erase all files from previous deployments, including other PRs.
         uses: actions/deploy-pages@v4
 
       - name: Add a comment with the VR report URL
+        # This step only runs if the VR tests have failed and the event is a pull request.
         if: steps.vr_test_step.outcome == 'failure' && github.event_name == 'pull_request'
+        # The artifact from `upload-pages-artifact` is named `github-pages` by default.
+        # We construct a URL to download it for manual inspection.
         run: |
           REPORT_URL=${{ steps.deployment.outputs.page_url }}vr-report/$SANITIZED_BRANCH_NAME
           ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload_vr_report.outputs.artifact_id }}"
@@ -248,5 +269,8 @@ jobs:
           gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"
 
       - name: Fail workflow if tests failed
+        # This step ensures that the entire job fails if the VR tests have failed.
+        # This is necessary because of `continue-on-error: true` in the test step.
+        # A failing job will block the PR from being merged.
         if: steps.vr_test_step.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,3 +178,19 @@ jobs:
       - name: Run Test
         # Use the output from the 'pack_library' step
         run: ./run-test.sh ${{ matrix.test_dir }} "file:${{ runner.temp }}/${{ env.PACKED_ARTIFACT_NAME }}"
+
+  vr_tests:
+    name: Visual Regression Tests
+    runs-on: ubuntu-latest
+    needs: [build_test_pack]
+    steps:
+      - name: Checkout Recharts Repository
+        uses: actions/checkout@v4
+        with:
+          repository: recharts/recharts # Checkout the main repo again but this time all directories and files
+
+      - name: Build Docker Image
+        run: npm run test-vr:prepare
+
+      - name: Run Visual Regression Tests
+        run: npm run test-vr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,164 +19,164 @@ env:
   PACKED_ARTIFACT_NAME: 'recharts-snapshot.tgz'
 
 jobs:
-#  list_integration_tests:
-#    name: List Integration Test Directories
-#    runs-on: ubuntu-latest
-#    outputs:
-#      # Output the list of directories as a JSON array string
-#      directories: ${{ steps.set_matrix.outputs.directories }}
-#    steps:
-#      - name: Checkout Integration Tests Repository
-#        uses: actions/checkout@v4
-#        with:
-#          repository: recharts/recharts-integ
-#
-#      - name: List Integration Test Directories
-#        id: set_matrix
-#        # This command finds all integration test directories
-#        # and formats them as a JSON array.
-#        run: |
-#          JSON_ARRAY=$(node list.js --ci --json)
-#          echo "Generated directory list: $JSON_ARRAY"
-#          echo "directories=$JSON_ARRAY" >> $GITHUB_OUTPUT
-#
-#  build_test_pack:
-#    name: Build, Test, Pack
-#    runs-on: ubuntu-latest
-#    container:
-#        # Use the Playwright container to run tests, as recommended in https://storybook.js.org/docs/writing-tests/in-ci
-#      # Make sure to grab the latest version of the Playwright image
-#      # https://playwright.dev/docs/docker#pull-the-image
-#      image: mcr.microsoft.com/playwright:v1.54.1-jammy
-#    env:
-#      ENCRYPTED_CHROMATIC_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-#      # /root home is required to allow Firefox to run in the container
-#      HOME: /root
-#    outputs:
-#      # Output the *name* of the generated tgz file (relative to RECHARTS_PATH)
-#      # The actual file will be passed via artifact
-#      tgz_name: ${{ steps.pack_library.outputs.tgz_name }}
-#    steps:
-#      - name: Checkout Recharts Repository
-#        uses: actions/checkout@v4
-#        with:
-#          # Chromatic needs access to full git history
-#          # see https://www.chromatic.com/docs/github-actions/
-#          fetch-depth: 0
-#
-#      - name: Use Node.js ${{ env.NODE_VERSION }}
-#        uses: actions/setup-node@v4
-#        with:
-#          node-version: ${{ env.NODE_VERSION }}
-#          cache: 'npm'
-#          # Cache depends on the lock file within the checked-out path
-#          cache-dependency-path: 'package-lock.json'
-#
-#      - name: Install Dependencies
-#        run: npm ci
-#
-#      - name: Build
-#        run: npm run build
-#
-#      - name: Unit Tests
-#        run: npm run test-coverage
-#
-#      - name: Typecheck
-#        run: npm run check-types
-#
-#      - name: Lint
-#        run: npm run lint
-#
-#      - name: Storybook doctor
-#        run: npm run storybook-doctor
-#
-#      - name: Storybook Test
-#        run: npm run test-storybook
-#        timeout-minutes: 10
-#
-#      - name: Storybook Build
-#        run: npm run build-storybook
-#
-#      - name: Pack Library
-#        # Give this step an ID so we can reference its output
-#        id: pack_library
-#        run: |
-#          # Run npm pack and capture the output filename (relative to current dir)
-#          tgz_filename=$(npm pack | tail -n 1)
-#          # rename from the default packed name to PACKED_ARTIFACT_NAME so that we don't need to guess the name later.
-#          # artifact upload/download in GitHub has a 'name' property but that's the artifact name, not the file name.
-#          mv $tgz_filename ${{ env.PACKED_ARTIFACT_NAME }}
-#          echo "Packed library file: $tgz_filename renamed to ${{ env.PACKED_ARTIFACT_NAME }}"
-#          echo "tgz_name=${{ env.PACKED_ARTIFACT_NAME }}" >> $GITHUB_OUTPUT
-#
-#      - name: Upload Packed Library Artifact
-#        uses: actions/upload-artifact@v4
-#        with:
-#          # This is the "artifact name", it's not a file name. The file name remains original.
-#          name: ${{ env.PACKED_ARTIFACT_NAME }}
-#          # Upload the file specified by the output of the 'pack_library' step
-#          path: ${{ steps.pack_library.outputs.tgz_name }}
-#          retention-days: 14
-#
-#      # Now that we know all the tests are passing, let's report code coverage
-#      - name: Upload coverage report to Codecov
-#        uses: codecov/codecov-action@v5
-#        with:
-#          slug: recharts/recharts
-#          files: ./coverage/coverage-final.json
-#          token: ${{ secrets.CODECOV_TOKEN }}
-#
-#      - name: Upload bundle analysis report to Codecov
-#        env:
-#          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-#        run: node ./scripts/upload-bundle-analysis.js
-#
-#      # Chromatic gives us only this many free credits per month
-#      # so let's publish only at the end so that we don't waste them when we know we can't merge from the previous steps anyway.
-#      - name: Publish visual regression tests to Chromatic
-#        if: ${{ env.ENCRYPTED_CHROMATIC_TOKEN }}
-#        # Chromatic action from https://www.chromatic.com/docs/github-actions
-#        uses: chromaui/action@latest
-#        # Chromatic GitHub Action options
-#        with:
-#          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
-#          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-#          # Let's say that we don't want to use our Chromatic credits for PRs from dependabot
-#          skip: 'dependabot/**'
-#
-#  integration_tests:
-#    name: Test ${{ matrix.test_dir }}
-#    runs-on: ubuntu-latest
-#    needs: [list_integration_tests, build_test_pack]
-#    strategy:
-#      # Allow all integration tests to run even if one fails
-#      fail-fast: false
-#      matrix:
-#        # Dynamically generate the matrix from the JSON output of the previous job
-#        test_dir: ${{ fromJson(needs.list_integration_tests.outputs.directories) }}
-#    steps:
-#      - name: Checkout Integration Tests Repository
-#        uses: actions/checkout@v4
-#        with:
-#          repository: recharts/recharts-integ # Checkout the test repo again but this time all directories and files
-#
-#      - name: Use Node.js ${{ env.NODE_VERSION }}
-#        uses: actions/setup-node@v4
-#        with:
-#          node-version: ${{ env.NODE_VERSION }}
-#
-#      - name: Download Packed Library Artifact
-#        uses: actions/download-artifact@v4
-#        with:
-#          # name is not the filename, it's the "artifact name". The actual filename is the original of what was uploaded.
-#          name: ${{ env.PACKED_ARTIFACT_NAME }}
-#          # path is the directory where the artifact will be downloaded
-#          # so the full path to the artifact will be ${{ runner.temp }}/${{ env.PACKED_ARTIFACT_NAME }}
-#          path: ${{ runner.temp }}
-#
-#      - name: Run Test
-#        # Use the output from the 'pack_library' step
-#        run: ./run-test.sh ${{ matrix.test_dir }} "file:${{ runner.temp }}/${{ env.PACKED_ARTIFACT_NAME }}"
+  list_integration_tests:
+    name: List Integration Test Directories
+    runs-on: ubuntu-latest
+    outputs:
+      # Output the list of directories as a JSON array string
+      directories: ${{ steps.set_matrix.outputs.directories }}
+    steps:
+      - name: Checkout Integration Tests Repository
+        uses: actions/checkout@v4
+        with:
+          repository: recharts/recharts-integ
+
+      - name: List Integration Test Directories
+        id: set_matrix
+        # This command finds all integration test directories
+        # and formats them as a JSON array.
+        run: |
+          JSON_ARRAY=$(node list.js --ci --json)
+          echo "Generated directory list: $JSON_ARRAY"
+          echo "directories=$JSON_ARRAY" >> $GITHUB_OUTPUT
+
+  build_test_pack:
+    name: Build, Test, Pack
+    runs-on: ubuntu-latest
+    container:
+        # Use the Playwright container to run tests, as recommended in https://storybook.js.org/docs/writing-tests/in-ci
+      # Make sure to grab the latest version of the Playwright image
+      # https://playwright.dev/docs/docker#pull-the-image
+      image: mcr.microsoft.com/playwright:v1.54.1-jammy
+    env:
+      ENCRYPTED_CHROMATIC_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      # /root home is required to allow Firefox to run in the container
+      HOME: /root
+    outputs:
+      # Output the *name* of the generated tgz file (relative to RECHARTS_PATH)
+      # The actual file will be passed via artifact
+      tgz_name: ${{ steps.pack_library.outputs.tgz_name }}
+    steps:
+      - name: Checkout Recharts Repository
+        uses: actions/checkout@v4
+        with:
+          # Chromatic needs access to full git history
+          # see https://www.chromatic.com/docs/github-actions/
+          fetch-depth: 0
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          # Cache depends on the lock file within the checked-out path
+          cache-dependency-path: 'package-lock.json'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Unit Tests
+        run: npm run test-coverage
+
+      - name: Typecheck
+        run: npm run check-types
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Storybook doctor
+        run: npm run storybook-doctor
+
+      - name: Storybook Test
+        run: npm run test-storybook
+        timeout-minutes: 10
+
+      - name: Storybook Build
+        run: npm run build-storybook
+
+      - name: Pack Library
+        # Give this step an ID so we can reference its output
+        id: pack_library
+        run: |
+          # Run npm pack and capture the output filename (relative to current dir)
+          tgz_filename=$(npm pack | tail -n 1)
+          # rename from the default packed name to PACKED_ARTIFACT_NAME so that we don't need to guess the name later.
+          # artifact upload/download in GitHub has a 'name' property but that's the artifact name, not the file name.
+          mv $tgz_filename ${{ env.PACKED_ARTIFACT_NAME }}
+          echo "Packed library file: $tgz_filename renamed to ${{ env.PACKED_ARTIFACT_NAME }}"
+          echo "tgz_name=${{ env.PACKED_ARTIFACT_NAME }}" >> $GITHUB_OUTPUT
+
+      - name: Upload Packed Library Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          # This is the "artifact name", it's not a file name. The file name remains original.
+          name: ${{ env.PACKED_ARTIFACT_NAME }}
+          # Upload the file specified by the output of the 'pack_library' step
+          path: ${{ steps.pack_library.outputs.tgz_name }}
+          retention-days: 14
+
+      # Now that we know all the tests are passing, let's report code coverage
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          slug: recharts/recharts
+          files: ./coverage/coverage-final.json
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload bundle analysis report to Codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: node ./scripts/upload-bundle-analysis.js
+
+      # Chromatic gives us only this many free credits per month
+      # so let's publish only at the end so that we don't waste them when we know we can't merge from the previous steps anyway.
+      - name: Publish visual regression tests to Chromatic
+        if: ${{ env.ENCRYPTED_CHROMATIC_TOKEN }}
+        # Chromatic action from https://www.chromatic.com/docs/github-actions
+        uses: chromaui/action@latest
+        # Chromatic GitHub Action options
+        with:
+          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          # Let's say that we don't want to use our Chromatic credits for PRs from dependabot
+          skip: 'dependabot/**'
+
+  integration_tests:
+    name: Test ${{ matrix.test_dir }}
+    runs-on: ubuntu-latest
+    needs: [list_integration_tests, build_test_pack]
+    strategy:
+      # Allow all integration tests to run even if one fails
+      fail-fast: false
+      matrix:
+        # Dynamically generate the matrix from the JSON output of the previous job
+        test_dir: ${{ fromJson(needs.list_integration_tests.outputs.directories) }}
+    steps:
+      - name: Checkout Integration Tests Repository
+        uses: actions/checkout@v4
+        with:
+          repository: recharts/recharts-integ # Checkout the test repo again but this time all directories and files
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Download Packed Library Artifact
+        uses: actions/download-artifact@v4
+        with:
+          # name is not the filename, it's the "artifact name". The actual filename is the original of what was uploaded.
+          name: ${{ env.PACKED_ARTIFACT_NAME }}
+          # path is the directory where the artifact will be downloaded
+          # so the full path to the artifact will be ${{ runner.temp }}/${{ env.PACKED_ARTIFACT_NAME }}
+          path: ${{ runner.temp }}
+
+      - name: Run Test
+        # Use the output from the 'pack_library' step
+        run: ./run-test.sh ${{ matrix.test_dir }} "file:${{ runner.temp }}/${{ env.PACKED_ARTIFACT_NAME }}"
 
   vr_tests:
     name: Visual Regression Tests
@@ -186,7 +186,7 @@ jobs:
       id-token: write
       pull-requests: write
     runs-on: ubuntu-latest
-#    needs: [build_test_pack]
+    needs: [build_test_pack]
     env:
       # GH_TOKEN is needed to use `gh` CLI to comment on the PR
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,11 +199,21 @@ jobs:
       - name: Run Visual Regression Tests
         run: npm run test-vr
 
+      - name: Prepare VR report for publishing
+        if: ${{ !cancelled() }}
+        run: |
+          BRANCH_NAME=${{ github.head_ref || github.ref_name }}
+          # Sanitize branch name for URL
+          BRANCH_NAME=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9]/-/g')
+          REPORT_DIR=vr-report/$BRANCH_NAME
+          mkdir -p $REPORT_DIR
+          mv ./test-vr/playwright-report $REPORT_DIR/
+
       - name: Upload Visual Regression Report artifact
         if: ${{ !cancelled() }}
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./test-vr/playwright-report
+          path: ./vr-report
 
       - name: Upload VR report to GitHub Pages
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,7 @@ jobs:
       contents: read
       pages: write
       id-token: write
+      pull-requests: write
     runs-on: ubuntu-latest
 #    needs: [build_test_pack]
     env:
@@ -220,11 +221,15 @@ jobs:
 
       - name: Upload VR report to GitHub Pages
         if: ${{ !cancelled() }}
+        id: deployment
         uses: actions/deploy-pages@v4
 
       - name: Add a comment with the VR report URL
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         run: |
-          REPORT_URL=${{ steps.deployment.outputs.page_url }}
+          BRANCH_NAME=${{ github.head_ref || github.ref_name }}
+          # Sanitize branch name for URL
+          BRANCH_NAME=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9]/-/g')
+          REPORT_URL=${{ steps.deployment.outputs.page_url }}/vr-report/$BRANCH_NAME/playwright-report/
           echo "Visual Regression Report URL: $REPORT_URL"
           gh pr comment ${{ github.event.pull_request.number }} --body "Visual Regression Report: $REPORT_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         # Use the Playwright container to run tests, as recommended in https://storybook.js.org/docs/writing-tests/in-ci
       # Make sure to grab the latest version of the Playwright image
       # https://playwright.dev/docs/docker#pull-the-image
-      image: mcr.microsoft.com/playwright:v1.54.0-noble
+      image: mcr.microsoft.com/playwright:v1.54.1-jammy
     env:
       ENCRYPTED_CHROMATIC_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
       # /root home is required to allow Firefox to run in the container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,35 +201,54 @@ jobs:
         run: npm run test-vr:prepare
 
       - name: Run Visual Regression Tests
+        id: vr_test_step
         run: npm run test-vr
+        continue-on-error: true
 
       - name: Prepare VR report for publishing
-        if: ${{ !cancelled() }}
+        if: steps.vr_test_step.outcome == 'failure'
         run: |
           BRANCH_NAME=${{ github.head_ref || github.ref_name }}
           # Sanitize branch name for URL
           BRANCH_NAME=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9]/-/g')
-          REPORT_DIR=./gh-pages/vr-report/$BRANCH_NAME
+          REPORT_DIR=vr-report/$BRANCH_NAME
           mkdir -p $REPORT_DIR
           sudo mv ./test-vr/playwright-report/* $REPORT_DIR/
 
-      - name: Upload Visual Regression Report artifact
-        if: ${{ !cancelled() }}
+      - name: Upload VR Report as Artifact
+        if: steps.vr_test_step.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: vr-report-artifact-${{ github.run_id }}
+          path: ./vr-report/
+
+      - name: Upload Visual Regression Report artifact for Pages
+        if: steps.vr_test_step.outcome == 'failure'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./gh-pages
+          path: ./vr-report
 
       - name: Upload VR report to GitHub Pages
-        if: ${{ !cancelled() }}
+        if: steps.vr_test_step.outcome == 'failure'
         id: deployment
         uses: actions/deploy-pages@v4
 
       - name: Add a comment with the VR report URL
-        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        if: steps.vr_test_step.outcome == 'failure' && github.event_name == 'pull_request'
         run: |
           BRANCH_NAME=${{ github.head_ref || github.ref_name }}
           # Sanitize branch name for URL
           BRANCH_NAME=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9]/-/g')
           REPORT_URL=${{ steps.deployment.outputs.page_url }}vr-report/$BRANCH_NAME
-          echo "Visual Regression Report URL: $REPORT_URL"
-          gh pr comment ${{ github.event.pull_request.number }} --body "Visual Regression Report: $REPORT_URL"
+          ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMENT_BODY=$(cat <<EOF
+          Visual Regression tests failed.
+
+          - **Live Report URL:** $REPORT_URL
+            *(Note: This URL is temporary and may be overwritten by other PRs.)*
+
+          - **Artifact Download:** [Download report artifact]($ARTIFACT_URL)
+            *(This link provides a stable copy of the report for this specific run.)*
+          EOF
+          )
+          gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,7 @@ jobs:
 
       - name: Upload Visual Regression Report artifact for Pages
         if: steps.vr_test_step.outcome == 'failure'
+        id: upload_vr_report
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./gh-pages
@@ -232,16 +233,16 @@ jobs:
       - name: Add a comment with the VR report URL
         if: steps.vr_test_step.outcome == 'failure' && github.event_name == 'pull_request'
         run: |
-          REPORT_URL=${{ steps.deployment.outputs.page_url }}/vr-report/$SANITIZED_BRANCH_NAME
+          REPORT_URL=${{ steps.deployment.outputs.page_url }}vr-report/$SANITIZED_BRANCH_NAME
           ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.upload_vr_report.outputs.artifact_id }}"
           COMMENT_BODY=$(cat <<EOF
           Visual Regression tests failed.
 
           - **Live Report URL:** $REPORT_URL
-            *(Note: This URL is temporary and may be overwritten by other PRs.)*
+            *This URL is temporary and may be overwritten by other PRs. If that happens, download the artifact:*
 
           - **Artifact Download:** [Download report artifact]($ARTIFACT_URL)
-            *(This link provides a stable copy of the report for this specific run.)*
+            *This link provides a stable copy of the report for this specific run.*
           EOF
           )
           gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,3 +194,10 @@ jobs:
 
       - name: Run Visual Regression Tests
         run: npm run test-vr
+
+      - name: Upload Visual Regression Report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: recharts-vr-report
+          path: ./test-vr/playwright-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,20 +215,13 @@ jobs:
           mkdir -p $REPORT_DIR
           sudo mv ./test-vr/playwright-report/* $REPORT_DIR/
 
-      - name: Upload VR Report as Artifact
-        if: steps.vr_test_step.outcome == 'failure'
-        uses: actions/upload-artifact@v4
-        with:
-          name: vr-report-artifact-${{ github.run_id }}
-          path: ./vr-report/
-
       - name: Upload Visual Regression Report artifact for Pages
         if: steps.vr_test_step.outcome == 'failure'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./vr-report
 
-      - name: Upload VR report to GitHub Pages
+      - name: Deploy to GitHub Pages
         if: steps.vr_test_step.outcome == 'failure'
         id: deployment
         uses: actions/deploy-pages@v4
@@ -239,8 +232,8 @@ jobs:
           BRANCH_NAME=${{ github.head_ref || github.ref_name }}
           # Sanitize branch name for URL
           BRANCH_NAME=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9]/-/g')
-          REPORT_URL=${{ steps.deployment.outputs.page_url }}vr-report/$BRANCH_NAME
-          ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/${{ steps.vr_test_step.outputs.artifact_id }}"
+          REPORT_URL=${{ steps.deployment.outputs.page_url }}/vr-report/$BRANCH_NAME
+          ARTIFACT_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/github-pages"
           COMMENT_BODY=$(cat <<EOF
           Visual Regression tests failed.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,9 +195,12 @@ jobs:
       - name: Run Visual Regression Tests
         run: npm run test-vr
 
-      - name: Upload Visual Regression Report
+      - name: Upload Visual Regression Report artifact
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: recharts-vr-report
           path: ./test-vr/playwright-report
+
+      - name: Upload VR report to GitHub Pages
+        if: ${{ !cancelled() }}
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,15 +209,15 @@ jobs:
           BRANCH_NAME=${{ github.head_ref || github.ref_name }}
           # Sanitize branch name for URL
           BRANCH_NAME=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9]/-/g')
-          REPORT_DIR=./vr-report/$BRANCH_NAME
+          REPORT_DIR=./gh-pages/vr-report/$BRANCH_NAME
           mkdir -p $REPORT_DIR
-          sudo mv ./test-vr/playwright-report $REPORT_DIR/
+          sudo mv ./test-vr/playwright-report/* $REPORT_DIR/
 
       - name: Upload Visual Regression Report artifact
         if: ${{ !cancelled() }}
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./vr-report
+          path: ./gh-pages
 
       - name: Upload VR report to GitHub Pages
         if: ${{ !cancelled() }}
@@ -230,6 +230,6 @@ jobs:
           BRANCH_NAME=${{ github.head_ref || github.ref_name }}
           # Sanitize branch name for URL
           BRANCH_NAME=$(echo $BRANCH_NAME | sed 's/[^a-zA-Z0-9]/-/g')
-          REPORT_URL=${{ steps.deployment.outputs.page_url }}/vr-report/$BRANCH_NAME/playwright-report/
+          REPORT_URL=${{ steps.deployment.outputs.page_url }}vr-report/$BRANCH_NAME
           echo "Visual Regression Report URL: $REPORT_URL"
           gh pr comment ${{ github.event.pull_request.number }} --body "Visual Regression Report: $REPORT_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,10 @@ jobs:
 
   vr_tests:
     name: Visual Regression Tests
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
 #    needs: [build_test_pack]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,170 +19,170 @@ env:
   PACKED_ARTIFACT_NAME: 'recharts-snapshot.tgz'
 
 jobs:
-  list_integration_tests:
-    name: List Integration Test Directories
-    runs-on: ubuntu-latest
-    outputs:
-      # Output the list of directories as a JSON array string
-      directories: ${{ steps.set_matrix.outputs.directories }}
-    steps:
-      - name: Checkout Integration Tests Repository
-        uses: actions/checkout@v4
-        with:
-          repository: recharts/recharts-integ
-
-      - name: List Integration Test Directories
-        id: set_matrix
-        # This command finds all integration test directories
-        # and formats them as a JSON array.
-        run: |
-          JSON_ARRAY=$(node list.js --ci --json)
-          echo "Generated directory list: $JSON_ARRAY"
-          echo "directories=$JSON_ARRAY" >> $GITHUB_OUTPUT
-
-  build_test_pack:
-    name: Build, Test, Pack
-    runs-on: ubuntu-latest
-    container:
-        # Use the Playwright container to run tests, as recommended in https://storybook.js.org/docs/writing-tests/in-ci
-      # Make sure to grab the latest version of the Playwright image
-      # https://playwright.dev/docs/docker#pull-the-image
-      image: mcr.microsoft.com/playwright:v1.54.1-jammy
-    env:
-      ENCRYPTED_CHROMATIC_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-      # /root home is required to allow Firefox to run in the container
-      HOME: /root
-    outputs:
-      # Output the *name* of the generated tgz file (relative to RECHARTS_PATH)
-      # The actual file will be passed via artifact
-      tgz_name: ${{ steps.pack_library.outputs.tgz_name }}
-    steps:
-      - name: Checkout Recharts Repository
-        uses: actions/checkout@v4
-        with:
-          # Chromatic needs access to full git history
-          # see https://www.chromatic.com/docs/github-actions/
-          fetch-depth: 0
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          # Cache depends on the lock file within the checked-out path
-          cache-dependency-path: 'package-lock.json'
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Unit Tests
-        run: npm run test-coverage
-
-      - name: Typecheck
-        run: npm run check-types
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Storybook doctor
-        run: npm run storybook-doctor
-
-      - name: Storybook Test
-        run: npm run test-storybook
-        timeout-minutes: 10
-
-      - name: Storybook Build
-        run: npm run build-storybook
-
-      - name: Pack Library
-        # Give this step an ID so we can reference its output
-        id: pack_library
-        run: |
-          # Run npm pack and capture the output filename (relative to current dir)
-          tgz_filename=$(npm pack | tail -n 1)
-          # rename from the default packed name to PACKED_ARTIFACT_NAME so that we don't need to guess the name later.
-          # artifact upload/download in GitHub has a 'name' property but that's the artifact name, not the file name.
-          mv $tgz_filename ${{ env.PACKED_ARTIFACT_NAME }}
-          echo "Packed library file: $tgz_filename renamed to ${{ env.PACKED_ARTIFACT_NAME }}"
-          echo "tgz_name=${{ env.PACKED_ARTIFACT_NAME }}" >> $GITHUB_OUTPUT
-
-      - name: Upload Packed Library Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          # This is the "artifact name", it's not a file name. The file name remains original.
-          name: ${{ env.PACKED_ARTIFACT_NAME }}
-          # Upload the file specified by the output of the 'pack_library' step
-          path: ${{ steps.pack_library.outputs.tgz_name }}
-          retention-days: 14
-
-      # Now that we know all the tests are passing, let's report code coverage
-      - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          slug: recharts/recharts
-          files: ./coverage/coverage-final.json
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload bundle analysis report to Codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: node ./scripts/upload-bundle-analysis.js
-
-      # Chromatic gives us only this many free credits per month
-      # so let's publish only at the end so that we don't waste them when we know we can't merge from the previous steps anyway.
-      - name: Publish visual regression tests to Chromatic
-        if: ${{ env.ENCRYPTED_CHROMATIC_TOKEN }}
-        # Chromatic action from https://www.chromatic.com/docs/github-actions
-        uses: chromaui/action@latest
-        # Chromatic GitHub Action options
-        with:
-          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          # Let's say that we don't want to use our Chromatic credits for PRs from dependabot
-          skip: 'dependabot/**'
-
-  integration_tests:
-    name: Test ${{ matrix.test_dir }}
-    runs-on: ubuntu-latest
-    needs: [list_integration_tests, build_test_pack]
-    strategy:
-      # Allow all integration tests to run even if one fails
-      fail-fast: false
-      matrix:
-        # Dynamically generate the matrix from the JSON output of the previous job
-        test_dir: ${{ fromJson(needs.list_integration_tests.outputs.directories) }}
-    steps:
-      - name: Checkout Integration Tests Repository
-        uses: actions/checkout@v4
-        with:
-          repository: recharts/recharts-integ # Checkout the test repo again but this time all directories and files
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Download Packed Library Artifact
-        uses: actions/download-artifact@v4
-        with:
-          # name is not the filename, it's the "artifact name". The actual filename is the original of what was uploaded.
-          # In this workflow we keep them the same but GitHub treats them differently.
-          name: ${{ env.PACKED_ARTIFACT_NAME }}
-          # path is the directory where the artifact will be downloaded
-          # so the full path to the artifact will be ${{ runner.temp }}/${{ env.PACKED_ARTIFACT_NAME }}
-          path: ${{ runner.temp }}
-
-      - name: Run Test
-        # Use the output from the 'pack_library' step
-        run: ./run-test.sh ${{ matrix.test_dir }} "file:${{ runner.temp }}/${{ env.PACKED_ARTIFACT_NAME }}"
+#  list_integration_tests:
+#    name: List Integration Test Directories
+#    runs-on: ubuntu-latest
+#    outputs:
+#      # Output the list of directories as a JSON array string
+#      directories: ${{ steps.set_matrix.outputs.directories }}
+#    steps:
+#      - name: Checkout Integration Tests Repository
+#        uses: actions/checkout@v4
+#        with:
+#          repository: recharts/recharts-integ
+#
+#      - name: List Integration Test Directories
+#        id: set_matrix
+#        # This command finds all integration test directories
+#        # and formats them as a JSON array.
+#        run: |
+#          JSON_ARRAY=$(node list.js --ci --json)
+#          echo "Generated directory list: $JSON_ARRAY"
+#          echo "directories=$JSON_ARRAY" >> $GITHUB_OUTPUT
+#
+#  build_test_pack:
+#    name: Build, Test, Pack
+#    runs-on: ubuntu-latest
+#    container:
+#        # Use the Playwright container to run tests, as recommended in https://storybook.js.org/docs/writing-tests/in-ci
+#      # Make sure to grab the latest version of the Playwright image
+#      # https://playwright.dev/docs/docker#pull-the-image
+#      image: mcr.microsoft.com/playwright:v1.54.1-jammy
+#    env:
+#      ENCRYPTED_CHROMATIC_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+#      # /root home is required to allow Firefox to run in the container
+#      HOME: /root
+#    outputs:
+#      # Output the *name* of the generated tgz file (relative to RECHARTS_PATH)
+#      # The actual file will be passed via artifact
+#      tgz_name: ${{ steps.pack_library.outputs.tgz_name }}
+#    steps:
+#      - name: Checkout Recharts Repository
+#        uses: actions/checkout@v4
+#        with:
+#          # Chromatic needs access to full git history
+#          # see https://www.chromatic.com/docs/github-actions/
+#          fetch-depth: 0
+#
+#      - name: Use Node.js ${{ env.NODE_VERSION }}
+#        uses: actions/setup-node@v4
+#        with:
+#          node-version: ${{ env.NODE_VERSION }}
+#          cache: 'npm'
+#          # Cache depends on the lock file within the checked-out path
+#          cache-dependency-path: 'package-lock.json'
+#
+#      - name: Install Dependencies
+#        run: npm ci
+#
+#      - name: Build
+#        run: npm run build
+#
+#      - name: Unit Tests
+#        run: npm run test-coverage
+#
+#      - name: Typecheck
+#        run: npm run check-types
+#
+#      - name: Lint
+#        run: npm run lint
+#
+#      - name: Storybook doctor
+#        run: npm run storybook-doctor
+#
+#      - name: Storybook Test
+#        run: npm run test-storybook
+#        timeout-minutes: 10
+#
+#      - name: Storybook Build
+#        run: npm run build-storybook
+#
+#      - name: Pack Library
+#        # Give this step an ID so we can reference its output
+#        id: pack_library
+#        run: |
+#          # Run npm pack and capture the output filename (relative to current dir)
+#          tgz_filename=$(npm pack | tail -n 1)
+#          # rename from the default packed name to PACKED_ARTIFACT_NAME so that we don't need to guess the name later.
+#          # artifact upload/download in GitHub has a 'name' property but that's the artifact name, not the file name.
+#          mv $tgz_filename ${{ env.PACKED_ARTIFACT_NAME }}
+#          echo "Packed library file: $tgz_filename renamed to ${{ env.PACKED_ARTIFACT_NAME }}"
+#          echo "tgz_name=${{ env.PACKED_ARTIFACT_NAME }}" >> $GITHUB_OUTPUT
+#
+#      - name: Upload Packed Library Artifact
+#        uses: actions/upload-artifact@v4
+#        with:
+#          # This is the "artifact name", it's not a file name. The file name remains original.
+#          name: ${{ env.PACKED_ARTIFACT_NAME }}
+#          # Upload the file specified by the output of the 'pack_library' step
+#          path: ${{ steps.pack_library.outputs.tgz_name }}
+#          retention-days: 14
+#
+#      # Now that we know all the tests are passing, let's report code coverage
+#      - name: Upload coverage report to Codecov
+#        uses: codecov/codecov-action@v5
+#        with:
+#          slug: recharts/recharts
+#          files: ./coverage/coverage-final.json
+#          token: ${{ secrets.CODECOV_TOKEN }}
+#
+#      - name: Upload bundle analysis report to Codecov
+#        env:
+#          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+#        run: node ./scripts/upload-bundle-analysis.js
+#
+#      # Chromatic gives us only this many free credits per month
+#      # so let's publish only at the end so that we don't waste them when we know we can't merge from the previous steps anyway.
+#      - name: Publish visual regression tests to Chromatic
+#        if: ${{ env.ENCRYPTED_CHROMATIC_TOKEN }}
+#        # Chromatic action from https://www.chromatic.com/docs/github-actions
+#        uses: chromaui/action@latest
+#        # Chromatic GitHub Action options
+#        with:
+#          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
+#          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+#          # Let's say that we don't want to use our Chromatic credits for PRs from dependabot
+#          skip: 'dependabot/**'
+#
+#  integration_tests:
+#    name: Test ${{ matrix.test_dir }}
+#    runs-on: ubuntu-latest
+#    needs: [list_integration_tests, build_test_pack]
+#    strategy:
+#      # Allow all integration tests to run even if one fails
+#      fail-fast: false
+#      matrix:
+#        # Dynamically generate the matrix from the JSON output of the previous job
+#        test_dir: ${{ fromJson(needs.list_integration_tests.outputs.directories) }}
+#    steps:
+#      - name: Checkout Integration Tests Repository
+#        uses: actions/checkout@v4
+#        with:
+#          repository: recharts/recharts-integ # Checkout the test repo again but this time all directories and files
+#
+#      - name: Use Node.js ${{ env.NODE_VERSION }}
+#        uses: actions/setup-node@v4
+#        with:
+#          node-version: ${{ env.NODE_VERSION }}
+#
+#      - name: Download Packed Library Artifact
+#        uses: actions/download-artifact@v4
+#        with:
+#          # name is not the filename, it's the "artifact name". The actual filename is the original of what was uploaded.
+#          # In this workflow we keep them the same but GitHub treats them differently.
+#          name: ${{ env.PACKED_ARTIFACT_NAME }}
+#          # path is the directory where the artifact will be downloaded
+#          # so the full path to the artifact will be ${{ runner.temp }}/${{ env.PACKED_ARTIFACT_NAME }}
+#          path: ${{ runner.temp }}
+#
+#      - name: Run Test
+#        # Use the output from the 'pack_library' step
+#        run: ./run-test.sh ${{ matrix.test_dir }} "file:${{ runner.temp }}/${{ env.PACKED_ARTIFACT_NAME }}"
 
   vr_tests:
     name: Visual Regression Tests
     runs-on: ubuntu-latest
-    needs: [build_test_pack]
+#    needs: [build_test_pack]
     steps:
       - name: Checkout Recharts Repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,9 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
 #    needs: [build_test_pack]
+    env:
+      # GH_TOKEN is needed to use `gh` CLI to comment on the PR
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout Recharts Repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,3 +245,7 @@ jobs:
           EOF
           )
           gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"
+
+      - name: Fail workflow if tests failed
+        if: steps.vr_test_step.outcome == 'failure'
+        run: exit 1

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "chromatic": "npx chromatic",
     "test-build-output": "vitest run --config scripts/vitest-build.config.ts",
     "test-storybook": "vitest --config vitest.config.mts --project storybook",
-    "test-vr:prepare": "docker-compose up -d --build",
-    "test-vr": "docker-compose run --rm test-vr playwright-test",
-    "test-vr:update": "docker-compose run --rm test-vr playwright-test --update-snapshots",
-    "test-vr:ui": "docker-compose run -p 8080:8080 --rm test-vr playwright-test --ui --ui-host=0.0.0.0 --ui-port=8080"
+    "test-vr:prepare": "docker compose up -d --build",
+    "test-vr": "docker compose run --rm test-vr playwright-test",
+    "test-vr:update": "docker compose run --rm test-vr playwright-test --update-snapshots",
+    "test-vr:ui": "docker compose run -p 8080:8080 --rm test-vr playwright-test --ui --ui-host=0.0.0.0 --ui-port=8080"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/test-vr/README.md
+++ b/test-vr/README.md
@@ -25,6 +25,8 @@ which will allow us to avoid test flakes due to different fonts and box shadows 
 The basic commands are prepared in `package.json` but you can go beyond that too
 and use whatever dockers allows you to do.
 
+## Debugging VR tests
+
 All images and containers are available in Docker desktop, or via `docker ps -a` and other usual commands.
 
 You can run arbitrary commands inside the container using `docker compose run test-vr <command>`.
@@ -94,3 +96,21 @@ because the tests are run inside a Docker container and the paths will be consis
 
 You will not be able to run the tests outside of Docker because of this.
 Please do not modify the paths because they are hardcoded all over the place.
+
+## Error: browserType.launch: Executable doesn't exist
+
+Sometimes you may find an error that the `playwright` package no longer matches the `playwright` version in the Docker image:
+
+```
+    Error: browserType.launch: Executable doesn't exist at /ms-playwright/webkit-2191/pw_run.sh
+    ╔══════════════════════════════════════════════════════════════════════╗
+    ║ Looks like Playwright Test or Playwright was just updated to 1.54.1. ║
+    ║ Please update docker image as well.                                  ║
+    ║ -  current: mcr.microsoft.com/playwright:v1.44.0-jammy               ║
+    ║ - required: mcr.microsoft.com/playwright:v1.54.1-jammy               ║
+    ║                                                                      ║
+    ║ <3 Playwright Team                                                   ║
+    ╚══════════════════════════════════════════════════════════════════════╝
+```
+
+In that case edit the `playwright-ct.config.ts` file and change the `FROM` field to the recommended version.

--- a/test-vr/README.md
+++ b/test-vr/README.md
@@ -113,4 +113,4 @@ Sometimes you may find an error that the `playwright` package no longer matches 
     ╚══════════════════════════════════════════════════════════════════════╝
 ```
 
-In that case edit the `playwright-ct.config.ts` file and change the `FROM` field to the recommended version.
+In that case edit the `playwright-ct.Dockerfile` file and change the `FROM` field to the recommended version.

--- a/test-vr/playwright-ct.Dockerfile
+++ b/test-vr/playwright-ct.Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Playwright image which includes browsers and dependencies
-FROM mcr.microsoft.com/playwright:v1.44.0-jammy
+FROM mcr.microsoft.com/playwright:v1.54.1-jammy
 
 # Set the working directory inside the container
 WORKDIR /recharts

--- a/test-vr/tests/App.spec-vr.tsx
+++ b/test-vr/tests/App.spec-vr.tsx
@@ -10,7 +10,7 @@ test('LineChart', async ({ mount }) => {
       <XAxis dataKey="name" interval="preserveEnd" />
       <YAxis interval="preserveEnd" />
       <Legend />
-      <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
+      {/* <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} /> */}
       <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
     </LineChart>,
   );

--- a/test-vr/tests/App.spec-vr.tsx
+++ b/test-vr/tests/App.spec-vr.tsx
@@ -10,7 +10,7 @@ test('LineChart', async ({ mount }) => {
       <XAxis dataKey="name" interval="preserveEnd" />
       <YAxis interval="preserveEnd" />
       <Legend />
-      {/* <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} /> */}
+      <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
       <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
     </LineChart>,
   );


### PR DESCRIPTION
Runs the VR tests in CI. If there is a failure it will upload the report to github pages and write a comment with links:

<img width="945" height="306" alt="image" src="https://github.com/user-attachments/assets/e95b79a1-85f3-438e-8474-821467ffad11" />

Main trouble now is that the github pages upload will overwrite whatever is there now. We could hack around it with a branch and merging and things but I decided against that because:

1. we don't have that many PRs to begin with
3. if they fail, they fail on unit tests or typescript (so the VR test never starts executing)
4. if a VR test passes then it does not publish the report (to reduce the risk of overwriting another, failing, and therefore more interesting report)
5. if two concurrent PRs fail on VR tests, then yes they will overwrite each others' reports, in that case we will have to use the artifact link to download to local and examine from there (or rerun the PR build)

I think I'm fine with this limitation. If it turns out to be a problem then we can refine further.

Closes https://github.com/recharts/recharts/discussions/6031