### PR TITLE
feat: Support string value in Pie `outerRadius` callbacks

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -60,7 +60,7 @@ interface PieDef {
   /** The inner radius of sectors */
   innerRadius?: number | string;
   /** The outer radius of sectors */
-  outerRadius?: number | string | ((dataPoint: any) => number);
+  outerRadius?: number | string | ((dataPoint: any) => number | string);
   cornerRadius?: number | string;
 }
 
@@ -242,11 +242,11 @@ const getTextAnchor = (x: number, cx: number) => {
 
 const getOuterRadius = (
   dataPoint: any,
-  outerRadius?: number | string | ((element: any) => number),
+  outerRadius?: number | string | ((element: any) => number | string),
   maxPieRadius?: number,
 ) => {
   if (typeof outerRadius === 'function') {
-    return outerRadius(dataPoint);
+    return getPercentValue(outerRadius(dataPoint), maxPieRadius, maxPieRadius * 0.8);
   }
   return getPercentValue(outerRadius, maxPieRadius, maxPieRadius * 0.8);
 };
@@ -256,7 +256,7 @@ const parseCoordinateOfPie = (
     cx?: number | string;
     cy?: number | string;
     innerRadius?: number | string;
-    outerRadius?: number | string | ((dataPoint: any) => number);
+    outerRadius?: number | string | ((dataPoint: any) => number | string);
     maxRadius?: number;
   },
   offset: ChartOffsetInternal,

--- a/src/state/types/PieSettings.ts
+++ b/src/state/types/PieSettings.ts
@@ -18,7 +18,7 @@ export interface PieSettings extends BasePolarGraphicalItemSettings {
   paddingAngle: number;
   minAngle: number;
   innerRadius: number | string;
-  outerRadius: number | string | ((element: any) => number);
+  outerRadius: number | string | ((element: any) => number | string);
   cornerRadius: number | string | undefined;
   presentationProps: Record<string, string | number>;
 }

--- a/storybook/stories/API/polar/Pie.stories.tsx
+++ b/storybook/stories/API/polar/Pie.stories.tsx
@@ -36,7 +36,7 @@ const GeneralProps: Args = {
   outerRadius: {
     description: `The outer radius of all the sectors. If set a percentage, the final value is
       obtained by multiplying the percentage of maxRadius which is calculated by the width, height, cx, cy.
-      If set a function, the function will be called to return customized radius.`,
+      If set a function, the function will be called to return customized radius, in the form of a string percentage or a number.`,
     table: {
       type: { summary: 'percentage | number | Function', defaultValue: '80%' },
       category: 'General',

--- a/test/polar/Pie.spec.tsx
+++ b/test/polar/Pie.spec.tsx
@@ -1710,4 +1710,84 @@ describe('<Pie />', () => {
       expectLastCalledWith(spy, [expectedPie]);
     });
   });
+
+  describe('Coordinates', () => {
+    it('should allow outerRadius callback to return string', () => {
+      const data = [
+        { name: 'A', value: 40 },
+        { name: 'B', value: 30 },
+        { name: 'C', value: 20 },
+      ];
+
+      const outerRadiusCallback = (dataPoint: any) => {
+        // Return different string values based on data point
+        if (dataPoint.name === 'A') return '60%';
+        if (dataPoint.name === 'B') return '80%';
+        return '100%';
+      };
+
+      const { container } = render(
+        <PieChart width={500} height={500}>
+          <Pie
+            isAnimationActive={false}
+            cx={250}
+            cy={250}
+            innerRadius={0}
+            outerRadius={outerRadiusCallback}
+            data={data}
+            dataKey="value"
+          />
+        </PieChart>,
+      );
+
+      // Verify that sectors are rendered with different outer radius values
+      const sectors = container.querySelectorAll('.recharts-sector');
+      expect(sectors).toHaveLength(3);
+
+      // Check that sectors have different sizes due to different outer radius values
+      const sectorPaths = Array.from(sectors).map(sector => sector.getAttribute('d'));
+      expect(sectorPaths[0]).not.toBe(sectorPaths[1]);
+      expect(sectorPaths[1]).not.toBe(sectorPaths[2]);
+      expect(sectorPaths[0]).not.toBe(sectorPaths[2]);
+    });
+
+    it('should allow outerRadius callback to return number', () => {
+      const data = [
+        { name: 'A', value: 40 },
+        { name: 'B', value: 30 },
+        { name: 'C', value: 20 },
+      ];
+
+      const outerRadiusCallback = (dataPoint: any) => {
+        // Return different number values based on data point
+        if (dataPoint.name === 'A') return 100;
+        if (dataPoint.name === 'B') return 150;
+        return 200;
+      };
+
+      const { container } = render(
+        <PieChart width={500} height={500}>
+          <Pie
+            isAnimationActive={false}
+            cx={250}
+            cy={250}
+            innerRadius={0}
+            outerRadius={outerRadiusCallback}
+            data={data}
+            dataKey="value"
+          />
+        </PieChart>,
+      );
+
+      // Verify that sectors are rendered
+      const sectors = container.querySelectorAll('.recharts-sector');
+      expect(sectors).toHaveLength(3);
+
+      // Check that sectors have different sizes due to different outer radius values
+      const sectorPaths = Array.from(sectors).map(sector => sector.getAttribute('d'));
+      expect(sectorPaths[0]).not.toBe(sectorPaths[1]);
+      expect(sectorPaths[1]).not.toBe(sectorPaths[2]);
+      expect(sectorPaths[0]).not.toBe(sectorPaths[2]);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Adds support for string values as returned by `outerRadius` callback in Pie.

## Related Issue

[5998](https://github.com/recharts/recharts/issues/5998)

## Motivation and Context

Currently, Pie supports number and string values, which are handled by the `getPercentValue()` util. Additionally, Pie supports callbacks that return number values, which are not handled and instead returned directly

This PR adds support for callbacks that return string values, by using `getPercentValue()` to handle the returned string/number from the callback.

## How Has This Been Tested?

Added unit test to Pie's test suite, testing the execution of `outerRadius` callbacks that return numbers and strings.

I ran the tests locally, using `npm run test`.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
