### PR TITLE
perf: implement FIFO on string caching in DOMUtils.ts when cache is full

### DIFF
--- a/src/util/DOMUtils.ts
+++ b/src/util/DOMUtils.ts
@@ -3,15 +3,13 @@ import { Global } from './Global';
 import { Size } from './types';
 
 interface StringCache {
-  widthCache: Record<string, any>;
-  cacheCount: number;
+  widthCache: Map<string, any>;
 }
 
 const stringCache: StringCache = {
-  widthCache: {},
-  cacheCount: 0,
+  widthCache: new Map<string, Size>(),
 };
-const MAX_CACHE_NUM = 2000;
+export const MAX_CACHE_NUM = 2000;
 const SPAN_STYLE = {
   position: 'absolute',
   top: '-20000px',
@@ -41,8 +39,8 @@ export const getStringSize = (text: string | number, style: CSSProperties = {}):
   const copyStyle = removeInvalidKeys(style);
   const cacheKey = JSON.stringify({ text, copyStyle });
 
-  if (stringCache.widthCache[cacheKey]) {
-    return stringCache.widthCache[cacheKey];
+  if (stringCache.widthCache.has(cacheKey)) {
+    return stringCache.widthCache.get(cacheKey)!;
   }
 
   try {
@@ -63,11 +61,11 @@ export const getStringSize = (text: string | number, style: CSSProperties = {}):
     const rect = measurementSpan.getBoundingClientRect();
     const result = { width: rect.width, height: rect.height };
 
-    stringCache.widthCache[cacheKey] = result;
+    stringCache.widthCache.set(cacheKey, result);
 
-    if (++stringCache.cacheCount > MAX_CACHE_NUM) {
-      stringCache.cacheCount = 0;
-      stringCache.widthCache = {};
+    if (stringCache.widthCache.size > MAX_CACHE_NUM) {
+      const oldestKey = stringCache.widthCache.keys().next().value;
+      stringCache.widthCache.delete(oldestKey);
     }
 
     return result;

--- a/test/util/DomUtils.spec.tsx
+++ b/test/util/DomUtils.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import { getStringSize } from '../../src/util/DOMUtils';
+import { getStringSize, MAX_CACHE_NUM } from '../../src/util/DOMUtils';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 
 describe('DOMUtils', () => {
@@ -25,5 +25,40 @@ describe('DOMUtils', () => {
       width: 25,
       height: 17,
     });
+  });
+
+  test('getStringSize() reuses cached value', () => {
+    render(<span id="recharts_measurement_span">hello</span>);
+    mockGetBoundingClientRect({
+      width: 100,
+      height: 20,
+    });
+
+    const first = getStringSize('hello');
+    expect(first).toEqual({ width: 100, height: 20 });
+
+    // Change mocked values to see if cache is used
+    mockGetBoundingClientRect({
+      width: 999,
+      height: 999,
+    });
+
+    const second = getStringSize('hello');
+    expect(second).toEqual({ width: 100, height: 20 }); // cached value
+  });
+
+  test('getStringSize() evicts oldest cache entry when exceeding limit', () => {
+    render(<span id="recharts_measurement_span">eviction</span>);
+
+    for (let i = 0; i < MAX_CACHE_NUM + 1; i++) {
+      mockGetBoundingClientRect({ width: i, height: 10 });
+      getStringSize(`text-${i}`);
+    }
+
+    // expected the evicted key to be calculated again
+    mockGetBoundingClientRect({ width: 9999, height: 999 });
+    const result = getStringSize('text-0');
+
+    expect(result).toEqual({ width: 9999, height: 999 }); // not cached
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

In the original string caching mechanism, the 2000 keys in cache is entirely purged, which can be inefficient.
This PR implements FIFO for the string cache, remove the key that came in the first when the cache is full.

## Description

<!--- Describe your changes in detail -->

1. Change the type of `StringCache.widthCache` from `Record<string,any>` to `Map<string,any>`, so that the cache records which key came in the first, and the functions used are also changed into functions of `Map`
2. remove unused property `cacheCount` in `StringCache`
3. export `MAX_CACHE_NUM` to be used in unit tests
4. Add test case to test the cache is used after previous `getStringSize`
5. Add test case to test the first key is evicted when 2001 keys are inserted into the cache

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#3955 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Changing the cache mechanism into using FIFO will be have higher hit rate than purging all cache after the cache is full.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. If the 2001st cache is inserted, the first key should be evicted and its value being calculated again
2. `npm run test`, all unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
