### PR TITLE
Select Line points by ID instead of object reference

### DIFF
--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line max-classes-per-file
 import * as React from 'react';
-import { Component, MutableRefObject, PureComponent, Ref, useCallback, useMemo, useRef, useState } from 'react';
+import { Component, MutableRefObject, PureComponent, Ref, useCallback, useRef, useState } from 'react';
 
 import { clsx } from 'clsx';
 import { Curve, CurveType, Point as CurvePoint, Props as CurveProps } from '../shape/Curve';
@@ -31,7 +31,7 @@ import { GraphicalItemClipPath, useNeedsClip } from './GraphicalItemClipPath';
 import { useChartLayout } from '../context/chartLayoutContext';
 import { BaseAxisWithScale } from '../state/selectors/axisSelectors';
 import { useIsPanorama } from '../context/PanoramaContext';
-import { ResolvedLineSettings, selectLinePoints } from '../state/selectors/lineSelectors';
+import { selectLinePoints } from '../state/selectors/lineSelectors';
 import { useAppSelector } from '../state/hooks';
 import { AxisId } from '../state/cartesianAxisSlice';
 import { SetLegendPayload } from '../state/SetLegendPayload';
@@ -626,6 +626,7 @@ function LineImpl(props: WithIdRequired<Props>) {
     legendType,
     xAxisId,
     yAxisId,
+    id,
     ...everythingElse
   } = resolveDefaultProps(props, defaultLineProps);
 
@@ -633,14 +634,10 @@ function LineImpl(props: WithIdRequired<Props>) {
   const { height, width, x: left, y: top } = usePlotArea();
   const layout = useChartLayout();
   const isPanorama = useIsPanorama();
-  const lineSettings: ResolvedLineSettings = useMemo(
-    () => ({ dataKey: props.dataKey, data: props.data }),
-    [props.dataKey, props.data],
-  );
   const points: ReadonlyArray<LinePointItem> | undefined = useAppSelector(state =>
-    selectLinePoints(state, xAxisId, yAxisId, isPanorama, lineSettings),
+    selectLinePoints(state, xAxisId, yAxisId, isPanorama, id),
   );
-  if (layout !== 'horizontal' && layout !== 'vertical') {
+  if ((layout !== 'horizontal' && layout !== 'vertical') || points == null) {
     // Cannot render Line in an unsupported layout
     return null;
   }
@@ -648,6 +645,7 @@ function LineImpl(props: WithIdRequired<Props>) {
   return (
     <LineWithState
       {...everythingElse}
+      id={id}
       connectNulls={connectNulls}
       dot={dot}
       activeDot={activeDot}

--- a/test/cartesian/Line.animation.spec.tsx
+++ b/test/cartesian/Line.animation.spec.tsx
@@ -556,10 +556,10 @@ describe('Line animation', () => {
         const fullyVisibleLine = '100px 0px';
 
         /*
-         * The path ref has not been updated yet, so this will hide the whole line for a single tick.
-         * Looks like a bug, but it's invisible in the browser because the animation is so quick.
+         * During priming we have progressed the animation to 30% of the path,
+         * so the stroke-dasharray should be 30px visible and 70px hidden.
          */
-        expect(getLine(container)).toHaveAttribute('stroke-dasharray', '0px 0px');
+        expect(getLine(container)).toHaveAttribute('stroke-dasharray', '30px 70px');
 
         /*
          * Now, the line should continue growing from where it left off. Previously it was 30% of the path, so 30px visible and 70px hidden.
@@ -788,10 +788,8 @@ describe('Line animation', () => {
 
         /*
          * stroke-dasharray should still be 100px visible and 0px hidden because the animation works by changing the path, not the dasharray
-         * but unfortunately the path ref has not been updated yet, so this will hide the whole line for a single tick.
-         * Looks like a bug, but it's invisible in the browser because the animation is so quick.
          */
-        expect(getLine(container)).toHaveAttribute('stroke-dasharray', '0px 0px');
+        expect(getLine(container)).toHaveAttribute('stroke-dasharray', '100px 0px');
 
         await animationManager.setAnimationProgress(0.1);
         expect(getLine(container)).toHaveAttribute('stroke-dasharray', fullyVisibleLine);

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -2498,8 +2498,8 @@ describe('selectErrorBarsSettings', () => {
     // There are ErrorBars but they are specified for another XAxis
     expect(xAxisSpy).toHaveBeenLastCalledWith([]);
     expect(yAxisSpy).toHaveBeenLastCalledWith([]);
-    expect(xAxisSpy).toHaveBeenCalledTimes(3);
-    expect(yAxisSpy).toHaveBeenCalledTimes(3);
+    expect(xAxisSpy).toHaveBeenCalledTimes(2);
+    expect(yAxisSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should return bars settings if present in BarChart', () => {


### PR DESCRIPTION
## Description

Now that we have an ID we don't need the state hacks and memo anymore. I'll do the same for other graphical elements too but that will need a change to types first.
