### PR TITLE
Add expectLastCalledWith type helper

### DIFF
--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -18,6 +18,7 @@ import { useLegendPayload } from '../../src/context/legendPayloadContext';
 import { selectTooltipPayloadConfigurations } from '../../src/state/selectors/selectors';
 import { assertNotNull } from '../helper/assertNotNull';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 type TestCase = CartesianChartTestCase;
 
@@ -492,14 +493,14 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
           id: 'my-custom-area-id',
         },
       ];
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
 
       rerender(
         <ChartElement data={data}>
           <Comp />
         </ChartElement>,
       );
-      expect(spy).toHaveBeenLastCalledWith([]);
+      expectLastCalledWith(spy, []);
     });
 
     it('should report default props to redux state', () => {
@@ -532,7 +533,7 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
           barSize: undefined,
         },
       ];
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should remember the auto-generated ID between renders', () => {

--- a/test/cartesian/Bar.spec.tsx
+++ b/test/cartesian/Bar.spec.tsx
@@ -27,6 +27,7 @@ import { barChartMouseHoverTooltipSelector } from '../component/Tooltip/tooltipM
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 import { noInteraction, TooltipState } from '../../src/state/tooltipSlice';
 import { assertNotNull } from '../helper/assertNotNull';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 type TestCase = CartesianChartTestCase;
 
@@ -1286,14 +1287,14 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
           barSize: undefined,
         },
       ];
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
 
       rerender(
         <ChartElement data={data}>
           <Customized component={<Comp />} />
         </ChartElement>,
       );
-      expect(spy).toHaveBeenLastCalledWith([]);
+      expectLastCalledWith(spy, []);
     });
 
     it('should report default props to redux state', () => {
@@ -1325,7 +1326,7 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
           barSize: undefined,
         },
       ];
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
   });
 });
@@ -1435,10 +1436,10 @@ describe('mouse interactions in stacked bar: https://github.com/recharts/rechart
 
     it('should show tooltip when hovering over a chart', () => {
       const { container, spy } = renderTestCase(selectActiveTooltipIndex);
-      expect(spy).toHaveBeenLastCalledWith(null);
+      expectLastCalledWith(spy, null);
 
       showTooltipOnCoordinate(container, barChartMouseHoverTooltipSelector, { clientX: 10, clientY: 10 });
-      expect(spy).toHaveBeenLastCalledWith('0');
+      expectLastCalledWith(spy, '0');
       expectTooltipPayload(container, '0', ['x : 1', 'y : 2']);
     });
 
@@ -1512,17 +1513,17 @@ describe('mouse interactions in stacked bar: https://github.com/recharts/rechart
 
     it('should show tooltip when hovering over a bar', () => {
       const { container, spy } = renderTestCase(selectActiveTooltipIndex);
-      expect(spy).toHaveBeenLastCalledWith(null);
+      expectLastCalledWith(spy, null);
 
       const bars = getAllBars(container);
       showTooltipOnCoordinate(bars[0], undefined, { clientX: 10, clientY: 10 });
-      expect(spy).toHaveBeenLastCalledWith('0');
+      expectLastCalledWith(spy, '0');
       expectTooltipPayload(container, '', ['x : 1']);
     });
 
     it('should select tooltip axis ticks', () => {
       const { spy } = renderTestCase(selectTooltipAxisTicks);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           coordinate: 50,
           index: 0,
@@ -1590,7 +1591,7 @@ describe('mouse interactions in stacked bar: https://github.com/recharts/rechart
           },
         ],
       };
-      expect(spy).toHaveBeenLastCalledWith(expectedStateBeforeHover);
+      expectLastCalledWith(spy, expectedStateBeforeHover);
 
       const bars = getAllBars(container);
       showTooltipOnCoordinate(bars[0], undefined, { clientX: 10, clientY: 10 });
@@ -1659,7 +1660,7 @@ describe('mouse interactions in stacked bar: https://github.com/recharts/rechart
           },
         ],
       };
-      expect(spy).toHaveBeenLastCalledWith(expectedStateAfterHover);
+      expectLastCalledWith(spy, expectedStateAfterHover);
     });
 
     it('should show tooltip somewhere close to the mouse cursor', () => {

--- a/test/cartesian/Brush.spec.tsx
+++ b/test/cartesian/Brush.spec.tsx
@@ -12,6 +12,7 @@ import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { selectChartDataWithIndexes } from '../../src/state/selectors/dataSelectors';
 import { useIsPanorama } from '../../src/context/PanoramaContext';
 import { expectBrush } from '../helper/expectBrush';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('<Brush />', () => {
   const data = [
@@ -65,7 +66,7 @@ describe('<Brush />', () => {
     it('should hide dots in the main chart after moving the slider, but keep all dots in the panorama visible', () => {
       const { container, spy } = renderTestCase(selectChartDataWithIndexes);
 
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         chartData: data,
         dataStartIndex: 0,
         dataEndIndex: data.length - 1,
@@ -77,7 +78,7 @@ describe('<Brush />', () => {
       fireEvent.mouseMove(slider, { clientX: 200 });
       fireEvent.mouseUp(slider);
 
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         chartData: data,
         dataStartIndex: 6,
         dataEndIndex: data.length - 1,

--- a/test/cartesian/Brush.stacked.spec.tsx
+++ b/test/cartesian/Brush.stacked.spec.tsx
@@ -7,6 +7,7 @@ import { PageData } from '../_data';
 import { expectBrush } from '../helper/expectBrush';
 import { assertNotNull } from '../helper/assertNotNull';
 import { selectStackGroups } from '../../src/state/selectors/axisSelectors';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('Brush in a stacked chart', () => {
   const renderTestCase = createSelectorTestCase(({ children }) => (
@@ -31,7 +32,7 @@ describe('Brush in a stacked chart', () => {
 
     it('should select stack groups', () => {
       const { spy } = renderTestCase(state => selectStackGroups(state, 'xAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         a: {
           graphicalItems: [
             {
@@ -39,6 +40,7 @@ describe('Brush in a stacked chart', () => {
               barSize: undefined,
               data: undefined,
               dataKey: 'pv',
+              // @ts-expect-error unexpected property
               hide: false,
               isPanorama: false,
               stackId: 'a',
@@ -52,6 +54,7 @@ describe('Brush in a stacked chart', () => {
               barSize: undefined,
               data: undefined,
               dataKey: 'uv',
+              // @ts-expect-error unexpected property
               hide: false,
               isPanorama: false,
               stackId: 'a',
@@ -110,7 +113,7 @@ describe('Brush in a stacked chart', () => {
     it('should select stack groups', () => {
       const { container, spy } = renderTestCase(state => selectStackGroups(state, 'xAxis', 0, false));
       prime(container);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         a: {
           graphicalItems: [
             {
@@ -118,6 +121,7 @@ describe('Brush in a stacked chart', () => {
               barSize: undefined,
               data: undefined,
               dataKey: 'pv',
+              // @ts-expect-error unexpected property
               hide: false,
               isPanorama: false,
               stackId: 'a',
@@ -131,6 +135,7 @@ describe('Brush in a stacked chart', () => {
               barSize: undefined,
               data: undefined,
               dataKey: 'uv',
+              // @ts-expect-error unexpected property
               hide: false,
               isPanorama: false,
               stackId: 'a',

--- a/test/cartesian/Line.spec.tsx
+++ b/test/cartesian/Line.spec.tsx
@@ -13,6 +13,7 @@ import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 import { showTooltip } from '../component/Tooltip/tooltipTestHelpers';
 import { lineChartMouseHoverTooltipSelector } from '../component/Tooltip/tooltipMouseHoverSelectors';
 import { assertNotNull } from '../helper/assertNotNull';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('<Line />', () => {
   beforeEach(() => {
@@ -166,7 +167,7 @@ describe('<Line />', () => {
       </LineChart>,
     );
 
-    expect(spy).toHaveBeenLastCalledWith([
+    expectLastCalledWith(spy, [
       {
         dataKey: 'x',
         // this defaults to y even in an absence of explicit prop
@@ -191,7 +192,7 @@ describe('<Line />', () => {
       </LineChart>,
     );
 
-    expect(spy).toHaveBeenLastCalledWith([
+    expectLastCalledWith(spy, [
       {
         dataKey: 'x',
         // in horizontal chart the default direction is y, in vertical it's x
@@ -272,7 +273,7 @@ describe('<Line />', () => {
 
     it('should select tooltip payload', () => {
       const { spy } = renderTestCase(state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: '#3182bd',
           dataKey: 'y',

--- a/test/cartesian/Scatter.spec.tsx
+++ b/test/cartesian/Scatter.spec.tsx
@@ -10,6 +10,7 @@ import { expectScatterPoints } from '../helper/expectScatterPoints';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { selectTooltipPayload } from '../../src/state/selectors/selectors';
 import { dataWithSpecialNameAndFillProperties, PageData } from '../_data';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('<Scatter />', () => {
   const data = [
@@ -257,7 +258,7 @@ describe('<Scatter />', () => {
 
     it('should return tooltip payload', () => {
       const { spy } = renderTestCase(state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: undefined,
           dataKey: 'uv',

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -48,6 +48,7 @@ import {
 import { selectChartOffsetInternal } from '../../src/state/selectors/selectChartOffsetInternal';
 import { selectChartDataWithIndexes } from '../../src/state/selectors/dataSelectors';
 import { useIsPanorama } from '../../src/context/PanoramaContext';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('<XAxis />', () => {
   const data = [
@@ -214,7 +215,7 @@ describe('<XAxis />', () => {
     );
 
     expectXAxisTicks(container, []);
-    expect(spy).toHaveBeenLastCalledWith([]);
+    expectLastCalledWith(spy, []);
   });
 
   it('Render duplicated ticks of XAxis', () => {
@@ -261,7 +262,7 @@ describe('<XAxis />', () => {
         y: '273',
       },
     ]);
-    expect(spy).toHaveBeenLastCalledWith(['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
+    expectLastCalledWith(spy, ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
   });
 
   describe('time scale', () => {
@@ -778,7 +779,7 @@ describe('<XAxis />', () => {
           </BarChart>,
         );
 
-        expect(spy).toHaveBeenLastCalledWith([90, 170]);
+        expectLastCalledWith(spy, [90, 170]);
         const allTicks = container.querySelectorAll('.recharts-xAxis .recharts-cartesian-axis-tick-value');
         expect(allTicks).toHaveLength(expectedTickCount);
       },
@@ -1288,7 +1289,7 @@ describe('<XAxis />', () => {
         y: '273',
       },
     ]);
-    expect(spy).toHaveBeenLastCalledWith([90, 90]);
+    expectLastCalledWith(spy, [90, 90]);
   });
 
   it('Should render the axis line without any ticks', () => {
@@ -1307,7 +1308,7 @@ describe('<XAxis />', () => {
     const axisLine = container.getElementsByClassName('recharts-cartesian-axis-line');
     expect(axisLine).toHaveLength(1);
     expectXAxisTicks(container, []);
-    expect(spy).toHaveBeenLastCalledWith(undefined);
+    expectLastCalledWith(spy, undefined);
   });
 
   it('Render Bars for a single data point with barSize=50%', () => {
@@ -1532,7 +1533,7 @@ describe('<XAxis />', () => {
 
     expect(container.querySelectorAll('.recharts-xAxis .recharts-cartesian-axis-tick')).toHaveLength(0);
     expectXAxisTicks(container, []);
-    expect(spy).toHaveBeenLastCalledWith(undefined);
+    expectLastCalledWith(spy, undefined);
   });
 
   it('should render multiple axes', () => {
@@ -2044,7 +2045,7 @@ describe('<XAxis />', () => {
         },
         reversed: false,
       };
-      expect(spy).toHaveBeenLastCalledWith(expectedSettings);
+      expectLastCalledWith(spy, expectedSettings);
     });
 
     it('should remove the configuration from store when DOM element is removed', () => {
@@ -2090,7 +2091,7 @@ describe('<XAxis />', () => {
         },
         reversed: false,
       };
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         foo: expectedSettings1,
         bar: implicitXAxis,
       });
@@ -2164,7 +2165,7 @@ describe('<XAxis />', () => {
           reversed: false,
         },
       };
-      expect(spy).toHaveBeenLastCalledWith(expectedSettings2);
+      expectLastCalledWith(spy, expectedSettings2);
       rerender(
         <BarChart width={100} height={100}>
           <XAxis xAxisId="bar" scale="utc" type="category" />
@@ -2201,7 +2202,7 @@ describe('<XAxis />', () => {
         allowDecimals: true,
         reversed: false,
       };
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         foo: implicitXAxis,
         bar: expectedSettings3,
       });
@@ -2211,7 +2212,7 @@ describe('<XAxis />', () => {
         </BarChart>,
       );
 
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         foo: implicitXAxis,
         bar: implicitXAxis,
       });
@@ -2280,7 +2281,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expectLastCalledWith(spy, [0, 180]);
       });
 
       it('should reverse ticks', () => {
@@ -2318,7 +2319,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expectLastCalledWith(spy, [0, 180]);
       });
 
       it('should reverse ticks', () => {
@@ -2356,7 +2357,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expectLastCalledWith(spy, [0, 180]);
       });
 
       describe.each([true, false, undefined])('auto domain with allowDataOverflow = %s', allowDataOverflow => {
@@ -2395,7 +2396,7 @@ describe('<XAxis />', () => {
               y: '273',
             },
           ]);
-          expect(spy).toHaveBeenLastCalledWith([75, 175]);
+          expectLastCalledWith(spy, [75, 175]);
         });
 
         it('should render ticks from number, auto', () => {
@@ -2434,7 +2435,7 @@ describe('<XAxis />', () => {
               y: '273',
             },
           ]);
-          expect(spy).toHaveBeenLastCalledWith([-60, 180]);
+          expectLastCalledWith(spy, [-60, 180]);
         });
 
         it('should render ticks from auto, number', () => {
@@ -2472,7 +2473,7 @@ describe('<XAxis />', () => {
               y: '273',
             },
           ]);
-          expect(spy).toHaveBeenLastCalledWith([0, 600]);
+          expectLastCalledWith(spy, [0, 600]);
         });
       });
 
@@ -2511,7 +2512,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([-500, 500]);
+        expectLastCalledWith(spy, [-500, 500]);
       });
 
       it('should shrink down, but respect the data domain, if the provided domain is smaller than the data', () => {
@@ -2529,7 +2530,7 @@ describe('<XAxis />', () => {
           { textContent: '110', x: '230.55555555555557', y: '273' },
           { textContent: '170', x: '295', y: '273' },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([-100, 170]);
+        expectLastCalledWith(spy, [-100, 170]);
 
         rerender(
           <Component>
@@ -2544,7 +2545,7 @@ describe('<XAxis />', () => {
           { textContent: '165', x: '260.88235294117646', y: '273' },
           { textContent: '175', x: '295', y: '273' },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([90, 175]);
+        expectLastCalledWith(spy, [90, 175]);
 
         rerender(
           <Component>
@@ -2559,7 +2560,7 @@ describe('<XAxis />', () => {
           { textContent: '150', x: '222.5', y: '273' },
           { textContent: '170', x: '295', y: '273' },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([90, 170]);
+        expectLastCalledWith(spy, [90, 170]);
       });
 
       it('should default to dataMin, dataMax for domain where the larger number is first', () => {
@@ -2597,7 +2598,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([90, 170]);
+        expectLastCalledWith(spy, [90, 170]);
       });
 
       it('should reverse domain where the larger number is first, and allowDataOverflow is true', () => {
@@ -2635,7 +2636,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([100, 0]);
+        expectLastCalledWith(spy, [100, 0]);
       });
 
       it('should render one tick for domain that does not have any gap', () => {
@@ -2653,7 +2654,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([150, 150]);
+        expectLastCalledWith(spy, [150, 150]);
       });
 
       it('should shrink properly when allowDataOverflow = true', () => {
@@ -2691,7 +2692,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 100]);
+        expectLastCalledWith(spy, [0, 100]);
       });
 
       it('should allow providing more tickCount', () => {
@@ -2739,7 +2740,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expectLastCalledWith(spy, [0, 180]);
       });
 
       it('should allow providing less tickCount', () => {
@@ -2767,7 +2768,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 170]);
+        expectLastCalledWith(spy, [0, 170]);
       });
 
       it('should make ticks from dataMin, dataMax', () => {
@@ -2805,7 +2806,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([90, 170]);
+        expectLastCalledWith(spy, [90, 170]);
       });
 
       it('should default to dataMin, dataMax when domain is provided as an array of invalid values', () => {
@@ -2848,7 +2849,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([90, 170]);
+        expectLastCalledWith(spy, [90, 170]);
       });
 
       it('should allow a function that returns a domain, and pass inside a computed domain and allowDataOverflow prop', () => {
@@ -3010,7 +3011,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([-500, 500]);
+        expectLastCalledWith(spy, [-500, 500]);
       });
     });
 
@@ -3141,7 +3142,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expectLastCalledWith(spy, [0, 180]);
       });
 
       it('should only display domain of data with matching xAxisId', () => {
@@ -3313,7 +3314,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 1]);
+        expectLastCalledWith(spy, [0, 1]);
       });
 
       it('should not allow decimals in small numbers if allowDecimals is false', () => {
@@ -3351,7 +3352,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 4]);
+        expectLastCalledWith(spy, [0, 4]);
       });
 
       it.each([true, false, undefined])(
@@ -3391,7 +3392,7 @@ describe('<XAxis />', () => {
               y: '273',
             },
           ]);
-          expect(spy).toHaveBeenLastCalledWith([0, 16]);
+          expectLastCalledWith(spy, [0, 16]);
         },
       );
     });
@@ -3432,7 +3433,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expectLastCalledWith(spy, [0, 180]);
       });
 
       it('should display every second tick with interval = 1', () => {
@@ -3460,7 +3461,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expectLastCalledWith(spy, [0, 180]);
       });
 
       it('should display every third tick with interval = 2', () => {
@@ -3483,7 +3484,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 180]);
+        expectLastCalledWith(spy, [0, 180]);
       });
 
       it('should add more ticks with tickCount and then reduce them again with interval', () => {
@@ -3531,7 +3532,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 171]);
+        expectLastCalledWith(spy, [0, 171]);
       });
 
       it('should attempt to show the ticks start with interval = preserveStart', () => {
@@ -3702,7 +3703,7 @@ describe('<XAxis />', () => {
           y: '273',
         },
       ]);
-      expect(spy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
+      expectLastCalledWith(spy, [90, 100, 120, 170, 140, 150, 110]);
     });
 
     it('should reverse ticks', () => {
@@ -3750,7 +3751,7 @@ describe('<XAxis />', () => {
           y: '273',
         },
       ]);
-      expect(spy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
+      expectLastCalledWith(spy, [90, 100, 120, 170, 140, 150, 110]);
     });
 
     it.each([undefined, true])(
@@ -3800,7 +3801,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6]);
+        expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5, 6]);
       },
     );
 
@@ -3844,7 +3845,7 @@ describe('<XAxis />', () => {
           y: '273',
         },
       ]);
-      expect(spy).toHaveBeenLastCalledWith([90, 200, 260, 400, 280, 500]);
+      expectLastCalledWith(spy, [90, 200, 260, 400, 280, 500]);
     });
 
     it.each([undefined, 0, -1, 3, 7, 100, Infinity, NaN])('should ignore tickCount = %s', tickCount => {
@@ -3892,7 +3893,7 @@ describe('<XAxis />', () => {
           y: '273',
         },
       ]);
-      expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6]);
+      expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5, 6]);
     });
 
     const variousDomains: ReadonlyArray<{ domain: ReadonlyArray<string> | ReadonlyArray<number> | undefined }> = [
@@ -3948,7 +3949,7 @@ describe('<XAxis />', () => {
           y: '273',
         },
       ]);
-      expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6]);
+      expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5, 6]);
     });
 
     describe.each([true, false, undefined])('allowDecimals=%s', allowDecimals => {
@@ -3987,7 +3988,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0.1, 0.3, 0.5, 0.7, 0.9]);
+        expectLastCalledWith(spy, [0.1, 0.3, 0.5, 0.7, 0.9]);
       });
 
       it('should have no effect whatsoever on decimal numbers', () => {
@@ -4080,7 +4081,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6]);
+        expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5, 6]);
       });
 
       it('should merge and display domain of all data, and remove duplicates, even when the duplicates are defined on different elements', () => {
@@ -4125,7 +4126,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([90, 200, 260, 400, 280, 500]);
+        expectLastCalledWith(spy, [90, 200, 260, 400, 280, 500]);
       });
 
       it.each([true, false, undefined])(
@@ -4366,7 +4367,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
+        expectLastCalledWith(spy, [90, 100, 120, 170, 140, 150, 110]);
       });
 
       it('should attempt to show the ticks start and end with interval = preserveStartEnd', () => {
@@ -4399,7 +4400,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
+        expectLastCalledWith(spy, [90, 100, 120, 170, 140, 150, 110]);
       });
 
       it('should do ... same thing as preserveStart? with interval = equidistantPreserveStart', () => {
@@ -4432,7 +4433,7 @@ describe('<XAxis />', () => {
             y: '273',
           },
         ]);
-        expect(spy).toHaveBeenLastCalledWith([90, 100, 120, 170, 140, 150, 110]);
+        expectLastCalledWith(spy, [90, 100, 120, 170, 140, 150, 110]);
       });
     });
   });

--- a/test/cartesian/YAxis/YAxis.spec.tsx
+++ b/test/cartesian/YAxis/YAxis.spec.tsx
@@ -28,6 +28,7 @@ import { IfOverflow } from '../../../src/util/IfOverflow';
 import { useIsPanorama } from '../../../src/context/PanoramaContext';
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
 import { getCalculatedYAxisWidth } from '../../../src/util/YAxisUtils';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('<YAxis />', () => {
   const data = [
@@ -969,7 +970,7 @@ describe('<YAxis />', () => {
         },
         reversed: true,
       };
-      expect(spy).toHaveBeenLastCalledWith(expectedSettings);
+      expectLastCalledWith(spy, expectedSettings);
     });
 
     it('should remove the configuration from store when DOM element is removed', () => {
@@ -1015,7 +1016,7 @@ describe('<YAxis />', () => {
         reversed: false,
         hide: false,
       };
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         foo: expectedSettings1,
         bar: implicitYAxis,
       });
@@ -1089,7 +1090,7 @@ describe('<YAxis />', () => {
           ticks: undefined,
         },
       };
-      expect(spy).toHaveBeenLastCalledWith(expectedSettings2);
+      expectLastCalledWith(spy, expectedSettings2);
       rerender(
         <BarChart width={100} height={100}>
           <YAxis yAxisId="bar" scale="utc" type="category" />
@@ -1126,7 +1127,7 @@ describe('<YAxis />', () => {
         allowDecimals: true,
         reversed: false,
       };
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         foo: implicitYAxis,
         bar: expectedSettings3,
       });
@@ -1136,7 +1137,7 @@ describe('<YAxis />', () => {
         </BarChart>,
       );
 
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         foo: implicitYAxis,
         bar: implicitYAxis,
       });

--- a/test/cartesian/YAxis/YAxis.ticks.spec.tsx
+++ b/test/cartesian/YAxis/YAxis.ticks.spec.tsx
@@ -11,6 +11,7 @@ import {
   selectNiceTicks,
   selectTicksOfAxis,
 } from '../../../src/state/selectors/axisSelectors';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 const dataWithDecimals = PageData.map(item => ({
   ...item,
@@ -60,12 +61,13 @@ describe('YAxis ticks', () => {
 
     it('should select YAxis settings', () => {
       const { spy } = renderTestCase(state => selectAxisSettings(state, 'yAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith(defaultExpectedYAxisSettings);
+      expectLastCalledWith(spy, defaultExpectedYAxisSettings);
     });
 
     it('should select scale', () => {
       const { spy } = renderTestCase(state => selectAxisScale(state, 'yAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith(
+      expectLastCalledWith(
+        spy,
         expect.toBeRechartsScale({
           domain: [0, 100],
           range: [265, 5],
@@ -75,12 +77,12 @@ describe('YAxis ticks', () => {
 
     it('should select niceTicks', () => {
       const { spy } = renderTestCase(state => selectNiceTicks(state, 'yAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([0, 25, 50, 75, 100]);
+      expectLastCalledWith(spy, [0, 25, 50, 75, 100]);
     });
 
     it('should select ticks', () => {
       const { spy } = renderTestCase(state => selectTicksOfAxis(state, 'yAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         { coordinate: 265, index: 0, offset: 0, value: 0 },
         { coordinate: 200, index: 1, offset: 0, value: 25 },
         { coordinate: 135, index: 2, offset: 0, value: 50 },
@@ -113,7 +115,7 @@ describe('YAxis ticks', () => {
 
     it('should select YAxis settings all the same except for the domain', () => {
       const { spy } = renderTestCase(state => selectAxisSettings(state, 'yAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         ...defaultExpectedYAxisSettings,
         domain: ['dataMin', 'dataMax'],
       });
@@ -121,7 +123,8 @@ describe('YAxis ticks', () => {
 
     it('should select scale', () => {
       const { spy } = renderTestCase(state => selectAxisScale(state, 'yAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith(
+      expectLastCalledWith(
+        spy,
         expect.toBeRechartsScale({
           domain: [13.98, 98],
           range: [265, 5],
@@ -131,12 +134,12 @@ describe('YAxis ticks', () => {
 
     it('should select niceTicks', () => {
       const { spy } = renderTestCase(state => selectNiceTicks(state, 'yAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([13.98, 38.98, 63.98, 88.98, 98]);
+      expectLastCalledWith(spy, [13.98, 38.98, 63.98, 88.98, 98]);
     });
 
     it('should select ticks', () => {
       const { spy } = renderTestCase(state => selectTicksOfAxis(state, 'yAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         { coordinate: 265, index: 0, offset: 0, value: 13.98 },
         { coordinate: 187.6374672696977, index: 1, offset: 0, value: 38.98 },
         { coordinate: 110.27493453939539, index: 2, offset: 0, value: 63.98 },
@@ -169,7 +172,7 @@ describe('YAxis ticks', () => {
 
     it('should select YAxis settings all the same except for the domain, and tick count', () => {
       const { spy } = renderTestCase(state => selectAxisSettings(state, 'yAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         ...defaultExpectedYAxisSettings,
         domain: ['dataMin', 'dataMax'],
         tickCount: 3,
@@ -179,7 +182,8 @@ describe('YAxis ticks', () => {
 
     it('should select scale', () => {
       const { spy } = renderTestCase(state => selectAxisScale(state, 'yAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith(
+      expectLastCalledWith(
+        spy,
         expect.toBeRechartsScale({
           domain: [13.98, 98],
           range: [265, 5],
@@ -189,12 +193,12 @@ describe('YAxis ticks', () => {
 
     it('should select niceTicks', () => {
       const { spy } = renderTestCase(state => selectNiceTicks(state, 'yAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([14, 59, 98]);
+      expectLastCalledWith(spy, [14, 59, 98]);
     });
 
     it('should select ticks', () => {
       const { spy } = renderTestCase(state => selectTicksOfAxis(state, 'yAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         { coordinate: 264.93810997381576, index: 0, offset: 0, value: 14 },
         { coordinate: 125.68555105927162, index: 1, offset: 0, value: 59 },
         { coordinate: 5, index: 2, offset: 0, value: 98 },
@@ -223,7 +227,7 @@ describe('YAxis ticks', () => {
 
     it('should select YAxis settings all the same except for the domain, and tick count', () => {
       const { spy } = renderTestCase(state => selectAxisSettings(state, 'yAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         ...defaultExpectedYAxisSettings,
         domain: [0, 200],
         tickCount: 4,
@@ -233,7 +237,8 @@ describe('YAxis ticks', () => {
 
     it('should select scale', () => {
       const { spy } = renderTestCase(state => selectAxisScale(state, 'yAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith(
+      expectLastCalledWith(
+        spy,
         expect.toBeRechartsScale({
           domain: [0, 200],
           range: [265, 5],
@@ -243,12 +248,12 @@ describe('YAxis ticks', () => {
 
     it('should select niceTicks', () => {
       const { spy } = renderTestCase(state => selectNiceTicks(state, 'yAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([0, 70, 140, 200]);
+      expectLastCalledWith(spy, [0, 70, 140, 200]);
     });
 
     it('should select ticks', () => {
       const { spy } = renderTestCase(state => selectTicksOfAxis(state, 'yAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         { coordinate: 265, index: 0, offset: 0, value: 0 },
         { coordinate: 174, index: 1, offset: 0, value: 70 },
         { coordinate: 83.00000000000001, index: 2, offset: 0, value: 140 },

--- a/test/chart/AreaChart.spec.tsx
+++ b/test/chart/AreaChart.spec.tsx
@@ -14,6 +14,7 @@ import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { useClipPathId } from '../../src/container/ClipPathProvider';
 import { expectAreaCurve } from '../helper/expectAreaCurve';
 import { rangeData } from '../../storybook/stories/data/Page';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('AreaChart', () => {
   beforeEach(() => {
@@ -538,7 +539,7 @@ describe('AreaChart', () => {
       );
 
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenLastCalledWith({ x: 5, y: 5, width: 90, height: 40 });
+      expectLastCalledWith(spy, { x: 5, y: 5, width: 90, height: 40 });
     });
 
     it('should provide clipPathId', () => {

--- a/test/chart/AreaChart.stacked.spec.tsx
+++ b/test/chart/AreaChart.stacked.spec.tsx
@@ -233,6 +233,7 @@ describe('AreaChart stacked', () => {
           {
             x: 65,
             y: 335,
+            // @ts-expect-error extra properties not expected in the type
             payload: {
               name: 'a',
               value1: 5,
@@ -243,6 +244,7 @@ describe('AreaChart stacked', () => {
           {
             x: 495,
             y: 214.99999999999997,
+            // @ts-expect-error extra properties not expected in the type
             payload: {
               name: 'b',
               value1: 25,
@@ -469,6 +471,7 @@ describe('AreaChart stacked', () => {
           {
             x: 65,
             y: 335,
+            // @ts-expect-error extra properties not expected in the type
             payload: {
               name: 'a',
               value1: 5,
@@ -479,6 +482,7 @@ describe('AreaChart stacked', () => {
           {
             x: 495,
             y: 214.99999999999997,
+            // @ts-expect-error extra properties not expected in the type
             payload: {
               name: 'b',
               value1: 25,
@@ -689,7 +693,9 @@ describe('AreaChart stacked', () => {
       expectLastCalledWith(spy, {
         baseLine: [
           // baseline.y from second point is the same as points.y from first point
+          // @ts-expect-error extra properties not expected in the type
           { x: 65, y: 335, payload: { name: 'a', value2: 10 } },
+          // @ts-expect-error extra properties not expected in the type
           { x: 495, y: 214.99999999999997, payload: { name: 'b', value2: 10 } },
         ],
         isRange: false,
@@ -906,6 +912,7 @@ describe('AreaChart stacked', () => {
           {
             x: 65,
             y: 335,
+            // @ts-expect-error extra properties not expected in the type
             payload: {
               name: 'a',
               value: 10,
@@ -914,6 +921,7 @@ describe('AreaChart stacked', () => {
           {
             x: 495,
             y: 214.99999999999997,
+            // @ts-expect-error extra properties not expected in the type
             payload: {
               name: 'b',
               value: 10,
@@ -1137,6 +1145,7 @@ describe('AreaChart stacked', () => {
           {
             x: 65,
             y: 335,
+            // @ts-expect-error extra properties not expected in the type
             payload: {
               name: 'a',
               value: 10,
@@ -1145,6 +1154,7 @@ describe('AreaChart stacked', () => {
           {
             x: 151,
             y: 214.99999999999997,
+            // @ts-expect-error extra properties not expected in the type
             payload: {
               name: 'b',
               value: 10,

--- a/test/chart/AreaChart.stacked.spec.tsx
+++ b/test/chart/AreaChart.stacked.spec.tsx
@@ -9,6 +9,7 @@ import { StackId } from '../../src/util/ChartUtils';
 import { ExpectedStackedDataSeries, expectGraphicalItemSettings } from '../helper/expectStackGroups';
 import { ChartData } from '../../src/state/chartDataSlice';
 import { StackGroup } from '../../src/util/stacks/stackTypes';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 const data1 = [
   { name: 'a', value: 5 },
@@ -103,7 +104,7 @@ describe('AreaChart stacked', () => {
         { name: 'a', value1: 5, value2: 10, value3: 23 },
         { name: 'b', value1: 25, value2: 10, value3: 13 },
       ];
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select stack groups for all areas', () => {
@@ -149,7 +150,7 @@ describe('AreaChart stacked', () => {
           ]),
         },
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select data stacks for the first area', () => {
@@ -158,7 +159,7 @@ describe('AreaChart stacked', () => {
         [0, 5],
         [0, 25],
       ];
-      expect(spy).toHaveBeenLastCalledWith(expect.toBeRechartsStackedSeries(expected));
+      expectLastCalledWith(spy, expect.toBeRechartsStackedSeries(expected));
     });
 
     it('should select data stacks for the second area', () => {
@@ -167,7 +168,7 @@ describe('AreaChart stacked', () => {
         [5, 15],
         [25, 35],
       ];
-      expect(spy).toHaveBeenLastCalledWith(expect.toBeRechartsStackedSeries(expected));
+      expectLastCalledWith(spy, expect.toBeRechartsStackedSeries(expected));
     });
 
     it('should select points for the first area', () => {
@@ -221,12 +222,12 @@ describe('AreaChart stacked', () => {
           },
         ],
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select points for the second area', () => {
       const { spy } = renderTestCase(state => selectArea(state, 0, 0, false, areaSettings2));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         baseLine: [
           // y-value of the first area becomes the baseline for the second area
           {
@@ -339,7 +340,7 @@ describe('AreaChart stacked', () => {
         { name: 'a', value1: 5, value2: 10, value3: 23 },
         { name: 'b', value1: 25, value2: 10, value3: 13 },
       ];
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select stack groups for all areas', () => {
@@ -385,7 +386,7 @@ describe('AreaChart stacked', () => {
           ]),
         },
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select data stacks for the first area', () => {
@@ -394,7 +395,7 @@ describe('AreaChart stacked', () => {
         [0, 5],
         [0, 25],
       ];
-      expect(spy).toHaveBeenLastCalledWith(expect.toBeRechartsStackedSeries(expected));
+      expectLastCalledWith(spy, expect.toBeRechartsStackedSeries(expected));
     });
 
     it('should select data stacks for the second area', () => {
@@ -403,7 +404,7 @@ describe('AreaChart stacked', () => {
         [5, 15],
         [25, 35],
       ];
-      expect(spy).toHaveBeenLastCalledWith(expect.toBeRechartsStackedSeries(expected));
+      expectLastCalledWith(spy, expect.toBeRechartsStackedSeries(expected));
     });
 
     it('should select points for the first area', () => {
@@ -457,12 +458,12 @@ describe('AreaChart stacked', () => {
           },
         ],
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select points for the second area', () => {
       const { spy } = renderTestCase(state => selectArea(state, 0, 0, false, areaSettings2));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         baseLine: [
           // y-value of the first area becomes the baseline for the second area
           {
@@ -581,7 +582,7 @@ describe('AreaChart stacked', () => {
         { name: 'a', value3: 23 },
         { name: 'b', value3: 13 },
       ];
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select stack groups for all areas', () => {
@@ -636,7 +637,7 @@ describe('AreaChart stacked', () => {
           ]),
         },
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select data stacks for the first area', () => {
@@ -645,7 +646,7 @@ describe('AreaChart stacked', () => {
         [0, 5],
         [0, 25],
       ];
-      expect(spy).toHaveBeenLastCalledWith(expect.toBeRechartsStackedSeries(expected));
+      expectLastCalledWith(spy, expect.toBeRechartsStackedSeries(expected));
     });
 
     it('should select data stacks for the second area', () => {
@@ -654,7 +655,7 @@ describe('AreaChart stacked', () => {
         [5, 15],
         [25, 35],
       ];
-      expect(spy).toHaveBeenLastCalledWith(expect.toBeRechartsStackedSeries(expected));
+      expectLastCalledWith(spy, expect.toBeRechartsStackedSeries(expected));
     });
 
     it('should select points for the first area', () => {
@@ -680,12 +681,12 @@ describe('AreaChart stacked', () => {
           },
         ],
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select points for the second area', () => {
       const { spy } = renderTestCase(state => selectArea(state, 0, 0, false, areaSettings2));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         baseLine: [
           // baseline.y from second point is the same as points.y from first point
           { x: 65, y: 335, payload: { name: 'a', value2: 10 } },
@@ -782,7 +783,7 @@ describe('AreaChart stacked', () => {
         { name: 'a', value: 23 },
         { name: 'b', value: 13 },
       ];
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select stack groups for all areas', () => {
@@ -837,7 +838,7 @@ describe('AreaChart stacked', () => {
           ]),
         },
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select data stacks for the first area', () => {
@@ -846,7 +847,7 @@ describe('AreaChart stacked', () => {
         [0, 5],
         [0, 25],
       ];
-      expect(spy).toHaveBeenLastCalledWith(expect.toBeRechartsStackedSeries(expected));
+      expectLastCalledWith(spy, expect.toBeRechartsStackedSeries(expected));
     });
 
     it('should select data stacks for the second area', () => {
@@ -855,7 +856,7 @@ describe('AreaChart stacked', () => {
         [5, 15],
         [25, 35],
       ];
-      expect(spy).toHaveBeenLastCalledWith(expect.toBeRechartsStackedSeries(expected));
+      expectLastCalledWith(spy, expect.toBeRechartsStackedSeries(expected));
     });
 
     it('should select points for the first area', () => {
@@ -895,12 +896,12 @@ describe('AreaChart stacked', () => {
           },
         ],
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select points for the second area', () => {
       const { spy } = renderTestCase(state => selectArea(state, 0, 0, false, areaSettings2));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         baseLine: [
           {
             x: 65,
@@ -1013,7 +1014,7 @@ describe('AreaChart stacked', () => {
         { name: 'a', value: 23 },
         { name: 'b', value: 13 },
       ];
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select stack groups for all areas', () => {
@@ -1068,7 +1069,7 @@ describe('AreaChart stacked', () => {
           ]),
         },
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select data stacks for the first area', () => {
@@ -1077,7 +1078,7 @@ describe('AreaChart stacked', () => {
         [0, 5],
         [0, 25],
       ];
-      expect(spy).toHaveBeenLastCalledWith(expect.toBeRechartsStackedSeries(expected));
+      expectLastCalledWith(spy, expect.toBeRechartsStackedSeries(expected));
     });
 
     it('should select data stacks for the second area', () => {
@@ -1086,7 +1087,7 @@ describe('AreaChart stacked', () => {
         [5, 15],
         [25, 35],
       ];
-      expect(spy).toHaveBeenLastCalledWith(expect.toBeRechartsStackedSeries(expected));
+      expectLastCalledWith(spy, expect.toBeRechartsStackedSeries(expected));
     });
 
     it('should select points for the first area', () => {
@@ -1126,12 +1127,12 @@ describe('AreaChart stacked', () => {
           },
         ],
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select points for the second area', () => {
       const { spy } = renderTestCase(state => selectArea(state, 0, 0, false, areaSettings2));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         baseLine: [
           {
             x: 65,

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -671,6 +671,7 @@ describe('<BarChart />', () => {
               pv: 2400,
               uv: 400,
             },
+            // @ts-expect-error extra properties not expected in the type
             pv: 2400,
             tooltipPosition: {
               x: 68.75,
@@ -696,6 +697,7 @@ describe('<BarChart />', () => {
               pv: 4567,
               uv: 300,
             },
+            // @ts-expect-error extra properties not expected in the type
             pv: 4567,
             tooltipPosition: {
               x: 76.25,
@@ -721,6 +723,7 @@ describe('<BarChart />', () => {
               pv: 1398,
               uv: 300,
             },
+            // @ts-expect-error extra properties not expected in the type
             pv: 1398,
             tooltipPosition: {
               x: 83.75,
@@ -746,6 +749,7 @@ describe('<BarChart />', () => {
               pv: 9800,
               uv: 200,
             },
+            // @ts-expect-error extra properties not expected in the type
             pv: 9800,
             tooltipPosition: {
               x: 91.25,

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
-
 import { beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
+
 import {
   Bar,
   BarChart,
@@ -655,7 +656,7 @@ describe('<BarChart />', () => {
 
       it('should select bars', () => {
         const { spy } = renderTestCase(state => selectBarRectangles(state, 0, 0, false, barSettings, cells));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             background: {
               height: 40,
@@ -761,7 +762,7 @@ describe('<BarChart />', () => {
 
       it('should select bar size list', () => {
         const { spy } = renderTestCase(state => selectBarSizeList(state, 0, 0, false, barSettings));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             barSize: undefined,
             dataKeys: ['uv', 'pv'],
@@ -772,37 +773,37 @@ describe('<BarChart />', () => {
 
       test('selectRootMaxBarSize', () => {
         const { spy } = renderTestCase(selectRootMaxBarSize);
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
       });
 
       test('selectBarGap', () => {
         const { spy } = renderTestCase(selectBarGap);
-        expect(spy).toHaveBeenLastCalledWith(4);
+        expectLastCalledWith(spy, 4);
       });
 
       test('selectBarCategoryGap', () => {
         const { spy } = renderTestCase(selectBarCategoryGap);
-        expect(spy).toHaveBeenLastCalledWith('10%');
+        expectLastCalledWith(spy, '10%');
       });
 
       test('selectBarBandSize', () => {
         const { spy } = renderTestCase(state => selectBarBandSize(state, 0, 0, false, barSettings));
-        expect(spy).toHaveBeenLastCalledWith(7.5);
+        expectLastCalledWith(spy, 7.5);
       });
 
       test('selectAxisBandSize', () => {
         const { spy } = renderTestCase(state => selectAxisBandSize(state, 0, 0, false));
-        expect(spy).toHaveBeenLastCalledWith(7.5);
+        expectLastCalledWith(spy, 7.5);
       });
 
       test('pickMaxBarSize', () => {
         const { spy } = renderTestCase(state => pickMaxBarSize(state, 0, 0, false, barSettings));
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
       });
 
       it('should select all bar positions', () => {
         const { spy } = renderTestCase(state => selectAllBarPositions(state, 0, 0, false, barSettings));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataKeys: ['uv', 'pv'],
             position: {
@@ -816,7 +817,7 @@ describe('<BarChart />', () => {
 
       it('should select bar position', () => {
         const { spy } = renderTestCase(state => selectBarPosition(state, 0, 0, false, barSettings));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           offset: 0.75,
           size: 6,
         });
@@ -1319,13 +1320,13 @@ describe('<BarChart />', () => {
               zAxisId: 0,
             },
           ];
-          expect(spy).toHaveBeenLastCalledWith(expected);
+          expectLastCalledWith(spy, expected);
           expect(spy).toHaveBeenCalledTimes(2);
         });
 
         it('should select bars for first axis', () => {
           const { spy } = renderTestCase(state => selectAllVisibleBars(state, 'one', 0, false));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               id: expect.stringMatching('^recharts-bar-[:a-z0-9]+$'),
               isPanorama: false,
@@ -1345,7 +1346,7 @@ describe('<BarChart />', () => {
 
         it('should select bars for second axis', () => {
           const { spy } = renderTestCase(state => selectAllVisibleBars(state, 'two', 0, false));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               id: expect.stringMatching('^recharts-bar-[:a-z0-9]+$'),
               isPanorama: false,
@@ -1501,13 +1502,13 @@ describe('<BarChart />', () => {
               zAxisId: 0,
             },
           ];
-          expect(spy).toHaveBeenLastCalledWith(expected);
+          expectLastCalledWith(spy, expected);
           expect(spy).toHaveBeenCalledTimes(2);
         });
 
         it('should select bars for left axis', () => {
           const { spy } = renderTestCase(state => selectAllVisibleBars(state, 0, 'left', false));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               id: 'my-bar-id-1',
               isPanorama: false,
@@ -1541,7 +1542,7 @@ describe('<BarChart />', () => {
 
         it('should select bars for right axis', () => {
           const { spy } = renderTestCase(state => selectAllVisibleBars(state, 0, 'right', false));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               id: 'my-bar-id-1',
               isPanorama: false,
@@ -1575,7 +1576,7 @@ describe('<BarChart />', () => {
 
         it('should select bar size list for left axis', () => {
           const { spy } = renderTestCase(state => selectBarSizeList(state, 0, 'left', false, leftBarSettings));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               barSize: undefined,
               dataKeys: ['pv'],
@@ -1592,7 +1593,7 @@ describe('<BarChart />', () => {
 
         it('should select bar size list for right axis', () => {
           const { spy } = renderTestCase(state => selectBarSizeList(state, 0, 'right', false, rightBarSettings));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               barSize: undefined,
               dataKeys: ['pv'],
@@ -1609,7 +1610,7 @@ describe('<BarChart />', () => {
 
         it('should select all bar positions for left axis', () => {
           const { spy } = renderTestCase(state => selectAllBarPositions(state, 0, 'left', false, leftBarSettings));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               dataKeys: ['pv'],
               position: {
@@ -1632,7 +1633,7 @@ describe('<BarChart />', () => {
 
         it('should select all bar positions for right axis', () => {
           const { spy } = renderTestCase(state => selectAllBarPositions(state, 0, 'right', false, rightBarSettings));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               dataKeys: ['pv'],
               position: {
@@ -1772,13 +1773,13 @@ describe('<BarChart />', () => {
               zAxisId: 0,
             },
           ];
-          expect(spy).toHaveBeenLastCalledWith(expected);
+          expectLastCalledWith(spy, expected);
           expect(spy).toHaveBeenCalledTimes(2);
         });
 
         it('should select bars for first axis', () => {
           const { spy } = renderTestCase(state => selectAllVisibleBars(state, 2, 0, false));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               id: expect.stringMatching('^recharts-bar-[:a-z0-9]+$'),
               isPanorama: false,
@@ -1812,7 +1813,7 @@ describe('<BarChart />', () => {
 
         it('should select bars for second axis', () => {
           const { spy } = renderTestCase(state => selectAllVisibleBars(state, 1, 0, false));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               id: expect.stringMatching('^recharts-bar-[:a-z0-9]+$'),
               isPanorama: false,
@@ -1992,13 +1993,13 @@ describe('<BarChart />', () => {
               zAxisId: 0,
             },
           ];
-          expect(spy).toHaveBeenLastCalledWith(expected);
+          expectLastCalledWith(spy, expected);
           expect(spy).toHaveBeenCalledTimes(2);
         });
 
         it('should select bars for left axis', () => {
           const { spy } = renderTestCase(state => selectAllVisibleBars(state, 0, 'left', false));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               id: 'bar-left',
               isPanorama: false,
@@ -2018,7 +2019,7 @@ describe('<BarChart />', () => {
 
         it('should select bars for right axis', () => {
           const { spy } = renderTestCase(state => selectAllVisibleBars(state, 0, 'right', false));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               id: 'bar-right',
               isPanorama: false,
@@ -2038,7 +2039,7 @@ describe('<BarChart />', () => {
 
         it('should select bar size list for left axis', () => {
           const { spy } = renderTestCase(state => selectBarSizeList(state, 0, 'left', false, leftBarSettings));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               barSize: 30,
               dataKeys: ['uv'],
@@ -2050,7 +2051,7 @@ describe('<BarChart />', () => {
 
         it('should select bar size list for right axis', () => {
           const { spy } = renderTestCase(state => selectBarSizeList(state, 0, 'right', false, rightBarSettings));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               barSize: 20,
               dataKeys: ['pv'],
@@ -2062,7 +2063,7 @@ describe('<BarChart />', () => {
 
         it('should select all bar positions for left axis', () => {
           const { spy } = renderTestCase(state => selectAllBarPositions(state, 0, 'left', false, leftBarSettings));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               dataKeys: ['uv'],
               position: {
@@ -2077,7 +2078,7 @@ describe('<BarChart />', () => {
 
         it('should select all bar positions for right axis', () => {
           const { spy } = renderTestCase(state => selectAllBarPositions(state, 0, 'right', false, rightBarSettings));
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               dataKeys: ['pv'],
               position: {
@@ -3163,7 +3164,7 @@ describe('<BarChart />', () => {
 
     it('should return offset', () => {
       const { spy } = renderTestCase(useOffset);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         bottom: 80,
         left: 160,
         right: 100,
@@ -3173,7 +3174,7 @@ describe('<BarChart />', () => {
 
     it('should return plot area', () => {
       const { spy } = renderTestCase(usePlotArea);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         height: 0,
         width: 0,
         x: 160,
@@ -3183,7 +3184,7 @@ describe('<BarChart />', () => {
 
     it('should return internal offset', () => {
       const { spy } = renderTestCase(useOffsetInternal);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         bottom: 80,
         brushBottom: 80,
         height: 0,

--- a/test/chart/LineChart.multiseries.spec.tsx
+++ b/test/chart/LineChart.multiseries.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { describe, it, test, expect } from 'vitest';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { Line, LineChart, Tooltip, useActiveTooltipDataPoints } from '../../src';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 const data1 = [
   { numberIndex: 1, date: new Date('2024-10-01'), uv: 4000, amt: undefined },
@@ -31,7 +32,7 @@ describe('LineChart with multiple data series', () => {
 
   test('useActiveTooltipDataPoints', () => {
     const { spy } = renderTestCase(useActiveTooltipDataPoints);
-    expect(spy).toHaveBeenLastCalledWith([data1[1], data2[1]]);
+    expectLastCalledWith(spy, [data1[1], data2[1]]);
   });
 
   it('should activate dots on both lines when hovering over the chart', () => {

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -30,7 +30,7 @@ import { MouseHandlerDataParam } from '../../src/synchronisation/types';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 import { useChartHeight, useChartWidth, useViewBox } from '../../src/context/chartLayoutContext';
 import { expectLines } from '../helper/expectLine';
-
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 import { useClipPathId } from '../../src/container/ClipPathProvider';
 
 describe('<LineChart />', () => {
@@ -815,7 +815,7 @@ describe('<LineChart />', () => {
 
     it('should select tooltip payload', () => {
       const { spy } = renderTestCase(state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: '#3182bd',
           dataKey: 'y',

--- a/test/chart/PieChart.spec.tsx
+++ b/test/chart/PieChart.spec.tsx
@@ -4,11 +4,11 @@ import userEvent from '@testing-library/user-event';
 import { expect, Mock, vi } from 'vitest';
 import { Cell, Legend, Pie, PieChart, Sector, SectorProps, Tooltip, useChartHeight } from '../../src';
 import { useChartWidth, useViewBox } from '../../src/context/chartLayoutContext';
-
 import { useClipPathId } from '../../src/container/ClipPathProvider';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { expectPieSectorAngles, expectPieSectors, selectPieSectors } from '../helper/expectPieSectors';
 import { expectLegendLabels } from '../helper/expectLegendLabels';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('<PieChart />', () => {
   const data = [
@@ -420,28 +420,28 @@ describe('<PieChart />', () => {
     it('should provide viewBox', () => {
       const { spy } = renderTestCase(useViewBox);
 
-      expect(spy).toHaveBeenLastCalledWith({ height: 40, width: 90, x: 5, y: 5 });
+      expectLastCalledWith(spy, { height: 40, width: 90, x: 5, y: 5 });
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide clipPathId', () => {
       const { spy } = renderTestCase(useClipPathId);
 
-      expect(spy).toHaveBeenLastCalledWith(expect.stringMatching(/recharts\d+-clip/));
+      expectLastCalledWith(spy, expect.stringMatching(/recharts\d+-clip/));
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide chart width', () => {
       const { spy } = renderTestCase(useChartWidth);
 
-      expect(spy).toHaveBeenLastCalledWith(100);
+      expectLastCalledWith(spy, 100);
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should provide chart height', () => {
       const { spy } = renderTestCase(useChartHeight);
 
-      expect(spy).toHaveBeenLastCalledWith(50);
+      expectLastCalledWith(spy, 50);
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });

--- a/test/chart/RadarChart.spec.tsx
+++ b/test/chart/RadarChart.spec.tsx
@@ -18,6 +18,7 @@ import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { selectPolarAxisScale } from '../../src/state/selectors/polarScaleSelectors';
 import { expectLastCalledWithScale } from '../helper/expectScale';
 import { useChartHeight, useChartWidth, useViewBox } from '../../src/context/chartLayoutContext';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('<RadarChart />', () => {
   describe('with implicit axes', () => {
@@ -30,7 +31,7 @@ describe('<RadarChart />', () => {
 
     it('should select angle settings', () => {
       const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: false,
         allowDuplicatedCategory: false,
@@ -56,12 +57,12 @@ describe('<RadarChart />', () => {
 
     it('should select angle axis scale type', () => {
       const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith('band');
+      expectLastCalledWith(spy, 'band');
     });
 
     it('should select radius axis settings', () => {
       const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: false,
         allowDuplicatedCategory: false,
@@ -82,12 +83,12 @@ describe('<RadarChart />', () => {
 
     it('should select max radius', () => {
       const { spy } = renderTestCase(selectMaxRadius);
-      expect(spy).toHaveBeenLastCalledWith(245);
+      expectLastCalledWith(spy, 245);
     });
 
     it('should select polar options', () => {
       const { spy } = renderTestCase(selectPolarOptions);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         cx: 100,
         cy: 150,
         endAngle: -270,
@@ -99,12 +100,12 @@ describe('<RadarChart />', () => {
 
     it('should select outer radius', () => {
       const { spy } = renderTestCase(selectOuterRadius);
-      expect(spy).toHaveBeenLastCalledWith(150); // TODO this returns 196, why?
+      expectLastCalledWith(spy, 150); // TODO this returns 196, why?
     });
 
     it('should select radius axis range', () => {
       const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
-      expect(spy).toHaveBeenLastCalledWith([0, 150]);
+      expectLastCalledWith(spy, [0, 150]);
     });
 
     it('should select radius axis scale', () => {
@@ -114,7 +115,7 @@ describe('<RadarChart />', () => {
 
     it('should select radius axis scale type', () => {
       const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith('linear');
+      expectLastCalledWith(spy, 'linear');
     });
 
     it('should render polygon', () => {
@@ -549,7 +550,7 @@ describe('<RadarChart />', () => {
         </RadarChart>,
       );
 
-      expect(spy).toHaveBeenLastCalledWith({ height: 40, width: 90, x: 5, y: 5 });
+      expectLastCalledWith(spy, { height: 40, width: 90, x: 5, y: 5 });
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
@@ -566,7 +567,7 @@ describe('<RadarChart />', () => {
         </RadarChart>,
       );
 
-      expect(spy).toHaveBeenLastCalledWith({ height: 40, width: 90, x: 5, y: 5 });
+      expectLastCalledWith(spy, { height: 40, width: 90, x: 5, y: 5 });
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
@@ -583,7 +584,7 @@ describe('<RadarChart />', () => {
         </RadarChart>,
       );
 
-      expect(spy).toHaveBeenLastCalledWith(100);
+      expectLastCalledWith(spy, 100);
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
@@ -600,7 +601,7 @@ describe('<RadarChart />', () => {
         </RadarChart>,
       );
 
-      expect(spy).toHaveBeenLastCalledWith(50);
+      expectLastCalledWith(spy, 50);
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });

--- a/test/chart/RadialBarChart.5966.spec.tsx
+++ b/test/chart/RadialBarChart.5966.spec.tsx
@@ -4,6 +4,7 @@ import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { PolarAngleAxis, RadialBar, RadialBarChart } from '../../src';
 import { PageData } from '../_data';
 import { selectRadiusAxisTicks } from '../../src/state/selectors/radialBarSelectors';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('RadialBarChart reproducing bug #5966', () => {
   const renderTestCase = createSelectorTestCase(({ children }) => (
@@ -38,6 +39,6 @@ describe('RadialBarChart reproducing bug #5966', () => {
 
   it('should not select any radius axis ticks', () => {
     const { spy } = renderTestCase(state => selectRadiusAxisTicks(state, 0, 0, false));
-    expect(spy).toHaveBeenLastCalledWith(undefined);
+    expectLastCalledWith(spy, undefined);
   });
 });

--- a/test/chart/RadialBarChart.spec.tsx
+++ b/test/chart/RadialBarChart.spec.tsx
@@ -7,8 +7,8 @@ import { selectRootBarSize } from '../../src/state/selectors/rootPropsSelectors'
 import { useAppSelector } from '../../src/state/hooks';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 import { useChartHeight, useChartWidth, useViewBox } from '../../src/context/chartLayoutContext';
-
 import { useClipPathId } from '../../src/container/ClipPathProvider';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 function assertActiveShapeInteractions(container: HTMLElement) {
   const sectorNodes = container.querySelectorAll('.recharts-sector');
@@ -611,7 +611,7 @@ describe('<RadialBarChart />', () => {
         </RadialBarChart>,
       );
 
-      expect(spy).toHaveBeenLastCalledWith({ height: 40, width: 90, x: 5, y: 5 });
+      expectLastCalledWith(spy, { height: 40, width: 90, x: 5, y: 5 });
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
@@ -628,7 +628,7 @@ describe('<RadialBarChart />', () => {
         </RadialBarChart>,
       );
 
-      expect(spy).toHaveBeenLastCalledWith(expect.stringMatching(/recharts\d+-clip/));
+      expectLastCalledWith(spy, expect.stringMatching(/recharts\d+-clip/));
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
@@ -645,7 +645,7 @@ describe('<RadialBarChart />', () => {
         </RadialBarChart>,
       );
 
-      expect(spy).toHaveBeenLastCalledWith(100);
+      expectLastCalledWith(spy, 100);
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
@@ -662,7 +662,7 @@ describe('<RadialBarChart />', () => {
         </RadialBarChart>,
       );
 
-      expect(spy).toHaveBeenLastCalledWith(50);
+      expectLastCalledWith(spy, 50);
       expect(spy).toHaveBeenCalledTimes(1);
     });
 

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -48,7 +48,7 @@ import { useIsPanorama } from '../../src/context/PanoramaContext';
 import { selectTooltipState } from '../../src/state/selectors/selectTooltipState';
 import { selectChartDataWithIndexes } from '../../src/state/selectors/dataSelectors';
 import { useChartHeight, useChartWidth, useViewBox } from '../../src/context/chartLayoutContext';
-
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 import { useClipPathId } from '../../src/container/ClipPathProvider';
 
 describe('ScatterChart of three dimension data', () => {
@@ -1290,7 +1290,7 @@ describe('ScatterChart of two dimension data', () => {
       );
 
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenLastCalledWith({ x: 5, y: 5, width: 90, height: 40 });
+      expectLastCalledWith(spy, { x: 5, y: 5, width: 90, height: 40 });
     });
 
     it('should provide clipPathId', () => {
@@ -1553,7 +1553,7 @@ describe('Tooltip integration', () => {
     it('should return tooltip payload', () => {
       // ScatterChart only allows item interaction
       const { spy } = renderTestCase(state => selectTooltipPayload(state, 'item', 'hover', '0'));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: undefined,
           dataKey: 'uv',
@@ -1901,12 +1901,12 @@ describe('Tooltip integration', () => {
           },
         ],
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select tooltip payload configurations', () => {
       const { spy } = renderTestCase(state => selectTooltipPayloadConfigurations(state, 'axis', 'hover', '0'));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           dataDefinedOnItem: [
             [
@@ -2122,7 +2122,7 @@ describe('Tooltip integration', () => {
 
     it('should select active coordinate', () => {
       const { spy } = renderTestCase(state => selectActiveCoordinate(state, 'item', 'hover', '0'));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         x: 67.5,
         y: 50.6,
       });
@@ -2342,7 +2342,7 @@ describe('Tooltip integration', () => {
           },
         },
       ];
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
   });
 });
@@ -2402,15 +2402,15 @@ describe('ScatterChart with allowDuplicateCategory=false', () => {
 
   it('should select tooltip active', () => {
     const { container, spy } = renderTestCase(state => selectIsTooltipActive(state, 'item', 'hover', undefined));
-    expect(spy).toHaveBeenLastCalledWith({ activeIndex: null, isActive: false });
+    expectLastCalledWith(spy, { activeIndex: null, isActive: false });
 
     showTooltip(container, scatterChartMouseHoverTooltipSelector);
-    expect(spy).toHaveBeenLastCalledWith({ activeIndex: '0', isActive: true });
+    expectLastCalledWith(spy, { activeIndex: '0', isActive: true });
   });
 
   it('should select tooltipPayloadConfigurations', () => {
     const { spy } = renderTestCase(state => selectTooltipPayloadConfigurations(state, 'axis', 'hover', undefined));
-    expect(spy).toHaveBeenLastCalledWith([
+    expectLastCalledWith(spy, [
       {
         dataDefinedOnItem: [
           [
@@ -2524,7 +2524,7 @@ describe('ScatterChart with allowDuplicateCategory=false', () => {
 
   it('should select chartDataWithIndexes', () => {
     const { spy } = renderTestCase(selectChartDataWithIndexes);
-    expect(spy).toHaveBeenLastCalledWith({
+    expectLastCalledWith(spy, {
       chartData: undefined,
       computedData: undefined,
       dataEndIndex: 0,
@@ -2535,11 +2535,11 @@ describe('ScatterChart with allowDuplicateCategory=false', () => {
   it('should select tooltip payload', () => {
     const { container, spy } = renderTestCase(state => selectTooltipPayload(state, 'item', 'hover', undefined));
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenLastCalledWith(undefined);
+    expectLastCalledWith(spy, undefined);
 
     showTooltip(container, scatterChartMouseHoverTooltipSelector);
     expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy).toHaveBeenLastCalledWith([
+    expectLastCalledWith(spy, [
       {
         color: undefined,
         dataKey: 'x',

--- a/test/component/Legend.itemSorter.spec.tsx
+++ b/test/component/Legend.itemSorter.spec.tsx
@@ -5,6 +5,7 @@ import { Area, AreaChart, DefaultLegendContentProps, Legend, LegendPayload, Line
 import { numericalData } from '../_data';
 import { expectLegendLabels } from '../helper/expectLegendLabels';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('Legend.itemSorter', () => {
   describe('with default content', () => {
@@ -390,7 +391,8 @@ describe('Legend.itemSorter', () => {
         it('should render all items sorted by dataKey', () => {
           renderTestCase();
 
-          expect(spy).toHaveBeenLastCalledWith(
+          expectLastCalledWith(
+            spy,
             expect.objectContaining({
               payload: [
                 expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'red', inactive: false }),
@@ -408,7 +410,8 @@ describe('Legend.itemSorter', () => {
           act(() => {
             getByText('A').click();
           });
-          expect(spy).toHaveBeenLastCalledWith(
+          expectLastCalledWith(
+            spy,
             expect.objectContaining({
               payload: [
                 expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'red', inactive: false }),
@@ -420,7 +423,8 @@ describe('Legend.itemSorter', () => {
           act(() => {
             getByText('B').click();
           });
-          expect(spy).toHaveBeenLastCalledWith(
+          expectLastCalledWith(
+            spy,
             expect.objectContaining({
               payload: [
                 expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'gold', inactive: true }),
@@ -466,7 +470,8 @@ describe('Legend.itemSorter', () => {
         it('should render all items sorted by dataKey', () => {
           renderTestCase();
 
-          expect(spy).toHaveBeenLastCalledWith(
+          expectLastCalledWith(
+            spy,
             expect.objectContaining({
               payload: [
                 expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'red', inactive: false }),
@@ -484,7 +489,8 @@ describe('Legend.itemSorter', () => {
           act(() => {
             getByText('A').click();
           });
-          expect(spy).toHaveBeenLastCalledWith(
+          expectLastCalledWith(
+            spy,
             expect.objectContaining({
               payload: [
                 expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'red', inactive: false }),
@@ -496,7 +502,8 @@ describe('Legend.itemSorter', () => {
           act(() => {
             getByText('B').click();
           });
-          expect(spy).toHaveBeenLastCalledWith(
+          expectLastCalledWith(
+            spy,
             expect.objectContaining({
               payload: [
                 expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'gold', inactive: true }),
@@ -513,7 +520,8 @@ describe('Legend.itemSorter', () => {
             getByText('A').click();
             getByText('B').click();
           });
-          expect(spy).toHaveBeenLastCalledWith(
+          expectLastCalledWith(
+            spy,
             expect.objectContaining({
               payload: [
                 expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'gold', inactive: true }),
@@ -525,7 +533,8 @@ describe('Legend.itemSorter', () => {
           act(() => {
             getByText('B').click();
           });
-          expect(spy).toHaveBeenLastCalledWith(
+          expectLastCalledWith(
+            spy,
             expect.objectContaining({
               payload: [
                 expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'red', inactive: false }),
@@ -537,7 +546,8 @@ describe('Legend.itemSorter', () => {
           act(() => {
             getByText('A').click();
           });
-          expect(spy).toHaveBeenLastCalledWith(
+          expectLastCalledWith(
+            spy,
             expect.objectContaining({
               payload: [
                 expect.objectContaining({ value: 'B', dataKey: 'percent', color: 'red', inactive: false }),

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -1846,6 +1846,7 @@ describe('<Legend />', () => {
             color: '#3182bd',
             value: '%',
             payload: {
+              // @ts-expect-error extra properties not expected in the type
               dataKey: 'percent',
               name: '%',
               activeDot: true,

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -35,6 +35,7 @@ import { dataWithSpecialNameAndFillProperties, numericalData } from '../_data';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { Size } from '../../src/util/types';
 import { assertHasLegend, expectLegendLabels } from '../helper/expectLegendLabels';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 type LegendTypeTestCases = ReadonlyArray<{
   legendType: LegendType;
@@ -430,7 +431,7 @@ describe('<Legend />', () => {
         </LineChart>,
       );
       expect(spy).toHaveBeenCalledTimes(2);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         align: 'center',
         chartHeight: 300,
         chartWidth: 600,
@@ -773,7 +774,7 @@ describe('<Legend />', () => {
         </LineChart>,
       );
       expect.soft(spy).toHaveBeenCalledTimes(2);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         align: 'center',
         chartHeight: 300,
         chartWidth: 600,
@@ -1574,7 +1575,7 @@ describe('<Legend />', () => {
           },
         )();
         expect(spy).toHaveBeenCalledTimes(3);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           brushBottom: 5,
           top: 5,
           bottom: 5 + 13,
@@ -1603,7 +1604,7 @@ describe('<Legend />', () => {
           },
         )();
         expect(spy).toHaveBeenCalledTimes(2);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           brushBottom: 5,
           top: 5,
           bottom: 5,
@@ -1632,7 +1633,7 @@ describe('<Legend />', () => {
           },
         )();
         expect(spy).toHaveBeenCalledTimes(3);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           brushBottom: 5,
           top: 5,
           bottom: 5,
@@ -1661,7 +1662,7 @@ describe('<Legend />', () => {
           },
         )();
         expect(spy).toHaveBeenCalledTimes(3);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           brushBottom: 5,
           top: 5,
           bottom: 5 + 13,
@@ -1837,7 +1838,7 @@ describe('<Legend />', () => {
 
       it('should select legend payload', () => {
         const { spy } = renderTestCase(selectLegendPayload);
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             inactive: false,
             dataKey: 'percent',

--- a/test/component/Tooltip/Tooltip.animation.spec.tsx
+++ b/test/component/Tooltip/Tooltip.animation.spec.tsx
@@ -12,6 +12,7 @@ import {
 import { lineChartMouseHoverTooltipSelector } from './tooltipMouseHoverSelectors';
 import { selectIsTooltipActive } from '../../../src/state/selectors/selectors';
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('Tooltip animation', () => {
   beforeEach(() => {
@@ -47,9 +48,9 @@ describe('Tooltip animation', () => {
 
       it('should select isActive: true', () => {
         const { container, spy } = renderTestCase(state => selectIsTooltipActive(state, 'axis', 'hover', undefined));
-        expect(spy).toHaveBeenLastCalledWith({ activeIndex: null, isActive: false });
+        expectLastCalledWith(spy, { activeIndex: null, isActive: false });
         prime(container);
-        expect(spy).toHaveBeenLastCalledWith({ activeIndex: '0', isActive: true });
+        expectLastCalledWith(spy, { activeIndex: '0', isActive: true });
       });
 
       it('should animate towards the final position', () => {
@@ -134,9 +135,9 @@ describe('Tooltip animation', () => {
 
       it('should select isActive: true', () => {
         const { container, spy } = renderTestCase(state => selectIsTooltipActive(state, 'axis', 'hover', undefined));
-        expect(spy).toHaveBeenLastCalledWith({ activeIndex: null, isActive: false });
+        expectLastCalledWith(spy, { activeIndex: null, isActive: false });
         prime(container);
-        expect(spy).toHaveBeenLastCalledWith({ activeIndex: '0', isActive: true });
+        expectLastCalledWith(spy, { activeIndex: '0', isActive: true });
       });
 
       it('should animate towards the final position', () => {

--- a/test/component/Tooltip/Tooltip.formatter.spec.tsx
+++ b/test/component/Tooltip/Tooltip.formatter.spec.tsx
@@ -7,6 +7,7 @@ import { barChartMouseHoverTooltipSelector } from './tooltipMouseHoverSelectors'
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
 import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
 import { selectTooltipPayload } from '../../../src/state/selectors/selectors';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('Tooltip.formatter reproducing https://github.com/recharts/recharts/issues/5658', () => {
   beforeEach(() => {
@@ -48,7 +49,7 @@ describe('Tooltip.formatter reproducing https://github.com/recharts/recharts/iss
 
     it('should select payload', () => {
       const { spy } = renderTestCase(state => selectTooltipPayload(state, 'axis', 'hover', '1'));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: '#8884d8',
           dataKey: dataKeyAsFunction,
@@ -125,7 +126,7 @@ describe('Tooltip.formatter reproducing https://github.com/recharts/recharts/iss
 
     it('should select payload', () => {
       const { spy } = renderTestCase(state => selectTooltipPayload(state, 'axis', 'hover', '1'));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: '#8884d8',
           dataKey: dataKeyAsFunction,

--- a/test/component/Tooltip/Tooltip.multipleDataArrays.spec.tsx
+++ b/test/component/Tooltip/Tooltip.multipleDataArrays.spec.tsx
@@ -16,6 +16,7 @@ import { selectActiveTooltipIndex } from '../../../src/state/selectors/tooltipSe
 import { showTooltipOnCoordinate } from './tooltipTestHelpers';
 import { composedChartMouseHoverTooltipSelector } from './tooltipMouseHoverSelectors';
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('Tooltip in chart with multiple data arrays', () => {
   beforeEach(() => {
@@ -54,12 +55,12 @@ describe('Tooltip in chart with multiple data arrays', () => {
     it('should select activeTooltipDataPoints', () => {
       const { container, spy } = renderTestCase(useActiveTooltipDataPoints);
 
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
       expect(spy).toHaveBeenCalledTimes(3);
 
       showTooltipOnCoordinate(container, composedChartMouseHoverTooltipSelector, { clientX: 387.5, clientY: 100 });
 
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         { xAxis: 30, y1: 6 },
         { xAxis: 30, y2: 12 },
       ]);
@@ -82,7 +83,7 @@ describe('Tooltip in chart with multiple data arrays', () => {
     it('should select individual items data', () => {
       const { spy } = renderTestCase(state => selectCartesianGraphicalItemsData(state, 'xAxis', 0));
 
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         { xAxis: 10, y1: 4 },
         { xAxis: 20, y1: 10 },
         { xAxis: 30, y1: 6 },
@@ -100,7 +101,7 @@ describe('Tooltip in chart with multiple data arrays', () => {
     it('should select displayed data', () => {
       const { spy } = renderTestCase(state => selectDisplayedData(state, 'xAxis', 0, false));
 
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         { xAxis: 10, y1: 4 },
         { xAxis: 20, y1: 10 },
         { xAxis: 30, y1: 6 },
@@ -118,7 +119,8 @@ describe('Tooltip in chart with multiple data arrays', () => {
     it('should select scale', () => {
       const { spy } = renderTestCase(state => selectAxisScale(state, 'xAxis', 0, false));
 
-      expect(spy).toHaveBeenLastCalledWith(
+      expectLastCalledWith(
+        spy,
         expect.toBeRechartsScale({
           domain: [0, 40],
           range: [65, 495],
@@ -138,20 +140,20 @@ describe('Tooltip in chart with multiple data arrays', () => {
 
     it('should highlight the first dot when hovering the first xaxis tick', () => {
       const { container, spy } = renderTestCase(selectActiveTooltipIndex);
-      expect(spy).toHaveBeenLastCalledWith(null);
+      expectLastCalledWith(spy, null);
 
       showTooltipOnCoordinate(container, composedChartMouseHoverTooltipSelector, { clientX: 118.75, clientY: 100 });
       // this is 4 because the tick is at xAxis=5 which is the fifth point in the displayedData array
-      expect(spy).toHaveBeenLastCalledWith('4');
+      expectLastCalledWith(spy, '4');
     });
 
     it('should highlight the last dot when hovering the last xaxis tick', () => {
       const { container, spy } = renderTestCase(selectActiveTooltipIndex);
-      expect(spy).toHaveBeenLastCalledWith(null);
+      expectLastCalledWith(spy, null);
 
       showTooltipOnCoordinate(container, composedChartMouseHoverTooltipSelector, { clientX: 495, clientY: 100 });
       // this is 3 because the tick is at xAxis=40 which is the fourth point in the displayedData array
-      expect(spy).toHaveBeenLastCalledWith('3');
+      expectLastCalledWith(spy, '3');
     });
   });
 
@@ -170,7 +172,7 @@ describe('Tooltip in chart with multiple data arrays', () => {
 
     it('should highlight the first dot', () => {
       const { spy } = renderTestCase(selectActiveTooltipIndex);
-      expect(spy).toHaveBeenLastCalledWith('0');
+      expectLastCalledWith(spy, '0');
     });
   });
 });

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -533,6 +533,7 @@ describe('Tooltip payload', () => {
           ],
           dataKey: 'uv',
           hide: false,
+          // @ts-expect-error extra properties not expected in the type
           isPanorama: false,
           stackId: undefined,
           type: 'line',
@@ -583,6 +584,7 @@ describe('Tooltip payload', () => {
           ],
           dataKey: 'pv',
           hide: false,
+          // @ts-expect-error extra properties not expected in the type
           isPanorama: false,
           stackId: undefined,
           type: 'line',
@@ -633,6 +635,7 @@ describe('Tooltip payload', () => {
           ],
           dataKey: 'amt',
           hide: false,
+          // @ts-expect-error extra properties not expected in the type
           isPanorama: false,
           stackId: undefined,
           type: 'line',
@@ -689,6 +692,7 @@ describe('Tooltip payload', () => {
           ],
           dataKey: 'uv',
           hide: false,
+          // @ts-expect-error extra properties not expected in the type
           isPanorama: false,
           stackId: undefined,
           type: 'line',
@@ -739,6 +743,7 @@ describe('Tooltip payload', () => {
           ],
           dataKey: 'pv',
           hide: false,
+          // @ts-expect-error extra properties not expected in the type
           isPanorama: false,
           stackId: undefined,
           type: 'line',
@@ -789,6 +794,7 @@ describe('Tooltip payload', () => {
           ],
           dataKey: 'amt',
           hide: false,
+          // @ts-expect-error extra properties not expected in the type
           isPanorama: false,
           stackId: undefined,
           type: 'line',
@@ -1228,6 +1234,7 @@ describe('Tooltip payload', () => {
         chartData: undefined,
         dataEndIndex: 0,
         dataStartIndex: 0,
+        computedData: undefined,
       });
     });
 
@@ -1235,6 +1242,7 @@ describe('Tooltip payload', () => {
       const { spy } = renderTestCase(state => selectTooltipPayloadConfigurations(state, 'axis', 'hover', undefined));
       expectLastCalledWith(spy, [
         {
+          positions: undefined,
           dataDefinedOnItem: [
             {
               amt: 2400,
@@ -1287,6 +1295,7 @@ describe('Tooltip payload', () => {
           },
         },
         {
+          positions: undefined,
           dataDefinedOnItem: [
             {
               amt: 2400,
@@ -1339,6 +1348,7 @@ describe('Tooltip payload', () => {
           },
         },
         {
+          positions: undefined,
           dataDefinedOnItem: [
             {
               amt: 2400,

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -79,6 +79,7 @@ import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRec
 import { selectTooltipAxisId } from '../../../src/state/selectors/selectTooltipAxisId';
 import { selectTooltipAxisType } from '../../../src/state/selectors/selectTooltipAxisType';
 import { selectTooltipAxis } from '../../../src/state/selectors/selectTooltipAxis';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 type TooltipPayloadTestCase = {
   // Identify which test is running
@@ -473,22 +474,22 @@ describe('Tooltip payload', () => {
 
     it('should select xaxis domain', () => {
       const { spy } = renderTestCase(state => selectAxisDomain(state, 'xAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
+      expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
     });
 
     it('should select tooltip axis type', () => {
       const { spy } = renderTestCase(selectTooltipAxisType);
-      expect(spy).toHaveBeenLastCalledWith('xAxis');
+      expectLastCalledWith(spy, 'xAxis');
     });
 
     it('should select tooltip axis ID', () => {
       const { spy } = renderTestCase(selectTooltipAxisId);
-      expect(spy).toHaveBeenLastCalledWith(0);
+      expectLastCalledWith(spy, 0);
     });
 
     it('should select unfiltered graphical items', () => {
       const { spy } = renderTestCase(selectAllUnfilteredGraphicalItems);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           id: expect.stringMatching('line-'),
           barSize: undefined,
@@ -644,7 +645,7 @@ describe('Tooltip payload', () => {
 
     it('should select all graphical items', () => {
       const { spy } = renderTestCase(selectAllGraphicalItemsSettings);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           id: expect.stringMatching('line-'),
           barSize: undefined,
@@ -800,7 +801,7 @@ describe('Tooltip payload', () => {
 
     it('should select tooltip data defined on graphical items', () => {
       const { spy } = renderTestCase(selectTooltipGraphicalItemsData);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           amt: 2400,
           name: 'Page A',
@@ -914,7 +915,7 @@ describe('Tooltip payload', () => {
 
     it('should select tooltip displayed data', () => {
       const { spy } = renderTestCase(selectTooltipDisplayedData);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           amt: 2400,
           name: 'Page A',
@@ -1028,12 +1029,12 @@ describe('Tooltip payload', () => {
 
     it('should select tooltip axis domain', () => {
       const { spy } = renderTestCase(selectTooltipAxisDomain);
-      expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
+      expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
     });
 
     it('should select tooltip axis domain with nice ticks', () => {
       const { spy } = renderTestCase(selectTooltipAxisDomainIncludingNiceTicks);
-      expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
+      expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
     });
 
     it('should select tooltip axis scale', () => {
@@ -1046,7 +1047,7 @@ describe('Tooltip payload', () => {
 
     it('should select tooltip ticks', () => {
       const { spy } = renderTestCase(selectTooltipAxisTicks);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           coordinate: 5,
           index: 0,
@@ -1160,7 +1161,7 @@ describe('Tooltip payload', () => {
 
     it('should select Tooltip payload when given defaultIndex', () => {
       const { spy } = renderTestCase(state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: '#3182bd',
           dataKey: 'uv',
@@ -1223,7 +1224,7 @@ describe('Tooltip payload', () => {
 
     it('should select dataStartIndex and dataEndIndex', () => {
       const { spy } = renderTestCase(selectChartDataWithIndexes);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         chartData: undefined,
         dataEndIndex: 0,
         dataStartIndex: 0,
@@ -1232,7 +1233,7 @@ describe('Tooltip payload', () => {
 
     it('should select tooltip payload settings for every graphical item', () => {
       const { spy } = renderTestCase(state => selectTooltipPayloadConfigurations(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           dataDefinedOnItem: [
             {
@@ -1395,7 +1396,7 @@ describe('Tooltip payload', () => {
 
     it('should select Tooltip payload after mouse hover', () => {
       const { container, spy } = renderTestCase(state => selectTooltipPayload(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
       expect(spy).toHaveBeenCalledTimes(1);
 
       showTooltipOnCoordinate(
@@ -1404,7 +1405,7 @@ describe('Tooltip payload', () => {
         LineChartDataOnGraphicalItemTestCase.mouseCoordinate,
       );
 
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: '#3182bd',
           dataKey: 'uv',
@@ -1486,12 +1487,12 @@ describe('Tooltip payload', () => {
 
     it('should select active label', () => {
       const { spy } = renderTestCase(state => selectActiveLabel(state, 'axis', 'hover', '2'));
-      expect(spy).toHaveBeenLastCalledWith(2);
+      expectLastCalledWith(spy, 2);
     });
 
     it('should select isActive and activeIndex, and update it after mouse hover', () => {
       const { container, spy } = renderTestCase(state => selectIsTooltipActive(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
@@ -1503,7 +1504,7 @@ describe('Tooltip payload', () => {
         LineChartDataOnGraphicalItemTestCase.mouseCoordinate,
       );
 
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '1',
         isActive: true,
       });
@@ -1512,7 +1513,7 @@ describe('Tooltip payload', () => {
 
     it('should select active coordinate', () => {
       const { container, spy } = renderTestCase(state => selectActiveCoordinate(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
       expect(spy).toHaveBeenCalledTimes(1);
 
       showTooltipOnCoordinate(
@@ -1521,7 +1522,7 @@ describe('Tooltip payload', () => {
         LineChartDataOnGraphicalItemTestCase.mouseCoordinate,
       );
 
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         x: 27.941176470588236,
         y: 20,
       });
@@ -1539,17 +1540,17 @@ describe('Tooltip payload', () => {
 
     it('should select tooltip axis type', () => {
       const { spy } = renderTestCase(selectTooltipAxisType);
-      expect(spy).toHaveBeenLastCalledWith('yAxis');
+      expectLastCalledWith(spy, 'yAxis');
     });
 
     it('should select tooltip axis ID', () => {
       const { spy } = renderTestCase(selectTooltipAxisId);
-      expect(spy).toHaveBeenLastCalledWith(0);
+      expectLastCalledWith(spy, 0);
     });
 
     it('should select dataStartIndex and dataEndIndex', () => {
       const { spy } = renderTestCase(selectChartDataWithIndexes);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         chartData: [
           {
             amt: 2400,
@@ -1596,12 +1597,12 @@ describe('Tooltip payload', () => {
 
     it('should select active label', () => {
       const { spy } = renderTestCase(state => selectActiveLabel(state, 'axis', 'hover', '2'));
-      expect(spy).toHaveBeenLastCalledWith('Page C');
+      expectLastCalledWith(spy, 'Page C');
     });
 
     it('should select active coordinate', () => {
       const { container, spy } = renderTestCase(state => selectActiveCoordinate(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
       expect(spy).toHaveBeenCalledTimes(1);
 
       showTooltipOnCoordinate(
@@ -1610,7 +1611,7 @@ describe('Tooltip payload', () => {
         LineChartVerticalTestCase.mouseCoordinate,
       );
 
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         x: 200,
         y: 213,
       });
@@ -1619,7 +1620,7 @@ describe('Tooltip payload', () => {
 
     it('should select isActive and activeIndex, and update it after mouse hover', () => {
       const { container, spy } = renderTestCase(state => selectIsTooltipActive(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
@@ -1631,7 +1632,7 @@ describe('Tooltip payload', () => {
         LineChartVerticalTestCase.mouseCoordinate,
       );
 
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '4',
         isActive: true,
       });
@@ -1770,17 +1771,17 @@ describe('Tooltip payload', () => {
 
         it('should select tooltip axis type', () => {
           const { spy } = renderTestCase(selectTooltipAxisType);
-          expect(spy).toHaveBeenLastCalledWith('radiusAxis');
+          expectLastCalledWith(spy, 'radiusAxis');
         });
 
         it('should select tooltip axis ID', () => {
           const { spy } = renderTestCase(selectTooltipAxisId);
-          expect(spy).toHaveBeenLastCalledWith(0);
+          expectLastCalledWith(spy, 0);
         });
 
         it('should select tooltip axis settings', () => {
           const { spy } = renderTestCase(selectTooltipAxis);
-          expect(spy).toHaveBeenLastCalledWith({
+          expectLastCalledWith(spy, {
             allowDataOverflow: false,
             allowDecimals: false,
             allowDuplicatedCategory: true,
@@ -1801,7 +1802,7 @@ describe('Tooltip payload', () => {
 
         it('should select tooltip axis ticks', () => {
           const { spy } = renderTestCase(selectTooltipAxisTicks);
-          expect(spy).toHaveBeenLastCalledWith([
+          expectLastCalledWith(spy, [
             {
               coordinate: 19.666666666666668,
               index: 0,
@@ -1843,7 +1844,7 @@ describe('Tooltip payload', () => {
 
         it('should select active label', () => {
           const { spy } = renderTestCase(state => selectActiveLabel(state, 'axis', 'hover', '2'));
-          expect(spy).toHaveBeenLastCalledWith(2);
+          expectLastCalledWith(spy, 2);
         });
 
         it('should render tooltip payload with data from all Bars', () => {

--- a/test/component/Tooltip/Tooltip.state.spec.tsx
+++ b/test/component/Tooltip/Tooltip.state.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
 import { LineChart, Tooltip } from '../../../src';
 import { TooltipSettingsState } from '../../../src/state/tooltipSlice';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('Tooltip state integration', () => {
   describe('with explicit settings', () => {
@@ -21,7 +22,7 @@ describe('Tooltip state integration', () => {
         active: true,
         defaultIndex: '4',
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
   });
 
@@ -42,7 +43,7 @@ describe('Tooltip state integration', () => {
         shared: undefined,
         trigger: 'hover',
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
   });
 
@@ -62,7 +63,7 @@ describe('Tooltip state integration', () => {
         shared: undefined,
         trigger: 'hover',
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
   });
 });

--- a/test/component/Tooltip/Tooltip.sync.spec.tsx
+++ b/test/component/Tooltip/Tooltip.sync.spec.tsx
@@ -56,6 +56,7 @@ import { selectActiveTooltipIndex } from '../../../src/state/selectors/tooltipSe
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
 import { selectSynchronisedTooltipState } from '../../../src/synchronisation/syncSelectors';
 import { selectTooltipPayloadSearcher } from '../../../src/state/selectors/selectTooltipPayloadSearcher';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 type TooltipSyncTestCase = {
   // For identifying which test is running
@@ -367,12 +368,12 @@ describe('Tooltip synchronization', () => {
 
       test(`${name} should put the syncId into redux state`, () => {
         const { spy } = renderTestCase(selectSyncId);
-        expect(spy).toHaveBeenLastCalledWith('tooltipSync');
+        expectLastCalledWith(spy, 'tooltipSync');
       });
 
       test(`${name} should select syncMethod`, () => {
         const { spy } = renderTestCase(selectSyncMethod);
-        expect(spy).toHaveBeenLastCalledWith('index');
+        expectLastCalledWith(spy, 'index');
       });
     },
   );

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -87,6 +87,7 @@ import { LegendSettings } from '../../../src/state/legendSlice';
 import { selectTooltipAxisId } from '../../../src/state/selectors/selectTooltipAxisId';
 import { selectTooltipAxisType } from '../../../src/state/selectors/selectTooltipAxisType';
 import { selectTooltipAxis } from '../../../src/state/selectors/selectTooltipAxis';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 type TooltipVisibilityTestCase = {
   // For identifying which test is running
@@ -723,12 +724,12 @@ describe('Tooltip visibility', () => {
 
     it('should select chart layout', () => {
       const { spy } = renderTestCase(selectChartLayout);
-      expect(spy).toHaveBeenLastCalledWith('vertical');
+      expectLastCalledWith(spy, 'vertical');
     });
 
     it('should select chart offset', () => {
       const { spy } = renderTestCase(selectChartOffsetInternal);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         bottom: 135,
         brushBottom: 35,
         height: 245,
@@ -747,12 +748,12 @@ describe('Tooltip visibility', () => {
         layout: 'horizontal',
         verticalAlign: 'bottom',
       };
-      expect(spy).toHaveBeenLastCalledWith(expected);
+      expectLastCalledWith(spy, expected);
     });
 
     it('should select legend size', () => {
       const { spy } = renderTestCase(selectLegendSize);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         height: 100,
         width: 100,
       });
@@ -760,7 +761,7 @@ describe('Tooltip visibility', () => {
 
     it('should select legend payload', () => {
       const { spy } = renderTestCase(selectLegendPayload);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: '#82ca9d',
           dataKey: 'uv',
@@ -792,17 +793,17 @@ describe('Tooltip visibility', () => {
 
     it('should select tooltip axis type', () => {
       const { spy } = renderTestCase(selectTooltipAxisType);
-      expect(spy).toHaveBeenLastCalledWith('yAxis');
+      expectLastCalledWith(spy, 'yAxis');
     });
 
     it('should select tooltip axis ID', () => {
       const { spy } = renderTestCase(selectTooltipAxisId);
-      expect(spy).toHaveBeenLastCalledWith(0);
+      expectLastCalledWith(spy, 0);
     });
 
     it('should select dataStartIndex and dataEndIndex', () => {
       const { spy } = renderTestCase(selectChartDataWithIndexes);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         chartData: [
           {
             amt: 2400,
@@ -849,12 +850,12 @@ describe('Tooltip visibility', () => {
 
     it('should select active label', () => {
       const { spy } = renderTestCase(state => selectActiveLabel(state, 'axis', 'hover', '2'));
-      expect(spy).toHaveBeenLastCalledWith('Page C');
+      expectLastCalledWith(spy, 'Page C');
     });
 
     it('should select active coordinate', () => {
       const { container, spy } = renderTestCase(state => selectActiveCoordinate(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
       expect(spy).toHaveBeenCalledTimes(1);
 
       showTooltipOnCoordinate(
@@ -863,7 +864,7 @@ describe('Tooltip visibility', () => {
         LineChartVerticalTestCase.mouseCoordinate,
       );
 
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         x: 200,
         y: 216,
       });
@@ -872,7 +873,7 @@ describe('Tooltip visibility', () => {
 
     it('should select tooltip axis range', () => {
       const { spy } = renderTestCase(selectTooltipAxisRangeWithReverse);
-      expect(spy).toHaveBeenLastCalledWith([20, 265]);
+      expectLastCalledWith(spy, [20, 265]);
     });
 
     it('should select tooltip axis scale', () => {
@@ -885,13 +886,13 @@ describe('Tooltip visibility', () => {
 
     it('should select categorical domain', () => {
       const { spy } = renderTestCase(selectTooltipCategoricalDomain);
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
     });
 
     it('should select tooltip axis ticks', () => {
       const { spy } = renderTestCase(selectTooltipAxisTicks);
 
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           coordinate: 20,
           index: 0,
@@ -933,7 +934,7 @@ describe('Tooltip visibility', () => {
 
     it('should select isActive and activeIndex, and update it after mouse hover', () => {
       const { container, spy } = renderTestCase(state => selectIsTooltipActive(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
@@ -945,7 +946,7 @@ describe('Tooltip visibility', () => {
         LineChartVerticalTestCase.mouseCoordinate,
       );
 
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '4',
         isActive: true,
       });
@@ -963,17 +964,17 @@ describe('Tooltip visibility', () => {
 
     it('should select tooltip axis type', () => {
       const { spy } = renderTestCase(selectTooltipAxisType);
-      expect(spy).toHaveBeenLastCalledWith('angleAxis');
+      expectLastCalledWith(spy, 'angleAxis');
     });
 
     it('should select tooltip axis ID', () => {
       const { spy } = renderTestCase(selectTooltipAxisId);
-      expect(spy).toHaveBeenLastCalledWith(0);
+      expectLastCalledWith(spy, 0);
     });
 
     it('should select tooltip axis settings', () => {
       const { spy } = renderTestCase(selectTooltipAxis);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: undefined,
         allowDuplicatedCategory: false,
@@ -994,7 +995,7 @@ describe('Tooltip visibility', () => {
 
     it('should select tooltip axis range', () => {
       const { spy } = renderTestCase(selectTooltipAxisRangeWithReverse);
-      expect(spy).toHaveBeenLastCalledWith([90, -270]);
+      expectLastCalledWith(spy, [90, -270]);
     });
 
     it('should select tooltip axis scale', () => {
@@ -1007,7 +1008,7 @@ describe('Tooltip visibility', () => {
 
     it('should select tooltip axis ticks', () => {
       const { spy } = renderTestCase(selectTooltipAxisTicks);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           coordinate: 90,
           index: 0,
@@ -1118,7 +1119,7 @@ describe('Tooltip visibility', () => {
           },
         ],
       };
-      expect(spy).toHaveBeenLastCalledWith(expectedBeforeHover);
+      expectLastCalledWith(spy, expectedBeforeHover);
 
       showTooltip(container, RadarChartTestCase.mouseHoverSelector);
 
@@ -1204,22 +1205,22 @@ describe('Tooltip visibility', () => {
           },
         ],
       };
-      expect(spy).toHaveBeenLastCalledWith(expectedAfterHover);
+      expectLastCalledWith(spy, expectedAfterHover);
     });
 
     it('should select active label', () => {
       const { spy } = renderTestCase(state => selectActiveLabel(state, 'axis', 'hover', '2'));
-      expect(spy).toHaveBeenLastCalledWith('Page C');
+      expectLastCalledWith(spy, 'Page C');
     });
 
     it('should select active coordinate', () => {
       const { container, spy } = renderTestCase(state => selectActiveCoordinate(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
       expect(spy).toHaveBeenCalledTimes(1);
 
       showTooltipOnCoordinate(container, RadarChartTestCase.mouseHoverSelector, RadarChartTestCase.mouseCoordinate);
 
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         angle: -210,
         clockWise: false,
         cx: 300,
@@ -1246,22 +1247,22 @@ describe('Tooltip visibility', () => {
 
     it('should select chart layout', () => {
       const { spy } = renderTestCase(selectChartLayout);
-      expect(spy).toHaveBeenLastCalledWith('radial');
+      expectLastCalledWith(spy, 'radial');
     });
 
     it('should select tooltip axis type', () => {
       const { spy } = renderTestCase(selectTooltipAxisType);
-      expect(spy).toHaveBeenLastCalledWith('radiusAxis');
+      expectLastCalledWith(spy, 'radiusAxis');
     });
 
     it('should select tooltip axis ID', () => {
       const { spy } = renderTestCase(selectTooltipAxisId);
-      expect(spy).toHaveBeenLastCalledWith(0);
+      expectLastCalledWith(spy, 0);
     });
 
     it('should select tooltip axis settings', () => {
       const { spy } = renderTestCase(selectTooltipAxis);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: undefined,
         allowDuplicatedCategory: true,
@@ -1282,7 +1283,7 @@ describe('Tooltip visibility', () => {
 
     it('should select tooltip axis range', () => {
       const { spy } = renderTestCase(selectTooltipAxisRangeWithReverse);
-      expect(spy).toHaveBeenLastCalledWith([0, 236]);
+      expectLastCalledWith(spy, [0, 236]);
     });
 
     it('should select tooltip axis scale', () => {
@@ -1295,12 +1296,12 @@ describe('Tooltip visibility', () => {
 
     it('should select categoricalDomain = undefined', () => {
       const { spy } = renderTestCase(selectTooltipCategoricalDomain);
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
     });
 
     it('should select tooltip axis ticks', () => {
       const { spy } = renderTestCase(selectTooltipAxisTicks);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           coordinate: 0,
           index: 0,
@@ -1410,27 +1411,27 @@ describe('Tooltip visibility', () => {
 
       it('should select tooltip axis ID', () => {
         const { spy } = renderTestCase(selectTooltipAxisId);
-        expect(spy).toHaveBeenLastCalledWith(0);
+        expectLastCalledWith(spy, 0);
       });
 
       it('should select tooltip axis type', () => {
         const { spy } = renderTestCase(selectTooltipAxisType);
-        expect(spy).toHaveBeenLastCalledWith('xAxis');
+        expectLastCalledWith(spy, 'xAxis');
       });
 
       it('should select active label when given explicit index', () => {
         const { spy } = renderTestCase(state => selectActiveLabel(state, 'axis', 'hover', '2'));
-        expect(spy).toHaveBeenLastCalledWith(2400);
+        expectLastCalledWith(spy, 2400);
       });
 
       it('should select active coordinate', () => {
         const { container, spy } = renderTestCase(state => selectActiveCoordinate(state, 'axis', 'hover', undefined));
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
         expect(spy).toHaveBeenCalledTimes(1);
 
         showTooltip(container, composedChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           x: 395,
           y: 200,
         });
@@ -1447,7 +1448,7 @@ describe('Tooltip visibility', () => {
 
       it('should select tooltip axis settings', () => {
         const { spy } = renderTestCase(selectTooltipAxis);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: true,
           allowDuplicatedCategory: true,
@@ -1480,12 +1481,12 @@ describe('Tooltip visibility', () => {
 
       it('should select tooltip axis real scale type', () => {
         const { spy } = renderTestCase(selectTooltipAxisRealScaleType);
-        expect(spy).toHaveBeenLastCalledWith('linear');
+        expectLastCalledWith(spy, 'linear');
       });
 
       it('should select tooltip axis ticks', () => {
         const { spy } = renderTestCase(selectTooltipAxisTicks);
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           { coordinate: 395, value: 2400, index: 0, offset: 0 },
           { coordinate: 395, value: 2400, index: 1, offset: 0 },
           { coordinate: 395, value: 2400, index: 2, offset: 0 },
@@ -1497,7 +1498,7 @@ describe('Tooltip visibility', () => {
 
       it('should select isActive', () => {
         const { container, spy } = renderTestCase(state => selectIsTooltipActive(state, 'axis', 'hover', undefined));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           activeIndex: null,
           isActive: false,
         });
@@ -1505,7 +1506,7 @@ describe('Tooltip visibility', () => {
 
         showTooltip(container, composedChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           activeIndex: '0',
           isActive: true,
         });

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -767,6 +767,7 @@ describe('Tooltip visibility', () => {
           dataKey: 'uv',
           inactive: false,
           payload: {
+            // @ts-expect-error extra properties not expected in the type
             activeDot: true,
             animateNewValues: true,
             animationBegin: 0,
@@ -1221,6 +1222,7 @@ describe('Tooltip visibility', () => {
       showTooltipOnCoordinate(container, RadarChartTestCase.mouseHoverSelector, RadarChartTestCase.mouseCoordinate);
 
       expectLastCalledWith(spy, {
+        // @ts-expect-error extra properties not expected in the type
         angle: -210,
         clockWise: false,
         cx: 300,

--- a/test/component/Tooltip/defaultIndex.spec.tsx
+++ b/test/component/Tooltip/defaultIndex.spec.tsx
@@ -7,6 +7,7 @@ import { selectActiveIndex, selectActiveLabel, selectTooltipPayload } from '../.
 import { expectTooltipPayload, showTooltip } from './tooltipTestHelpers';
 import { barChartMouseHoverTooltipSelector, pieChartMouseHoverTooltipSelector } from './tooltipMouseHoverSelectors';
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('defaultIndex', () => {
   describe('in BarChart', () => {
@@ -22,7 +23,7 @@ describe('defaultIndex', () => {
 
     it('should select tooltip payload', () => {
       const { spy } = renderTestCase(state => selectTooltipPayload(state, 'axis', 'hover', '3'));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: undefined,
           dataKey: 'uv',
@@ -49,7 +50,7 @@ describe('defaultIndex', () => {
       mockGetBoundingClientRect({ width: 100, height: 100 });
       const { container, spy } = renderTestCase(state => selectTooltipPayload(state, 'axis', 'hover', undefined));
       showTooltip(container, barChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: undefined,
           dataKey: 'uv',
@@ -92,7 +93,7 @@ describe('defaultIndex', () => {
 
     it('should select tooltip axis ticks', () => {
       const { spy } = renderTestCase(state => selectTooltipPayload(state, 'axis', 'hover', '3'));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: '#3182bd',
           dataKey: 'uv',
@@ -117,7 +118,7 @@ describe('defaultIndex', () => {
 
     it('should select active label', () => {
       const { spy } = renderTestCase(state => selectActiveLabel(state, 'axis', 'hover', '3'));
-      expect(spy).toHaveBeenLastCalledWith('Page D');
+      expectLastCalledWith(spy, 'Page D');
     });
 
     it('should render tooltip before user interaction', () => {
@@ -136,7 +137,7 @@ describe('defaultIndex', () => {
 
     it('should select active index as the default', () => {
       const { spy } = renderTestCase(state => selectActiveIndex(state, 'item', 'hover', '3'));
-      expect(spy).toHaveBeenLastCalledWith('3');
+      expectLastCalledWith(spy, '3');
     });
 
     it('should render sectors', () => {
@@ -147,12 +148,12 @@ describe('defaultIndex', () => {
     it('should update the active index after mouse hover', () => {
       const { container, spy } = renderTestCase(state => selectActiveIndex(state, 'item', 'hover', '3'));
       showTooltip(container, pieChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith('0');
+      expectLastCalledWith(spy, '0');
     });
 
     it('should select tooltip payload', () => {
       const { spy } = renderTestCase(state => selectTooltipPayload(state, 'item', 'hover', '3'));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: undefined,
           dataKey: 'pv',
@@ -178,7 +179,7 @@ describe('defaultIndex', () => {
     it('should update the payload after mouse hover', () => {
       const { container, spy } = renderTestCase(state => selectTooltipPayload(state, 'item', 'hover', '3'));
       showTooltip(container, pieChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: undefined,
           dataKey: 'pv',

--- a/test/component/Tooltip/itemSorter.spec.tsx
+++ b/test/component/Tooltip/itemSorter.spec.tsx
@@ -35,6 +35,7 @@ import {
 } from './tooltipMouseHoverSelectors';
 import { selectTooltipPayload, selectTooltipPayloadConfigurations } from '../../../src/state/selectors/selectors';
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('itemSorter in ComposedChart', () => {
   beforeEach(() => {
@@ -78,7 +79,7 @@ describe('itemSorter in ComposedChart', () => {
         const { spy } = renderTestCase(undefined, state =>
           selectTooltipPayloadConfigurations(state, 'axis', 'hover', '0'),
         );
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataDefinedOnItem: undefined,
             positions: undefined,
@@ -324,7 +325,7 @@ describe('itemSorter in ComposedChart', () => {
 
       it('should select payload sorted by name', () => {
         const { spy } = renderTestCase(undefined, state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             color: '#3182bd',
             dataKey: 'uv',
@@ -619,7 +620,7 @@ describe('itemSorter in ComposedChart', () => {
 
       it('should select payload sorted by name', () => {
         const { spy } = renderTestCase(undefined, state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             color: '#3182bd',
             dataKey: 'amt',
@@ -908,7 +909,7 @@ describe('itemSorter in PieChart', () => {
 
     it('should select payload with only one item so there is nothing to sort', () => {
       const { spy } = renderTestCase(undefined, state => selectTooltipPayload(state, 'item', 'hover', '0'));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           color: undefined,
           dataKey: 'uv',
@@ -965,7 +966,7 @@ describe('itemSorter in RadarChart', () => {
 
       it('should select payload sorted by name', () => {
         const { spy } = renderTestCase(undefined, state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             color: undefined,
             dataKey: 'uv',
@@ -1152,7 +1153,7 @@ describe('itemSorter in RadarChart', () => {
 
       it('should select payload sorted by name', () => {
         const { spy } = renderTestCase(undefined, state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             color: undefined,
             dataKey: 'uv',
@@ -1272,7 +1273,7 @@ describe('itemSorter in RadialBarChart', () => {
 
       it('should select payload sorted by name', () => {
         const { spy } = renderTestCase(undefined, state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             color: undefined,
             dataKey: 'uv',
@@ -1585,7 +1586,7 @@ describe('itemSorter in RadialBarChart', () => {
 
       it('should select payload sorted by name', () => {
         const { spy } = renderTestCase(undefined, state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             color: undefined,
             dataKey: 'uv',
@@ -1906,7 +1907,7 @@ describe('itemSorter in stacked BarChart', () => {
 
       it('should select payload sorted by name', () => {
         const { spy } = renderTestCase(undefined, state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             color: undefined,
             dataKey: 'pv',
@@ -2093,7 +2094,7 @@ describe('itemSorter in stacked BarChart', () => {
 
       it('should select payload sorted by name', () => {
         const { spy } = renderTestCase(undefined, state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             color: undefined,
             dataKey: 'pv',
@@ -2286,7 +2287,7 @@ describe('itemSorter in stacked AreaChart', () => {
 
       it('should select payload sorted by name', () => {
         const { spy } = renderTestCase(undefined, state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             color: '#3182bd',
             dataKey: 'pv',
@@ -2473,7 +2474,7 @@ describe('itemSorter in stacked AreaChart', () => {
 
       it('should select payload sorted by name', () => {
         const { spy } = renderTestCase(undefined, state => selectTooltipPayload(state, 'axis', 'hover', '0'));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             color: '#3182bd',
             dataKey: 'pv',

--- a/test/container/chartDimensions.spec.tsx
+++ b/test/container/chartDimensions.spec.tsx
@@ -7,6 +7,7 @@ import { selectBrushDimensions } from '../../src/state/selectors/brushSelectors'
 import { useClipPathId } from '../../src/container/ClipPathProvider';
 import { useIsPanorama } from '../../src/context/PanoramaContext';
 import { useAccessibilityLayer } from '../../src/context/accessibilityContext';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('Chart dimensions', () => {
   describe('simple chart', () => {
@@ -41,7 +42,7 @@ describe('Chart dimensions', () => {
 
     it('should return chart offset', () => {
       const { spy } = renderTestCase(useOffsetInternal);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         bottom: 13,
         brushBottom: 13,
         height: 176,
@@ -76,7 +77,7 @@ describe('Chart dimensions', () => {
 
     it('should select all brush dimensions = 0', () => {
       const { spy } = renderTestCase(selectBrushDimensions);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         height: 0,
         width: 0,
         x: 0,
@@ -166,7 +167,7 @@ describe('Chart dimensions', () => {
 
       it('should return chart offset', () => {
         const { spy } = renderTestCase(useOffsetInternal);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           bottom: 53,
           brushBottom: 13,
           height: 136,
@@ -213,7 +214,7 @@ describe('Chart dimensions', () => {
 
       it('should select brush dimensions', () => {
         const { spy } = renderTestCase(selectBrushDimensions);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           height: 40,
           width: 74,
           x: 14,
@@ -285,7 +286,7 @@ describe('Chart dimensions', () => {
 
       it('should return chart offset from the main chart', () => {
         const { spy } = renderTestCase(useOffsetInternal);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           bottom: 53,
           brushBottom: 13,
           height: 136,
@@ -316,7 +317,7 @@ describe('Chart dimensions', () => {
 
       it('should select brush dimensions', () => {
         const { spy } = renderTestCase(selectBrushDimensions);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           height: 40,
           width: 74,
           x: 14,

--- a/test/helper/expectLastCalledWith.ts
+++ b/test/helper/expectLastCalledWith.ts
@@ -4,10 +4,31 @@ import { Mock } from 'vitest';
  * Same as calling `expect(spy)toHaveBeenLastCalledWith(expected)` but this time it has correct typescript types.
  * This function will check that the type of `expected` is the same as the type of the argument of the spy.
  * @param spy vi.fn()
- * @param expected the expected argument that the spy was last called with
+ * @param expected1 the first expected argument
+ * @param expected2 the second expected argument (optional)
+ * @param expected3 the third expected argument (optional)
+ * @param expected4 the fourth expected argument (optional)
  * @throws if the spy was not called with the expected argument
  * @return void
  */
-export function expectLastCalledWith<T>(spy: Mock<(arg: T) => void>, expected: T): void {
-  expect(spy).toHaveBeenLastCalledWith(expected);
+export function expectLastCalledWith<T1, T2, T3, T4>(
+  spy: Mock<(arg1: T1, arg2: T2, arg3: T3, arg4: T4) => void>,
+  expected1: T1,
+  expected2?: T2,
+  expected3?: T3,
+  expected4?: T4,
+): void {
+  if (expected4 !== undefined) {
+    expect(spy).toHaveBeenLastCalledWith(expected1, expected2, expected3, expected4);
+    return;
+  }
+  if (expected3 !== undefined) {
+    expect(spy).toHaveBeenLastCalledWith(expected1, expected2, expected3);
+    return;
+  }
+  if (expected2 !== undefined) {
+    expect(spy).toHaveBeenLastCalledWith(expected1, expected2);
+    return;
+  }
+  expect(spy).toHaveBeenLastCalledWith(expected1);
 }

--- a/test/helper/expectLastCalledWith.ts
+++ b/test/helper/expectLastCalledWith.ts
@@ -1,0 +1,13 @@
+import { Mock } from 'vitest';
+
+/**
+ * Same as calling `expect(spy)toHaveBeenLastCalledWith(expected)` but this time it has correct typescript types.
+ * This function will check that the type of `expected` is the same as the type of the argument of the spy.
+ * @param spy vi.fn()
+ * @param expected the expected argument that the spy was last called with
+ * @throws if the spy was not called with the expected argument
+ * @return void
+ */
+export function expectLastCalledWith<T>(spy: Mock<(arg: T) => void>, expected: T): void {
+  expect(spy).toHaveBeenLastCalledWith(expected);
+}

--- a/test/hooks/useActiveTooltipDataPoints.spec.tsx
+++ b/test/hooks/useActiveTooltipDataPoints.spec.tsx
@@ -1,9 +1,19 @@
 import React, { ReactNode } from 'react';
 import { render } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { useActiveTooltipDataPoints } from '../../src/hooks';
+import {
+  useActiveTooltipDataPoints,
+  Area,
+  AreaChart,
+  Bar,
+  ComposedChart,
+  Line,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+} from '../../src';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
-import { Area, AreaChart, Bar, ComposedChart, Line, Scatter, ScatterChart, Tooltip, XAxis } from '../../src';
 import { PageData } from '../_data';
 import { hideTooltip, showTooltip, showTooltipClick } from '../component/Tooltip/tooltipTestHelpers';
 import {
@@ -12,6 +22,7 @@ import {
   scatterChartMouseHoverTooltipSelector,
 } from '../component/Tooltip/tooltipMouseHoverSelectors';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('useActiveTooltipDataPoints', () => {
   beforeEach(() => {
@@ -27,7 +38,7 @@ describe('useActiveTooltipDataPoints', () => {
         return null;
       };
       render(<Comp />);
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
@@ -43,7 +54,7 @@ describe('useActiveTooltipDataPoints', () => {
 
       it('should return undefined before any interactions', () => {
         const { spy } = renderTestCase(useActiveTooltipDataPoints);
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
@@ -51,7 +62,7 @@ describe('useActiveTooltipDataPoints', () => {
         const { container, spy } = renderTestCase(useActiveTooltipDataPoints);
         showTooltip(container, areaChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             amt: 2400,
             name: 'Page C',
@@ -67,7 +78,7 @@ describe('useActiveTooltipDataPoints', () => {
         showTooltip(container, areaChartMouseHoverTooltipSelector);
         hideTooltip(container, areaChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
         expect(spy).toHaveBeenCalledTimes(4);
       });
 
@@ -75,7 +86,7 @@ describe('useActiveTooltipDataPoints', () => {
         const { container, spy } = renderTestCase(useActiveTooltipDataPoints);
         showTooltipClick(container, areaChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
         expect(spy).toHaveBeenCalledTimes(3);
       });
     });
@@ -91,7 +102,7 @@ describe('useActiveTooltipDataPoints', () => {
 
       it('should return data point before any interactions', () => {
         const { spy } = renderTestCase(useActiveTooltipDataPoints);
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             amt: 2400,
             name: 'Page B',
@@ -106,7 +117,7 @@ describe('useActiveTooltipDataPoints', () => {
         const { container, spy } = renderTestCase(useActiveTooltipDataPoints);
         showTooltip(container, areaChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             amt: 2400,
             name: 'Page C',
@@ -122,7 +133,7 @@ describe('useActiveTooltipDataPoints', () => {
         showTooltip(container, areaChartMouseHoverTooltipSelector);
         hideTooltip(container, areaChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
         expect(spy).toHaveBeenCalledTimes(4);
       });
 
@@ -130,7 +141,7 @@ describe('useActiveTooltipDataPoints', () => {
         const { container, spy } = renderTestCase(useActiveTooltipDataPoints);
         showTooltipClick(container, areaChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             amt: 2400,
             name: 'Page B',
@@ -153,7 +164,7 @@ describe('useActiveTooltipDataPoints', () => {
 
       it('should return undefined before any interactions', () => {
         const { spy } = renderTestCase(useActiveTooltipDataPoints);
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
@@ -161,7 +172,7 @@ describe('useActiveTooltipDataPoints', () => {
         const { container, spy } = renderTestCase(useActiveTooltipDataPoints);
         showTooltip(container, areaChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             amt: 2400,
             name: 'Page C',
@@ -177,7 +188,7 @@ describe('useActiveTooltipDataPoints', () => {
         showTooltip(container, areaChartMouseHoverTooltipSelector);
         hideTooltip(container, areaChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             amt: 2400,
             name: 'Page C',
@@ -192,7 +203,7 @@ describe('useActiveTooltipDataPoints', () => {
         const { container, spy } = renderTestCase(useActiveTooltipDataPoints);
         showTooltipClick(container, areaChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
         expect(spy).toHaveBeenCalledTimes(3);
       });
     });
@@ -208,7 +219,7 @@ describe('useActiveTooltipDataPoints', () => {
 
       it('should return undefined before any interactions', () => {
         const { spy } = renderTestCase(useActiveTooltipDataPoints);
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
@@ -216,7 +227,7 @@ describe('useActiveTooltipDataPoints', () => {
         const { container, spy } = renderTestCase(useActiveTooltipDataPoints);
         showTooltipClick(container, areaChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             amt: 2400,
             name: 'Page C',
@@ -232,7 +243,7 @@ describe('useActiveTooltipDataPoints', () => {
         showTooltipClick(container, areaChartMouseHoverTooltipSelector);
         hideTooltip(container, areaChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             amt: 2400,
             name: 'Page C',
@@ -247,7 +258,7 @@ describe('useActiveTooltipDataPoints', () => {
         const { container, spy } = renderTestCase(useActiveTooltipDataPoints);
         showTooltip(container, areaChartMouseHoverTooltipSelector);
 
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
         expect(spy).toHaveBeenCalledTimes(3);
       });
     });
@@ -272,7 +283,7 @@ describe('useActiveTooltipDataPoints', () => {
        * but externally that looks just weird when it returns two of the same items.
        * So let's deduplicate.
        */
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           amt: 2400,
           name: 'Page A',
@@ -298,7 +309,7 @@ describe('useActiveTooltipDataPoints', () => {
       const { container, spy } = renderTestCase(useActiveTooltipDataPoints);
       showTooltip(container, composedChartMouseHoverTooltipSelector);
 
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           amt: 2400,
           name: 'Page C',
@@ -328,7 +339,7 @@ describe('useActiveTooltipDataPoints', () => {
       const { container, spy } = renderTestCase(useActiveTooltipDataPoints);
       showTooltip(container, composedChartMouseHoverTooltipSelector);
 
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         { name: 'Page C', pv: 1398 },
         { name: 'Page C', uv: 300 },
         { amt: 2400, name: 'Page C' },

--- a/test/polar/Pie.spec.tsx
+++ b/test/polar/Pie.spec.tsx
@@ -42,6 +42,7 @@ import { selectTooltipAxisId } from '../../src/state/selectors/selectTooltipAxis
 import { selectTooltipAxisType } from '../../src/state/selectors/selectTooltipAxisType';
 import { selectTooltipAxis } from '../../src/state/selectors/selectTooltipAxis';
 import { expectPieSectors } from '../helper/expectPieSectors';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 type CustomizedLabelLineProps = { points?: Array<Point> };
 
@@ -678,7 +679,7 @@ describe('<Pie />', () => {
       it('should start with empty tooltip state', () => {
         const { container, spy } = renderTestCase(state => state.tooltip.itemInteraction);
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           click: {
             active: false,
             index: null,
@@ -703,7 +704,7 @@ describe('<Pie />', () => {
         const { container, spy } = renderTestCase(state => state.tooltip.itemInteraction);
         showTooltipOnCoordinate(container, pieChartMouseHoverTooltipSelector, { clientX: 10, clientY: 10 });
         expect(spy).toHaveBeenCalledTimes(2);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           click: {
             active: false,
             index: null,
@@ -761,7 +762,7 @@ describe('<Pie />', () => {
         );
 
         expect(spy).toHaveBeenCalledTimes(4);
-        expect(spy).toHaveBeenLastCalledWith([]);
+        expectLastCalledWith(spy, []);
 
         showTooltipOnCoordinateTouch(container, pieChartMouseHoverTooltipSelector, {
           clientX: 200,
@@ -769,7 +770,7 @@ describe('<Pie />', () => {
         });
 
         expect(spy).toHaveBeenCalledTimes(5);
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataDefinedOnItem: [
               [
@@ -923,7 +924,7 @@ describe('<Pie />', () => {
         const { container, spy } = renderTestCase(state => state.tooltip.itemInteraction);
 
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           click: {
             active: false,
             coordinate: undefined,
@@ -944,7 +945,7 @@ describe('<Pie />', () => {
         });
 
         expect(spy).toHaveBeenCalledTimes(2);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           click: {
             active: false,
             coordinate: undefined,
@@ -970,7 +971,7 @@ describe('<Pie />', () => {
         const { container, spy } = renderTestCase(state => selectActiveIndex(state, 'item', 'hover', undefined));
 
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenLastCalledWith(null);
+        expectLastCalledWith(spy, null);
 
         showTooltipOnCoordinateTouch(container, pieChartMouseHoverTooltipSelector, {
           clientX: 10,
@@ -978,7 +979,7 @@ describe('<Pie />', () => {
         });
 
         expect(spy).toHaveBeenCalledTimes(2);
-        expect(spy).toHaveBeenLastCalledWith('2');
+        expectLastCalledWith(spy, '2');
       });
 
       it('should select coordinate after touch', () => {
@@ -991,7 +992,7 @@ describe('<Pie />', () => {
         const { container, spy } = renderTestCase(state => selectActiveCoordinate(state, 'item', 'hover', undefined));
 
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
 
         showTooltipOnCoordinateTouch(container, pieChartMouseHoverTooltipSelector, {
           clientX: 10,
@@ -999,12 +1000,12 @@ describe('<Pie />', () => {
         });
 
         expect(spy).toHaveBeenCalledTimes(2);
-        expect(spy).toHaveBeenLastCalledWith({ x: 122, y: 200 });
+        expectLastCalledWith(spy, { x: 122, y: 200 });
       });
 
       it('should select tooltip data', () => {
         const { container, spy } = renderTestCase(selectTooltipDisplayedData);
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             cx: 250,
             cy: 250,
@@ -1067,7 +1068,7 @@ describe('<Pie />', () => {
           clientY: 10,
         });
 
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             color: undefined,
             dataKey: 'cy',
@@ -1107,7 +1108,7 @@ describe('<Pie />', () => {
 
       it('should select tooltip axis', () => {
         const { spy } = renderTestCase(selectTooltipAxis);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: false,
           allowDuplicatedCategory: false,
@@ -1128,19 +1129,20 @@ describe('<Pie />', () => {
 
       it('should select tooltip axis type', () => {
         const { spy } = renderTestCase(selectTooltipAxisType);
-        expect(spy).toHaveBeenLastCalledWith('angleAxis');
+        expectLastCalledWith(spy, 'angleAxis');
       });
 
       it('should select tooltip axis ID', () => {
         const { spy } = renderTestCase(selectTooltipAxisId);
-        expect(spy).toHaveBeenLastCalledWith(0);
+        expectLastCalledWith(spy, 0);
       });
 
       it('should select unfiltered graphical items', () => {
         const { spy } = renderTestCase(selectAllUnfilteredGraphicalItems);
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             id: expect.stringMatching(/^pie-.+$/),
+            // @ts-expect-error unexpected property
             angleAxisId: 0,
             barSize: undefined,
             data: [
@@ -1200,9 +1202,10 @@ describe('<Pie />', () => {
 
       it('should select filtered graphical items', () => {
         const { spy } = renderTestCase(selectAllGraphicalItemsSettings);
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             id: expect.stringMatching(/^pie-.+$/),
+            // @ts-expect-error unexpected property
             angleAxisId: 0,
             barSize: undefined,
             data: [
@@ -1262,7 +1265,7 @@ describe('<Pie />', () => {
 
       it('should select displayed data', () => {
         const { spy } = renderTestCase(selectTooltipDisplayedData);
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             cx: 250,
             cy: 250,
@@ -1312,12 +1315,12 @@ describe('<Pie />', () => {
 
       it('should select tooltip axis domain', () => {
         const { spy } = renderTestCase(selectTooltipAxisDomain);
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4]);
+        expectLastCalledWith(spy, [0, 1, 2, 3, 4]);
       });
 
       it('should select tooltip axis domain with nice ticks', () => {
         const { spy } = renderTestCase(selectTooltipAxisDomainIncludingNiceTicks);
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4]);
+        expectLastCalledWith(spy, [0, 1, 2, 3, 4]);
       });
 
       it('should select tooltip axis scale', () => {
@@ -1328,7 +1331,7 @@ describe('<Pie />', () => {
       it('should select tooltip ticks', () => {
         const { spy } = renderTestCase(selectTooltipAxisTicks);
         expect(spy).toHaveBeenCalledTimes(3);
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             coordinate: -72,
             value: 0,
@@ -1369,7 +1372,7 @@ describe('<Pie />', () => {
         });
         const { container, spy } = renderTestCase(state => state.tooltip.itemInteraction);
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           click: {
             active: false,
             index: null,
@@ -1395,7 +1398,7 @@ describe('<Pie />', () => {
         const { container, spy } = renderTestCase(state => state.tooltip.itemInteraction);
         showTooltipOnCoordinate(container, pieChartMouseHoverTooltipSelector, { clientX: 10, clientY: 10 });
         expect(spy).toHaveBeenCalledTimes(2);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           click: {
             active: false,
             index: null,
@@ -1646,7 +1649,7 @@ describe('<Pie />', () => {
       );
 
       expect(spy).toHaveBeenCalledTimes(2);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           angleAxisId: 0,
           barSize: undefined,
@@ -1668,7 +1671,7 @@ describe('<Pie />', () => {
       );
 
       expect(spy).toHaveBeenCalledTimes(4);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           angleAxisId: 0,
           barSize: undefined,
@@ -1698,7 +1701,7 @@ describe('<Pie />', () => {
       );
 
       expect(spy).toHaveBeenCalledTimes(2);
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           angleAxisId: 0,
           barSize: undefined,

--- a/test/polar/PolarAngleAxis.spec.tsx
+++ b/test/polar/PolarAngleAxis.spec.tsx
@@ -25,6 +25,7 @@ import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { RadialBarSettings } from '../../src/state/selectors/radialBarSelectors';
 import { useIsPanorama } from '../../src/context/PanoramaContext';
 import { TickItemTextProps } from '../../src/polar/PolarAngleAxis';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 type ExpectedAngleAxisTick = {
   x1: string;
@@ -118,7 +119,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select angle axis settings', () => {
         const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: false,
@@ -140,7 +141,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select polar items', () => {
         const { spy } = renderTestCase(state => selectPolarItemsSettings(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             id: expect.stringMatching('radar-'),
             barSize: undefined,
@@ -158,19 +159,19 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([420, 460, 999, 500, 864, 650, 765, 365]);
+        expectLastCalledWith(spy, [420, 460, 999, 500, 864, 650, 765, 365]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([90, -270]);
+        expectLastCalledWith(spy, [90, -270]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('band');
+        expectLastCalledWith(spy, 'band');
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
@@ -182,7 +183,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'angleAxis', 0, false));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             coordinate: 90,
             index: 0,
@@ -237,13 +238,13 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select nice ticks', () => {
         const { spy } = renderTestCase(state => selectNiceTicks(state, 'angleAxis', 0, false));
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select applied data', () => {
         const { spy } = renderTestCase(state => selectPolarAppliedValues(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           { value: 420 },
           { value: 460 },
           { value: 999 },
@@ -368,7 +369,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select angle axis settings', () => {
         const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: false,
@@ -390,7 +391,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select polar items', () => {
         const { spy } = renderTestCase(state => selectPolarItemsSettings(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             id: expect.stringMatching('radar-'),
             barSize: undefined,
@@ -408,19 +409,19 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7]);
+        expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5, 6, 7]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([90, -270]);
+        expectLastCalledWith(spy, [90, -270]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('band');
+        expectLastCalledWith(spy, 'band');
       });
 
       it('should select scale', () => {
@@ -431,7 +432,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select applied data', () => {
         const { spy } = renderTestCase(state => selectPolarAppliedValues(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           { value: 420 },
           { value: 460 },
           { value: 999 },
@@ -555,7 +556,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select angle axis settings', () => {
         const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: false,
           allowDuplicatedCategory: false,
@@ -577,7 +578,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select polar items', () => {
         const { spy } = renderTestCase(state => selectPolarItemsSettings(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             id: expect.stringMatching('radar-'),
             barSize: undefined,
@@ -595,7 +596,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select applied values', () => {
         const { spy } = renderTestCase(state => selectPolarAppliedValues(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           { value: 420 },
           { value: 460 },
           { value: 999 },
@@ -609,19 +610,19 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7]);
+        expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5, 6, 7]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([90, -270]);
+        expectLastCalledWith(spy, [90, -270]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('band');
+        expectLastCalledWith(spy, 'band');
       });
 
       it('should select scale', () => {
@@ -659,7 +660,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select axis settings', () => {
         const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: false,
@@ -681,7 +682,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select polar items', () => {
         const { spy } = renderTestCase(state => selectPolarItemsSettings(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             id: expect.stringMatching('radar-'),
             barSize: undefined,
@@ -699,19 +700,19 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select angle axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 360]);
+        expectLastCalledWith(spy, [0, 360]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select angle axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([90, -270]);
+        expectLastCalledWith(spy, [90, -270]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('linear');
+        expectLastCalledWith(spy, 'linear');
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
@@ -723,7 +724,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'angleAxis', 0, false));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             coordinate: 90,
             index: 0,
@@ -754,13 +755,13 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select nice ticks', () => {
         const { spy } = renderTestCase(state => selectNiceTicks(state, 'angleAxis', 0, false));
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select applied data', () => {
         const { spy } = renderTestCase(state => selectPolarAppliedValues(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([{ value: 0 }, { value: 90 }, { value: 180 }, { value: 270 }]);
+        expectLastCalledWith(spy, [{ value: 0 }, { value: 90 }, { value: 180 }, { value: 270 }]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
@@ -1712,7 +1713,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select axis settings', () => {
         const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: false,
@@ -1733,7 +1734,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select applied values', () => {
         const { spy } = renderTestCase(state => selectPolarAppliedValues(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           { value: 400 },
           { value: 300 },
           { value: 300 },
@@ -1746,13 +1747,13 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([400, 300, 200, 278, 189]);
+        expectLastCalledWith(spy, [400, 300, 200, 278, 189]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 360]);
+        expectLastCalledWith(spy, [0, 360]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
@@ -1763,13 +1764,13 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('linear');
+        expectLastCalledWith(spy, 'linear');
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select polarItemsSettings', () => {
         const { spy } = renderTestCase(state => selectPolarItemsSettings(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             id: expect.stringMatching('radialBar-'),
             barSize: undefined,
@@ -1786,17 +1787,28 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'angleAxis', 0, false));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 0, value: 400, offset: -0 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 34.12322274881516, value: 380, offset: -0 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 68.24644549763032, value: 360, offset: -0 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 102.36966824644551, value: 340, offset: -0 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 136.49289099526067, value: 320, offset: -0 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 170.61611374407585, value: 300, offset: -0 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 204.739336492891, value: 280, offset: -0 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 238.86255924170615, value: 260, offset: -0 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 272.98578199052133, value: 240, offset: -0 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 307.1090047393365, value: 220, offset: -0 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 341.2322274881517, value: 200, offset: -0 },
         ]);
         expect(spy).toHaveBeenCalledTimes(3);
@@ -1823,7 +1835,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select axis settings', () => {
         const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: false,
           allowDuplicatedCategory: true,
@@ -1844,7 +1856,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select applied values', () => {
         const { spy } = renderTestCase(state => selectPolarAppliedValues(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           { value: 400 },
           { value: 300 },
           { value: 300 },
@@ -1857,13 +1869,13 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 400]);
+        expectLastCalledWith(spy, [0, 400]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 360]);
+        expectLastCalledWith(spy, [0, 360]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
@@ -1875,13 +1887,13 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('linear');
+        expectLastCalledWith(spy, 'linear');
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select polarItemsSettings', () => {
         const { spy } = renderTestCase(state => selectPolarItemsSettings(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             id: expect.stringMatching('radialBar-'),
             barSize: undefined,
@@ -1898,15 +1910,24 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'angleAxis', 0, false));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 0, offset: -0, value: 0 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 45, offset: -0, value: 50 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 90, offset: -0, value: 100 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 135, offset: -0, value: 150 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 180, offset: -0, value: 200 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 225, offset: -0, value: 250 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 270, offset: -0, value: 300 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 315, offset: -0, value: 350 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
           { coordinate: 360, offset: -0, value: 400 },
         ]);
         expect(spy).toHaveBeenCalledTimes(3);
@@ -1925,7 +1946,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select axis settings', () => {
         const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: false,
@@ -1946,13 +1967,13 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([400, 300, 200, 278, 189]);
+        expectLastCalledWith(spy, [400, 300, 200, 278, 189]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([360, 0]);
+        expectLastCalledWith(spy, [360, 0]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
@@ -2108,7 +2129,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select axis settings', () => {
         const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: false,
@@ -2129,7 +2150,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select polar chart options', () => {
         const { spy } = renderTestCase(selectPolarOptions);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           startAngle: 20,
           endAngle: 220,
           cx: '50%',
@@ -2141,13 +2162,13 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select axis domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 9]);
+        expectLastCalledWith(spy, [0, 9]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select axis range', () => {
         const { spy } = renderTestCase(state => selectAngleAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([20, 220]);
+        expectLastCalledWith(spy, [20, 220]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
@@ -2388,7 +2409,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([31.47, 26.69, 15.69, 8.22, 8.63, 2.63, 6.67]);
+        expectLastCalledWith(spy, [31.47, 26.69, 15.69, 8.22, 8.63, 2.63, 6.67]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
@@ -2429,7 +2450,7 @@ describe('<PolarAngleAxis />', () => {
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 9800]);
+        expectLastCalledWith(spy, [0, 9800]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
@@ -2758,7 +2779,7 @@ describe('<PolarAngleAxis />', () => {
 
     it('should select ticks', () => {
       const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'angleAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         { coordinate: 90, index: 0, offset: 45, value: 'iPhone 3GS' },
         { coordinate: 45, index: 1, offset: 45, value: 'iPhone 4' },
         { coordinate: 0, index: 2, offset: 45, value: 'iPhone 4s' },

--- a/test/polar/PolarGrid.spec.tsx
+++ b/test/polar/PolarGrid.spec.tsx
@@ -667,15 +667,25 @@ describe('<PolarGrid />', () => {
     it('should select angle ticks', () => {
       const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'angleAxis', 0, false));
       expectLastCalledWith(spy, [
+        // @ts-expect-error the type demands an `index` property but the selector does not return it
         { coordinate: 0, value: 0, offset: -0 },
+        // @ts-expect-error the type demands an `index` property but the selector does not return it
         { coordinate: 40, value: 1, offset: -0 },
+        // @ts-expect-error the type demands an `index` property but the selector does not return it
         { coordinate: 80, value: 2, offset: -0 },
+        // @ts-expect-error the type demands an `index` property but the selector does not return it
         { coordinate: 120, value: 3, offset: -0 },
+        // @ts-expect-error the type demands an `index` property but the selector does not return it
         { coordinate: 160, value: 4, offset: -0 },
+        // @ts-expect-error the type demands an `index` property but the selector does not return it
         { coordinate: 200, value: 5, offset: -0 },
+        // @ts-expect-error the type demands an `index` property but the selector does not return it
         { coordinate: 240, value: 6, offset: -0 },
+        // @ts-expect-error the type demands an `index` property but the selector does not return it
         { coordinate: 280, value: 7, offset: -0 },
+        // @ts-expect-error the type demands an `index` property but the selector does not return it
         { coordinate: 320, value: 8, offset: -0 },
+        // @ts-expect-error the type demands an `index` property but the selector does not return it
         { coordinate: 360, value: 9, offset: -0 },
       ]);
     });
@@ -903,46 +913,22 @@ describe('<PolarGrid />', () => {
       it('should select ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'angleAxis', 'axis-uv', false));
         expectLastCalledWith(spy, [
-          {
-            coordinate: 0,
-            offset: -0,
-            value: 0,
-          },
-          {
-            coordinate: 47.368421052631575,
-            offset: -0,
-            value: 200,
-          },
-          {
-            coordinate: 94.73684210526315,
-            offset: -0,
-            value: 400,
-          },
-          {
-            coordinate: 142.10526315789474,
-            offset: -0,
-            value: 600,
-          },
-          {
-            coordinate: 189.4736842105263,
-            offset: -0,
-            value: 800,
-          },
-          {
-            coordinate: 236.84210526315792,
-            offset: -0,
-            value: 1000,
-          },
-          {
-            coordinate: 284.2105263157895,
-            offset: -0,
-            value: 1200,
-          },
-          {
-            coordinate: 331.57894736842104,
-            offset: -0,
-            value: 1400,
-          },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
+          { coordinate: 0, offset: -0, value: 0 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
+          { coordinate: 47.368421052631575, offset: -0, value: 200 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
+          { coordinate: 94.73684210526315, offset: -0, value: 400 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
+          { coordinate: 142.10526315789474, offset: -0, value: 600 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
+          { coordinate: 189.4736842105263, offset: -0, value: 800 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
+          { coordinate: 236.84210526315792, offset: -0, value: 1000 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
+          { coordinate: 284.2105263157895, offset: -0, value: 1200 },
+          // @ts-expect-error the type demands an `index` property but the selector does not return it
+          { coordinate: 331.57894736842104, offset: -0, value: 1400 },
         ]);
       });
 

--- a/test/polar/PolarGrid.spec.tsx
+++ b/test/polar/PolarGrid.spec.tsx
@@ -23,6 +23,7 @@ import { selectPolarGridAngles, selectPolarGridRadii } from '../../src/state/sel
 import { expectLastCalledWithScale } from '../helper/expectScale';
 import { selectAllPolarAppliedNumericalValues, selectPolarNiceTicks } from '../../src/state/selectors/polarSelectors';
 import { TickItem } from '../../src/util/types';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 type ExpectedLine = {
   x1: string;
@@ -522,7 +523,7 @@ describe('<PolarGrid />', () => {
 
     it('should select radius axis settings', () => {
       const { spy } = renderTestCase(state => selectPolarAxis(state, 'radiusAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: false,
         allowDuplicatedCategory: true,
@@ -552,12 +553,12 @@ describe('<PolarGrid />', () => {
 
     it('should select categorical domain', () => {
       const { spy } = renderTestCase(state => selectPolarCategoricalDomain(state, 'radiusAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
     });
 
     it('should select all polar applied values', () => {
       const { spy } = renderTestCase(state => selectAllPolarAppliedNumericalValues(state, 'radiusAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           errorDomain: [],
           value: 3,
@@ -579,7 +580,7 @@ describe('<PolarGrid />', () => {
 
     it('should select radius axis ticks', () => {
       const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'radiusAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           coordinate: 14.5,
           index: 0,
@@ -644,7 +645,7 @@ describe('<PolarGrid />', () => {
 
     it('should select angle axis settings', () => {
       const { spy } = renderTestCase(state => selectPolarAxis(state, 'angleAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: false,
         allowDuplicatedCategory: true,
@@ -665,7 +666,7 @@ describe('<PolarGrid />', () => {
 
     it('should select angle ticks', () => {
       const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'angleAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         { coordinate: 0, value: 0, offset: -0 },
         { coordinate: 40, value: 1, offset: -0 },
         { coordinate: 80, value: 2, offset: -0 },
@@ -681,7 +682,7 @@ describe('<PolarGrid />', () => {
 
     it('should select grid angles', () => {
       const { spy } = renderTestCase(state => selectPolarGridAngles(state, 0));
-      expect(spy).toHaveBeenLastCalledWith([0, 40, 80, 120, 160, 200, 240, 280, 320, 360]);
+      expectLastCalledWith(spy, [0, 40, 80, 120, 160, 200, 240, 280, 320, 360]);
     });
 
     it('should render lines', () => {
@@ -848,12 +849,12 @@ describe('<PolarGrid />', () => {
             index: 2,
           },
         ];
-        expect(spy).toHaveBeenLastCalledWith(expected);
+        expectLastCalledWith(spy, expected);
       });
 
       it('should select angles', () => {
         const { spy } = renderTestCase(state => selectPolarGridAngles(state, 'axis-pv'));
-        expect(spy).toHaveBeenLastCalledWith([0, 180, 360]);
+        expectLastCalledWith(spy, [0, 180, 360]);
       });
     });
 
@@ -867,7 +868,7 @@ describe('<PolarGrid />', () => {
 
       it('should select axis settings', () => {
         const { spy } = renderTestCase(state => selectPolarAxis(state, 'angleAxis', 'axis-uv'));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: false,
@@ -888,7 +889,7 @@ describe('<PolarGrid />', () => {
 
       it('should select nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarNiceTicks(state, 'angleAxis', 'axis-uv'));
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
       });
 
       it('should select scale', () => {
@@ -901,7 +902,7 @@ describe('<PolarGrid />', () => {
 
       it('should select ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'angleAxis', 'axis-uv', false));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             coordinate: 0,
             offset: -0,
@@ -947,10 +948,13 @@ describe('<PolarGrid />', () => {
 
       it('should select angles', () => {
         const { spy } = renderTestCase(state => selectPolarGridAngles(state, 'axis-uv'));
-        expect(spy).toHaveBeenLastCalledWith([
-          0, 47.368421052631575, 94.73684210526315, 142.10526315789474, 189.4736842105263, 236.84210526315792,
-          284.2105263157895, 331.57894736842104,
-        ]);
+        expectLastCalledWith(
+          spy,
+          [
+            0, 47.368421052631575, 94.73684210526315, 142.10526315789474, 189.4736842105263, 236.84210526315792,
+            284.2105263157895, 331.57894736842104,
+          ],
+        );
       });
 
       it('should render lines pointing to labels of second angle axis', () => {
@@ -1123,7 +1127,7 @@ describe('<PolarGrid />', () => {
 
       it('should select nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarNiceTicks(state, 'radiusAxis', 'axis-name'));
-        expect(spy).toHaveBeenLastCalledWith(undefined);
+        expectLastCalledWith(spy, undefined);
       });
 
       it('should select scale', () => {
@@ -1136,7 +1140,7 @@ describe('<PolarGrid />', () => {
 
       it('should select ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'radiusAxis', 'axis-name', false));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             coordinate: 8.28571428571428,
             value: 'Page A',
@@ -1184,10 +1188,13 @@ describe('<PolarGrid />', () => {
 
       it('should select array of radii', () => {
         const { spy } = renderTestCase(state => selectPolarGridRadii(state, 'axis-name'));
-        expect(spy).toHaveBeenLastCalledWith([
-          8.28571428571428, 24.857142857142854, 41.42857142857142, 58, 74.57142857142857, 91.14285714285715,
-          107.71428571428574,
-        ]);
+        expectLastCalledWith(
+          spy,
+          [
+            8.28571428571428, 24.857142857142854, 41.42857142857142, 58, 74.57142857142857, 91.14285714285715,
+            107.71428571428574,
+          ],
+        );
       });
     });
   });

--- a/test/polar/PolarRadiusAxis.spec.tsx
+++ b/test/polar/PolarRadiusAxis.spec.tsx
@@ -21,6 +21,7 @@ import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { selectPolarAxisScale } from '../../src/state/selectors/polarScaleSelectors';
 import { expectLastCalledWithScale } from '../helper/expectScale';
 import { useIsPanorama } from '../../src/context/PanoramaContext';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 type ExpectedRadiusAxisTick = {
   x: string;
@@ -82,7 +83,7 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select angle settings', () => {
         const { spy } = renderTestCase(state => selectRadiusAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: true,
@@ -104,25 +105,25 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 999]);
+        expectLastCalledWith(spy, [0, 999]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('linear');
+        expectLastCalledWith(spy, 'linear');
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 1000]);
+        expectLastCalledWith(spy, [0, 1000]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 196]);
+        expectLastCalledWith(spy, [0, 196]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
@@ -199,7 +200,7 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select angle settings', () => {
         const { spy } = renderTestCase(state => selectRadiusAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: true,
@@ -221,7 +222,7 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           'iPhone 3GS',
           'iPhone 4',
           'iPhone 4s',
@@ -236,13 +237,13 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('band');
+        expectLastCalledWith(spy, 'band');
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           'iPhone 3GS',
           'iPhone 4',
           'iPhone 4s',
@@ -332,7 +333,7 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select axis settings', () => {
         const { spy } = renderTestCase(state => selectRadiusAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: true,
@@ -354,25 +355,25 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 999]);
+        expectLastCalledWith(spy, [0, 999]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('linear');
+        expectLastCalledWith(spy, 'linear');
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 1000]);
+        expectLastCalledWith(spy, [0, 1000]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 196]);
+        expectLastCalledWith(spy, [0, 196]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
@@ -439,31 +440,31 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select angle settings', () => {
         const { spy } = renderTestCase(state => selectRadiusAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith(implicitRadiusAxis);
+        expectLastCalledWith(spy, implicitRadiusAxis);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 999]);
+        expectLastCalledWith(spy, [0, 999]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('linear');
+        expectLastCalledWith(spy, 'linear');
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 1000]);
+        expectLastCalledWith(spy, [0, 1000]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 196]);
+        expectLastCalledWith(spy, [0, 196]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
@@ -729,31 +730,31 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select angle settings', () => {
         const { spy } = renderTestCase(state => selectRadiusAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith(implicitRadialBarRadiusAxis);
+        expectLastCalledWith(spy, implicitRadialBarRadiusAxis);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+        expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('band');
+        expectLastCalledWith(spy, 'band');
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+        expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 196]);
+        expectLastCalledWith(spy, [0, 196]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
@@ -790,7 +791,7 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select angle settings', () => {
         const { spy } = renderTestCase(state => selectRadiusAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: true,
@@ -812,25 +813,25 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+        expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('band');
+        expectLastCalledWith(spy, 'band');
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+        expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 196]);
+        expectLastCalledWith(spy, [0, 196]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
@@ -904,7 +905,7 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select angle settings', () => {
         const { spy } = renderTestCase(state => selectRadiusAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: true,
@@ -926,25 +927,25 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 400]);
+        expectLastCalledWith(spy, [0, 400]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('band');
+        expectLastCalledWith(spy, 'band');
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 400]);
+        expectLastCalledWith(spy, [0, 400]);
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 196]);
+        expectLastCalledWith(spy, [0, 196]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
@@ -991,7 +992,7 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select angle settings', () => {
         const { spy } = renderTestCase(state => selectRadiusAxis(state, 0));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: undefined,
           allowDuplicatedCategory: true,
@@ -1013,25 +1014,25 @@ describe('<PolarRadiusAxis />', () => {
 
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 400]);
+        expectLastCalledWith(spy, [0, 400]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select real scale type', () => {
         const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith('band');
+        expectLastCalledWith(spy, 'band');
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
       it('should select domain with nice ticks', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomainIncludingNiceTicks(state, 'radiusAxis', 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 400]);
+        expectLastCalledWith(spy, [0, 400]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
       it('should select range', () => {
         const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
-        expect(spy).toHaveBeenLastCalledWith([0, 196]);
+        expectLastCalledWith(spy, [0, 196]);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 

--- a/test/polar/RadialBar.spec.tsx
+++ b/test/polar/RadialBar.spec.tsx
@@ -39,6 +39,7 @@ import {
 } from '../../src/state/selectors/polarAxisSelectors';
 import { selectBarCategoryGap, selectBarGap, selectRootMaxBarSize } from '../../src/state/selectors/rootPropsSelectors';
 import { selectRealScaleType } from '../../src/state/selectors/axisSelectors';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('<RadialBar />', () => {
   describe('with implicit axes', () => {
@@ -60,7 +61,7 @@ describe('<RadialBar />', () => {
 
     it('should select polar items', () => {
       const { spy } = renderTestCase(state => selectPolarItemsSettings(state, 'angleAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           id: expect.stringMatching('radialBar-'),
           angleAxisId: 0,
@@ -77,7 +78,7 @@ describe('<RadialBar />', () => {
 
     it('should select angle axis settings', () => {
       const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: false,
         // generator has allowDuplicatedCategory set to true, but the actual axis rendering ignores the prop
@@ -107,7 +108,7 @@ describe('<RadialBar />', () => {
 
     it('should select radius axis settings', () => {
       const { spy } = renderTestCase(state => selectRadiusAxis(state, 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: false,
         allowDuplicatedCategory: true,
@@ -136,7 +137,7 @@ describe('<RadialBar />', () => {
 
     it('should select radius axis ticks', () => {
       const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'radiusAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           coordinate: 16.333333333333332,
           index: 0,
@@ -178,22 +179,22 @@ describe('<RadialBar />', () => {
 
     it('should select barBandSize', () => {
       const { spy } = renderTestCase(state => selectBandSizeOfPolarAxis(state, 0, 0, false));
-      expect(spy).toHaveBeenLastCalledWith(32.666666666666664);
+      expectLastCalledWith(spy, 32.666666666666664);
     });
 
     it('should pick childMaxBarSize', () => {
       const { spy } = renderTestCase(state => pickMaxBarSize(state, 0, 0, radialBarSettings, undefined));
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
     });
 
     it('should select selectRootMaxBarSize', () => {
       const { spy } = renderTestCase(selectRootMaxBarSize);
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
     });
 
     it('should select bar size list', () => {
       const { spy } = renderTestCase(state => selectPolarBarSizeList(state, 0, 0, radialBarSettings, undefined));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           barSize: undefined,
           dataKeys: ['pv'],
@@ -204,28 +205,29 @@ describe('<RadialBar />', () => {
 
     it('should select barGap', () => {
       const { spy } = renderTestCase(selectBarGap);
-      expect(spy).toHaveBeenLastCalledWith(4);
+      expectLastCalledWith(spy, 4);
     });
 
     it('should select barCategoryGap', () => {
       const { spy } = renderTestCase(selectBarCategoryGap);
-      expect(spy).toHaveBeenLastCalledWith('10%');
+      expectLastCalledWith(spy, '10%');
     });
 
     it('should select bandSize', () => {
       const { spy } = renderTestCase(state => selectPolarBarBandSize(state, 0, 0, radialBarSettings, undefined));
-      expect(spy).toHaveBeenLastCalledWith(32.666666666666664);
+      expectLastCalledWith(spy, 32.666666666666664);
     });
 
     it('should select bar position and offset', () => {
       const { spy } = renderTestCase(state => selectPolarBarPosition(state, 0, 0, radialBarSettings, undefined));
-      expect(spy).toHaveBeenLastCalledWith({ offset: 3.266666666666666, size: 26 });
+      expectLastCalledWith(spy, { offset: 3.266666666666666, size: 26 });
     });
 
     it('should select radial bar sectors', () => {
       const { spy } = renderTestCase(state => selectRadialBarSectors(state, 0, 0, radialBarSettings, undefined));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
+          // @ts-expect-error extra properties not expected in the type
           amt: 2400,
           background: {
             cx: 250,
@@ -253,6 +255,7 @@ describe('<RadialBar />', () => {
           value: 2400,
         },
         {
+          // @ts-expect-error extra properties not expected in the type
           amt: 2400,
           background: {
             cx: 250,
@@ -280,6 +283,7 @@ describe('<RadialBar />', () => {
           value: 4567,
         },
         {
+          // @ts-expect-error extra properties not expected in the type
           amt: 2400,
           background: {
             cx: 250,
@@ -307,6 +311,7 @@ describe('<RadialBar />', () => {
           value: 1398,
         },
         {
+          // @ts-expect-error extra properties not expected in the type
           amt: 2400,
           background: {
             cx: 250,
@@ -334,6 +339,7 @@ describe('<RadialBar />', () => {
           value: 9800,
         },
         {
+          // @ts-expect-error extra properties not expected in the type
           amt: 2400,
           background: {
             cx: 250,
@@ -361,6 +367,7 @@ describe('<RadialBar />', () => {
           value: 3908,
         },
         {
+          // @ts-expect-error extra properties not expected in the type
           amt: 2400,
           background: {
             cx: 250,
@@ -437,7 +444,7 @@ describe('<RadialBar />', () => {
 
     it('should select polar items', () => {
       const { spy } = renderTestCase(state => selectPolarItemsSettings(state, 'angleAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           id: expect.stringMatching('radialBar-'),
           angleAxisId: 0,
@@ -454,7 +461,7 @@ describe('<RadialBar />', () => {
 
     it('should select angle axis settings', () => {
       const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: undefined,
         allowDuplicatedCategory: false,
@@ -483,7 +490,7 @@ describe('<RadialBar />', () => {
 
     it('should select radius axis settings', () => {
       const { spy } = renderTestCase(state => selectRadiusAxis(state, 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: undefined,
         allowDuplicatedCategory: true,
@@ -504,7 +511,7 @@ describe('<RadialBar />', () => {
 
     it('should select radius axis realScaleType', () => {
       const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith('band');
+      expectLastCalledWith(spy, 'band');
     });
 
     it('should select radius axis scale', () => {
@@ -518,12 +525,12 @@ describe('<RadialBar />', () => {
 
     it('should select radius axis range', () => {
       const { spy } = renderTestCase(state => selectRadiusAxisRangeWithReversed(state, 0));
-      expect(spy).toHaveBeenLastCalledWith([0, 196]);
+      expectLastCalledWith(spy, [0, 196]);
     });
 
     it('should select radius axis ticks', () => {
       const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'radiusAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           coordinate: 16.333333333333332,
           index: 0,
@@ -565,17 +572,17 @@ describe('<RadialBar />', () => {
 
     it('should select bar size and offset', () => {
       const { spy } = renderTestCase(state => selectPolarBarPosition(state, 0, 0, radialBarSettings, undefined));
-      expect(spy).toHaveBeenLastCalledWith({ offset: 3.266666666666666, size: 26 });
+      expectLastCalledWith(spy, { offset: 3.266666666666666, size: 26 });
     });
 
     it('should select bandSize', () => {
       const { spy } = renderTestCase(state => selectPolarBarBandSize(state, 0, 0, radialBarSettings, undefined));
-      expect(spy).toHaveBeenLastCalledWith(32.666666666666664);
+      expectLastCalledWith(spy, 32.666666666666664);
     });
 
     it('should select bar size list', () => {
       const { spy } = renderTestCase(state => selectPolarBarSizeList(state, 0, 0, radialBarSettings, undefined));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           barSize: undefined,
           dataKeys: ['pv'],
@@ -586,18 +593,19 @@ describe('<RadialBar />', () => {
 
     it('should select barGap', () => {
       const { spy } = renderTestCase(selectBarGap);
-      expect(spy).toHaveBeenLastCalledWith(4);
+      expectLastCalledWith(spy, 4);
     });
 
     it('should select barCategoryGap', () => {
       const { spy } = renderTestCase(selectBarCategoryGap);
-      expect(spy).toHaveBeenLastCalledWith('10%');
+      expectLastCalledWith(spy, '10%');
     });
 
     it('should select radial bar sectors', () => {
       const { spy } = renderTestCase(state => selectRadialBarSectors(state, 0, 0, radialBarSettings, undefined));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
+          // @ts-expect-error extra properties not expected in the type
           amt: 2400,
           background: {
             cx: 250,
@@ -625,6 +633,7 @@ describe('<RadialBar />', () => {
           value: 2400,
         },
         {
+          // @ts-expect-error extra properties not expected in the type
           amt: 2400,
           background: {
             cx: 250,
@@ -652,6 +661,7 @@ describe('<RadialBar />', () => {
           value: 4567,
         },
         {
+          // @ts-expect-error extra properties not expected in the type
           amt: 2400,
           background: {
             cx: 250,
@@ -679,6 +689,7 @@ describe('<RadialBar />', () => {
           value: 1398,
         },
         {
+          // @ts-expect-error extra properties not expected in the type
           amt: 2400,
           background: {
             cx: 250,
@@ -706,6 +717,7 @@ describe('<RadialBar />', () => {
           value: 9800,
         },
         {
+          // @ts-expect-error extra properties not expected in the type
           amt: 2400,
           background: {
             cx: 250,
@@ -733,6 +745,7 @@ describe('<RadialBar />', () => {
           value: 3908,
         },
         {
+          // @ts-expect-error extra properties not expected in the type
           amt: 2400,
           background: {
             cx: 250,
@@ -809,7 +822,7 @@ describe('<RadialBar />', () => {
 
     it('should select polar items', () => {
       const { spy } = renderTestCase(state => selectPolarItemsSettings(state, 'angleAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           id: expect.stringMatching('radialBar-'),
           angleAxisId: 0,
@@ -826,7 +839,7 @@ describe('<RadialBar />', () => {
 
     it('should select angle axis settings', () => {
       const { spy } = renderTestCase(state => selectAngleAxis(state, 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: undefined,
         allowDuplicatedCategory: false,
@@ -847,7 +860,7 @@ describe('<RadialBar />', () => {
 
     it('should select angle axis realScaleType', () => {
       const { spy } = renderTestCase(state => selectRealScaleType(state, 'angleAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith('linear');
+      expectLastCalledWith(spy, 'linear');
     });
 
     it('should select angle axis scale', () => {
@@ -860,7 +873,7 @@ describe('<RadialBar />', () => {
 
     it('should select radius axis settings', () => {
       const { spy } = renderTestCase(state => selectRadiusAxis(state, 0));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: undefined,
         allowDuplicatedCategory: true,
@@ -881,7 +894,7 @@ describe('<RadialBar />', () => {
 
     it('should select radius axis realScaleType', () => {
       const { spy } = renderTestCase(state => selectRealScaleType(state, 'radiusAxis', 0));
-      expect(spy).toHaveBeenLastCalledWith('band');
+      expectLastCalledWith(spy, 'band');
     });
 
     it('should select radius axis scale', () => {
@@ -895,7 +908,7 @@ describe('<RadialBar />', () => {
 
     it('should select radius axis ticks for axis', () => {
       const { spy } = renderTestCase(state => selectPolarAxisTicks(state, 'radiusAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         { coordinate: 24.5, index: 0, offset: 24.5, value: 0 },
         { coordinate: 73.5, index: 1, offset: 24.5, value: 1 },
         { coordinate: 122.5, index: 2, offset: 24.5, value: 2 },
@@ -905,7 +918,7 @@ describe('<RadialBar />', () => {
 
     it('should select radius axis ticks for graphical item', () => {
       const { spy } = renderTestCase(state => selectPolarGraphicalItemAxisTicks(state, 'radiusAxis', 0, false));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         { coordinate: 0, value: 0, index: 0, offset: 0 },
         { coordinate: 49, value: 1, index: 1, offset: 0 },
         { coordinate: 98, value: 2, index: 2, offset: 0 },
@@ -915,9 +928,10 @@ describe('<RadialBar />', () => {
 
     it('should select radial bar sectors', () => {
       const { spy } = renderTestCase(state => selectRadialBarSectors(state, 0, 0, radialBarSettings, undefined));
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           name: 'Elves',
+          // @ts-expect-error extra properties not expected in the type
           rings: 3,
           fill: 'green',
           background: {
@@ -939,6 +953,7 @@ describe('<RadialBar />', () => {
         },
         {
           name: 'Dwarves',
+          // @ts-expect-error extra properties not expected in the type
           rings: 7,
           fill: 'blue',
           background: {
@@ -960,6 +975,7 @@ describe('<RadialBar />', () => {
         },
         {
           name: 'Humans',
+          // @ts-expect-error extra properties not expected in the type
           rings: 9,
           fill: 'red',
           background: {
@@ -981,6 +997,7 @@ describe('<RadialBar />', () => {
         },
         {
           name: 'Sauron',
+          // @ts-expect-error extra properties not expected in the type
           rings: 1,
           fill: 'black',
           background: {

--- a/test/state/redux-nesting.spec.tsx
+++ b/test/state/redux-nesting.spec.tsx
@@ -6,6 +6,7 @@ import { act, render } from '@testing-library/react';
 import { Line, LineChart } from '../../src';
 import { selectChartHeight } from '../../src/state/selectors/containerSelectors';
 import { useAppSelector } from '../../src/state/hooks';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 const exampleSlice = createSlice({
   name: 'example',
@@ -60,7 +61,7 @@ describe('when a Recharts chart is used in another Redux app as a neighbour', ()
     const spy = vi.fn();
     render(<App spy={spy} />);
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenLastCalledWith(100);
+    expectLastCalledWith(spy, 100);
   });
 
   it('should allow selecting data from the parent app store', () => {
@@ -109,7 +110,7 @@ describe('when a Recharts chart is used in another Redux app as a parent', () =>
     const spy = vi.fn();
     render(<App spy={spy} />);
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenLastCalledWith(100);
+    expectLastCalledWith(spy, 100);
   });
 
   it('should allow selecting data from the parent app store', () => {

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -3062,6 +3062,7 @@ describe('selectAxisWithScale', () => {
       const { spy } = renderTestCase(state => selectAxisWithScale(state, 'xAxis', defaultAxisId, false));
       expectLastCalledWith(spy, {
         allowDataOverflow: false,
+        // @ts-expect-error extra properties not expected in the type
         allowDecimals: true,
         allowDuplicatedCategory: true,
         angle: 0,
@@ -3143,6 +3144,7 @@ describe('selectAxisWithScale', () => {
       const { spy } = renderTestCase(state => selectAxisWithScale(state, 'yAxis', defaultAxisId, false));
       expectLastCalledWith(spy, {
         allowDataOverflow: false,
+        // @ts-expect-error extra properties not expected in the type
         allowDecimals: true,
         allowDuplicatedCategory: true,
         angle: 0,

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -71,6 +71,7 @@ import { useIsPanorama } from '../../../src/context/PanoramaContext';
 import { assertNotNull } from '../../helper/assertNotNull';
 import { expectLastCalledWithScale } from '../../helper/expectScale';
 import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 const defaultAxisId: AxisId = 0;
 
@@ -567,7 +568,7 @@ describe('selectAxisDomain', () => {
           <Comp />
         </BarChart>,
       );
-      expect(spy).toHaveBeenLastCalledWith([0, 400]);
+      expectLastCalledWith(spy, [0, 400]);
       expectXAxisTicks(container, [
         {
           textContent: '0',
@@ -611,7 +612,7 @@ describe('selectAxisDomain', () => {
           <Comp />
         </BarChart>,
       );
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
       expectXAxisTicks(container, []);
     });
 
@@ -630,7 +631,7 @@ describe('selectAxisDomain', () => {
           <Comp />
         </BarChart>,
       );
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
       expect(spy).toHaveBeenCalledTimes(2);
     });
 
@@ -663,7 +664,7 @@ describe('selectAxisDomain', () => {
           <Comp />
         </BarChart>,
       );
-      expect(spy).toHaveBeenLastCalledWith([0, 9999]);
+      expectLastCalledWith(spy, [0, 9999]);
       expectXAxisTicks(container, [
         {
           textContent: '0',
@@ -810,7 +811,7 @@ describe('selectAxisDomain', () => {
           <Comp />
         </BarChart>,
       );
-      expect(spy).toHaveBeenLastCalledWith(['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
+      expectLastCalledWith(spy, ['Page A', 'Page B', 'Page C', 'Page D', 'Page E', 'Page F']);
       expectXAxisTicks(container, [
         {
           textContent: 'Page A',
@@ -861,7 +862,7 @@ describe('selectAxisDomain', () => {
             <Comp />
           </BarChart>,
         );
-        expect(spy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5]);
+        expectLastCalledWith(spy, [0, 1, 2, 3, 4, 5]);
         expectXAxisTicks(container, [
           {
             textContent: '400',
@@ -911,7 +912,7 @@ describe('selectAxisDomain', () => {
           <Comp />
         </BarChart>,
       );
-      expect(spy).toHaveBeenLastCalledWith([400, 300, 200, 278, 189]);
+      expectLastCalledWith(spy, [400, 300, 200, 278, 189]);
       expectXAxisTicks(container, [
         {
           textContent: '400',
@@ -1137,7 +1138,7 @@ describe('selectAxisDomain', () => {
           <Comp />
         </BarChart>,
       );
-      expect(spy).toHaveBeenLastCalledWith(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun']);
+      expectLastCalledWith(spy, ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun']);
       expectXAxisTicks(container, [
         {
           textContent: 'Jan',
@@ -1186,7 +1187,7 @@ describe('selectAxisDomain', () => {
           <Comp />
         </BarChart>,
       );
-      expect(spy).toHaveBeenLastCalledWith(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug']);
+      expectLastCalledWith(spy, ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug']);
       expectXAxisTicks(container, [
         {
           textContent: 'Jan',
@@ -1246,7 +1247,7 @@ describe('selectAxisDomain', () => {
           <Comp />
         </BarChart>,
       );
-      expect(spy).toHaveBeenLastCalledWith([0, 1, 2]);
+      expectLastCalledWith(spy, [0, 1, 2]);
       expectXAxisTicks(container, [
         {
           textContent: '0',
@@ -1286,7 +1287,7 @@ describe('selectHasBar', () => {
       </BarChart>,
     );
     expect(container.querySelector('.recharts-bar')).toBeVisible();
-    expect(spy).toHaveBeenLastCalledWith(true);
+    expectLastCalledWith(spy, true);
 
     // returns false after Bar is removed from DOM
     rerender(
@@ -1295,7 +1296,7 @@ describe('selectHasBar', () => {
       </BarChart>,
     );
     expect(container.querySelector('.recharts-bar')).toBeNull();
-    expect(spy).toHaveBeenLastCalledWith(false);
+    expectLastCalledWith(spy, false);
   });
 
   it('should return false if there is no Bar in the chart', () => {
@@ -1312,7 +1313,7 @@ describe('selectHasBar', () => {
       </BarChart>,
     );
     expect(container.querySelector('.recharts-bar')).toBeNull();
-    expect(spy).toHaveBeenLastCalledWith(false);
+    expectLastCalledWith(spy, false);
   });
 
   it('should return true if there are two Bars in the chart and then I remove one', () => {
@@ -1330,7 +1331,7 @@ describe('selectHasBar', () => {
       </BarChart>,
     );
     expect(container.querySelectorAll('.recharts-bar')).toHaveLength(2);
-    expect(spy).toHaveBeenLastCalledWith(true);
+    expectLastCalledWith(spy, true);
     rerender(
       <BarChart data={PageData} width={100} height={100}>
         <Bar dataKey="uv" />
@@ -1338,7 +1339,7 @@ describe('selectHasBar', () => {
       </BarChart>,
     );
     expect(container.querySelectorAll('.recharts-bar')).toHaveLength(1);
-    expect(spy).toHaveBeenLastCalledWith(true);
+    expectLastCalledWith(spy, true);
   });
 
   it('should return true if there is RadialBar in RadialChart', () => {
@@ -1355,7 +1356,7 @@ describe('selectHasBar', () => {
       </RadialBarChart>,
     );
     expect(container.querySelector('.recharts-radial-bar-sectors')).toBeVisible();
-    expect(spy).toHaveBeenLastCalledWith(true);
+    expectLastCalledWith(spy, true);
 
     // returns false after the only RadialBar is removed from DOM
     rerender(
@@ -1364,7 +1365,7 @@ describe('selectHasBar', () => {
       </RadialBarChart>,
     );
     expect(container.querySelector('.recharts-radial-bar-sectors')).toBeNull();
-    expect(spy).toHaveBeenLastCalledWith(false);
+    expectLastCalledWith(spy, false);
   });
 
   it('should return false if RadialBarChart has no RadialBar in it', () => {
@@ -1380,7 +1381,7 @@ describe('selectHasBar', () => {
       </RadialBarChart>,
     );
     expect(container.querySelector('.recharts-radial-bar-sectors')).toBeNull();
-    expect(spy).toHaveBeenLastCalledWith(false);
+    expectLastCalledWith(spy, false);
   });
 });
 
@@ -1403,7 +1404,7 @@ describe('selectCalculatedPadding', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(0);
+    expectLastCalledWith(spy, 0);
   });
 
   it('should return a number when padding is "gap"', () => {
@@ -1419,7 +1420,7 @@ describe('selectCalculatedPadding', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(1.247917162580338);
+    expectLastCalledWith(spy, 1.247917162580338);
   });
 
   it('should return a number when padding is "no-gap"', () => {
@@ -1435,7 +1436,7 @@ describe('selectCalculatedPadding', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(0.9955652016293147);
+    expectLastCalledWith(spy, 0.9955652016293147);
   });
 
   it('should return 0 when padding=no-gap and there is only one data point on the chart', () => {
@@ -1451,7 +1452,7 @@ describe('selectCalculatedPadding', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(0);
+    expectLastCalledWith(spy, 0);
   });
 
   it('should return 0 when padding is an object', () => {
@@ -1467,7 +1468,7 @@ describe('selectCalculatedPadding', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(0);
+    expectLastCalledWith(spy, 0);
   });
 });
 
@@ -1525,7 +1526,7 @@ describe('selectSmallestDistanceBetweenValues', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(0.02773149250178529);
+    expectLastCalledWith(spy, 0.02773149250178529);
   });
 
   it('should return the smallest distance, in percent, between values if type=number', () => {
@@ -1541,7 +1542,7 @@ describe('selectSmallestDistanceBetweenValues', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(0.02773149250178529);
+    expectLastCalledWith(spy, 0.02773149250178529);
   });
 
   it('should return Infinity, if the data is an empty array', () => {
@@ -1557,7 +1558,7 @@ describe('selectSmallestDistanceBetweenValues', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(Infinity);
+    expectLastCalledWith(spy, Infinity);
   });
 
   it('should return Infinity, if the data has only one entry', () => {
@@ -1573,7 +1574,7 @@ describe('selectSmallestDistanceBetweenValues', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(Infinity);
+    expectLastCalledWith(spy, Infinity);
   });
 
   it('should return 0 if the data has two items with the same value', () => {
@@ -1589,7 +1590,7 @@ describe('selectSmallestDistanceBetweenValues', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(0);
+    expectLastCalledWith(spy, 0);
   });
 });
 
@@ -1634,7 +1635,7 @@ describe('selectCartesianGraphicalItemsData', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([]);
+    expectLastCalledWith(spy, []);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -1654,7 +1655,7 @@ describe('selectCartesianGraphicalItemsData', () => {
         <Bar dataKey="uv" />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([]);
+    expectLastCalledWith(spy, []);
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
@@ -1679,7 +1680,8 @@ describe('selectCartesianGraphicalItemsData', () => {
       </ComposedChart>,
     );
     // as opposed to the tooltip data selector - this one stores all original data without transformation.
-    expect(spy).toHaveBeenLastCalledWith(
+    expectLastCalledWith(
+      spy,
       // the arrayContaining is there because it ignores elements order.
       expect.arrayContaining([7, 8, 9, 70, 80, 90, 1, 2, 3, 10, 20, 30, 4, 5, 6, 40, 50, 60]),
     );
@@ -1795,7 +1797,7 @@ describe('selectCartesianGraphicalItemsData', () => {
      * and then it pretends it was there from the start.
      * Well in this test let's pretend that's not happening and assume it provides the original array instead.
      */
-    expect(spy).toHaveBeenLastCalledWith([]);
+    expectLastCalledWith(spy, []);
   });
 });
 
@@ -1817,7 +1819,7 @@ describe('selectDisplayedData', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([]);
+    expectLastCalledWith(spy, []);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -1835,7 +1837,7 @@ describe('selectDisplayedData', () => {
         <Comp />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([
+    expectLastCalledWith(spy, [
       {
         label: 'Iter: 0',
         x: 211,
@@ -1938,7 +1940,7 @@ describe('selectDisplayedData', () => {
         <Comp />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([
+    expectLastCalledWith(spy, [
       {
         label: 'Iter: 0',
         x: 211,
@@ -2021,7 +2023,7 @@ describe('selectDisplayedData', () => {
         <Comp />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([
+    expectLastCalledWith(spy, [
       { value: 211 },
       { value: 245 },
       { value: 266 },
@@ -2162,7 +2164,7 @@ describe('selectDisplayedData', () => {
         <Comp />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([
+    expectLastCalledWith(spy, [
       {
         label: 'Iter: 0',
         x: 211,
@@ -2263,7 +2265,7 @@ describe('selectDisplayedData', () => {
         <Comp />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([
+    expectLastCalledWith(spy, [
       {
         label: 'Iter: 1',
         x: 245,
@@ -2314,7 +2316,7 @@ describe('selectAllAppliedValues', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([]);
+    expectLastCalledWith(spy, []);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -2334,7 +2336,7 @@ describe('selectAllAppliedValues', () => {
         <Comp />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([]);
+    expectLastCalledWith(spy, []);
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
@@ -2356,14 +2358,7 @@ describe('selectAllAppliedValues', () => {
         <Comp />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([
-      { value: 1 },
-      { value: 2 },
-      { value: 3 },
-      { value: 10 },
-      { value: 20 },
-      { value: 30 },
-    ]);
+    expectLastCalledWith(spy, [{ value: 1 }, { value: 2 }, { value: 3 }, { value: 10 }, { value: 20 }, { value: 30 }]);
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
@@ -2384,13 +2379,7 @@ describe('selectAllAppliedValues', () => {
         <Comp />
       </LineChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([
-      { value: 211 },
-      { value: 245 },
-      { value: 266 },
-      { value: 140 },
-      { value: 131 },
-    ]);
+    expectLastCalledWith(spy, [{ value: 211 }, { value: 245 }, { value: 266 }, { value: 140 }, { value: 131 }]);
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
@@ -2475,7 +2464,7 @@ describe('selectErrorBarsSettings', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith([]);
+    expectLastCalledWith(spy, []);
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
@@ -2520,7 +2509,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should select error bar state', () => {
         const { spy } = renderTestCase(selectAllErrorBarSettings);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           'my-bar-id': [
             {
               dataKey: 'data-x',
@@ -2536,7 +2525,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should return XAxis error bars', () => {
         const { spy } = renderTestCase(state => selectErrorBarsSettings(state, 'xAxis', defaultAxisId));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataKey: 'data-x',
             direction: 'x',
@@ -2547,7 +2536,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should return YAxis error bars', () => {
         const { spy } = renderTestCase(state => selectErrorBarsSettings(state, 'yAxis', defaultAxisId));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataKey: 'data-y',
             direction: 'y',
@@ -2573,7 +2562,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should select error bar state', () => {
         const { spy } = renderTestCase(selectAllErrorBarSettings);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           line2: [
             {
               dataKey: 'pv',
@@ -2589,7 +2578,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should return XAxis error bars', () => {
         const { spy } = renderTestCase(state => selectErrorBarsSettings(state, 'xAxis', defaultAxisId));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataKey: 'pv',
             direction: 'x',
@@ -2600,7 +2589,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should return YAxis error bars', () => {
         const { spy } = renderTestCase(state => selectErrorBarsSettings(state, 'yAxis', defaultAxisId));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataKey: 'amt',
             direction: 'y',
@@ -2631,7 +2620,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should select error bar state', () => {
         const { spy } = renderTestCase(selectAllErrorBarSettings);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           'line-with-error-bars': [
             {
               dataKey: 'data-x',
@@ -2647,7 +2636,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should return XAxis error bars', () => {
         const { spy } = renderTestCase(state => selectErrorBarsSettings(state, 'xAxis', defaultAxisId));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataKey: 'data-x',
             direction: 'x',
@@ -2658,7 +2647,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should return YAxis error bars', () => {
         const { spy } = renderTestCase(state => selectErrorBarsSettings(state, 'yAxis', defaultAxisId));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataKey: 'data-y',
             direction: 'y',
@@ -2689,7 +2678,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should select error bar state', () => {
         const { spy } = renderTestCase(selectAllErrorBarSettings);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           'scatter-with-error-bars': [
             {
               dataKey: 'data-x',
@@ -2705,7 +2694,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should return XAxis error bars', () => {
         const { spy } = renderTestCase(state => selectErrorBarsSettings(state, 'xAxis', defaultAxisId));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataKey: 'data-x',
             direction: 'x',
@@ -2716,7 +2705,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should return YAxis error bars', () => {
         const { spy } = renderTestCase(state => selectErrorBarsSettings(state, 'yAxis', defaultAxisId));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataKey: 'data-y',
             direction: 'y',
@@ -2750,7 +2739,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should select error bar state', () => {
         const { spy } = renderTestCase(selectAllErrorBarSettings);
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           'my-bar-id': [
             {
               dataKey: 'data-x',
@@ -2786,7 +2775,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should return XAxis error bars', () => {
         const { spy } = renderTestCase(state => selectErrorBarsSettings(state, 'xAxis', defaultAxisId));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataKey: 'data-x',
             direction: 'x',
@@ -2805,7 +2794,7 @@ describe('selectErrorBarsSettings', () => {
 
       it('should return YAxis error bars', () => {
         const { spy } = renderTestCase(state => selectErrorBarsSettings(state, 'yAxis', defaultAxisId));
-        expect(spy).toHaveBeenLastCalledWith([
+        expectLastCalledWith(spy, [
           {
             dataKey: 'data-y',
             direction: 'y',
@@ -2873,7 +2862,7 @@ describe('selectNiceTicks', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(undefined);
+    expectLastCalledWith(spy, undefined);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -3071,7 +3060,7 @@ describe('selectAxisWithScale', () => {
 
     it('should select XAxis settings', () => {
       const { spy } = renderTestCase(state => selectAxisWithScale(state, 'xAxis', defaultAxisId, false));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: true,
         allowDuplicatedCategory: true,
@@ -3110,7 +3099,7 @@ describe('selectAxisWithScale', () => {
       const { spy } = renderTestCase(state =>
         selectAllAppliedNumericalValuesIncludingErrorValues(state, 'yAxis', defaultAxisId, false),
       );
-      expect(spy).toHaveBeenLastCalledWith([
+      expectLastCalledWith(spy, [
         {
           errorDomain: [],
           value: 2400,
@@ -3140,19 +3129,19 @@ describe('selectAxisWithScale', () => {
 
     test('selectAxisDomain', () => {
       const { spy } = renderTestCase(state => selectAxisDomain(state, 'yAxis', defaultAxisId, false));
-      expect(spy).toHaveBeenLastCalledWith([0, 9800]);
+      expectLastCalledWith(spy, [0, 9800]);
       expect(spy).toHaveBeenCalledTimes(2);
     });
 
     test('selectNumericalDomain', () => {
       const { spy } = renderTestCase(state => selectNumericalDomain(state, 'yAxis', defaultAxisId, false));
-      expect(spy).toHaveBeenLastCalledWith([0, 9800]);
+      expectLastCalledWith(spy, [0, 9800]);
       expect(spy).toHaveBeenCalledTimes(2);
     });
 
     it('should select YAxis settings', () => {
       const { spy } = renderTestCase(state => selectAxisWithScale(state, 'yAxis', defaultAxisId, false));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: true,
         allowDuplicatedCategory: true,

--- a/test/state/selectors/containerSelectors.spec.tsx
+++ b/test/state/selectors/containerSelectors.spec.tsx
@@ -15,6 +15,7 @@ import { BarChart, ComposedChart, Customized } from '../../../src';
 import { shouldReturnFromInitialState, shouldReturnUndefinedOutOfContext } from '../../helper/selectorTestHelpers';
 import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
 import { mockHTMLElementProperty } from '../../helper/mockHTMLElementProperty';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('selectContainerScale', () => {
   shouldReturnUndefinedOutOfContext(selectContainerScale);
@@ -66,7 +67,7 @@ describe('selectContainerScale', () => {
       </ComposedChart>
     ));
     const { spy } = renderTestCase(selectContainerScale);
-    expect(spy).toHaveBeenLastCalledWith(3 / 5);
+    expectLastCalledWith(spy, 3 / 5);
   });
 
   it('should return scale: 1 in jsdom because jsdom returns zeroes everywhere', () => {
@@ -83,7 +84,7 @@ describe('selectContainerScale', () => {
       </ComposedChart>
     ));
     const { spy } = renderTestCase(selectContainerScale);
-    expect(spy).toHaveBeenLastCalledWith(1);
+    expectLastCalledWith(spy, 1);
   });
 });
 

--- a/test/state/selectors/dataSelectors.spec.tsx
+++ b/test/state/selectors/dataSelectors.spec.tsx
@@ -11,6 +11,7 @@ import {
   shouldReturnUndefinedOutOfContext,
   useAppSelectorWithStableTest,
 } from '../../helper/selectorTestHelpers';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('selectChartDataWithIndexes', () => {
   shouldReturnUndefinedOutOfContext(selectChartDataWithIndexes);
@@ -40,7 +41,7 @@ describe('selectChartDataWithIndexes', () => {
       dataStartIndex: 0,
       computedData: undefined,
     };
-    expect(spy).toHaveBeenLastCalledWith(expected);
+    expectLastCalledWith(spy, expected);
   });
 
   it('should return none of the data defined on graphical items', () => {
@@ -89,7 +90,7 @@ describe('selectChartDataWithIndexes', () => {
       dataStartIndex: 0,
       computedData: undefined,
     };
-    expect(spy).toHaveBeenLastCalledWith(expected);
+    expectLastCalledWith(spy, expected);
   });
 
   it('should return indexes from Brush element', () => {
@@ -111,6 +112,6 @@ describe('selectChartDataWithIndexes', () => {
       dataStartIndex: 3,
       computedData: undefined,
     };
-    expect(spy).toHaveBeenLastCalledWith(expected);
+    expectLastCalledWith(spy, expected);
   });
 });

--- a/test/state/selectors/rootPropsSelectors.spec.tsx
+++ b/test/state/selectors/rootPropsSelectors.spec.tsx
@@ -15,6 +15,7 @@ import {
   shouldReturnUndefinedOutOfContext,
   useAppSelectorWithStableTest,
 } from '../../helper/selectorTestHelpers';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('selectRootMaxBarSize', () => {
   shouldReturnUndefinedOutOfContext(selectRootMaxBarSize);
@@ -32,7 +33,7 @@ describe('selectRootMaxBarSize', () => {
         <Customized component={Comp} />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(undefined);
+    expectLastCalledWith(spy, undefined);
   });
 
   it('should return and update maxBarSize defined on chart root', () => {
@@ -48,7 +49,7 @@ describe('selectRootMaxBarSize', () => {
         <Customized component={Comp} />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(10);
+    expectLastCalledWith(spy, 10);
     expect(spy).toHaveBeenCalledTimes(1);
 
     rerender(
@@ -58,7 +59,7 @@ describe('selectRootMaxBarSize', () => {
       </BarChart>,
     );
 
-    expect(spy).toHaveBeenLastCalledWith(20);
+    expectLastCalledWith(spy, 20);
     expect(spy).toHaveBeenCalledTimes(3);
   });
 });
@@ -79,7 +80,7 @@ describe('selectBarGap', () => {
         <Customized component={Comp} />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(4);
+    expectLastCalledWith(spy, 4);
   });
 
   it('should return and update barGap defined on chart root', () => {
@@ -94,7 +95,7 @@ describe('selectBarGap', () => {
         <Customized component={Comp} />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(10);
+    expectLastCalledWith(spy, 10);
     expect(spy).toHaveBeenCalledTimes(1);
 
     rerender(
@@ -103,7 +104,7 @@ describe('selectBarGap', () => {
       </BarChart>,
     );
 
-    expect(spy).toHaveBeenLastCalledWith(20);
+    expectLastCalledWith(spy, 20);
     expect(spy).toHaveBeenCalledTimes(3);
   });
 });
@@ -139,7 +140,7 @@ describe('selectBarCategoryGap', () => {
         <Customized component={Comp} />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith('10%');
+    expectLastCalledWith(spy, '10%');
   });
 
   it('should return and update barCategoryGap defined on chart root', () => {
@@ -154,7 +155,7 @@ describe('selectBarCategoryGap', () => {
         <Customized component={Comp} />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(10);
+    expectLastCalledWith(spy, 10);
     expect(spy).toHaveBeenCalledTimes(1);
 
     rerender(
@@ -163,7 +164,7 @@ describe('selectBarCategoryGap', () => {
       </BarChart>,
     );
 
-    expect(spy).toHaveBeenLastCalledWith(20);
+    expectLastCalledWith(spy, 20);
     expect(spy).toHaveBeenCalledTimes(3);
   });
 });
@@ -184,7 +185,7 @@ describe('selectRootBarSize', () => {
         <Customized component={Comp} />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(undefined);
+    expectLastCalledWith(spy, undefined);
   });
 
   it('should return and update barSize defined on chart root', () => {
@@ -199,7 +200,7 @@ describe('selectRootBarSize', () => {
         <Customized component={Comp} />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith(10);
+    expectLastCalledWith(spy, 10);
     expect(spy).toHaveBeenCalledTimes(1);
 
     rerender(
@@ -208,7 +209,7 @@ describe('selectRootBarSize', () => {
       </BarChart>,
     );
 
-    expect(spy).toHaveBeenLastCalledWith(20);
+    expectLastCalledWith(spy, 20);
     expect(spy).toHaveBeenCalledTimes(3);
   });
 });
@@ -231,7 +232,7 @@ describe('selectSyncMethod', () => {
         <Comp />
       </BarChart>,
     );
-    expect(spy).toHaveBeenLastCalledWith('value');
+    expectLastCalledWith(spy, 'value');
     expect(spy).toHaveBeenCalledTimes(1);
 
     const fn = () => 1;
@@ -242,7 +243,7 @@ describe('selectSyncMethod', () => {
       </BarChart>,
     );
 
-    expect(spy).toHaveBeenLastCalledWith(fn);
+    expectLastCalledWith(spy, fn);
     expect(spy).toHaveBeenCalledTimes(3);
   });
 });

--- a/test/state/selectors/selectActiveTooltipIndex.spec.tsx
+++ b/test/state/selectors/selectActiveTooltipIndex.spec.tsx
@@ -9,6 +9,7 @@ import { showTooltip } from '../../component/Tooltip/tooltipTestHelpers';
 import { assertNotNull } from '../../helper/assertNotNull';
 import { radialBarChartMouseHoverTooltipSelector } from '../../component/Tooltip/tooltipMouseHoverSelectors';
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('selectActiveTooltipIndex', () => {
   beforeEach(() => {
@@ -27,25 +28,25 @@ describe('selectActiveTooltipIndex', () => {
 
       it('should return undefined before any interaction', () => {
         const { spy } = renderTestCase(selectActiveTooltipIndex);
-        expect(spy).toHaveBeenLastCalledWith(null);
+        expectLastCalledWith(spy, null);
       });
 
       it('should return index after mouse hover, and undefined again after mouse leave', () => {
         const { container, spy } = renderTestCase(selectActiveTooltipIndex);
         const trigger = showTooltip(container, '.recharts-radial-bar-sector');
-        expect(spy).toHaveBeenLastCalledWith('3');
+        expectLastCalledWith(spy, '3');
         fireEvent.mouseLeave(trigger);
-        expect(spy).toHaveBeenLastCalledWith(null);
+        expectLastCalledWith(spy, null);
       });
 
       it('should return undefined after clicking on a sector', () => {
         const { container, spy } = renderTestCase(selectActiveTooltipIndex);
         const trigger = container.querySelector('.recharts-radial-bar-sector');
         assertNotNull(trigger);
-        expect(spy).toHaveBeenLastCalledWith(null);
+        expectLastCalledWith(spy, null);
         expect(spy).toHaveBeenCalledTimes(1);
         fireEvent.click(trigger);
-        expect(spy).toHaveBeenLastCalledWith(null);
+        expectLastCalledWith(spy, null);
         expect(spy).toHaveBeenCalledTimes(1);
       });
     });
@@ -61,25 +62,25 @@ describe('selectActiveTooltipIndex', () => {
 
       it('should return the default index before any interaction', () => {
         const { spy } = renderTestCase(selectActiveTooltipIndex);
-        expect(spy).toHaveBeenLastCalledWith('0');
+        expectLastCalledWith(spy, '0');
       });
 
       it('should return mouse hover index after mouse hover, and undefined again after mouse leave', () => {
         const { container, spy } = renderTestCase(selectActiveTooltipIndex);
         const trigger = showTooltip(container, radialBarChartMouseHoverTooltipSelector);
-        expect(spy).toHaveBeenLastCalledWith('3');
+        expectLastCalledWith(spy, '3');
         fireEvent.mouseLeave(trigger);
-        expect(spy).toHaveBeenLastCalledWith(null);
+        expectLastCalledWith(spy, null);
       });
 
       it('should return the default index after clicking on a sector', () => {
         const { container, spy } = renderTestCase(selectActiveTooltipIndex);
         const trigger = container.querySelector('.recharts-radial-bar-sector');
         assertNotNull(trigger);
-        expect(spy).toHaveBeenLastCalledWith('0');
+        expectLastCalledWith(spy, '0');
         expect(spy).toHaveBeenCalledTimes(3);
         fireEvent.click(trigger);
-        expect(spy).toHaveBeenLastCalledWith('0');
+        expectLastCalledWith(spy, '0');
         expect(spy).toHaveBeenCalledTimes(3);
       });
     });
@@ -95,25 +96,25 @@ describe('selectActiveTooltipIndex', () => {
 
       it('should return undefined before any interaction', () => {
         const { spy } = renderTestCase(selectActiveTooltipIndex);
-        expect(spy).toHaveBeenLastCalledWith(null);
+        expectLastCalledWith(spy, null);
       });
 
       it('should return index after mouse hover, and undefined again after mouse leave', () => {
         const { container, spy } = renderTestCase(selectActiveTooltipIndex);
         const trigger = showTooltip(container, '.recharts-radial-bar-sector');
-        expect(spy).toHaveBeenLastCalledWith('0');
+        expectLastCalledWith(spy, '0');
         fireEvent.mouseLeave(trigger);
-        expect(spy).toHaveBeenLastCalledWith(null);
+        expectLastCalledWith(spy, null);
       });
 
       it('should return undefined after clicking on a sector', () => {
         const { container, spy } = renderTestCase(selectActiveTooltipIndex);
         const trigger = container.querySelector('.recharts-radial-bar-sector');
         assertNotNull(trigger);
-        expect(spy).toHaveBeenLastCalledWith(null);
+        expectLastCalledWith(spy, null);
         expect(spy).toHaveBeenCalledTimes(1);
         fireEvent.click(trigger);
-        expect(spy).toHaveBeenLastCalledWith(null);
+        expectLastCalledWith(spy, null);
         expect(spy).toHaveBeenCalledTimes(1);
       });
     });
@@ -129,25 +130,25 @@ describe('selectActiveTooltipIndex', () => {
 
       it('should return the default index before any interaction', () => {
         const { spy } = renderTestCase(selectActiveTooltipIndex);
-        expect(spy).toHaveBeenLastCalledWith('3');
+        expectLastCalledWith(spy, '3');
       });
 
       it('should return mouse hover index after mouse hover, and undefined again after mouse leave', () => {
         const { container, spy } = renderTestCase(selectActiveTooltipIndex);
         const trigger = showTooltip(container, '.recharts-radial-bar-sector');
-        expect(spy).toHaveBeenLastCalledWith('0');
+        expectLastCalledWith(spy, '0');
         fireEvent.mouseLeave(trigger);
-        expect(spy).toHaveBeenLastCalledWith(null);
+        expectLastCalledWith(spy, null);
       });
 
       it('should return the default index after clicking on a sector', () => {
         const { container, spy } = renderTestCase(selectActiveTooltipIndex);
         const trigger = container.querySelector('.recharts-radial-bar-sector');
         assertNotNull(trigger);
-        expect(spy).toHaveBeenLastCalledWith('3');
+        expectLastCalledWith(spy, '3');
         expect(spy).toHaveBeenCalledTimes(3);
         fireEvent.click(trigger);
-        expect(spy).toHaveBeenLastCalledWith('3');
+        expectLastCalledWith(spy, '3');
         expect(spy).toHaveBeenCalledTimes(3);
       });
     });
@@ -164,29 +165,29 @@ describe('selectActiveTooltipIndex', () => {
 
         it('should return undefined before any interaction', () => {
           const { spy } = renderTestCase(selectActiveTooltipIndex);
-          expect(spy).toHaveBeenLastCalledWith(null);
+          expectLastCalledWith(spy, null);
         });
 
         it('should return index after clicking on a chart, and continue returning that index after clicking again', () => {
           const { container, spy } = renderTestCase(selectActiveTooltipIndex);
           const trigger = container.querySelector(radialBarChartMouseHoverTooltipSelector);
           assertNotNull(trigger);
-          expect(spy).toHaveBeenLastCalledWith(null);
+          expectLastCalledWith(spy, null);
           expect(spy).toHaveBeenCalledTimes(1);
           fireEvent.click(trigger, { clientX: 200, clientY: 200 });
-          expect(spy).toHaveBeenLastCalledWith('3');
+          expectLastCalledWith(spy, '3');
           expect(spy).toHaveBeenCalledTimes(2);
           fireEvent.click(trigger, { clientX: 200, clientY: 200 });
-          expect(spy).toHaveBeenLastCalledWith('3');
+          expectLastCalledWith(spy, '3');
           expect(spy).toHaveBeenCalledTimes(2);
         });
 
         it('should return undefined after mouse hover', () => {
           const { container, spy } = renderTestCase(selectActiveTooltipIndex);
           const trigger = showTooltip(container, '.recharts-radial-bar-sector');
-          expect(spy).toHaveBeenLastCalledWith(null);
+          expectLastCalledWith(spy, null);
           fireEvent.mouseLeave(trigger);
-          expect(spy).toHaveBeenLastCalledWith(null);
+          expectLastCalledWith(spy, null);
         });
       });
 
@@ -201,29 +202,29 @@ describe('selectActiveTooltipIndex', () => {
 
         it('should return the default index before any interaction', () => {
           const { spy } = renderTestCase(selectActiveTooltipIndex);
-          expect(spy).toHaveBeenLastCalledWith('1');
+          expectLastCalledWith(spy, '1');
         });
 
         it('should return mouse hover index after clicking on the chart, and continue returning that index after clicking again', () => {
           const { container, spy } = renderTestCase(selectActiveTooltipIndex);
           const trigger = container.querySelector(radialBarChartMouseHoverTooltipSelector);
           assertNotNull(trigger);
-          expect(spy).toHaveBeenLastCalledWith('1');
+          expectLastCalledWith(spy, '1');
           expect(spy).toHaveBeenCalledTimes(3);
           fireEvent.click(trigger, { clientX: 200, clientY: 200 });
-          expect(spy).toHaveBeenLastCalledWith('3');
+          expectLastCalledWith(spy, '3');
           expect(spy).toHaveBeenCalledTimes(4);
           fireEvent.click(trigger, { clientX: 200, clientY: 200 });
-          expect(spy).toHaveBeenLastCalledWith('3');
+          expectLastCalledWith(spy, '3');
           expect(spy).toHaveBeenCalledTimes(4);
         });
 
         it('should ignore mouse hover events', () => {
           const { container, spy } = renderTestCase(selectActiveTooltipIndex);
           const trigger = showTooltip(container, radialBarChartMouseHoverTooltipSelector);
-          expect(spy).toHaveBeenLastCalledWith('1');
+          expectLastCalledWith(spy, '1');
           fireEvent.mouseLeave(trigger);
-          expect(spy).toHaveBeenLastCalledWith('1');
+          expectLastCalledWith(spy, '1');
         });
       });
     });

--- a/test/state/selectors/selectIsTooltipActive.spec.tsx
+++ b/test/state/selectors/selectIsTooltipActive.spec.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../component/Tooltip/tooltipMouseHoverSelectors';
 import { hideTooltip, showTooltip } from '../../component/Tooltip/tooltipTestHelpers';
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('selectIsTooltipActive', () => {
   beforeEach(() => {
@@ -27,7 +28,7 @@ describe('selectIsTooltipActive', () => {
 
     it('should select false before any interactions', () => {
       const { spy } = renderTestCase(state => selectIsTooltipActive(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
@@ -35,21 +36,21 @@ describe('selectIsTooltipActive', () => {
 
     it('should select true after mouse hover, and then false again on mouse leave', () => {
       const { container, spy } = renderTestCase(state => selectIsTooltipActive(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
       expect(spy).toHaveBeenCalledTimes(2);
 
       showTooltip(container, barChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '1',
         isActive: true,
       });
       expect(spy).toHaveBeenCalledTimes(3);
 
       hideTooltip(container, barChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
@@ -68,7 +69,7 @@ describe('selectIsTooltipActive', () => {
 
     it('should select true before any interactions', () => {
       const { spy } = renderTestCase(state => selectIsTooltipActive(state, 'axis', 'hover', '0'));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '0',
         isActive: true,
       });
@@ -76,21 +77,21 @@ describe('selectIsTooltipActive', () => {
 
     it('should select true after mouse hover, and then false on mouse leave', () => {
       const { container, spy } = renderTestCase(state => selectIsTooltipActive(state, 'axis', 'hover', '0'));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '0',
         isActive: true,
       });
       expect(spy).toHaveBeenCalledTimes(2);
 
       showTooltip(container, barChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '1',
         isActive: true,
       });
       expect(spy).toHaveBeenCalledTimes(3);
 
       hideTooltip(container, barChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
@@ -111,7 +112,7 @@ describe('selectIsTooltipActive', () => {
 
     it('should select false before any interactions', () => {
       const { spy } = renderTestCase(state => selectIsTooltipActive(state, 'item', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
@@ -119,21 +120,21 @@ describe('selectIsTooltipActive', () => {
 
     it('should select true after mouse hover, and then false on mouse leave', () => {
       const { container, spy } = renderTestCase(state => selectIsTooltipActive(state, 'item', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
       expect(spy).toHaveBeenCalledTimes(3);
 
       showTooltip(container, scatterChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '0',
         isActive: true,
       });
       expect(spy).toHaveBeenCalledTimes(4);
 
       hideTooltip(container, scatterChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
@@ -154,7 +155,7 @@ describe('selectIsTooltipActive', () => {
 
     it('should select true before any interactions', () => {
       const { spy } = renderTestCase(state => selectIsTooltipActive(state, 'item', 'hover', '0'));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '0',
         isActive: true,
       });
@@ -162,21 +163,21 @@ describe('selectIsTooltipActive', () => {
 
     it('should select true after mouse hover, and then false on mouse leave', () => {
       const { container, spy } = renderTestCase(state => selectIsTooltipActive(state, 'item', 'hover', '3'));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '3',
         isActive: true,
       });
       expect(spy).toHaveBeenCalledTimes(3);
 
       showTooltip(container, scatterChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '0',
         isActive: true,
       });
       expect(spy).toHaveBeenCalledTimes(4);
 
       hideTooltip(container, scatterChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
@@ -195,7 +196,7 @@ describe('selectIsTooltipActive', () => {
 
     it('should select false before any interactions', () => {
       const { spy } = renderTestCase(state => selectIsTooltipActive(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
@@ -203,21 +204,21 @@ describe('selectIsTooltipActive', () => {
 
     it('should select true after mouse hover, and then continue returning true after mouse leave', () => {
       const { container, spy } = renderTestCase(state => selectIsTooltipActive(state, 'axis', 'hover', undefined));
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
       expect(spy).toHaveBeenCalledTimes(2);
 
       showTooltip(container, barChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '1',
         isActive: true,
       });
       expect(spy).toHaveBeenCalledTimes(3);
 
       hideTooltip(container, barChartMouseHoverTooltipSelector);
-      expect(spy).toHaveBeenLastCalledWith({
+      expectLastCalledWith(spy, {
         activeIndex: '1',
         isActive: true,
       });

--- a/test/state/selectors/selectStackGroups.spec.tsx
+++ b/test/state/selectors/selectStackGroups.spec.tsx
@@ -13,6 +13,7 @@ import { Area, AreaChart, Bar, BarChart, Legend, LegendPayload } from '../../../
 import { PageData } from '../../_data';
 import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
 import { assertNotNull } from '../../helper/assertNotNull';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 describe('selectStackGroups', () => {
   const selector = (state: RechartsRootState) => selectStackGroups(state, 'xAxis', 0, false);
@@ -198,7 +199,7 @@ describe('selectStackGroups', () => {
     describe('on initial render', () => {
       it('should select two graphical items in stack group in the DOM insertion order', () => {
         const { spy } = renderTestCase((state: RechartsRootState) => selectStackGroups(state, 'xAxis', 0, false));
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           a: {
             graphicalItems: [
               {
@@ -206,6 +207,7 @@ describe('selectStackGroups', () => {
                 barSize: undefined,
                 data: undefined,
                 dataKey: 'uv',
+                // @ts-expect-error extra properties not expected in the type
                 hide: false,
                 isPanorama: false,
                 stackId: 'a',
@@ -219,6 +221,7 @@ describe('selectStackGroups', () => {
                 barSize: undefined,
                 data: undefined,
                 dataKey: 'pv',
+                // @ts-expect-error extra properties not expected in the type
                 hide: false,
                 isPanorama: false,
                 stackId: 'a',
@@ -259,7 +262,7 @@ describe('selectStackGroups', () => {
           selectStackGroups(state, 'xAxis', 0, false),
         );
 
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           a: expect.objectContaining({
             graphicalItems: [
               expect.objectContaining({ dataKey: 'uv', hide: false }),
@@ -278,7 +281,7 @@ describe('selectStackGroups', () => {
           fireEvent.click(uvItem);
         });
 
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           a: expect.objectContaining({
             graphicalItems: [expect.objectContaining({ dataKey: 'pv', hide: false })],
           }),
@@ -289,7 +292,7 @@ describe('selectStackGroups', () => {
           fireEvent.click(uvItem);
         });
 
-        expect(spy).toHaveBeenLastCalledWith({
+        expectLastCalledWith(spy, {
           a: expect.objectContaining({
             graphicalItems: [
               // This should be in the same order as before hiding

--- a/test/state/selectors/selectors.spec.tsx
+++ b/test/state/selectors/selectors.spec.tsx
@@ -48,6 +48,7 @@ import { selectActivePropsFromChartPointer } from '../../../src/state/selectors/
 import { useTooltipEventType } from '../../../src/state/selectors/selectTooltipEventType';
 import { selectTooltipState } from '../../../src/state/selectors/selectTooltipState';
 import { combineTooltipPayload } from '../../../src/state/selectors/combiners/combineTooltipPayload';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
 const exampleTooltipPayloadConfiguration1: TooltipPayloadConfiguration = {
   settings: {
@@ -1051,7 +1052,7 @@ describe('selectTooltipState.tooltipItemPayloads', () => {
       </BarChart>,
     );
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenLastCalledWith([]);
+    expectLastCalledWith(spy, []);
   });
 
   it('should return all tooltip payloads defined on graphical items in ComposedChart', () => {
@@ -1074,7 +1075,8 @@ describe('selectTooltipState.tooltipItemPayloads', () => {
     );
     expect(spy).toHaveBeenCalledTimes(3);
     // two of these elements will send the data as defined; Scatter decides to pre-chew it
-    expect(spy).toHaveBeenLastCalledWith(
+    expectLastCalledWith(
+      spy,
       expect.arrayContaining([
         [1, 2, 3],
         [10, 20, 30],
@@ -1235,7 +1237,7 @@ describe('selectTooltipState.tooltipItemPayloads', () => {
       </PieChart>,
     );
     expect(spy).toHaveBeenCalledTimes(4);
-    expect(spy).toHaveBeenLastCalledWith([
+    expectLastCalledWith(spy, [
       [
         [
           {

--- a/test/synchronisation/eventCenter.spec.ts
+++ b/test/synchronisation/eventCenter.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { eventCenter, TOOLTIP_SYNC_EVENT } from '../../src/util/Events';
 import { setSyncInteraction } from '../../src/state/tooltipSlice';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('eventCenter', () => {
   it('should send and receive events', () => {
@@ -21,7 +22,8 @@ describe('eventCenter', () => {
       symbol,
     );
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenLastCalledWith(
+    expectLastCalledWith(
+      spy,
       'my-sync-id',
       setSyncInteraction({
         active: true,

--- a/test/synchronisation/useChartSynchronisation.spec.tsx
+++ b/test/synchronisation/useChartSynchronisation.spec.tsx
@@ -9,6 +9,7 @@ import { selectSyncId } from '../../src/state/selectors/rootPropsSelectors';
 import { hideTooltip, showTooltip } from '../component/Tooltip/tooltipTestHelpers';
 import { barChartMouseHoverTooltipSelector } from '../component/Tooltip/tooltipMouseHoverSelectors';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
 describe('useTooltipChartSynchronisation', () => {
   let eventSpy: Mock<(...args: any[]) => any>;
@@ -30,7 +31,7 @@ describe('useTooltipChartSynchronisation', () => {
 
     it('should select syncId from the state', () => {
       const { spy } = renderTestCase(selectSyncId);
-      expect(spy).toHaveBeenLastCalledWith('my-sync-id');
+      expectLastCalledWith(spy, 'my-sync-id');
     });
 
     it('should send one sync event on the initial render', () => {
@@ -130,7 +131,7 @@ describe('useTooltipChartSynchronisation', () => {
 
     it('should select syncId from the state', () => {
       const { spy } = renderTestCase(selectSyncId);
-      expect(spy).toHaveBeenLastCalledWith('my-sync-id');
+      expectLastCalledWith(spy, 'my-sync-id');
     });
 
     it('should not send any sync events', () => {
@@ -149,7 +150,7 @@ describe('useTooltipChartSynchronisation', () => {
 
     it('should select syncId from the state', () => {
       const { spy } = renderTestCase(selectSyncId);
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
     });
 
     it('should not send any sync events', () => {
@@ -169,7 +170,7 @@ describe('useTooltipChartSynchronisation', () => {
 
     it('should select syncId from the state', () => {
       const { spy } = renderTestCase(selectSyncId);
-      expect(spy).toHaveBeenLastCalledWith(undefined);
+      expectLastCalledWith(spy, undefined);
     });
 
     it('should not send any sync events', () => {


### PR DESCRIPTION
## Description

Vitest out of the box does not check the return type so I added a helper for it.

## Related Issue

https://github.com/recharts/recharts/issues/5768