### PR TITLE
Fix empty chart issue

### DIFF
--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -933,10 +933,9 @@ export const combineAxisDomain = (
   axisType: XorYorZType,
   numericalDomain: NumberDomain | undefined,
 ): NumberDomain | CategoricalDomain | undefined => {
-  if (axisSettings == null || displayedData == null || displayedData.length === 0) {
+  if ((axisSettings == null || displayedData == null || displayedData.length === 0) && numericalDomain === undefined) {
     return undefined;
   }
-
   const { dataKey, type } = axisSettings;
   const isCategorical = isCategoricalAxis(layout, axisType);
 

--- a/storybook/stories/Examples/ScatterChart.stories.tsx
+++ b/storybook/stories/Examples/ScatterChart.stories.tsx
@@ -5,6 +5,7 @@ import {
   Cell,
   LabelList,
   Legend,
+  ReferenceArea,
   ResponsiveContainer,
   Scatter,
   ScatterChart,
@@ -744,5 +745,64 @@ export const ChangingDataKey = {
       left: 20,
       bottom: 5,
     },
+  },
+};
+
+const getHourFromTimestamp = (value: number) => {
+  const data = new Date(value as number);
+  let hour = data.getHours();
+  const minute = data.getMinutes();
+
+  // Format to 12-hour clock with AM/PM
+  const ampm = hour >= 12 ? 'PM' : 'AM';
+  hour %= 12;
+  hour = hour === 0 ? 12 : hour;
+
+  const label = minute > 0 ? `${hour}:${minute.toString().padStart(2, '0')} ${ampm}` : `${hour} ${ampm}`;
+  return label;
+};
+
+export const EmptyChart = {
+  render: () => {
+    return (
+      <ResponsiveContainer width="100%" height={400}>
+        <ScatterChart
+          margin={{
+            top: 20,
+            right: 20,
+            bottom: 20,
+            left: 20,
+          }}
+        >
+          <CartesianGrid />
+          <ReferenceArea y1={70} y2={150} />
+          <XAxis
+            type="number"
+            allowDataOverflow
+            ticks={[
+              new Date('2025-05-06T00:00:00').getTime(),
+              new Date('2025-05-06T03:00:00').getTime(),
+              new Date('2025-05-06T06:00:00').getTime(),
+              new Date('2025-05-06T09:00:00').getTime(),
+              new Date('2025-05-06T12:00:00').getTime(),
+              new Date('2025-05-06T15:00:00').getTime(),
+              new Date('2025-05-06T18:00:00').getTime(),
+              new Date('2025-05-06T21:00:00').getTime(),
+              new Date('2025-05-07T00:00:00').getTime(),
+            ]}
+            tickFormatter={(tickValue, _index) => {
+              if (typeof tickValue !== 'number') return String(tickValue);
+              const label = getHourFromTimestamp(tickValue);
+              return label;
+            }}
+            dataKey="hour"
+            domain={[new Date('2025-05-06T00:00:00').getTime(), new Date('2025-05-07T00:00:00').getTime()]}
+          />
+          <YAxis allowDataOverflow type="number" ticks={[0, 80, 180, 220]} />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+          <Scatter name="A school" data={[]} fill="#8884d8" />
+        </ScatterChart>
+      </ResponsiveContainer>
+    );
   },
 };

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -50,6 +50,7 @@ import { selectChartDataWithIndexes } from '../../src/state/selectors/dataSelect
 import { useChartHeight, useChartWidth, useViewBox } from '../../src/context/chartLayoutContext';
 import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 import { useClipPathId } from '../../src/container/ClipPathProvider';
+import { expectXAxisTicks, expectYAxisTicks } from '../helper/expectAxisTicks';
 
 describe('ScatterChart of three dimension data', () => {
   const data01 = [
@@ -2602,17 +2603,52 @@ describe('ScatterChart with allowDuplicateCategory=false', () => {
         <Legend layout="vertical" />
       </ScatterChart>,
     );
+    expectScatterPoints(container, []);
 
-    expect(container.querySelectorAll('.recharts-symbol')).toHaveLength(0);
+    expectXAxisTicks(container, [
+      {
+        textContent: '150cm',
+        x: '100',
+        y: '348',
+      },
+      {
+        textContent: '250cm',
+        x: '193.33333333333331',
+        y: '348',
+      },
+      {
+        textContent: '350cm',
+        x: '286.66666666666663',
+        y: '348',
+      },
+      {
+        textContent: '450cm',
+        x: '380',
+        y: '348',
+      },
+    ]);
 
-    expect(container.textContent).toContain('150cm');
-    expect(container.textContent).toContain('250cm');
-    expect(container.textContent).toContain('350cm');
-    expect(container.textContent).toContain('450cm');
-
-    expect(container.textContent).toContain('100kg');
-    expect(container.textContent).toContain('200kg');
-    expect(container.textContent).toContain('300kg');
-    expect(container.textContent).toContain('400kg');
+    expectYAxisTicks(container, [
+      {
+        textContent: '100kg',
+        x: '92',
+        y: '340',
+      },
+      {
+        textContent: '200kg',
+        x: '92',
+        y: '230.00000000000003',
+      },
+      {
+        textContent: '300kg',
+        x: '92',
+        y: '120.00000000000001',
+      },
+      {
+        textContent: '400kg',
+        x: '92',
+        y: '10',
+      },
+    ]);
   });
 });

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -2590,4 +2590,29 @@ describe('ScatterChart with allowDuplicateCategory=false', () => {
     showTooltip(container, `${scatterChartMouseHoverTooltipSelector}:nth-child(2)`);
     expectTooltipPayload(container, '', ['stature : 100cm', 'weight : 200kg']);
   });
+
+  it('should render an empty chart with tick labels when ticks are provided and allowDataOverflow is set to true', () => {
+    const { container } = render(
+      <ScatterChart width={400} height={400} margin={{ top: 10, right: 20, bottom: 30, left: 40 }}>
+        <XAxis dataKey="x" name="stature" unit="cm" type="number" allowDataOverflow ticks={[150, 250, 350, 450]} />
+        <YAxis dataKey="y" name="weight" unit="kg" type="number" allowDataOverflow ticks={[100, 200, 300, 400]} />
+        <CartesianGrid />
+        <Scatter name="A school" data={[]} fillOpacity={0.3} fill="#ff7300" />
+        <Tooltip />
+        <Legend layout="vertical" />
+      </ScatterChart>,
+    );
+
+    expect(container.querySelectorAll('.recharts-symbol')).toHaveLength(0);
+
+    expect(container.textContent).toContain('150cm');
+    expect(container.textContent).toContain('250cm');
+    expect(container.textContent).toContain('350cm');
+    expect(container.textContent).toContain('450cm');
+
+    expect(container.textContent).toContain('100kg');
+    expect(container.textContent).toContain('200kg');
+    expect(container.textContent).toContain('300kg');
+    expect(container.textContent).toContain('400kg');
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In Recharts v3, when rendering an empty chart (i.e., with no data), Axis labels are missing.
This behaviour worked as expected in Recharts v2.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/6084

## Motivation and Context

Rendering an empty chart with axis ticks is useful in cases where data is not yet available, but the chart layout should still be shown.

## How Has This Been Tested?

Added unit test to validate that Axis labels are not missing when no data is provided.

## Screenshots (if appropriate):

Added a story for Chart with No Data

<img width="1060" height="662" alt="Screenshot 2025-07-30 at 10 31 01 PM" src="https://github.com/user-attachments/assets/dd76b797-6dff-40e7-89f0-e5d810e48ba1" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or extended an existing story to show my changes
