### PR TITLE
New animation manager in storybook

### DIFF
--- a/src/animation/CSSTransitionAnimate.tsx
+++ b/src/animation/CSSTransitionAnimate.tsx
@@ -7,6 +7,7 @@ import { useAnimationManager } from './useAnimationManager';
 import { getTransitionVal } from './util';
 
 type CSSTransitionAnimateProps<T extends ReactSmoothStyle> = {
+  animationId: string;
   animationManager?: AnimationManager;
   duration?: number;
   begin?: number;
@@ -34,6 +35,7 @@ const defaultProps = {
 export function CSSTransitionAnimate<T extends ReactSmoothStyle>(outsideProps: CSSTransitionAnimateProps<T>) {
   const props = resolveDefaultProps(outsideProps, defaultProps);
   const {
+    animationId,
     from,
     to,
     attributeName,
@@ -47,8 +49,7 @@ export function CSSTransitionAnimate<T extends ReactSmoothStyle>(outsideProps: C
     children,
   } = props;
 
-  const animationManager = useAnimationManager(attributeName, props.animationManager);
-
+  const animationManager = useAnimationManager(animationId + attributeName, props.animationManager);
   const [style, setStyle] = useState<T>(isActive ? from : to);
 
   useEffect(() => {

--- a/src/animation/JavascriptAnimate.tsx
+++ b/src/animation/JavascriptAnimate.tsx
@@ -8,6 +8,11 @@ import { AnimationManager } from './AnimationManager';
 import { useAnimationManager } from './useAnimationManager';
 
 type JavascriptAnimateProps = {
+  /**
+   * Unique name for the animation.
+   * Used to identify the animation in the AnimationManager and for debugging.
+   */
+  animationName: string;
   animationManager?: AnimationManager;
   duration?: number;
   begin?: number;
@@ -40,7 +45,7 @@ export function JavascriptAnimate(outsideProps: JavascriptAnimateProps) {
   const props = resolveDefaultProps(outsideProps, defaultJavascriptAnimateProps);
   const { isActive, canBegin, duration, easing, begin, onAnimationEnd, onAnimationStart, children } = props;
 
-  const animationManager = useAnimationManager('JavascriptAnimate', props.animationManager);
+  const animationManager = useAnimationManager(props.animationName, props.animationManager);
 
   const [style, setStyle] = useState<TimeAsObject>(isActive ? from : to);
   const stopJSAnimation = useRef<(() => void) | null>(null);

--- a/src/animation/JavascriptAnimate.tsx
+++ b/src/animation/JavascriptAnimate.tsx
@@ -8,11 +8,7 @@ import { AnimationManager } from './AnimationManager';
 import { useAnimationManager } from './useAnimationManager';
 
 type JavascriptAnimateProps = {
-  /**
-   * Unique name for the animation.
-   * Used to identify the animation in the AnimationManager and for debugging.
-   */
-  animationName: string;
+  animationId: string;
   animationManager?: AnimationManager;
   duration?: number;
   begin?: number;
@@ -45,7 +41,7 @@ export function JavascriptAnimate(outsideProps: JavascriptAnimateProps) {
   const props = resolveDefaultProps(outsideProps, defaultJavascriptAnimateProps);
   const { isActive, canBegin, duration, easing, begin, onAnimationEnd, onAnimationStart, children } = props;
 
-  const animationManager = useAnimationManager(props.animationName, props.animationManager);
+  const animationManager = useAnimationManager(props.animationId, props.animationManager);
 
   const [style, setStyle] = useState<TimeAsObject>(isActive ? from : to);
   const stopJSAnimation = useRef<(() => void) | null>(null);

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -460,7 +460,7 @@ function AreaWithAnimation({
   const prevBaseLine = previousBaselineRef.current;
   return (
     <JavascriptAnimate
-      animationName={animationId}
+      animationId={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -460,6 +460,7 @@ function AreaWithAnimation({
   const prevBaseLine = previousBaselineRef.current;
   return (
     <JavascriptAnimate
+      animationName={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -407,7 +407,7 @@ function RectanglesWithAnimation({
   }, [onAnimationStart]);
   return (
     <JavascriptAnimate
-      animationName={`Bar-${props.dataKey}`}
+      animationName={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -407,6 +407,7 @@ function RectanglesWithAnimation({
   }, [onAnimationStart]);
   return (
     <JavascriptAnimate
+      animationName={`Bar-${props.dataKey}`}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -407,7 +407,7 @@ function RectanglesWithAnimation({
   }, [onAnimationStart]);
   return (
     <JavascriptAnimate
-      animationName={animationId}
+      animationId={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/cartesian/ErrorBar.tsx
+++ b/src/cartesian/ErrorBar.tsx
@@ -170,6 +170,7 @@ function ErrorBarImpl(props: ErrorBarInternalProps) {
           const lineStyle = isAnimationActive ? { transformOrigin } : undefined;
           return (
             <CSSTransitionAnimate
+              animationId={`error-bar-${direction}`}
               from={`${scaleDirection}(0)`}
               to={`${scaleDirection}(1)`}
               attributeName="transform"
@@ -177,7 +178,7 @@ function ErrorBarImpl(props: ErrorBarInternalProps) {
               easing={animationEasing}
               isActive={isAnimationActive}
               duration={animationDuration}
-              key={`line-${coordinates.x1}-${coordinates.x2}-${coordinates.y1}-${coordinates.y2}`}
+              key={`errorbar-${coordinates.x1}-${coordinates.x2}-${coordinates.y1}-${coordinates.y2}`}
             >
               {style => <line {...coordinates} style={{ ...lineStyle, ...style }} />}
             </CSSTransitionAnimate>

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -39,6 +39,7 @@ import { resolveDefaultProps } from '../util/resolveDefaultProps';
 import { usePlotArea } from '../hooks';
 import { svgPropertiesNoEvents } from '../util/svgPropertiesNoEvents';
 import { JavascriptAnimate } from '../animation/JavascriptAnimate';
+import { useAnimationId } from '../util/useAnimationId';
 
 export interface FunnelTrapezoidItem extends TrapezoidProps {
   value?: number | string;
@@ -189,27 +190,6 @@ function FunnelTrapezoids(props: FunnelTrapezoidsProps) {
   );
 }
 
-let latestId = 0;
-
-/**
- * This hook will return a unique animation id for the given reference.
- * The ID increments every time the reference changes.
- * @param reference The reference to track
- * @returns The unique animation ID
- */
-function useAnimationId(reference: unknown) {
-  const idRef = useRef<number>(latestId);
-  const ref = useRef(reference);
-
-  if (ref.current !== reference) {
-    idRef.current += 1;
-    latestId = idRef.current;
-    ref.current = reference;
-  }
-
-  return idRef.current;
-}
-
 function TrapezoidsWithAnimation({
   previousTrapezoidsRef,
   props,
@@ -230,7 +210,7 @@ function TrapezoidsWithAnimation({
 
   const [isAnimating, setIsAnimating] = useState(true);
 
-  const animationId = useAnimationId(trapezoids);
+  const animationId = useAnimationId(trapezoids, 'recharts-funnel-');
 
   const handleAnimationEnd = useCallback(() => {
     if (typeof onAnimationEnd === 'function') {
@@ -248,6 +228,7 @@ function TrapezoidsWithAnimation({
 
   return (
     <JavascriptAnimate
+      animationName={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -228,7 +228,7 @@ function TrapezoidsWithAnimation({
 
   return (
     <JavascriptAnimate
-      animationName={animationId}
+      animationId={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -400,6 +400,7 @@ function CurveWithAnimation({
 
   return (
     <JavascriptAnimate
+      animationName={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -400,7 +400,7 @@ function CurveWithAnimation({
 
   return (
     <JavascriptAnimate
-      animationName={animationId}
+      animationId={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -296,7 +296,7 @@ function SymbolsWithAnimation({
   }, []);
   return (
     <JavascriptAnimate
-      animationName={animationId}
+      animationId={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -296,6 +296,7 @@ function SymbolsWithAnimation({
   }, []);
   return (
     <JavascriptAnimate
+      animationName={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -715,6 +715,7 @@ class TreemapWithState extends PureComponent<InternalTreemapProps, State> {
 
     return (
       <CSSTransitionAnimate
+        animationId={`treemap-${nodeProps.tooltipIndex}`}
         from={`translate(${translateX}px, ${translateX}px)`}
         to="translate(0, 0)"
         attributeName="transform"

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -551,6 +551,7 @@ function SectorsWithAnimation({
   }, [onAnimationStart]);
   return (
     <JavascriptAnimate
+      animationName={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -551,7 +551,7 @@ function SectorsWithAnimation({
   }, [onAnimationStart]);
   return (
     <JavascriptAnimate
-      animationName={animationId}
+      animationId={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -337,6 +337,7 @@ function PolygonWithAnimation({
 
   return (
     <JavascriptAnimate
+      animationName={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -337,7 +337,7 @@ function PolygonWithAnimation({
 
   return (
     <JavascriptAnimate
-      animationName={animationId}
+      animationId={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -161,6 +161,7 @@ function SectorsWithAnimation({
   }, [onAnimationStart]);
   return (
     <JavascriptAnimate
+      animationName={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -161,7 +161,7 @@ function SectorsWithAnimation({
   }, [onAnimationStart]);
   return (
     <JavascriptAnimate
-      animationName={animationId}
+      animationId={animationId}
       begin={animationBegin}
       duration={animationDuration}
       isActive={isAnimationActive}

--- a/src/shape/Rectangle.tsx
+++ b/src/shape/Rectangle.tsx
@@ -148,7 +148,7 @@ export const Rectangle: React.FC<Props> = rectangleProps => {
 
   return (
     <JavascriptAnimate
-      animationName={animationId}
+      animationId={animationId}
       key={animationId}
       canBegin={totalLength > 0}
       duration={animationDuration}

--- a/src/shape/Rectangle.tsx
+++ b/src/shape/Rectangle.tsx
@@ -148,6 +148,7 @@ export const Rectangle: React.FC<Props> = rectangleProps => {
 
   return (
     <JavascriptAnimate
+      animationName={animationId}
       key={animationId}
       canBegin={totalLength > 0}
       duration={animationDuration}

--- a/src/shape/Rectangle.tsx
+++ b/src/shape/Rectangle.tsx
@@ -128,7 +128,7 @@ export const Rectangle: React.FC<Props> = rectangleProps => {
   const prevHeightRef = useRef<number>(height);
   const prevXRef = useRef<number>(x);
   const prevYRef = useRef<number>(y);
-  const animationId = useAnimationId(props);
+  const animationId = useAnimationId(rectangleProps, 'rectangle-');
 
   if (x !== +x || y !== +y || width !== +width || height !== +height || width === 0 || height === 0) {
     return null;
@@ -168,6 +168,7 @@ export const Rectangle: React.FC<Props> = rectangleProps => {
         }
         return (
           <CSSTransitionAnimate
+            animationId={animationId}
             canBegin={totalLength > 0}
             from={`0px ${totalLength === -1 ? 1 : totalLength}px`}
             to={`${totalLength}px 0px`}

--- a/storybook/stories/API/ResponsiveContainer.stories.tsx
+++ b/storybook/stories/API/ResponsiveContainer.stories.tsx
@@ -3,7 +3,6 @@ import { Args, StoryObj } from '@storybook/react-vite';
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from '../../../src';
 import { pageData } from '../data/Page';
 import { RechartsHookInspector } from '../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../storybook-addon-recharts/RechartsStoryContext';
 import { Props } from '../../../src/component/ResponsiveContainer';
 
 export default {
@@ -15,7 +14,7 @@ export default {
 
 export const API: StoryObj<Props> = {
   // https://github.com/recharts/recharts/issues/172
-  render: (args: Args, context: RechartsStoryContext<Props>) => {
+  render: (args: Args) => {
     return (
       <div
         style={{
@@ -44,10 +43,7 @@ export const API: StoryObj<Props> = {
               <YAxis />
               <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
               <Tooltip />
-              <RechartsHookInspector
-                position={context.rechartsInspectorPosition}
-                setPosition={context.rechartsSetInspectorPosition}
-              />
+              <RechartsHookInspector />
             </AreaChart>
           </ResponsiveContainer>
         </div>

--- a/storybook/stories/API/cartesian/Area.stories.tsx
+++ b/storybook/stories/API/cartesian/Area.stories.tsx
@@ -9,7 +9,6 @@ import { General as GeneralProps, data } from '../props/CartesianComponentShared
 import { ResponsiveProps } from '../props/Tooltip';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const AreaSpecificProps = {
   // These two props are not documented on the website. Further investigation is required to document them.
@@ -46,7 +45,7 @@ export default {
 const [surfaceWidth, surfaceHeight] = [600, 300];
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
         <ComposedChart
@@ -68,10 +67,7 @@ export const API = {
           {/* The target component */}
           <Area dataKey="uv" {...args} />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/Bar.stories.tsx
+++ b/storybook/stories/API/cartesian/Bar.stories.tsx
@@ -480,6 +480,7 @@ export const API = {
           {/* The target component */}
           <Bar dataKey="uv" {...args} />
           <Tooltip />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/Bar.stories.tsx
+++ b/storybook/stories/API/cartesian/Bar.stories.tsx
@@ -187,7 +187,6 @@ import {
   isAnimationActive,
 } from '../props/AnimationProps';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const [surfaceWidth, surfaceHeight] = [600, 300];
 
@@ -558,7 +557,7 @@ const dataWithSmallishValues = [
   },
 ];
 export const WithMinHeight = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const renderCustomizedLabel = (props: any) => {
       const { x, y, width, value } = props;
       const radius = 10;
@@ -595,10 +594,7 @@ export const WithMinHeight = {
             <LabelList dataKey="name" content={renderCustomizedLabel} />
           </Bar>
           <Bar dataKey="uv" fill="#82ca9d" minPointSize={10} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/Brush.stories.tsx
+++ b/storybook/stories/API/cartesian/Brush.stories.tsx
@@ -15,7 +15,6 @@ import {
 } from '../../../../src';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const GeneralProps: Args = {
   ariaLabel: {
@@ -97,15 +96,12 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => (
+  render: (args: Args) => (
     <ResponsiveContainer width="100%" height={400}>
       <ComposedChart data={pageData}>
         <Line dataKey="uv" />
         <Brush {...args} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </ComposedChart>
     </ResponsiveContainer>
   ),
@@ -123,7 +119,7 @@ export const API = {
 };
 
 export const PanoramaWithLine = {
-  render: (args: Args, context: RechartsStoryContext) => (
+  render: (args: Args) => (
     <ResponsiveContainer width="100%" height={400}>
       <ComposedChart data={pageData}>
         <Line dataKey="uv" />
@@ -133,10 +129,7 @@ export const PanoramaWithLine = {
             <Line dataKey="uv" />
           </ComposedChart>
         </Brush>
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </ComposedChart>
     </ResponsiveContainer>
   ),
@@ -144,7 +137,7 @@ export const PanoramaWithLine = {
 };
 
 export const PanoramaWithArea = {
-  render: (args: Args, context: RechartsStoryContext) => (
+  render: (args: Args) => (
     <ResponsiveContainer width="100%" height={400}>
       <ComposedChart data={pageData}>
         <Area dataKey="uv" />
@@ -154,10 +147,7 @@ export const PanoramaWithArea = {
             <Area dataKey="uv" />
           </ComposedChart>
         </Brush>
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </ComposedChart>
     </ResponsiveContainer>
   ),
@@ -165,7 +155,7 @@ export const PanoramaWithArea = {
 };
 
 export const PanoramaWithBar = {
-  render: (args: Args, context: RechartsStoryContext) => (
+  render: (args: Args) => (
     <ResponsiveContainer width="100%" height={400}>
       <ComposedChart data={pageData}>
         <Bar dataKey="uv" />
@@ -175,10 +165,7 @@ export const PanoramaWithBar = {
             <Bar dataKey="uv" />
           </ComposedChart>
         </Brush>
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </ComposedChart>
     </ResponsiveContainer>
   ),
@@ -186,7 +173,7 @@ export const PanoramaWithBar = {
 };
 
 export const PanoramaWithScatter = {
-  render: (args: Args, context: RechartsStoryContext) => (
+  render: (args: Args) => (
     <ResponsiveContainer width="100%" height={400}>
       <ScatterChart data={pageData}>
         <Scatter dataKey="uv" />
@@ -196,10 +183,7 @@ export const PanoramaWithScatter = {
             <Scatter dataKey="uv" />
           </ScatterChart>
         </Brush>
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </ScatterChart>
     </ResponsiveContainer>
   ),

--- a/storybook/stories/API/cartesian/CartesianGrid.stories.tsx
+++ b/storybook/stories/API/cartesian/CartesianGrid.stories.tsx
@@ -3,7 +3,6 @@ import { Args, ArgTypes } from '@storybook/react-vite';
 import { CartesianGrid, ResponsiveContainer, ComposedChart, XAxis, YAxis } from '../../../../src';
 import { pageData } from '../../data';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const GeneralProps: ArgTypes = {
   x: {
@@ -115,16 +114,13 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [surfaceWidth, surfaceHeight] = [500, 500];
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
         <ComposedChart width={surfaceWidth} height={surfaceHeight}>
           <CartesianGrid {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -144,7 +140,7 @@ export const API = {
 };
 
 export const MultipleGrids = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart width={500} height={500} data={pageData}>
@@ -152,10 +148,7 @@ export const MultipleGrids = {
           <YAxis dataKey="pv" />
           {args.displayGridA && <CartesianGrid verticalFill={['#aaeeee', '#eeeeaa']} stroke="trasparent" />}
           {args.displayGridB && <CartesianGrid stroke="silver" strokeDasharray="3 3" strokeWidth={3} />}
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/ErrorBar.stories.tsx
+++ b/storybook/stories/API/cartesian/ErrorBar.stories.tsx
@@ -4,7 +4,6 @@ import { ScatterChart, ErrorBar, CartesianGrid, XAxis, YAxis, ResponsiveContaine
 import { errorData } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const GeneralProps: Args = {
   dataKey: {
@@ -70,7 +69,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ScatterChart
@@ -89,10 +88,7 @@ export const API = {
           <Scatter data={errorData} fill="#ff7300">
             <ErrorBar dataKey="errorY" {...args} />
           </Scatter>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ScatterChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/Funnel.stories.tsx
+++ b/storybook/stories/API/cartesian/Funnel.stories.tsx
@@ -22,7 +22,6 @@ import {
 import { ResponsiveProps } from '../props/Tooltip';
 import { GeneralStyle } from '../props/Styles';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: {
@@ -51,7 +50,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={200}>
         <FunnelChart layout="horizontal">
@@ -59,10 +58,7 @@ export const API = {
             <LabelList dataKey="name" fill="#000" position="right" stroke="none" />
             <Legend />
           </Funnel>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </FunnelChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/Line.stories.tsx
+++ b/storybook/stories/API/cartesian/Line.stories.tsx
@@ -9,8 +9,7 @@ import { LineStyle } from '../props/Styles';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { data, General as GeneralProps } from '../props/CartesianComponentShared';
 import { ResponsiveProps } from '../props/Tooltip';
-import { ManualAnimations, RechartsHookInspector } from '../../../storybook-addon-recharts';
-import { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
+import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 
 export default {
   argTypes: {
@@ -29,33 +28,31 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
     return (
-      <ManualAnimations isEnabled={context.rechartsInspectorEnabled}>
-        <ResponsiveContainer width="100%" height={surfaceHeight}>
-          <ComposedChart
-            width={surfaceWidth}
-            height={surfaceHeight}
-            margin={{
-              top: 20,
-              right: 20,
-              bottom: 20,
-              left: 20,
-            }}
-            data={pageData}
-          >
-            {/* All components are added to show the interaction with the Line properties */}
-            <Legend />
-            <XAxis dataKey="name" />
-            <YAxis width="auto" />
-            {/* The target component */}
-            <Line dataKey="uv" {...args} />
-            <Tooltip />
-            <RechartsHookInspector />
-          </ComposedChart>
-        </ResponsiveContainer>
-      </ManualAnimations>
+      <ResponsiveContainer width="100%" height={surfaceHeight}>
+        <ComposedChart
+          width={surfaceWidth}
+          height={surfaceHeight}
+          margin={{
+            top: 20,
+            right: 20,
+            bottom: 20,
+            left: 20,
+          }}
+          data={pageData}
+        >
+          {/* All components are added to show the interaction with the Line properties */}
+          <Legend />
+          <XAxis dataKey="name" />
+          <YAxis width="auto" />
+          {/* The target component */}
+          <Line dataKey="uv" {...args} />
+          <Tooltip />
+          <RechartsHookInspector />
+        </ComposedChart>
+      </ResponsiveContainer>
     );
   },
   args: {

--- a/storybook/stories/API/cartesian/Line.stories.tsx
+++ b/storybook/stories/API/cartesian/Line.stories.tsx
@@ -52,10 +52,7 @@ export const API = {
             {/* The target component */}
             <Line dataKey="uv" {...args} />
             <Tooltip />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </ComposedChart>
         </ResponsiveContainer>
       </ManualAnimations>

--- a/storybook/stories/API/cartesian/ReferenceArea.stories.tsx
+++ b/storybook/stories/API/cartesian/ReferenceArea.stories.tsx
@@ -18,7 +18,6 @@ import { GeneralStyle } from '../props/Styles';
 import { ReferenceComponentGeneralArgs, ReferenceComponentStyle } from '../props/ReferenceComponentShared';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const StyleProps: Args = {
   ...GeneralStyle,
@@ -110,7 +109,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -127,10 +126,7 @@ export const API = {
           <YAxis type="number" />
           <Line dataKey="uv" />
           <ReferenceArea {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/ReferenceDot.stories.tsx
+++ b/storybook/stories/API/cartesian/ReferenceDot.stories.tsx
@@ -12,7 +12,6 @@ import {
   ReferenceComponentStyle,
 } from '../props/ReferenceComponentShared';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const GeneralProps: Args = {
   ...ReferenceComponentGeneralArgs,
@@ -79,7 +78,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -96,10 +95,7 @@ export const API = {
           <YAxis type="number" />
           <Bar type="monotone" dataKey="uv" />
           <ReferenceDot {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/ReferenceLine.stories.tsx
+++ b/storybook/stories/API/cartesian/ReferenceLine.stories.tsx
@@ -10,7 +10,6 @@ import {
   ReferenceComponentStyle,
 } from '../props/ReferenceComponentShared';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const GeneralProps: Args = {
   ...ReferenceComponentGeneralArgs,
@@ -96,7 +95,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -113,10 +112,7 @@ export const API = {
           <YAxis type="number" />
           <ReferenceLine {...args} />
           <Line dataKey="uv" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/Scatter.stories.tsx
+++ b/storybook/stories/API/cartesian/Scatter.stories.tsx
@@ -171,7 +171,6 @@ import { hide } from '../props/Styles';
 import { legendType } from '../props/Legend';
 import { StorybookArgs } from '../../../StorybookArgs';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const EventHandlers = {
   onAbort,
@@ -483,7 +482,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
         <ComposedChart
@@ -500,10 +499,7 @@ export const API = {
           <Scatter {...args} />
           <XAxis dataKey="pv" />
           <YAxis dataKey="uv" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/XAxis.stories.tsx
+++ b/storybook/stories/API/cartesian/XAxis.stories.tsx
@@ -5,7 +5,6 @@ import { coordinateWithValueData } from '../../data';
 import { XAxisProps } from '../props/XAxisProps';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: XAxis,
@@ -13,7 +12,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <LineChart width={600} height={300} data={coordinateWithValueData}>
@@ -23,10 +22,7 @@ export const API = {
           <Legend />
           <Line dataKey="y" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -74,7 +70,7 @@ const CustomXAxisTickWithPadding = (props: any) => {
 };
 
 export const CustomTickWithPadding = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const sampleData = [
       { name: 'Jan', value: 400, category: 'A' },
       { name: 'Feb', value: 300, category: 'B' },
@@ -93,10 +89,7 @@ export const CustomTickWithPadding = {
           <Line type="monotone" dataKey="value" stroke="#8884d8" />
           <Tooltip />
           <Legend />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -111,7 +104,7 @@ export const CustomTickWithPadding = {
 };
 
 export const CustomTickFunction = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const sampleData = [
       { month: 'Jan', sales: 1200, profit: 400 },
       { month: 'Feb', sales: 1900, profit: 500 },
@@ -154,10 +147,7 @@ export const CustomTickFunction = {
           <Line type="monotone" dataKey="profit" stroke="#82ca9d" name="Profit" />
           <Tooltip />
           <Legend />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/YAxis.stories.tsx
+++ b/storybook/stories/API/cartesian/YAxis.stories.tsx
@@ -5,7 +5,6 @@ import { coordinateWithValueData } from '../../data';
 import { YAxisProps } from '../props/YAxisProps';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: YAxis,
@@ -22,7 +21,7 @@ const getWidth = (width: string | number) => {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const width = getWidth(args.width);
 
     return (
@@ -34,10 +33,7 @@ export const API = {
           <Legend />
           <Line dataKey="y" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -89,7 +85,7 @@ const CustomYAxisTickWithPadding = (props: any) => {
 };
 
 export const YAxisCustomTickWithPadding = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const sampleData = [
       { category: 'Product A', value: 400, target: 450 },
       { category: 'Product B', value: 300, target: 350 },
@@ -108,10 +104,7 @@ export const YAxisCustomTickWithPadding = {
           <Line type="monotone" dataKey="target" stroke="#e74c3c" strokeDasharray="5 5" name="Target" />
           <Tooltip />
           <Legend />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/cartesian/ZAxis.stories.tsx
+++ b/storybook/stories/API/cartesian/ZAxis.stories.tsx
@@ -14,7 +14,6 @@ import { pageData } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { SCALE_TYPES } from '../../../../src/util/ReactUtils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const GeneralProps: Args = {
   zAxisId: {
@@ -52,7 +51,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ScatterChart width={400} height={400} margin={{ top: 20, right: 20, bottom: 0, left: 20 }}>
@@ -62,10 +61,7 @@ export const API = {
           <CartesianGrid />
           <Scatter name="pageData" data={pageData} />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ScatterChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/chart/AreaChart.stories.tsx
+++ b/storybook/stories/API/chart/AreaChart.stories.tsx
@@ -6,7 +6,6 @@ import { pageData, subjectData } from '../../data';
 import { CategoricalChartProps } from '../props/ChartProps';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: CategoricalChartProps,
@@ -14,7 +13,7 @@ export default {
 };
 
 export const Simple = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [myState, setMyState] = React.useState(0);
     return (
       <ResponsiveContainer width="100%" height={400}>
@@ -31,10 +30,7 @@ export const Simple = {
           <Area dataKey="pv" strokeWidth={3} stroke="#2451B7" fill="#5376C4" />
           <CartesianGrid opacity={0.1} vertical={false} />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -55,15 +51,12 @@ export const Simple = {
 const stepAround = curveCardinal.tension(0.5);
 
 export const CustomType = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <AreaChart {...args}>
           <Area type={stepAround} dataKey="pv" stroke="#ff7300" fill="#ff7300" fillOpacity={0.9} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -82,17 +75,14 @@ export const CustomType = {
 };
 
 export const CategoricalAreaChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <AreaChart {...args}>
           <Area dataKey="A" stroke="green" fill="green" fillOpacity={0.5} />
           <XAxis dataKey="subject" type="category" allowDuplicatedCategory={false} />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </AreaChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/chart/BarChart.stories.tsx
+++ b/storybook/stories/API/chart/BarChart.stories.tsx
@@ -5,7 +5,6 @@ import { pageData, pageDataWithNegativeNumbers } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { BarChartProps } from '../props/BarChartProps';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: BarChartProps,
@@ -13,16 +12,13 @@ export default {
 };
 
 export const Simple = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <StrictMode>
         <ResponsiveContainer width="100%" height={400}>
           <BarChart {...args}>
             <Bar dataKey="uv" />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </BarChart>
         </ResponsiveContainer>
       </StrictMode>
@@ -41,7 +37,7 @@ export const Simple = {
 };
 
 export const BarInBar = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <BarChart {...args}>
@@ -50,10 +46,7 @@ export const BarInBar = {
           {/* The smaller bar must be rendered in front of the larger one to be visible. */}
           <Bar dataKey="pv" fill="red" xAxisId="two" barSize={30} />
           <XAxis xAxisId="two" hide />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -71,7 +64,7 @@ export const BarInBar = {
 };
 
 export const Stacked = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <BarChart {...args}>
@@ -82,10 +75,7 @@ export const Stacked = {
           <Tooltip />
           <Bar dataKey="uv" stackId="a" fill="green" barSize={50} name="UV Bar" />
           <Bar dataKey="pv" stackId="a" fill="red" barSize={30} name="PV Bar" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -105,7 +95,7 @@ export const Stacked = {
 };
 
 export const VerticalWithMultipleAxes = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <BarChart {...args}>
         <Bar dataKey="uv" xAxisId={2} fill="blue" barSize={40} />
@@ -113,10 +103,7 @@ export const VerticalWithMultipleAxes = {
         <XAxis xAxisId={1} type="number" />
         <XAxis xAxisId={2} type="number" orientation="top" />
         <YAxis type="category" />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </BarChart>
     );
   },

--- a/storybook/stories/API/chart/ComposedChart.stories.tsx
+++ b/storybook/stories/API/chart/ComposedChart.stories.tsx
@@ -20,7 +20,6 @@ import {
 } from '../../../../src';
 import { CategoricalChartProps } from '../props/ChartProps';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: {
@@ -32,7 +31,7 @@ export default {
 // This render template can be shared across multiple stories.
 // All stories use the same data, but pass different children.
 const HorizontalChartTemplate = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={300}>
         <Composed
@@ -46,10 +45,7 @@ const HorizontalChartTemplate = {
           }}
         >
           {args.children}
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </Composed>
       </ResponsiveContainer>
     );
@@ -136,7 +132,7 @@ export const LineBarHorizontal = {
 };
 
 export const LineBarAreaScatterTimeScale = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const tickFormatter = (tick: Date) => {
       return tick.toLocaleString('en-GB', {
         /*
@@ -178,10 +174,7 @@ export const LineBarAreaScatterTimeScale = {
               <Bar dataKey="y" barSize={20} fill="#413ea0" />
               <Line type="monotone" dataKey="y" stroke="#ff7300" />
               <Tooltip />
-              <RechartsHookInspector
-                position={context.rechartsInspectorPosition}
-                setPosition={context.rechartsSetInspectorPosition}
-              />
+              <RechartsHookInspector />
             </Composed>
           </div>
         </div>

--- a/storybook/stories/API/chart/FunnelChart.stories.tsx
+++ b/storybook/stories/API/chart/FunnelChart.stories.tsx
@@ -6,7 +6,6 @@ import { ActiveShapeProps } from '../props/ActiveShapeProps';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { pageDataWithFillColor } from '../../data';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: {
@@ -17,7 +16,7 @@ export default {
 };
 
 export const Simple: StoryObj<FunnelProps> = {
-  render: (args: FunnelProps, context: RechartsStoryContext<FunnelProps>) => {
+  render: (args: FunnelProps) => {
     const { data } = args;
     return (
       <ResponsiveContainer width="100%" height={200}>
@@ -34,10 +33,7 @@ export const Simple: StoryObj<FunnelProps> = {
             <LabelList dataKey="name" fill="#000" position="right" stroke="none" />
           </Funnel>
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </FunnelChart>
       </ResponsiveContainer>
     );
@@ -86,7 +82,7 @@ export const Simple: StoryObj<FunnelProps> = {
 };
 
 export const WithChangingDataKey: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [dataKey, setDataKey] = React.useState('amt');
     return (
       <>
@@ -125,10 +121,7 @@ export const WithChangingDataKey: StoryObj = {
             label={{ dataKey: 'name', stroke: 'none', fill: 'black', strokeDasharray: '0 0' }}
           />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </FunnelChart>
       </>
     );

--- a/storybook/stories/API/chart/LineChart.stories.tsx
+++ b/storybook/stories/API/chart/LineChart.stories.tsx
@@ -4,7 +4,6 @@ import { pageData } from '../../data';
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis } from '../../../../src';
 import { CategoricalChartProps } from '../props/ChartProps';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: CategoricalChartProps,
@@ -12,15 +11,12 @@ export default {
 };
 
 export const Simple = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <LineChart {...args}>
           <Line dataKey="uv" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -31,17 +27,14 @@ export const Simple = {
 };
 
 export const SynchronizedTooltip = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <div>
         <LineChart {...args} id="BookOne" className="BookOne">
           <Line isAnimationActive={false} name="BookOne" type="monotone" dataKey="uv" stroke="#111" />
           <XAxis dataKey="name" />
           <Tooltip active />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
         <LineChart {...args} id="BookTwo" className="BookTwo">
           <Line isAnimationActive={false} name="BookTwo" type="monotone" dataKey="uv" stroke="#ff7300" />

--- a/storybook/stories/API/chart/PieChart.stories.tsx
+++ b/storybook/stories/API/chart/PieChart.stories.tsx
@@ -5,7 +5,6 @@ import { CategoricalChartProps } from '../props/ChartProps';
 import { ActiveShapeProps } from '../props/ActiveShapeProps';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: {
@@ -17,17 +16,14 @@ export default {
 };
 
 export const Simple = {
-  render: (args: Record<string, any>, context: RechartsStoryContext) => {
+  render: (args: Record<string, any>) => {
     const { data, activeShape } = args;
     return (
       <ResponsiveContainer width="100%" height={400}>
         <PieChart {...args}>
           <Pie data={data} dataKey="uv" activeShape={activeShape} />
           <Tooltip defaultIndex={3} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </PieChart>
       </ResponsiveContainer>
     );
@@ -46,7 +42,7 @@ export const Simple = {
 };
 
 export const Donut = {
-  render: (args: Record<string, any>, context: RechartsStoryContext) => {
+  render: (args: Record<string, any>) => {
     return (
       <PieChart {...args}>
         <Pie data={args.data} dataKey="uv" nameKey="name" innerRadius={50} outerRadius={80} cornerRadius={8}>
@@ -58,10 +54,7 @@ export const Donut = {
           </Label>
           <Legend align="right" verticalAlign="middle" layout="vertical" />
         </Pie>
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </PieChart>
     );
   },
@@ -74,7 +67,7 @@ export const Donut = {
 };
 
 export const ChangingDataKey = {
-  render: (args: Record<string, any>, context: RechartsStoryContext) => {
+  render: (args: Record<string, any>) => {
     const data1 = [
       { x: { value: 1 }, name: 'x1', fill: 'blue' },
       { x: { value: 2 }, name: 'x2', fill: 'red' },
@@ -127,10 +120,7 @@ export const ChangingDataKey = {
         <PieChart {...args} data={useData2 ? data2 : data1}>
           <Tooltip />
           <Legend />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
           <Pie
             data={useData2 ? data2 : data1}
             name="Animated line"

--- a/storybook/stories/API/chart/RadarChart.stories.tsx
+++ b/storybook/stories/API/chart/RadarChart.stories.tsx
@@ -5,7 +5,6 @@ import { PolarAngleAxis, PolarGrid, PolarRadiusAxis, Radar, RadarChart, Tooltip 
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RadarChartProps } from '../props/RadarChartProps';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: RadarChartProps,
@@ -13,7 +12,7 @@ export default {
 };
 
 export const Simple = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadarChart {...args}>
         <PolarAngleAxis dataKey="name" />
@@ -21,10 +20,7 @@ export const Simple = {
         <PolarGrid />
         <Tooltip defaultIndex={1} />
         <Radar dataKey="uv" stroke="green" strokeOpacity={0.7} fill="green" fillOpacity={0.5} strokeWidth={3} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadarChart>
     );
   },

--- a/storybook/stories/API/chart/RadialBarChart.stories.tsx
+++ b/storybook/stories/API/chart/RadialBarChart.stories.tsx
@@ -7,7 +7,6 @@ import { Cell, Legend, RadialBar, RadialBarChart, ResponsiveContainer, Tooltip }
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RadialBarChartProps } from '../props/RadialBarChartProps';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 import { StorybookArgs } from '../../../StorybookArgs';
 
 export default {
@@ -16,15 +15,12 @@ export default {
 };
 
 export const Simple: StoryObj = {
-  render: (args: StorybookArgs, context: RechartsStoryContext) => {
+  render: (args: StorybookArgs) => {
     return (
       <RadialBarChart {...args}>
         <RadialBar dataKey="uv" activeShape={{ fill: 'red' }} label={{ position: 'insideStart', fill: 'white' }} />
         <Tooltip defaultIndex={3} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },
@@ -37,7 +33,7 @@ export const Simple: StoryObj = {
 };
 
 export const WithCustomizedClickLegendEvent = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const { data } = args;
     const [selectedRadialBar, setSelectedRadialBar] = useState('35-39');
 
@@ -74,10 +70,7 @@ export const WithCustomizedClickLegendEvent = {
               </ul>
             )}
           />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </RadialBarChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/chart/Sankey.stories.tsx
+++ b/storybook/stories/API/chart/Sankey.stories.tsx
@@ -6,7 +6,6 @@ import { NodeProps } from '../../../../src/chart/Sankey';
 import { data, margin } from '../props/ChartProps';
 import { dataKey } from '../props/CartesianComponentShared';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: {
@@ -26,15 +25,12 @@ export default {
 };
 
 export const Simple = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <Sankey data={nodeLinkData} {...args}>
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </Sankey>
       </ResponsiveContainer>
     );
@@ -45,14 +41,11 @@ export const Simple = {
 };
 
 export const Customized = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <Sankey data={nodeLinkData} {...args}>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </Sankey>
       </ResponsiveContainer>
     );
@@ -67,7 +60,7 @@ export const Customized = {
 };
 
 export const CustomNodeAndLink = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const colors = ['#3C898E', '#486DF0', '#6F50E5'];
 
     type CustomNodePayload = {
@@ -176,10 +169,7 @@ export const CustomNodeAndLink = {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <Sankey data={complexNodeLinkData} node={CustomNode} link={CustomLink} {...args}>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </Sankey>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/chart/ScatterChart.stories.tsx
+++ b/storybook/stories/API/chart/ScatterChart.stories.tsx
@@ -5,7 +5,6 @@ import { ResponsiveContainer, Scatter, ScatterChart, XAxis, YAxis } from '../../
 import { CategoricalChartProps } from '../props/ChartProps';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: CategoricalChartProps,
@@ -13,7 +12,7 @@ export default {
 };
 
 export const Simple = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const { data, ...rest } = args;
     return (
       <ResponsiveContainer width="100%" height={400}>
@@ -21,10 +20,7 @@ export const Simple = {
           <XAxis dataKey="x" />
           <YAxis dataKey="y" />
           <Scatter data={data} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ScatterChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/chart/SunburstChart.stories.tsx
+++ b/storybook/stories/API/chart/SunburstChart.stories.tsx
@@ -5,7 +5,6 @@ import { SunburstData } from '../../../../src/chart/SunburstChart';
 import { CategoricalChartProps, ChartSizeProps, data, dataKey, margin } from '../props/ChartProps';
 import { PolarChartProps } from '../props/PolarChartProps';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const { innerRadius, outerRadius, cx, cy, startAngle, endAngle } = PolarChartProps;
 
@@ -112,14 +111,11 @@ const hierarchy: SunburstData = {
 };
 
 export const Sunburst = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={450}>
         <SunburstChart {...args} data={args.data}>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </SunburstChart>
       </ResponsiveContainer>
     );
@@ -131,14 +127,11 @@ export const Sunburst = {
 };
 
 export const WithStartAndEndAngle = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={450}>
         <SunburstChart {...args} data={args.data}>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </SunburstChart>
       </ResponsiveContainer>
     );
@@ -152,15 +145,12 @@ export const WithStartAndEndAngle = {
 };
 
 export const WithTooltip = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={450}>
         <SunburstChart {...args} data={args.data}>
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </SunburstChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/chart/Treemap.stories.tsx
+++ b/storybook/stories/API/chart/Treemap.stories.tsx
@@ -9,7 +9,6 @@ import { onAnimationEnd, onAnimationStart, onClick, onMouseEnter, onMouseLeave }
 import { dataKey } from '../props/CartesianComponentShared';
 import { GeneralStyle } from '../props/Styles';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: {
@@ -76,14 +75,11 @@ export default {
 };
 
 export const Simple = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <Treemap {...args}>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </Treemap>
       </ResponsiveContainer>
     );
@@ -97,15 +93,12 @@ export const Simple = {
 };
 
 export const WithTooltip = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <Treemap {...args}>
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </Treemap>
       </ResponsiveContainer>
     );
@@ -121,7 +114,7 @@ export const WithTooltip = {
 const colors = ['#8889DD', '#9597E4', '#8DC77B', '#A5D297', '#E2CF45', '#F8C12D'];
 
 export const WithCustomContent = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <Treemap
@@ -161,10 +154,7 @@ export const WithCustomContent = {
           }}
         >
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </Treemap>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/component/Cell.stories.tsx
+++ b/storybook/stories/API/component/Cell.stories.tsx
@@ -6,7 +6,6 @@ import { EventHandlers } from '../props/EventHandlers';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { pageData } from '../../data';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: {
@@ -21,7 +20,7 @@ export default {
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', 'red', 'pink', 'url(#pattern-checkers)'];
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const surfaceDimension = 400;
     return (
       <ResponsiveContainer width="100%" height={surfaceDimension}>
@@ -37,10 +36,7 @@ export const API = {
               <Cell key={`cell-pie-${entry.pv}-${entry.uv}`} fill={COLORS[index]} {...args} />
             ))}
           </Pie>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </PieChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/component/Label.stories.tsx
+++ b/storybook/stories/API/component/Label.stories.tsx
@@ -15,7 +15,6 @@ import {
   PolarGrid,
 } from '../../../../src';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 import { pageData } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 
@@ -113,7 +112,7 @@ const availablePositions = [
 ] as const;
 
 export const CartesianPositions = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <LineChart
@@ -133,10 +132,7 @@ export const CartesianPositions = {
             <Label key={position} value={`Position: ${position}`} position={position} className={position} {...args} />
           ))}
           <Label value="Position: x: 200, y: 100" position={{ x: 200, y: 100 }} className="custom-position" {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -145,7 +141,7 @@ export const CartesianPositions = {
 };
 
 export const PolarPositions = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadarChart
         width={800}
@@ -166,10 +162,7 @@ export const PolarPositions = {
           <Label key={position} value={`Position: ${position}`} position={position} className={position} {...args} />
         ))}
         <Label value="Position: x: 200, y: 100" position={{ x: 200, y: 100 }} className="custom-position" {...args} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadarChart>
     );
   },

--- a/storybook/stories/API/component/LabelList.stories.tsx
+++ b/storybook/stories/API/component/LabelList.stories.tsx
@@ -5,7 +5,6 @@ import { ResponsiveContainer, LabelList, LineChart, Line } from '../../../../src
 import { pageData } from '../../data';
 import { LabelListProps } from '../props/LabelListProps';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: {
@@ -15,7 +14,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
@@ -34,10 +33,7 @@ export const API = {
           <Line dataKey="uv">
             <LabelList {...args} />
           </Line>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/component/Legend.stories.tsx
+++ b/storybook/stories/API/component/Legend.stories.tsx
@@ -5,7 +5,6 @@ import { rechartsPackageDownloads, pageData } from '../../data';
 import { LegendProps } from '../props/Legend';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: LegendProps,
@@ -13,7 +12,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
@@ -32,10 +31,7 @@ export const API = {
           <Legend {...args} />
           <Line dataKey="uv" stroke="#8884d8" name="Series 1 (UV)" />
           <Line dataKey="pv" stroke="#82ca9d" name="Series 2 (PV)" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -44,7 +40,7 @@ export const API = {
 };
 
 export const LegendPortal = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [, surfaceHeight] = [600, 300];
     const [legendPortal, setLegendPortal] = useState<HTMLDivElement | null>(null);
 
@@ -96,10 +92,7 @@ export const LegendPortal = {
                 }}
                 labelFormatter={value => new Date(value).toLocaleDateString()}
               />
-              <RechartsHookInspector
-                position={context.rechartsInspectorPosition}
-                setPosition={context.rechartsSetInspectorPosition}
-              />
+              <RechartsHookInspector />
             </AreaChart>
           </ResponsiveContainer>
         </div>

--- a/storybook/stories/API/component/Tooltip.stories.tsx
+++ b/storybook/stories/API/component/Tooltip.stories.tsx
@@ -5,7 +5,6 @@ import { pageData } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { TooltipProps } from '../props/TooltipProps';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: TooltipProps,
@@ -13,7 +12,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
@@ -31,10 +30,7 @@ export const API = {
           <Line dataKey="uv" />
           {/* The target component */}
           <Tooltip {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/hooks/useActiveTooltipDataPoints.stories.tsx
+++ b/storybook/stories/API/hooks/useActiveTooltipDataPoints.stories.tsx
@@ -4,7 +4,6 @@ import { Area, ComposedChart, Legend, Line, ResponsiveContainer, Tooltip, XAxis,
 import { pageData } from '../../data';
 import { PageData } from '../../../../test/_data';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 import { TooltipProps } from '../props/TooltipProps';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 
@@ -19,7 +18,7 @@ const dataAmt = PageData.map(p => ({ name: p.name, amt: p.amt }));
 
 export const UseActiveTooltipDataPoints = {
   name: 'useActiveTooltipDataPoints',
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <ComposedChart data={pageData}>
@@ -30,11 +29,7 @@ export const UseActiveTooltipDataPoints = {
           <YAxis />
           <Legend />
           <Tooltip {...args} />
-          <RechartsHookInspector
-            defaultOpened="useActiveTooltipDataPoints"
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector defaultOpened="useActiveTooltipDataPoints" />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/polar/Pie.stories.tsx
+++ b/storybook/stories/API/polar/Pie.stories.tsx
@@ -6,7 +6,6 @@ import { EventHandlers } from '../props/EventHandlers';
 import { AnimationProps } from '../props/AnimationProps';
 import { ActiveShapeProps } from '../props/ActiveShapeProps';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const GeneralProps: Args = {
   cx: {
@@ -141,14 +140,11 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <PieChart width={300} height={300}>
         <Pie dataKey="uv" {...args} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </PieChart>
     );
   },

--- a/storybook/stories/API/polar/PolarAngleAxis.stories.tsx
+++ b/storybook/stories/API/polar/PolarAngleAxis.stories.tsx
@@ -6,7 +6,6 @@ import { pageData } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { StorybookArgs } from '../../../StorybookArgs';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const GeneralProps: StorybookArgs = {
   type: {
@@ -83,14 +82,11 @@ export default {
 const [surfaceWidth, surfaceHeight] = [600, 300];
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadialBarChart width={surfaceWidth} height={surfaceHeight} data={pageData}>
         <PolarAngleAxis {...args} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },

--- a/storybook/stories/API/polar/PolarRadiusAxis.stories.tsx
+++ b/storybook/stories/API/polar/PolarRadiusAxis.stories.tsx
@@ -6,7 +6,6 @@ import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { StorybookArgs } from '../../../StorybookArgs';
 import { pageData } from '../../data';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const GeneralProps: StorybookArgs = {
   angle: {
@@ -101,7 +100,7 @@ export default {
 const [surfaceWidth, surfaceHeight] = [600, 300];
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
         <RadarChart width={surfaceWidth} height={surfaceHeight} data={pageData}>
@@ -110,10 +109,7 @@ export const API = {
               PolarRadiusAxis
             </Label>
           </PolarRadiusAxis>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </RadarChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/polar/Radar.stories.tsx
+++ b/storybook/stories/API/polar/Radar.stories.tsx
@@ -5,8 +5,7 @@ import { subjectData } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { AnimationProps } from '../props/AnimationProps';
 import { legendType } from '../props/Legend';
-import { ManualAnimations, RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
+import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 
 const GeneralProps: Args = {
   dataKey: {
@@ -60,30 +59,28 @@ export default {
 };
 
 export const General = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
-      <ManualAnimations isEnabled={context.rechartsInspectorEnabled}>
-        <ResponsiveContainer width="100%" height={500}>
-          <RadarChart
-            cx="50%"
-            cy="50%"
-            outerRadius="80%"
-            data={subjectData}
-            margin={{
-              top: 5,
-              right: 30,
-              left: 20,
-              bottom: 5,
-            }}
-          >
-            <PolarGrid />
-            <PolarAngleAxis dataKey="subject" />
-            <PolarRadiusAxis />
-            <Radar {...args} />
-            <RechartsHookInspector />
-          </RadarChart>
-        </ResponsiveContainer>
-      </ManualAnimations>
+      <ResponsiveContainer width="100%" height={500}>
+        <RadarChart
+          cx="50%"
+          cy="50%"
+          outerRadius="80%"
+          data={subjectData}
+          margin={{
+            top: 5,
+            right: 30,
+            left: 20,
+            bottom: 5,
+          }}
+        >
+          <PolarGrid />
+          <PolarAngleAxis dataKey="subject" />
+          <PolarRadiusAxis />
+          <Radar {...args} />
+          <RechartsHookInspector />
+        </RadarChart>
+      </ResponsiveContainer>
     );
   },
   args: {

--- a/storybook/stories/API/polar/Radar.stories.tsx
+++ b/storybook/stories/API/polar/Radar.stories.tsx
@@ -80,10 +80,7 @@ export const General = {
             <PolarAngleAxis dataKey="subject" />
             <PolarRadiusAxis />
             <Radar {...args} />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </RadarChart>
         </ResponsiveContainer>
       </ManualAnimations>

--- a/storybook/stories/API/polar/RadialBar.stories.tsx
+++ b/storybook/stories/API/polar/RadialBar.stories.tsx
@@ -4,8 +4,7 @@ import { pageDataWithFillColor } from '../../data';
 import { Legend, PolarAngleAxis, RadialBar, RadialBarChart, ResponsiveContainer, Tooltip } from '../../../../src';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RadialBarProps } from '../props/RadialBarProps';
-import { ManualAnimations, RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
+import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 
 export default {
   argTypes: RadialBarProps,
@@ -13,19 +12,17 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
-      <ManualAnimations isEnabled={context.rechartsInspectorEnabled}>
-        <ResponsiveContainer width="100%" height={400}>
-          <RadialBarChart width={400} height={400} data={pageDataWithFillColor}>
-            <Legend />
-            <PolarAngleAxis />
-            <RadialBar dataKey="uv" {...args} />
-            <Tooltip />
-            <RechartsHookInspector />
-          </RadialBarChart>
-        </ResponsiveContainer>
-      </ManualAnimations>
+      <ResponsiveContainer width="100%" height={400}>
+        <RadialBarChart width={400} height={400} data={pageDataWithFillColor}>
+          <Legend />
+          <PolarAngleAxis />
+          <RadialBar dataKey="uv" {...args} />
+          <Tooltip />
+          <RechartsHookInspector />
+        </RadialBarChart>
+      </ResponsiveContainer>
     );
   },
   args: {

--- a/storybook/stories/API/polar/RadialBar.stories.tsx
+++ b/storybook/stories/API/polar/RadialBar.stories.tsx
@@ -22,10 +22,7 @@ export const API = {
             <PolarAngleAxis />
             <RadialBar dataKey="uv" {...args} />
             <Tooltip />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </RadialBarChart>
         </ResponsiveContainer>
       </ManualAnimations>

--- a/storybook/stories/API/shapes/Cross.stories.tsx
+++ b/storybook/stories/API/shapes/Cross.stories.tsx
@@ -3,7 +3,6 @@ import { Args } from '@storybook/react-vite';
 import { Cross, ComposedChart, ResponsiveContainer } from '../../../../src';
 import { GeneralStyle } from '../props/Styles';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: Cross,
@@ -50,7 +49,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -64,10 +63,7 @@ export const API = {
           }}
         >
           <Cross {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/shapes/Curve.stories.tsx
+++ b/storybook/stories/API/shapes/Curve.stories.tsx
@@ -166,7 +166,6 @@ import {
   onWheelCapture,
 } from '../props/EventHandlers';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: Curve,
@@ -350,7 +349,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -364,10 +363,7 @@ export const API = {
           }}
         >
           <Curve {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/shapes/Dot.stories.tsx
+++ b/storybook/stories/API/shapes/Dot.stories.tsx
@@ -164,7 +164,6 @@ import {
   onWheelCapture,
 } from '../props/EventHandlers';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: Dot,
@@ -339,7 +338,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -353,10 +352,7 @@ export const API = {
           }}
         >
           <Dot {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/shapes/Polygon.stories.tsx
+++ b/storybook/stories/API/shapes/Polygon.stories.tsx
@@ -163,7 +163,6 @@ import {
   onWheelCapture,
 } from '../props/EventHandlers';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const pointDefault = [
   { x: 100, y: 100 },
@@ -374,7 +373,7 @@ export default {
 };
 
 export const API = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -388,10 +387,7 @@ export const API = {
           }}
         >
           <Polygon {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -404,7 +400,7 @@ export const API = {
 };
 
 export const UsingConnectNulls = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -418,10 +414,7 @@ export const UsingConnectNulls = {
           }}
         >
           <Polygon {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -435,7 +428,7 @@ export const UsingConnectNulls = {
 };
 
 export const UsingBaselinePoints = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -449,10 +442,7 @@ export const UsingBaselinePoints = {
           }}
         >
           <Polygon {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/API/shapes/Rectangle.stories.tsx
+++ b/storybook/stories/API/shapes/Rectangle.stories.tsx
@@ -347,13 +347,14 @@ export const API = {
     );
   },
   args: {
-    radius: 0,
-    x: 0,
-    y: 0,
+    radius: 7,
+    x: 10,
+    y: 10,
     height: 200,
     width: 300,
     stroke: '#000',
-    fill: 'red',
+    strokeWidth: 5,
+    fill: '#67ba67',
     isAnimationActive: true,
     isUpdateAnimationActive: true,
     animationBegin: 0,

--- a/storybook/stories/Examples/AreaChart.stories.tsx
+++ b/storybook/stories/Examples/AreaChart.stories.tsx
@@ -29,7 +29,7 @@ export default {
 };
 
 export const Simple = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <AreaChart {...args}>
@@ -38,10 +38,7 @@ export const Simple = {
           <YAxis />
           <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -61,7 +58,7 @@ export const Simple = {
 };
 
 export const StackedAreaChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <AreaChart {...args}>
@@ -71,10 +68,7 @@ export const StackedAreaChart = {
           <Area type="monotone" dataKey="y" stackId="1" stroke="#8884d8" fill="#8884d8" />
           <Area type="monotone" dataKey="z" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
           <Tooltip active defaultIndex={2} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
           <Legend />
         </AreaChart>
       </ResponsiveContainer>
@@ -95,15 +89,12 @@ export const StackedAreaChart = {
 };
 
 export const TinyAreaChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <AreaChart {...args}>
           <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -123,7 +114,7 @@ export const TinyAreaChart = {
 };
 
 export const PercentAreaChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const toPercent = (decimal: number, fixed = 0) => `${(decimal * 100).toFixed(fixed)}%`;
 
     const getPercent = (value: number, total: number = 0) => {
@@ -160,10 +151,7 @@ export const PercentAreaChart = {
           <Area type="monotone" dataKey="pv" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
           <Area type="monotone" dataKey="amt" stackId="1" stroke="#ffc658" fill="#ffc658" />
           <Tooltip content={renderTooltipContent} defaultIndex={3} active />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -184,7 +172,7 @@ export const PercentAreaChart = {
 };
 
 export const CardinalAreaChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const cardinal = curveCardinal.tension(0.2);
 
     return (
@@ -196,10 +184,7 @@ export const CardinalAreaChart = {
           <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" fillOpacity={0.3} />
           <Area type={cardinal} dataKey="uv" stroke="#82ca9d" fill="#82ca9d" fillOpacity={0.3} />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -219,7 +204,7 @@ export const CardinalAreaChart = {
 };
 
 export const AreaChartConnectNulls = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <div style={{ width: '100%' }}>
         <ResponsiveContainer width="100%" height={200}>
@@ -238,10 +223,7 @@ export const AreaChartConnectNulls = {
             <YAxis />
             <Area connectNulls type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
             <Tooltip />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </AreaChart>
         </ResponsiveContainer>
       </div>
@@ -304,7 +286,7 @@ export const AreaChartConnectNulls = {
 };
 
 export const StackedAreaChartConnectNulls = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <div style={{ width: '100%' }}>
         <ResponsiveContainer width="100%" height={200}>
@@ -327,10 +309,7 @@ export const StackedAreaChartConnectNulls = {
             <Area connectNulls type="monotone" dataKey="uv" stackId="1" stroke="#8884d8" fill="#8884d8" />
             <Area connectNulls type="monotone" dataKey="pv" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
             <Area connectNulls type="monotone" dataKey="amt" stackId="1" stroke="#ffc658" fill="#ffc658" />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </AreaChart>
         </ResponsiveContainer>
       </div>
@@ -393,7 +372,7 @@ export const StackedAreaChartConnectNulls = {
 };
 
 export const SynchronisedAreaChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <div style={{ width: '100%' }}>
         <h4>A demo of synchronized AreaCharts</h4>
@@ -404,10 +383,7 @@ export const SynchronisedAreaChart = {
             <YAxis />
             <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
             <Tooltip />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </AreaChart>
         </ResponsiveContainer>
         <p>Maybe some other content</p>
@@ -419,10 +395,7 @@ export const SynchronisedAreaChart = {
             <YAxis />
             <Area type="monotone" dataKey="pv" stroke="#82ca9d" fill="#82ca9d" />
             <Tooltip />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </AreaChart>
         </ResponsiveContainer>
       </div>
@@ -444,7 +417,7 @@ export const SynchronisedAreaChart = {
 };
 
 export const AreaChartFillByValue = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const gradientOffset = () => {
       const dataMax = Math.max(...args.data.map((i: any) => i.uv));
       const dataMin = Math.min(...args.data.map((i: any) => i.uv));
@@ -475,10 +448,7 @@ export const AreaChartFillByValue = {
           </defs>
           <Area type="monotone" dataKey="uv" stroke="#000" fill="url(#splitColor)" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -541,7 +511,7 @@ export const AreaChartFillByValue = {
 };
 
 export const RangedAreaChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <AreaChart {...args}>
@@ -549,10 +519,7 @@ export const RangedAreaChart = {
           <YAxis />
           <Area dataKey="temperature" stroke="#d82428" fill="#8884d8" />
           <Tooltip defaultIndex={4} active />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -580,7 +547,7 @@ const rangeData2 = [
 ];
 
 export const RangedAreaChartWithGradient = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <AreaChart data={rangeData2} width={1000} height={600} margin={{ top: 20, right: 200, bottom: 20, left: 20 }}>
@@ -603,10 +570,7 @@ export const RangedAreaChartWithGradient = {
           />
           <YAxis unit="%" ticks={[-5, 0, 5, 10, 15]} domain={[-5, 15]} />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -652,10 +616,7 @@ export const WithChangingDataKeyAndAnimations = {
               <YAxis />
               <Area dataKey={dataKey} label={{ fill: 'green' }} dot />
               <Tooltip />
-              <RechartsHookInspector
-                position={context.rechartsInspectorPosition}
-                setPosition={context.rechartsSetInspectorPosition}
-              />
+              <RechartsHookInspector />
             </ComposedChart>
           </ResponsiveContainer>
         </ManualAnimations>
@@ -678,7 +639,7 @@ export const WithChangingDataKeyAndAnimations = {
 
 export const StackedAreaWithCustomLegend = {
   // Reproducing https://github.com/recharts/recharts/issues/5992
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [hiddenItems, setHiddenItems] = React.useState<ReadonlyArray<string>>([]);
 
     const handleClick = ({ dataKey }: LegendPayload) => {
@@ -724,10 +685,7 @@ export const StackedAreaWithCustomLegend = {
             hide={hiddenItems.includes('amt')}
             animationBegin={600}
           />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
           <Legend
             content={({ payload }) => (
               <ul style={{ display: 'flex', flexDirection: 'row', listStyleType: 'none', padding: 0 }}>

--- a/storybook/stories/Examples/AreaChart.stories.tsx
+++ b/storybook/stories/Examples/AreaChart.stories.tsx
@@ -17,8 +17,7 @@ import {
 } from '../../../src';
 import { CategoricalChartProps } from '../API/props/ChartProps';
 import { getStoryArgsFromArgsTypesObject } from '../API/props/utils';
-import { RechartsHookInspector, ManualAnimations } from '../../storybook-addon-recharts';
-import { RechartsStoryContext } from '../../storybook-addon-recharts/RechartsStoryContext';
+import { RechartsHookInspector } from '../../storybook-addon-recharts';
 
 export default {
   component: AreaChart,
@@ -581,7 +580,7 @@ export const RangedAreaChartWithGradient = {
 };
 
 export const WithChangingDataKeyAndAnimations = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [dataKey, setDataKey] = React.useState('uv');
     return (
       <>
@@ -608,18 +607,16 @@ export const WithChangingDataKeyAndAnimations = {
             Hidden
           </label>
         </form>
-        <ManualAnimations isEnabled={context.rechartsInspectorEnabled}>
-          <ResponsiveContainer width="100%">
-            <ComposedChart {...args}>
-              <Legend />
-              <XAxis dataKey="name" />
-              <YAxis />
-              <Area dataKey={dataKey} label={{ fill: 'green' }} dot />
-              <Tooltip />
-              <RechartsHookInspector />
-            </ComposedChart>
-          </ResponsiveContainer>
-        </ManualAnimations>
+        <ResponsiveContainer width="100%">
+          <ComposedChart {...args}>
+            <Legend />
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Area dataKey={dataKey} label={{ fill: 'green' }} dot />
+            <Tooltip />
+            <RechartsHookInspector />
+          </ComposedChart>
+        </ResponsiveContainer>
       </>
     );
   },

--- a/storybook/stories/Examples/AreaChart.stories.tsx
+++ b/storybook/stories/Examples/AreaChart.stories.tsx
@@ -394,7 +394,6 @@ export const SynchronisedAreaChart = {
             <YAxis />
             <Area type="monotone" dataKey="pv" stroke="#82ca9d" fill="#82ca9d" />
             <Tooltip />
-            <RechartsHookInspector />
           </AreaChart>
         </ResponsiveContainer>
       </div>

--- a/storybook/stories/Examples/BarChart/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart/BarChart.stories.tsx
@@ -19,8 +19,7 @@ import {
 } from '../../../../src';
 import { getStoryArgsFromArgsTypesObject } from '../../API/props/utils';
 import { BarChartProps } from '../../API/props/BarChartProps';
-import { ManualAnimations, RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
+import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 
 export default {
   argTypes: BarChartProps,
@@ -1133,7 +1132,7 @@ export const ChangingDataKeyAndStacked = {
 };
 
 export const ChangingData = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     type MyDataShape = Array<{ number: number }>;
 
     const [data, setData] = useState<MyDataShape>([{ number: 10 }]);
@@ -1155,27 +1154,25 @@ export const ChangingData = {
     };
 
     return (
-      <ManualAnimations isEnabled={context.rechartsInspectorEnabled}>
-        <div style={{ display: 'flex', gap: '4rem', alignItems: 'center' }}>
-          <BarChart {...args} data={data}>
-            <YAxis hide domain={[0, 100]} />
-            <Bar dataKey="number" fill="chocolate" background={{ fill: 'bisque' }} />
-            <RechartsHookInspector />
-          </BarChart>
+      <div style={{ display: 'flex', gap: '4rem', alignItems: 'center' }}>
+        <BarChart {...args} data={data}>
+          <YAxis hide domain={[0, 100]} />
+          <Bar dataKey="number" fill="chocolate" background={{ fill: 'bisque' }} />
+          <RechartsHookInspector />
+        </BarChart>
 
-          <button type="button" onClick={changeSynchronously}>
-            Change data synchronously
-          </button>
+        <button type="button" onClick={changeSynchronously}>
+          Change data synchronously
+        </button>
 
-          <button type="button" onClick={changeAsynchronously}>
-            Change data with setTimeout
-          </button>
+        <button type="button" onClick={changeAsynchronously}>
+          Change data with setTimeout
+        </button>
 
-          <button type="button" onClick={reset}>
-            Reset
-          </button>
-        </div>
-      </ManualAnimations>
+        <button type="button" onClick={reset}>
+          Reset
+        </button>
+      </div>
     );
   },
   args: {

--- a/storybook/stories/Examples/BarChart/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart/BarChart.stories.tsx
@@ -31,14 +31,11 @@ export default {
 };
 
 export const Tiny = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <BarChart {...args}>
         <Bar dataKey="uv" fill="#8884d8" />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </BarChart>
     );
   },
@@ -51,7 +48,7 @@ export const Tiny = {
 };
 
 export const Simple = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -62,10 +59,7 @@ export const Simple = {
           <Tooltip defaultIndex={3} />
           <Bar dataKey="pv" fill="#8884d8" activeBar={<Rectangle fill="pink" stroke="blue" />} />
           <Bar dataKey="uv" fill="#82ca9d" activeBar={<Rectangle fill="gold" stroke="purple" />} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -85,7 +79,7 @@ export const Simple = {
 };
 
 export const StackedAndDynamic = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [focusedDataKey, setFocusedDataKey] = useState<string | null>(null);
     const [locked, setLocked] = useState<boolean>(false);
 
@@ -137,10 +131,7 @@ export const StackedAndDynamic = {
             activeBar={{ fill: 'silver' }}
           />
           <Tooltip shared={false} defaultIndex={1} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -162,7 +153,7 @@ export const StackedAndDynamic = {
 const pvErrorData = pageData.map(d => ({ ...d, pvError: [100, 200] }));
 
 export const StackedWithErrorBar = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -175,10 +166,7 @@ export const StackedWithErrorBar = {
           <Bar dataKey="uv" stackId="a" fill="#82ca9d">
             <ErrorBar dataKey="pvError" width={5} stroke="red" direction="x" />
           </Bar>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -199,7 +187,7 @@ export const StackedWithErrorBar = {
 };
 
 export const Mix = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [focusedDataKey, setFocusedDataKey] = useState<string | null>(null);
     const [locked, setLocked] = useState<boolean>(false);
 
@@ -244,10 +232,7 @@ export const Mix = {
             fill={focusedDataKey == null || focusedDataKey === 'amt' ? '#82ca9d' : '#eee'}
           />
           <Bar dataKey="uv" fill={focusedDataKey == null || focusedDataKey === 'uv' ? '#ffc658' : '#eee'} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -267,7 +252,7 @@ export const Mix = {
 };
 
 export const CustomShape = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const getPath = (x: number, y: number, width: number, height: number) => {
       return `M${x},${y + height}C${x + width / 3},${y + height} ${x + width / 2},${y + height / 3}
   ${x + width / 2}, ${y}
@@ -294,10 +279,7 @@ export const CustomShape = {
             <Cell key={`cell-${name}`} fill={colors[index % 20]} />
           ))}
         </Bar>
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </BarChart>
     );
   },
@@ -360,7 +342,7 @@ const positiveAndNegativeData = [
   },
 ];
 export const PositiveAndNegative = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -372,10 +354,7 @@ export const PositiveAndNegative = {
           <Tooltip />
           <Bar dataKey="pv" fill="#8884d8" />
           <Bar dataKey="uv" fill="#82ca9d" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -436,7 +415,7 @@ const dataForBrush = [
   { name: '40', uv: -50, pv: 186 },
 ];
 export const WithBrush = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -449,10 +428,7 @@ export const WithBrush = {
           <Brush dataKey="name" height={30} stroke="#8884d8" />
           <Bar dataKey="pv" fill="#8884d8" />
           <Bar dataKey="uv" fill="#82ca9d" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -472,7 +448,7 @@ export const WithBrush = {
 };
 
 export const XAxisTickMarginWithBrushDy = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -485,10 +461,7 @@ export const XAxisTickMarginWithBrushDy = {
           <Brush dataKey="name" height={30} dy={30} stroke="#8884d8" />
           <Bar dataKey="pv" fill="#8884d8" />
           <Bar dataKey="uv" fill="#82ca9d" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -508,7 +481,7 @@ export const XAxisTickMarginWithBrushDy = {
 };
 
 export const WithCustomizedEvent = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [activeIndex, setActiveIndex] = useState(1);
 
     return (
@@ -519,10 +492,7 @@ export const WithCustomizedEvent = {
               <Cell cursor="pointer" fill={index === activeIndex ? '#82ca9d' : '#8884d8'} key={`cell-${name}`} />
             ))}
           </Bar>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -542,7 +512,7 @@ export const WithCustomizedEvent = {
 };
 
 export const StackedBySign = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -554,10 +524,7 @@ export const StackedBySign = {
           <ReferenceLine y={0} stroke="#000" />
           <Bar dataKey="pv" fill="#8884d8" stackId="stack" />
           <Bar dataKey="uv" fill="#82ca9d" stackId="stack" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -578,7 +545,7 @@ export const StackedBySign = {
 };
 
 export const Biaxial = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -590,10 +557,7 @@ export const Biaxial = {
           <Tooltip />
           <Bar yAxisId="left" dataKey="pv" fill="#8884d8" />
           <Bar yAxisId="right" dataKey="uv" fill="#82ca9d" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -613,7 +577,7 @@ export const Biaxial = {
 };
 
 export const HasBackground = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -624,10 +588,7 @@ export const HasBackground = {
           <Tooltip />
           <Bar dataKey="pv" fill="#8884d8" background={{ fill: '#eee' }} />
           <Bar dataKey="uv" fill="#82ca9d" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -647,7 +608,7 @@ export const HasBackground = {
 };
 
 export const HasLabelBasedOnSeparateDataKey = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const dataWithLabel = pageData.map(({ name, uv, pv }) => ({
       name,
       uv,
@@ -664,10 +625,7 @@ export const HasLabelBasedOnSeparateDataKey = {
           <Tooltip />
           <Bar dataKey="pv" fill="#8884d8" label={{ dataKey: 'label', position: 'top', fill: '#111' }} />
           <Bar dataKey="uv" fill="#82ca9d" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -761,7 +719,7 @@ const dataWithMultiXAxis = [
   },
 ];
 export const WithMultiXAxis = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const monthTickFormatter = (tick: any) => {
       const date = new Date(tick);
 
@@ -810,10 +768,7 @@ export const WithMultiXAxis = {
           <Tooltip />
           <Bar dataKey="pv" fill="#8884d8" />
           <Bar dataKey="uv" fill="#82ca9d" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -833,7 +788,7 @@ export const WithMultiXAxis = {
 };
 
 export const NoPadding = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -843,10 +798,7 @@ export const NoPadding = {
           <CartesianGrid strokeDasharray="3 3" />
           <Bar dataKey="pv" fill="#8884d8" background={{ fill: '#eee' }} />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -890,7 +842,7 @@ const dataWithSmallValuesAndZero = [
 ];
 
 export const WithMinPointSize = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -901,10 +853,7 @@ export const WithMinPointSize = {
           <Bar dataKey="pv" fill="purple" minPointSize={value => (value === 0 ? 0 : 2)} stackId="a" />
           <Bar dataKey="uv" fill="green" minPointSize={value => (value === 0 ? 0 : 2)} stackId="a" />
           <Bar dataKey="uv" fill="blue" minPointSize={value => (value === 0 ? 0 : 2)} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -924,7 +873,7 @@ export const WithMinPointSize = {
 };
 
 export const OneDataPointPercentSize = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -933,10 +882,7 @@ export const OneDataPointPercentSize = {
           <CartesianGrid strokeDasharray="3 3" />
           <Bar dataKey={v => v[1]} />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -958,7 +904,7 @@ export const OneDataPointPercentSize = {
 };
 
 export const RangedBarChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -967,10 +913,7 @@ export const RangedBarChart = {
           <CartesianGrid strokeDasharray="3 3" />
           <Tooltip />
           <Bar dataKey="temperature" fill="violet" stroke="indigo" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -997,7 +940,7 @@ const MyCustomCursor = (props: any) => {
 };
 
 export const CustomCursorBarChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <BarChart {...args}>
@@ -1006,10 +949,7 @@ export const CustomCursorBarChart = {
           <CartesianGrid strokeDasharray="3 3" />
           <Bar dataKey="uv" fill="violet" stroke="indigo" />
           <Tooltip cursor={<MyCustomCursor />} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -1031,7 +971,7 @@ export const CustomCursorBarChart = {
 };
 
 export const ChangingDataKey = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data1 = [
       { x: { value: 1 }, name: 'x1' },
       { x: { value: 2 }, name: 'x2' },
@@ -1087,10 +1027,7 @@ export const ChangingDataKey = {
           <YAxis dataKey={useData2 ? dataKey2 : dataKey1} />
           <Tooltip />
           <Legend />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
           <Bar
             name="Animated Bar"
             hide={!visible}
@@ -1119,7 +1056,7 @@ export const ChangingDataKey = {
 };
 
 export const ChangingDataKeyAndStacked = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [useData2, setUseData2] = useState(false);
     const [visible, setVisible] = useState(true);
 
@@ -1157,10 +1094,7 @@ export const ChangingDataKeyAndStacked = {
           <YAxis dataKey="uv" />
           <Tooltip />
           <Legend />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
           <Bar
             name="Animated Bar 1"
             hide={!visible}
@@ -1226,10 +1160,7 @@ export const ChangingData = {
           <BarChart {...args} data={data}>
             <YAxis hide domain={[0, 100]} />
             <Bar dataKey="number" fill="chocolate" background={{ fill: 'bisque' }} />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </BarChart>
 
           <button type="button" onClick={changeSynchronously}>
@@ -1268,7 +1199,7 @@ type TimelineDataType = {
  * https://github.com/recharts/recharts/issues/6034
  */
 export const Timeline = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const getBarColor = (type: string | undefined, subtype: string | undefined) => {
       switch (type) {
         case 'OP':
@@ -1317,10 +1248,7 @@ export const Timeline = {
             <Cell key={`cell-${entry.name}`} fill={getBarColor(entry.type, entry.subtype)} />
           ))}
         </Bar>
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </BarChart>
     );
   },

--- a/storybook/stories/Examples/ChartLayout.stories.tsx
+++ b/storybook/stories/Examples/ChartLayout.stories.tsx
@@ -4,7 +4,6 @@ import { ComposedChart, useChartHeight, useChartWidth } from '../../../src';
 import { selectContainerScale } from '../../../src/state/selectors/containerSelectors';
 import { useAppSelector } from '../../../src/state/hooks';
 import { RechartsHookInspector } from '../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../storybook-addon-recharts/RechartsStoryContext';
 import { ChartSizeDimensions } from '../../ChartSizeDimensions';
 
 function ShowScale() {
@@ -40,7 +39,7 @@ export default {
  * https://github.com/recharts/recharts/issues/5477
  */
 export const WithAbsolutePositionAndFlexboxParents = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <div style={{ display: 'flex', height: '100vh' }}>
         <div
@@ -65,10 +64,7 @@ export const WithAbsolutePositionAndFlexboxParents = {
             <ComposedChart {...args}>
               <ChartSizeDimensions />
               <ShowScale />
-              <RechartsHookInspector
-                position={context.rechartsInspectorPosition}
-                setPosition={context.rechartsSetInspectorPosition}
-              />
+              <RechartsHookInspector />
             </ComposedChart>
           </div>
         </div>

--- a/storybook/stories/Examples/ComposedChart/AccessibilityLayer.stories.tsx
+++ b/storybook/stories/Examples/ComposedChart/AccessibilityLayer.stories.tsx
@@ -15,14 +15,13 @@ import { pageData } from '../../data';
 import { General } from '../../API/props/CartesianComponentShared';
 import { getStoryArgsFromArgsTypesObject } from '../../API/props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: ComposedChart,
 };
 
 export const AreaChartWithAccessibilityLayer: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={300}>
         <ComposedChart
@@ -40,10 +39,7 @@ export const AreaChartWithAccessibilityLayer: StoryObj = {
           <XAxis dataKey="name" />
           <YAxis />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -62,7 +58,7 @@ export const AreaChartWithAccessibilityLayer: StoryObj = {
 };
 
 export const AccessibleWithButton = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const [toggle, setToggle] = useState(true);
 
     return (
@@ -89,10 +85,7 @@ export const AccessibleWithButton = {
           <Area type="monotone" dataKey="pv" stackId="1" stroke="#82ca9d" fill="#82ca9d" />
           <Area type="monotone" dataKey="amt" stackId="1" stroke="#ffc658" fill="#ffc658" />
           {toggle && <Tooltip />}
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </AreaChart>
       </div>
     );

--- a/storybook/stories/Examples/ComposedChart/BoxPlot.stories.tsx
+++ b/storybook/stories/Examples/ComposedChart/BoxPlot.stories.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-shadow */
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import {
   ResponsiveContainer,
   ComposedChart,
@@ -15,7 +14,6 @@ import {
 import { BoxPlot, BoxPlotData } from '../../data/DataProps';
 import { boxPlots } from '../../data';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: ComposedChart,
@@ -72,7 +70,7 @@ const useBoxPlot = (boxPlots: BoxPlot[]): BoxPlotData[] => {
 };
 
 export const BoxPlotChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const data = useBoxPlot(boxPlots);
     return (
       <ResponsiveContainer minHeight={600}>
@@ -91,10 +89,7 @@ export const BoxPlotChart = {
           <Scatter dataKey="average" fill="red" stroke="#FFF" />
           <XAxis />
           <YAxis />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/ComposedChart/StockPrice.stories.tsx
+++ b/storybook/stories/Examples/ComposedChart/StockPrice.stories.tsx
@@ -14,7 +14,6 @@ import {
 } from '../../../../src';
 import { stockData } from '../../data';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: ComposedChart,
@@ -109,7 +108,7 @@ const CustomTooltip = ({ active, payload }: { active: boolean; payload: Record<s
 };
 
 export const StockPriceChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const { data } = args;
 
     const minValue = data.reduce((minValue: number, { low, openClose: [open, close] }: any) => {
@@ -134,10 +133,7 @@ export const StockPriceChart = {
               <Cell key={`cell-${date}`} />
             ))}
           </Bar>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/LineChart/DualLineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart/DualLineChart.stories.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import { scaleTime } from 'victory-vendor/d3-scale';
-import { Args } from '@storybook/react-vite';
 import {
   CartesianGrid,
   Legend,
@@ -17,7 +16,6 @@ import {
   useActiveTooltipLabel,
 } from '../../../../src';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: LineChart,
@@ -155,7 +153,7 @@ function JointActiveDot({ dataKey, fill }: { dataKey: 'y1' | 'y2'; fill: string 
 }
 
 export const DualLineChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <LineChart
@@ -185,10 +183,7 @@ export const DualLineChart = {
           {/* Draw extra active dot for Series 2 */}
           <JointActiveDot dataKey="y2" fill="blue" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/LineChart/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart/LineChart.stories.tsx
@@ -30,7 +30,7 @@ export default {
 };
 
 export const Simple = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <LineChart {...args}>
@@ -41,10 +41,7 @@ export const Simple = {
           <Tooltip cursor={{ stroke: 'gold', strokeWidth: 2 }} defaultIndex={3} />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -63,15 +60,12 @@ export const Simple = {
 };
 
 export const Tiny = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <LineChart {...args}>
           <Line type="monotone" dataKey="pv" stroke="#8884d8" strokeWidth={2} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -84,7 +78,7 @@ export const Tiny = {
 };
 
 export const Dashed = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <LineChart
@@ -105,10 +99,7 @@ export const Dashed = {
           <Tooltip defaultIndex={3} active />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" strokeDasharray="5 5" />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" strokeDasharray="3 4 5 2" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -126,7 +117,7 @@ export const Dashed = {
 };
 
 export const LogarithmicYAxis = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <LineChart {...args}>
@@ -146,10 +137,7 @@ export const LogarithmicYAxis = {
             activeDot={{ r: 8 }}
             unit=" KFLOPS"
           />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -168,7 +156,7 @@ export const LogarithmicYAxis = {
 };
 
 export const Vertical = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <LineChart {...args}>
@@ -179,10 +167,7 @@ export const Vertical = {
           <Tooltip defaultIndex={4} active />
           <Line dataKey="pv" stroke="#8884d8" />
           <Line dataKey="uv" stroke="#82ca9d" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -202,7 +187,7 @@ export const Vertical = {
 };
 
 export const BiAxial = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <LineChart {...args}>
@@ -214,10 +199,7 @@ export const BiAxial = {
           <Line yAxisId="left" type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
           <Line yAxisId="right" type="monotone" dataKey="uv" stroke="#82ca9d" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -235,7 +217,7 @@ export const BiAxial = {
   },
 };
 export const VerticalWithSpecifiedDomain = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <LineChart {...args}>
@@ -246,10 +228,7 @@ export const VerticalWithSpecifiedDomain = {
           <Line dataKey="pv" stroke="#8884d8" />
           <Line dataKey="uv" stroke="#82ca9d" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -268,7 +247,7 @@ export const VerticalWithSpecifiedDomain = {
   },
 };
 export const ConnectNulls = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <>
         <ResponsiveContainer width="100%" height={200}>
@@ -278,10 +257,7 @@ export const ConnectNulls = {
             <YAxis />
             <Line type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
             <Tooltip />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </LineChart>
         </ResponsiveContainer>
 
@@ -318,7 +294,7 @@ export const ConnectNulls = {
   },
 };
 export const WithXAxisPadding = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <LineChart {...args}>
@@ -329,10 +305,7 @@ export const WithXAxisPadding = {
           <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -344,7 +317,7 @@ export const WithXAxisPadding = {
   },
 };
 export const WithReferenceLines = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <LineChart {...args}>
@@ -357,10 +330,7 @@ export const WithReferenceLines = {
           <Line type="monotone" dataKey="pv" stroke="#8884d8" />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -378,7 +348,7 @@ export const WithReferenceLines = {
   },
 };
 export const WithCustomizedDot = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const CustomizedDot = (props: any) => {
       const { cx, cy, value } = props;
 
@@ -434,10 +404,7 @@ export const WithCustomizedDot = {
           <Line type="monotone" dataKey="pv" stroke="#8884d8" dot={<CustomizedDot />} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -456,7 +423,7 @@ export const WithCustomizedDot = {
 };
 
 export const ClipDot: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={300}>
         <LineChart
@@ -478,10 +445,7 @@ export const ClipDot: StoryObj = {
           <XAxis dataKey="name" allowDataOverflow />
           <YAxis allowDataOverflow />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -502,7 +466,7 @@ export const ClipDot: StoryObj = {
 };
 
 export const WithCustomizedLabel = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const CustomizedLabel = ({ x, y, stroke, value }: any) => {
       return (
         <text x={x} y={y} dy={-4} fill={stroke} fontSize={10} textAnchor="middle">
@@ -531,10 +495,7 @@ export const WithCustomizedLabel = {
           <Line type="monotone" dataKey="pv" stroke="#8884d8" label={<CustomizedLabel />} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -554,7 +515,7 @@ export const WithCustomizedLabel = {
 };
 
 export const HighlightAndZoom = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const initialState = {
       data: impressionsData,
       left: 'dataMin',
@@ -668,10 +629,7 @@ export const HighlightAndZoom = {
               <ReferenceArea yAxisId="1" x1={refAreaLeft} x2={refAreaRight} strokeOpacity={0.3} />
             ) : null}
             <Tooltip />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </LineChart>
         </ResponsiveContainer>
       </div>
@@ -685,7 +643,7 @@ export const HighlightAndZoom = {
 };
 
 export const LineChartHasMultiSeries = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <LineChart {...args}>
@@ -697,10 +655,7 @@ export const LineChartHasMultiSeries = {
           <Line dataKey="pv" />
           <Line dataKey="amt" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -714,7 +669,7 @@ export const LineChartHasMultiSeries = {
 };
 
 export const LineChartAxisInterval = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <>
         <LineChart width={200} height={100} data={pageData}>
@@ -724,10 +679,7 @@ export const LineChartAxisInterval = {
           <Legend />
           <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
 
         <LineChart width={200} height={100} data={pageData}>
@@ -762,7 +714,7 @@ export const LineChartAxisInterval = {
 };
 
 export const NegativeValuesWithReferenceLines = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data = [
       { x: -50, y: -50 },
       { x: 0, y: 0 },
@@ -819,10 +771,7 @@ export const NegativeValuesWithReferenceLines = {
           {minX < 0 && <ReferenceLine x={0} stroke="gray" strokeWidth={1.5} strokeOpacity={0.65} />}
 
           <Line strokeWidth={2} data={data} dot={false} type="monotone" dataKey="y" stroke="black" tooltipType="none" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -848,7 +797,7 @@ export const ToggleChildrenComponentsExceptCartesianGrid: StoryObj = {
     await userEvent.click(canvas.getByTestId('toggle'));
     expect(canvas.queryByText('Page A')).not.toBeInTheDocument();
   },
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data = [
       {
         name: 'Page A',
@@ -954,10 +903,7 @@ export const ToggleChildrenComponentsExceptCartesianGrid: StoryObj = {
                 dot={false}
               />
               <Tooltip />
-              <RechartsHookInspector
-                position={context.rechartsInspectorPosition}
-                setPosition={context.rechartsSetInspectorPosition}
-              />
+              <RechartsHookInspector />
             </>
           )}
         </LineChart>
@@ -976,7 +922,7 @@ export const ToggleChildrenComponentsExceptCartesianGrid: StoryObj = {
 };
 
 export const WithBrush: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer>
         <LineChart {...args}>
@@ -988,10 +934,7 @@ export const WithBrush: StoryObj = {
           <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -1003,7 +946,7 @@ export const WithBrush: StoryObj = {
 };
 
 export const HideOnLegendClick: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [activeSeries, setActiveSeries] = React.useState<Array<string>>([]);
 
     const handleLegendClick = (dataKey?: DataKey<any>) => {
@@ -1028,10 +971,7 @@ export const HideOnLegendClick: StoryObj = {
           <Line hide={activeSeries.includes('uv')} type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
           <Line hide={activeSeries.includes('pv')} type="monotone" dataKey="pv" stroke="#987" fill="#8884d8" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -1043,7 +983,7 @@ export const HideOnLegendClick: StoryObj = {
 };
 
 export const LineTrailingIcon: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const lastDotKey = 'lastDot';
 
     return (
@@ -1062,10 +1002,7 @@ export const LineTrailingIcon: StoryObj = {
             dot={{ stroke: 'red', strokeWidth: 1, r: 4 }}
           />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -1080,7 +1017,7 @@ export const LineTrailingIcon: StoryObj = {
 };
 
 export const ReversedXAxis = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height="100%">
         <LineChart {...args}>
@@ -1091,10 +1028,7 @@ export const ReversedXAxis = {
           <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
           <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -1169,10 +1103,7 @@ export const ChangingDataKey = {
           <YAxis dataKey={useData2 ? dataKey2 : dataKey1} />
           <Tooltip />
           <Legend />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
           <Line
             name="Animated line"
             hide={!visible}

--- a/storybook/stories/Examples/LineChart/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart/LineChart.stories.tsx
@@ -16,8 +16,7 @@ import {
   ReferenceArea,
 } from '../../../../src';
 import { DataKey } from '../../../../src/util/types';
-import { RechartsHookInspector, ManualAnimations } from '../../../storybook-addon-recharts';
-import { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
+import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 import { CategoricalChartProps } from '../../API/props/ChartProps';
 import { getStoryArgsFromArgsTypesObject } from '../../API/props/utils';
 
@@ -1048,7 +1047,7 @@ export const ReversedXAxis = {
 };
 
 export const ChangingDataKey = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data1 = [
       { x: { value: 1 }, name: 'x1' },
       { x: { value: 2 }, name: 'x2' },
@@ -1070,7 +1069,7 @@ export const ChangingDataKey = {
     const [visible, setVisible] = useState(true);
 
     return (
-      <ManualAnimations isEnabled={context.rechartsInspectorEnabled}>
+      <>
         <button
           type="button"
           onClick={() => {
@@ -1115,7 +1114,7 @@ export const ChangingDataKey = {
             label={{ fill: 'red', dy: -25 }}
           />
         </LineChart>
-      </ManualAnimations>
+      </>
     );
   },
   args: {

--- a/storybook/stories/Examples/LineChart/ToggleBetweenDataKeys.stories.tsx
+++ b/storybook/stories/Examples/LineChart/ToggleBetweenDataKeys.stories.tsx
@@ -1,10 +1,7 @@
 import React, { useState } from 'react';
-
-import { Args } from '@storybook/react-vite';
 import { pageData } from '../../data';
 import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from '../../../../src';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: LineChart,
@@ -14,7 +11,7 @@ export default {
 };
 
 export const ToggleBetweenDataKeys = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const [dataKey, setDataKey] = useState('pv');
 
     return (
@@ -39,10 +36,7 @@ export const ToggleBetweenDataKeys = {
             <Legend />
             <Line type="monotone" dataKey={dataKey} stroke="#8884d8" activeDot={{ r: 8 }} />
             <Tooltip />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </LineChart>
         </ResponsiveContainer>
       </>

--- a/storybook/stories/Examples/Pie/CustomActiveShapePieChart.stories.tsx
+++ b/storybook/stories/Examples/Pie/CustomActiveShapePieChart.stories.tsx
@@ -3,7 +3,6 @@ import { Args } from '@storybook/react-vite';
 import { Pie, PieChart, ResponsiveContainer, Sector, Tooltip } from '../../../../src';
 import { PieSectorDataItem } from '../../../../src/polar/Pie';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: Pie,
@@ -19,7 +18,7 @@ const data = [
 const NoContent = (): null => null;
 
 export const CustomActiveShapePieChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const renderActiveShape = (props: PieSectorDataItem) => {
       const RADIAN = Math.PI / 180;
       const {
@@ -83,10 +82,7 @@ export const CustomActiveShapePieChart = {
         <PieChart width={400} height={400}>
           <Pie dataKey="value" {...args} activeShape={renderActiveShape} />
           <Tooltip defaultIndex={0} content={NoContent} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </PieChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/Pie/DraggablePie.stories.tsx
+++ b/storybook/stories/Examples/Pie/DraggablePie.stories.tsx
@@ -1,11 +1,9 @@
 import React, { useState } from 'react';
-import { Args } from '@storybook/react-vite';
 import { Pie, PieChart } from '../../../../src';
 import { getChartPointer } from '../../../../src/util/getChartPointer';
 
 import { ChartPointer } from '../../../../src/util/types';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: Pie,
@@ -50,7 +48,7 @@ function DraggablePoint({ cx, cy, angle, radius }: { cx: number; cy: number; ang
 }
 
 export const DraggablePie = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const [isDragging, setIsDragging] = useState<string | null>(null);
     const [email, setEmail] = useState(90);
     const [socialMedia, setSocialMedia] = useState(90);
@@ -85,10 +83,7 @@ export const DraggablePie = {
       >
         <Pie dataKey="value" data={data} outerRadius={200} label isAnimationActive={false} />
         <DraggablePoint angle={email} radius={200} cx={cx} cy={cy} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </PieChart>
     );
   },

--- a/storybook/stories/Examples/Pie/PieWithCells.stories.tsx
+++ b/storybook/stories/Examples/Pie/PieWithCells.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Args } from '@storybook/react-vite';
 import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from '../../../../src';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const data = [
   { value: 'Luck', percent: 10, color: 'orange' },
@@ -18,7 +17,7 @@ export default {
 };
 
 export const PieWithCells = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <PieChart width={400} height={400}>
@@ -29,10 +28,7 @@ export const PieWithCells = {
           </Pie>
           <Legend />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </PieChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/Pie/PieWithLegend.stories.tsx
+++ b/storybook/stories/Examples/Pie/PieWithLegend.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Args } from '@storybook/react-vite';
 import { Legend, Pie, PieChart, ResponsiveContainer } from '../../../../src';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const data = [
   { value: 'Luck', percent: 10 },
@@ -18,16 +17,13 @@ export default {
 };
 
 export const PieWithLegend = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <PieChart width={400} height={400}>
           <Pie dataKey="percent" {...args} />
           <Legend />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </PieChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/Pie/PieWithNeedle.stories.tsx
+++ b/storybook/stories/Examples/Pie/PieWithNeedle.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Args } from '@storybook/react-vite';
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from '../../../../src';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: Pie,
@@ -51,7 +50,7 @@ const Needle = ({
 };
 
 export const PieWithNeedle = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <PieChart>
@@ -78,10 +77,7 @@ export const PieWithNeedle = {
             activeShape={Needle}
           />
           <Tooltip defaultIndex={1} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </PieChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/Pie/PieWithPatterns.stories.tsx
+++ b/storybook/stories/Examples/Pie/PieWithPatterns.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Args } from '@storybook/react-vite';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 import { Cell, Pie, PieChart, ResponsiveContainer } from '../../../../src';
 
 export default {
@@ -9,7 +8,7 @@ export default {
 };
 
 export const PieWithPatterns = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <PieChart>
@@ -30,10 +29,7 @@ export const PieWithPatterns = {
               <Cell key={`cell-${entry.name}`} fill={`url(#pattern-${entry.name})`} />
             ))}
           </Pie>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </PieChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/Pie/PieWithStep.stories.tsx
+++ b/storybook/stories/Examples/Pie/PieWithStep.stories.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Args } from '@storybook/react-vite';
 import { Pie, PieChart, ResponsiveContainer } from '../../../../src';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const data = [
   { value: 'Luck', percent: 10, customRadius: 140 },
@@ -18,15 +17,12 @@ export default {
 };
 
 export const PieWithStep = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <PieChart width={400} height={400}>
           <Pie dataKey="percent" {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </PieChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/Pie/PieWithTooltip.stories.tsx
+++ b/storybook/stories/Examples/Pie/PieWithTooltip.stories.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Args } from '@storybook/react-vite';
 import { PieChart, Pie, Cell, Tooltip, Legend } from '../../../../src';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 const data = [
   { name: 'Group A', value: 400 },
@@ -48,7 +47,7 @@ export default {
 };
 
 export const PieWithTooltip = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [ttPos, setTtPos] = useState(undefined);
     const [active, setActive] = useState(false);
     const [randomData, setRandomData] = useState(data);
@@ -99,10 +98,7 @@ export const PieWithTooltip = {
           </Pie>
           <Tooltip content={CustomContent} position={ttPos} active={active} />
           <Legend />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </PieChart>
       </>
     );

--- a/storybook/stories/Examples/RadarChart.stories.tsx
+++ b/storybook/stories/Examples/RadarChart.stories.tsx
@@ -5,7 +5,6 @@ import { RadarChartProps } from '../API/props/RadarChartProps';
 import { getStoryArgsFromArgsTypesObject } from '../API/props/utils';
 import { rangeData } from '../data';
 import { RechartsHookInspector } from '../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: RadarChartProps,
@@ -16,7 +15,7 @@ export default {
 };
 
 export const NumberAngleType: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadarChart {...args}>
         <PolarGrid gridType="circle" />
@@ -26,10 +25,7 @@ export const NumberAngleType: StoryObj = {
         <PolarAngleAxis dataKey="angle" axisLineType="circle" type="number" domain={[0, 360]} />
 
         <Radar type="number" name="r" dataKey="r" fillOpacity={0} stroke="#000" />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadarChart>
     );
   },
@@ -47,7 +43,7 @@ export const NumberAngleType: StoryObj = {
 };
 
 export const CategoryAngleType: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadarChart {...args}>
         <PolarGrid gridType="circle" />
@@ -57,10 +53,7 @@ export const CategoryAngleType: StoryObj = {
         <PolarAngleAxis dataKey="angle" axisLineType="circle" type="category" />
 
         <Radar type="number" name="r" dataKey="r" fillOpacity={0} stroke="#000" />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadarChart>
     );
   },
@@ -78,7 +71,7 @@ export const CategoryAngleType: StoryObj = {
 };
 
 export const ShouldBeCorrectAngle: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadarChart {...args}>
         <PolarGrid />
@@ -87,10 +80,7 @@ export const ShouldBeCorrectAngle: StoryObj = {
 
         <Radar dataKey="value" fillOpacity={0} stroke="#000" />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadarChart>
     );
   },
@@ -114,7 +104,7 @@ export const ShouldBeCorrectAngle: StoryObj = {
 };
 
 export const RadarWithLegend: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadarChart {...args}>
         <PolarGrid gridType="circle" />
@@ -125,10 +115,7 @@ export const RadarWithLegend: StoryObj = {
 
         <Radar type="number" name="r" dataKey="r" fillOpacity={0} stroke="#000" />
         <Tooltip defaultIndex={2} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadarChart>
     );
   },
@@ -146,7 +133,7 @@ export const RadarWithLegend: StoryObj = {
 };
 
 export const RangedRadarChart: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadarChart {...args}>
         <PolarGrid />
@@ -154,10 +141,7 @@ export const RangedRadarChart: StoryObj = {
         <PolarAngleAxis dataKey="day" />
         <Radar type="number" name="Temperature" dataKey="temperature" fill="orange" fillOpacity={0.5} stroke="blue" />
         <Tooltip defaultIndex={2} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadarChart>
     );
   },
@@ -170,7 +154,7 @@ export const RangedRadarChart: StoryObj = {
 };
 
 export const RadarWithChangingDataKey: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [dataKey, setDataKey] = React.useState('key1');
     return (
       <>
@@ -211,10 +195,7 @@ export const RadarWithChangingDataKey: StoryObj = {
             label={{ fill: 'red' }}
           />
           <Tooltip defaultIndex={2} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </RadarChart>
       </>
     );

--- a/storybook/stories/Examples/RadialBarChart/RadialBarChart.stories.tsx
+++ b/storybook/stories/Examples/RadialBarChart/RadialBarChart.stories.tsx
@@ -13,7 +13,6 @@ import { pageData, pageDataWithFillColor } from '../../data';
 import { RadialBarChartProps } from '../../API/props/RadialBarChartProps';
 import { getStoryArgsFromArgsTypesObject } from '../../API/props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 import { StorybookArgs } from '../../../StorybookArgs';
 import { RadarChartProps } from '../../API/props/RadarChartProps';
 
@@ -24,16 +23,13 @@ export default {
 } satisfies Meta<typeof RadialBarChart>;
 
 export const SimpleRadialBarChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadialBarChart {...args}>
         <RadialBar dataKey="pv" />
         <Legend />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },
@@ -46,16 +42,13 @@ export const SimpleRadialBarChart = {
 };
 
 export const RadialBarWithColors = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadialBarChart {...args}>
         <RadialBar dataKey="pv" />
         <Legend />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },
@@ -68,7 +61,7 @@ export const RadialBarWithColors = {
 };
 
 export const RadialBarWithAxesAndGrid: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadialBarChart {...args}>
         <RadialBar dataKey="pv" />
@@ -77,10 +70,7 @@ export const RadialBarWithAxesAndGrid: StoryObj = {
         <PolarAngleAxis dataKey="pv" type="number" axisLineType="circle" stroke="red" />
         <PolarRadiusAxis dataKey="name" orientation="middle" type="category" angle={90} stroke="black" />
         <Tooltip cursor={{ strokeWidth: 3, stroke: 'black', strokeDasharray: '4 4' }} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },
@@ -93,7 +83,7 @@ export const RadialBarWithAxesAndGrid: StoryObj = {
 };
 
 export const StackedRadialBar = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadialBarChart {...args}>
         <RadialBar dataKey="pv" stackId="stack1" fill="gold" />
@@ -102,10 +92,7 @@ export const StackedRadialBar = {
         <PolarGrid gridType="circle" />
         <PolarAngleAxis dataKey="pv" type="number" axisLineType="circle" />
         <Tooltip defaultIndex={3} cursor={{ strokeWidth: 3, stroke: 'black', strokeDasharray: '4 4' }} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },
@@ -153,17 +140,14 @@ const ringsData = [
 ];
 
 export const RingsWithImplicitAxes = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadialBarChart {...args}>
         <RadialBar dataKey="rings" />
         <Legend />
         <PolarGrid gridType="circle" />
         <Tooltip defaultIndex={0} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },
@@ -176,7 +160,7 @@ export const RingsWithImplicitAxes = {
 };
 
 export const RingsWithDefaultAxes = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadialBarChart {...args}>
         <RadialBar dataKey="rings" />
@@ -185,10 +169,7 @@ export const RingsWithDefaultAxes = {
         <PolarAngleAxis />
         <PolarRadiusAxis />
         <Tooltip defaultIndex={0} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },
@@ -201,7 +182,7 @@ export const RingsWithDefaultAxes = {
 };
 
 export const RingsWithDataKeys = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadialBarChart {...args}>
         <RadialBar dataKey="rings" />
@@ -210,10 +191,7 @@ export const RingsWithDataKeys = {
         <PolarAngleAxis dataKey="rings" />
         <PolarRadiusAxis dataKey="name" stroke="black" />
         <Tooltip defaultIndex={0} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },
@@ -226,7 +204,7 @@ export const RingsWithDataKeys = {
 };
 
 export const RingsWithTypes = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadialBarChart {...args}>
         <RadialBar dataKey="rings" />
@@ -235,10 +213,7 @@ export const RingsWithTypes = {
         <PolarAngleAxis type="number" />
         <PolarRadiusAxis type="category" stroke="black" />
         <Tooltip defaultIndex={0} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },
@@ -251,7 +226,7 @@ export const RingsWithTypes = {
 };
 
 export const RingsWithDataKeysAndTypes = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadialBarChart {...args}>
         <RadialBar dataKey="rings" />
@@ -260,10 +235,7 @@ export const RingsWithDataKeysAndTypes = {
         <PolarAngleAxis dataKey="rings" type="number" />
         <PolarRadiusAxis dataKey="name" type="category" stroke="black" />
         <Tooltip defaultIndex={0} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },
@@ -276,7 +248,7 @@ export const RingsWithDataKeysAndTypes = {
 };
 
 export const RingsWithCustomDomain = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const totalCountOfRings = ringsData.reduce((acc, entry) => acc + entry.rings, 0);
     return (
       <RadialBarChart {...args}>
@@ -286,10 +258,7 @@ export const RingsWithCustomDomain = {
         <PolarAngleAxis dataKey="rings" type="number" domain={[0, totalCountOfRings]} />
         <PolarRadiusAxis dataKey="name" type="category" stroke="black" />
         <Tooltip defaultIndex={0} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },
@@ -302,7 +271,7 @@ export const RingsWithCustomDomain = {
 };
 
 export const RingsWithRadiusAxisVertically = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const totalCountOfRings = ringsData.reduce((acc, entry) => acc + entry.rings, 0);
     return (
       <RadialBarChart {...args}>
@@ -312,10 +281,7 @@ export const RingsWithRadiusAxisVertically = {
         <PolarAngleAxis dataKey="rings" type="number" domain={[0, totalCountOfRings]} />
         <PolarRadiusAxis dataKey="name" type="category" orientation="left" angle={90} stroke="black" />
         <Tooltip defaultIndex={0} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },
@@ -330,7 +296,7 @@ export const RingsWithRadiusAxisVertically = {
 };
 
 export const ReversedAngleAxis = {
-  render: (args: StorybookArgs, context: RechartsStoryContext) => (
+  render: (args: StorybookArgs) => (
     <>
       <p>Angle axis clockwise, starts on East</p>
       <RadialBarChart {...args}>
@@ -340,10 +306,7 @@ export const ReversedAngleAxis = {
         <PolarAngleAxis type="number" reversed />
         <PolarRadiusAxis type="category" stroke="black" />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     </>
   ),
@@ -356,7 +319,7 @@ export const ReversedAngleAxis = {
 };
 
 export const ReversedRadiusAxis = {
-  render: (args: StorybookArgs, context: RechartsStoryContext) => (
+  render: (args: StorybookArgs) => (
     <>
       <p>Counter-clockwise, starts East, bars come in reversed order</p>
       <RadialBarChart {...args}>
@@ -366,10 +329,7 @@ export const ReversedRadiusAxis = {
         <PolarAngleAxis type="number" />
         <PolarRadiusAxis type="category" stroke="black" reversed />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     </>
   ),
@@ -382,7 +342,7 @@ export const ReversedRadiusAxis = {
 };
 
 export const ReversedBothAxes = {
-  render: (args: StorybookArgs, context: RechartsStoryContext) => (
+  render: (args: StorybookArgs) => (
     <>
       <p>Counter-clockwise, starts East, bars come in reversed order</p>
       <RadialBarChart {...args}>
@@ -392,10 +352,7 @@ export const ReversedBothAxes = {
         <PolarAngleAxis type="number" reversed />
         <PolarRadiusAxis type="category" stroke="black" reversed />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     </>
   ),
@@ -408,7 +365,7 @@ export const ReversedBothAxes = {
 };
 
 export const Angled = {
-  render: (args: StorybookArgs, context: RechartsStoryContext) => (
+  render: (args: StorybookArgs) => (
     <>
       <p>Both angles are positive, chart starts at East + startAngle, CCW</p>
       <RadialBarChart {...args}>
@@ -418,10 +375,7 @@ export const Angled = {
         <PolarAngleAxis type="number" />
         <PolarRadiusAxis type="category" stroke="black" />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     </>
   ),
@@ -436,7 +390,7 @@ export const Angled = {
 };
 
 export const ChartReversedByAngles = {
-  render: (args: StorybookArgs, context: RechartsStoryContext) => (
+  render: (args: StorybookArgs) => (
     <>
       <p>If startAngle &gt; endAngle, the angle axis gets reversed too</p>
       <RadialBarChart {...args}>
@@ -446,10 +400,7 @@ export const ChartReversedByAngles = {
         <PolarAngleAxis type="number" />
         <PolarRadiusAxis type="category" stroke="black" />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     </>
   ),
@@ -464,7 +415,7 @@ export const ChartReversedByAngles = {
 };
 
 export const ChartReversedByBothAnglesAndReverseAxis = {
-  render: (args: StorybookArgs, context: RechartsStoryContext) => (
+  render: (args: StorybookArgs) => (
     <>
       <p>
         If the angle axis is reversed by making startAngle &gt; endAngle,
@@ -477,10 +428,7 @@ export const ChartReversedByBothAnglesAndReverseAxis = {
         <PolarAngleAxis type="number" />
         <PolarRadiusAxis type="category" stroke="black" />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     </>
   ),
@@ -495,7 +443,7 @@ export const ChartReversedByBothAnglesAndReverseAxis = {
 };
 
 export const RadialBarChartWithChangingDataKey: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [dataKey, setDataKey] = React.useState('amt');
     return (
       <>
@@ -528,10 +476,7 @@ export const RadialBarChartWithChangingDataKey: StoryObj = {
           <PolarRadiusAxis type="category" dataKey="name" />
           <RadialBar dataKey={dataKey} fill="orange" fillOpacity={0.5} stroke="blue" strokeDasharray="3 3" label />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </RadialBarChart>
       </>
     );

--- a/storybook/stories/Examples/RadialBarChart/RadialBarChartWithMultipleAxes.stories.tsx
+++ b/storybook/stories/Examples/RadialBarChart/RadialBarChartWithMultipleAxes.stories.tsx
@@ -14,7 +14,6 @@ import { StorybookArgs } from '../../../StorybookArgs';
 import { getStoryArgsFromArgsTypesObject } from '../../API/props/utils';
 import { pageDataWithFillColor } from '../../data';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   argTypes: RadialBarChartProps,
@@ -23,7 +22,7 @@ export default {
 } satisfies Meta<typeof RadialBarChart>;
 
 export const RadialBarChartWithMultipleAxes: StoryObj<StorybookArgs> = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <RadialBarChart {...args}>
         <RadialBar angleAxisId="axis-pv" radiusAxisId="axis-name" dataKey="pv" fillOpacity={0.3} fill="purple" />
@@ -51,10 +50,7 @@ export const RadialBarChartWithMultipleAxes: StoryObj<StorybookArgs> = {
         <PolarRadiusAxis radiusAxisId="axis-amt" dataKey="amt" type="number" angle={180} stroke="black" />
         <PolarGrid stroke="red" strokeOpacity={0.5} angleAxisId="axis-pv" radiusAxisId="axis-name" />
         <PolarGrid stroke="blue" strokeOpacity={0.5} angleAxisId="axis-uv" radiusAxisId="axis-amt" />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </RadialBarChart>
     );
   },

--- a/storybook/stories/Examples/ResponsiveContainer/MultiChartFlexbox.stories.tsx
+++ b/storybook/stories/Examples/ResponsiveContainer/MultiChartFlexbox.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import {
   Area,
   AreaChart,
@@ -14,14 +13,13 @@ import {
 import { pageData } from '../../data';
 import './style.css';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: AreaChart,
 };
 
 export const MultiChartFlexbox = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <>
         <p>Resize the window to test ResponsiveContainer</p>
@@ -41,10 +39,7 @@ export const MultiChartFlexbox = {
               <YAxis />
               <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
               <Tooltip />
-              <RechartsHookInspector
-                position={context.rechartsInspectorPosition}
-                setPosition={context.rechartsSetInspectorPosition}
-              />
+              <RechartsHookInspector />
             </AreaChart>
           </ResponsiveContainer>
           <ResponsiveContainer className="flex-child">
@@ -72,7 +67,7 @@ export const MultiChartFlexbox = {
 };
 
 export const ResponsiveContainerWithFlexbox = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const data = [
       { name: 'Page A', uv: 4000, pv: 2400, amt: 2400 },
       { name: 'Page B', uv: 3000, pv: 1398, amt: 2210 },
@@ -94,10 +89,7 @@ export const ResponsiveContainerWithFlexbox = {
                 <CartesianGrid strokeDasharray="3 3" />
                 <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
                 <Tooltip />
-                <RechartsHookInspector
-                  position={context.rechartsInspectorPosition}
-                  setPosition={context.rechartsSetInspectorPosition}
-                />
+                <RechartsHookInspector />
               </AreaChart>
             </ResponsiveContainer>
           </div>

--- a/storybook/stories/Examples/ScatterChart.stories.tsx
+++ b/storybook/stories/Examples/ScatterChart.stories.tsx
@@ -31,7 +31,7 @@ export default {
 };
 
 export const Simple: Meta<ScatterProps> = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data = [
       { x: 100, y: 200, z: 200 },
       { x: 100, y: 200, z: 200 },
@@ -58,10 +58,7 @@ export const Simple: Meta<ScatterProps> = {
           <Tooltip cursor={{ strokeDasharray: '3 3' }} defaultIndex={1} />
           <Scatter activeShape={args.activeShape} name="A school" data={data} fill="#8884d8" />
           <Legend />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ScatterChart>
       </ResponsiveContainer>
     );
@@ -72,7 +69,7 @@ export const Simple: Meta<ScatterProps> = {
 };
 
 export const ThreeDim = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data01 = [
       { x: 100, y: 200, z: 200 },
       { x: 120, y: 100, z: 260 },
@@ -101,10 +98,7 @@ export const ThreeDim = {
           <Scatter name="A school" data={data01} fill="#8884d8" shape="star" />
           <Scatter name="B school" data={data02} fill="#82ca9d" shape="triangle" />
           <Tooltip cursor={{ strokeDasharray: '3 3' }} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ScatterChart>
       </ResponsiveContainer>
     );
@@ -121,7 +115,7 @@ export const ThreeDim = {
 };
 
 export const JointLine = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data01 = [
       { x: 10, y: 30 },
       { x: 30, y: 200 },
@@ -149,10 +143,7 @@ export const JointLine = {
           <Scatter name="A school" data={data01} fill="#8884d8" line shape="cross" />
           <Scatter name="B school" data={data02} fill="#82ca9d" line shape="diamond" />
           <Tooltip cursor={{ strokeDasharray: '3 3' }} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ScatterChart>
       </ResponsiveContainer>
     );
@@ -169,7 +160,7 @@ export const JointLine = {
 };
 
 export const BubbleChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data01 = [
       { hour: '12a', index: 1, value: 170 },
       { hour: '1a', index: 1, value: 180 },
@@ -306,10 +297,7 @@ export const BubbleChart = {
             <BubbleAxes day="Sunday" />
             <Bubbles data={data01} />
             <MyTooltip />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </ScatterChart>
         </ResponsiveContainer>
 
@@ -377,7 +365,7 @@ export const BubbleChart = {
 };
 
 export const WithLabels = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data = [
       { x: 100, y: 200, z: 200 },
       { x: 120, y: 100, z: 260 },
@@ -397,10 +385,7 @@ export const WithLabels = {
             <LabelList dataKey="x" />
           </Scatter>
           <Tooltip cursor={{ strokeDasharray: '3 3' }} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ScatterChart>
       </ResponsiveContainer>
     );
@@ -417,7 +402,7 @@ export const WithLabels = {
 };
 
 export const MultipleYAxes = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data01 = [
       { x: 100, y: 200, z: 200 },
       { x: 120, y: 100, z: 260 },
@@ -459,10 +444,7 @@ export const MultipleYAxes = {
           <Scatter yAxisId="left" name="A school" data={data01} fill="#8884d8" />
           <Scatter yAxisId="right" name="A school" data={data02} fill="#82ca9d" />
           <Tooltip cursor={{ strokeDasharray: '3 3' }} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ScatterChart>
       </ResponsiveContainer>
     );
@@ -479,7 +461,7 @@ export const MultipleYAxes = {
 };
 
 export const WithCells = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data = [
       { x: 100, y: 200, z: 200 },
       { x: 120, y: 100, z: 260 },
@@ -501,10 +483,7 @@ export const WithCells = {
           ))}
         </Scatter>
         <Tooltip cursor={{ strokeDasharray: '3 3' }} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </ScatterChart>
     );
   },
@@ -522,7 +501,7 @@ export const WithCells = {
 };
 
 export const SpurriousCorrelation: StoryObj<StorybookArgs> = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ScatterChart {...args}>
         <CartesianGrid vertical={false} yAxisId="axis-babies" />
@@ -588,10 +567,7 @@ export const SpurriousCorrelation: StoryObj<StorybookArgs> = {
           shape="circle"
         />
         <Tooltip cursor={{ strokeDasharray: '3 3' }} shared={false} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </ScatterChart>
     );
   },
@@ -610,7 +586,7 @@ export const SpurriousCorrelation: StoryObj<StorybookArgs> = {
 };
 
 export const WithDuplicatedCategory: StoryObj<StorybookArgs> = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data = [
       { x: 100, y: 100, z: 200 },
       { x: 100, y: 200, z: 200 },
@@ -638,10 +614,7 @@ export const WithDuplicatedCategory: StoryObj<StorybookArgs> = {
           <Scatter activeShape={{ fill: 'red' }} name="A school" data={data} />
           <Tooltip cursor={{ strokeDasharray: '3 3' }} />
           <Legend />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ScatterChart>
       </ResponsiveContainer>
     );
@@ -710,10 +683,7 @@ export const ChangingDataKey = {
             <ZAxis range={[200, 200]} />
             <Tooltip />
             <Legend />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
             <Scatter
               name="Animated Scatter"
               lineType="joint"
@@ -726,10 +696,7 @@ export const ChangingDataKey = {
               strokeDasharray="2 2"
               label={{ fill: 'red', dy: -25, dataKey: useData2 ? dataKey2 : dataKey1 }}
             />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </ScatterChart>
         </ManualAnimations>
       </>

--- a/storybook/stories/Examples/ScatterChart.stories.tsx
+++ b/storybook/stories/Examples/ScatterChart.stories.tsx
@@ -18,8 +18,7 @@ import { Props as ScatterProps } from '../../../src/cartesian/Scatter';
 import { CategoricalChartProps } from '../API/props/ChartProps';
 import { getStoryArgsFromArgsTypesObject } from '../API/props/utils';
 import { StorybookArgs } from '../../StorybookArgs';
-import { ManualAnimations, RechartsHookInspector } from '../../storybook-addon-recharts';
-import { RechartsStoryContext } from '../../storybook-addon-recharts/RechartsStoryContext';
+import { RechartsHookInspector } from '../../storybook-addon-recharts';
 import { babiesAndVideosCorrelation } from '../data/spurriousCorrelations';
 
 export default {
@@ -625,7 +624,7 @@ export const WithDuplicatedCategory: StoryObj<StorybookArgs> = {
 };
 
 export const ChangingDataKey = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data1 = [
       { x: { value: 1 }, name: 'x1' },
       { x: { value: 2 }, name: 'x2' },
@@ -675,30 +674,28 @@ export const ChangingDataKey = {
         >
           Hide
         </button>
-        <ManualAnimations isEnabled={context.rechartsInspectorEnabled}>
-          <ScatterChart {...args} data={useData2 ? data2 : data1}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="name" padding={{ left: 30, right: 30 }} />
-            <YAxis dataKey={useData2 ? dataKey2 : dataKey1} width="auto" />
-            <ZAxis range={[200, 200]} />
-            <Tooltip />
-            <Legend />
-            <RechartsHookInspector />
-            <Scatter
-              name="Animated Scatter"
-              lineType="joint"
-              line
-              hide={!visible}
-              dataKey={useData2 ? dataKey2 : dataKey1}
-              stroke="#8884d8"
-              fill="#8884d8"
-              strokeWidth={3}
-              strokeDasharray="2 2"
-              label={{ fill: 'red', dy: -25, dataKey: useData2 ? dataKey2 : dataKey1 }}
-            />
-            <RechartsHookInspector />
-          </ScatterChart>
-        </ManualAnimations>
+        <ScatterChart {...args} data={useData2 ? data2 : data1}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" padding={{ left: 30, right: 30 }} />
+          <YAxis dataKey={useData2 ? dataKey2 : dataKey1} width="auto" />
+          <ZAxis range={[200, 200]} />
+          <Tooltip />
+          <Legend />
+          <RechartsHookInspector />
+          <Scatter
+            name="Animated Scatter"
+            lineType="joint"
+            line
+            hide={!visible}
+            dataKey={useData2 ? dataKey2 : dataKey1}
+            stroke="#8884d8"
+            fill="#8884d8"
+            strokeWidth={3}
+            strokeDasharray="2 2"
+            label={{ fill: 'red', dy: -25, dataKey: useData2 ? dataKey2 : dataKey1 }}
+          />
+          <RechartsHookInspector />
+        </ScatterChart>
       </>
     );
   },

--- a/storybook/stories/Examples/ScatterChartWithTwoErrorBars.stories.tsx
+++ b/storybook/stories/Examples/ScatterChartWithTwoErrorBars.stories.tsx
@@ -4,8 +4,7 @@ import { ScatterChart, CartesianGrid, XAxis, YAxis, Tooltip, Scatter, ErrorBar }
 import { getStoryArgsFromArgsTypesObject } from '../API/props/utils';
 import { XAxisProps } from '../API/props/XAxisProps';
 import { CartesianChartProps } from '../API/props/CartesianChartProps';
-import { ManualAnimations, RechartsHookInspector } from '../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../storybook-addon-recharts/RechartsStoryContext';
+import { RechartsHookInspector } from '../../storybook-addon-recharts';
 
 const bespokeArgTypes = {
   layout: {
@@ -27,7 +26,7 @@ export default {
 };
 
 export const WithErrorBarsAndExtendedDomain = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const data = [
       { x: 100, y: 200, errorY: 30, errorX: 30 },
       { x: 120, y: 100, errorY: [500, 30], errorX: [200, 30] },
@@ -38,30 +37,28 @@ export const WithErrorBarsAndExtendedDomain = {
     ];
 
     return (
-      <ManualAnimations isEnabled={context.rechartsInspectorEnabled}>
-        <ScatterChart
-          width={400}
-          height={400}
-          margin={{
-            top: 20,
-            right: 20,
-            bottom: 20,
-            left: 20,
-          }}
-          layout={args.layout}
-        >
-          <CartesianGrid />
-          <XAxis type="number" dataKey="x" name="stature" unit="cm" allowDataOverflow={args.allowDataOverflow} />
-          <YAxis type="number" dataKey="y" name="weight" unit="kg" allowDataOverflow={args.allowDataOverflow} />
-          <Scatter name="A school" data={data} fill="blue">
-            {/* This ErrorBar does render, but it does not extend the domain of XAxis unfortunately */}
-            <ErrorBar dataKey="errorX" width={2} strokeWidth={3} stroke="green" direction="x" />
-            <ErrorBar dataKey="errorY" width={4} strokeWidth={2} stroke="red" direction="y" />
-          </Scatter>
-          <Tooltip cursor={{ strokeDasharray: '3 3' }} />
-          <RechartsHookInspector />
-        </ScatterChart>
-      </ManualAnimations>
+      <ScatterChart
+        width={400}
+        height={400}
+        margin={{
+          top: 20,
+          right: 20,
+          bottom: 20,
+          left: 20,
+        }}
+        layout={args.layout}
+      >
+        <CartesianGrid />
+        <XAxis type="number" dataKey="x" name="stature" unit="cm" allowDataOverflow={args.allowDataOverflow} />
+        <YAxis type="number" dataKey="y" name="weight" unit="kg" allowDataOverflow={args.allowDataOverflow} />
+        <Scatter name="A school" data={data} fill="blue">
+          {/* This ErrorBar does render, but it does not extend the domain of XAxis unfortunately */}
+          <ErrorBar dataKey="errorX" width={2} strokeWidth={3} stroke="green" direction="x" />
+          <ErrorBar dataKey="errorY" width={4} strokeWidth={2} stroke="red" direction="y" />
+        </Scatter>
+        <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+        <RechartsHookInspector />
+      </ScatterChart>
     );
   },
   args: getStoryArgsFromArgsTypesObject(bespokeArgTypes),

--- a/storybook/stories/Examples/ScatterChartWithTwoErrorBars.stories.tsx
+++ b/storybook/stories/Examples/ScatterChartWithTwoErrorBars.stories.tsx
@@ -59,10 +59,7 @@ export const WithErrorBarsAndExtendedDomain = {
             <ErrorBar dataKey="errorY" width={4} strokeWidth={2} stroke="red" direction="y" />
           </Scatter>
           <Tooltip cursor={{ strokeDasharray: '3 3' }} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ScatterChart>
       </ManualAnimations>
     );

--- a/storybook/stories/Examples/Synchronised.stories.tsx
+++ b/storybook/stories/Examples/Synchronised.stories.tsx
@@ -25,7 +25,6 @@ import {
 } from '../../../src';
 import { PageData } from '../../../test/_data';
 import { RechartsHookInspector } from '../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../storybook-addon-recharts/RechartsStoryContext';
 
 const SynchronisationProps = {
   syncId: { control: 'text' },
@@ -77,7 +76,7 @@ const orange = '#ff7300';
 const pink = '#dd4a98';
 
 export const Synchronised = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <>
         <ResponsiveContainer width="100%" height={200}>
@@ -99,10 +98,7 @@ export const Synchronised = {
             <Area type="monotone" dataKey="uv" stroke={green} fill={green} />
             <Brush />
             <Tooltip />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </AreaChart>
         </ResponsiveContainer>
 
@@ -219,7 +215,7 @@ export const Synchronised = {
 };
 
 export const SynchronisedWithDataOnItem = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const series = [
       {
         name: 'Series 1',
@@ -251,10 +247,7 @@ export const SynchronisedWithDataOnItem = {
           {series.map(s => (
             <Line dataKey="y" data={s.data} name={s.name} key={s.name} />
           ))}
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
         <LineChart {...args} width={500} height={300}>
           <XAxis dataKey="x" type="number" domain={[0, 3]} />

--- a/storybook/stories/Examples/TimeSeries.stories.tsx
+++ b/storybook/stories/Examples/TimeSeries.stories.tsx
@@ -7,7 +7,6 @@ import { timeData } from '../data';
 import { ComposedChart, Line, ResponsiveContainer, XAxis, Tooltip } from '../../../src';
 import { Props as XAxisProps } from '../../../src/cartesian/XAxis';
 import { RechartsHookInspector } from '../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: XAxis,
@@ -18,7 +17,7 @@ interface Args {
 }
 
 const StoryTemplate = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <ComposedChart
@@ -32,10 +31,7 @@ const StoryTemplate = {
         >
           <XAxis dataKey="x" {...args} domain={['auto', 'auto']} />
           <Line dataKey="y" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -97,7 +93,7 @@ function multiFormat(date: Date): string {
 
 export const WithD3Scale = {
   ...StoryTemplate,
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const timeValues = args.data.map(row => row.x);
     // The d3 scaleTime domain requires numeric values
     const numericValues = timeValues.map(time => time.valueOf());
@@ -129,10 +125,7 @@ export const WithD3Scale = {
           <XAxis dataKey="x" {...args} {...xAxisArgs} />
           <Line dataKey="y" />
           <Tooltip />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/Tooltip.stories.tsx
+++ b/storybook/stories/Examples/Tooltip.stories.tsx
@@ -20,7 +20,6 @@ import {
 } from '../../../src';
 import { generateMockData } from '../../../test/helper/generateMockData';
 import { RechartsHookInspector } from '../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../storybook-addon-recharts/RechartsStoryContext';
 import { TooltipProps } from '../API/props/TooltipProps';
 import { getStoryArgsFromArgsTypesObject } from '../API/props/utils';
 
@@ -31,7 +30,7 @@ export default {
 
 // We do not export this story, but reuse the rendering across multiple examples with various args.
 const SimpleTooltipStory = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <ComposedChart data={pageData}>
@@ -39,10 +38,7 @@ const SimpleTooltipStory = {
           <YAxis />
           <Tooltip {...args} />
           <Line dataKey="uv" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -58,7 +54,7 @@ export const ActiveTooltip = {
 };
 
 export const SettingTooltipIndex = {
-  render: (args: Args, context: RechartsStoryContext) => (
+  render: (args: Args) => (
     <LineChart
       width={500}
       height={300}
@@ -77,10 +73,7 @@ export const SettingTooltipIndex = {
       <Tooltip {...args} />
       <Line type="monotone" dataKey="uv" stroke="#8884d8" />
       <Line type="monotone" dataKey="pv" stroke="#82ca9d" />
-      <RechartsHookInspector
-        position={context.rechartsInspectorPosition}
-        setPosition={context.rechartsSetInspectorPosition}
-      />
+      <RechartsHookInspector />
     </LineChart>
   ),
   args: {
@@ -90,7 +83,7 @@ export const SettingTooltipIndex = {
 };
 
 export const LockedByClick = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [isLocked, setIsLocked] = React.useState(false);
     // The TooltipData contains the payload, the label and the x position of the tooltip.
     // Their update is interrupted by the click event, so we need to store them in a state.
@@ -129,10 +122,7 @@ export const LockedByClick = {
           />
           <Line dataKey="uv" />
           <Bar dataKey="pv" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -145,7 +135,7 @@ export const LockedByClick = {
 };
 
 export const CssScaledParent = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [scale, setScale] = useState(1.2);
     const handleZoomIn = useCallback(() => setScale(s => s + 0.1), []);
     const handleZoomOut = useCallback(() => setScale(s => s - 0.1), []);
@@ -180,10 +170,7 @@ export const CssScaledParent = {
               <Line dataKey="uv" />
               <Bar dataKey="pv" />
               <Tooltip {...args} />
-              <RechartsHookInspector
-                position={context.rechartsInspectorPosition}
-                setPosition={context.rechartsSetInspectorPosition}
-              />
+              <RechartsHookInspector />
             </ComposedChart>
           </ResponsiveContainer>
         </div>
@@ -215,7 +202,7 @@ const lineData = [
 ];
 
 export const SeparateDataSetsForChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart data={areaData}>
@@ -224,10 +211,7 @@ export const SeparateDataSetsForChart = {
           <Tooltip {...args} />
           <Area dataKey="value" />
           <Line dataKey="value" data={lineData} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -295,7 +279,7 @@ export const CustomContentExample = {
 };
 
 export const LargeDataArray = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
@@ -314,10 +298,7 @@ export const LargeDataArray = {
           <Line dataKey="x" />
           <Line dataKey="y" />
           <Line dataKey="z" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -328,7 +309,7 @@ export const LargeDataArray = {
 };
 
 export const IncludeHidden = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
@@ -346,10 +327,7 @@ export const IncludeHidden = {
           <Tooltip {...args} />
           <Line dataKey="uv" />
           <Line dataKey="pv" hide />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -361,17 +339,14 @@ export const IncludeHidden = {
 };
 
 export const SharedTooltipInBarChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <BarChart data={pageData}>
           <Bar dataKey="uv" fill="green" />
           <Bar dataKey="pv" fill="red" />
           <Tooltip {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -385,17 +360,14 @@ export const SharedTooltipInBarChart = {
 };
 
 export const SharedTooltipInRadialBarChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <RadialBarChart data={pageData}>
           <RadialBar dataKey="uv" fill="green" />
           <RadialBar dataKey="pv" fill="red" />
           <Tooltip {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </RadialBarChart>
       </ResponsiveContainer>
     );
@@ -415,7 +387,7 @@ export const SharedTooltipInRadialBarChart = {
  * It should instead overflow the chart.
  */
 export const TallTooltipInNarrowChart = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={50}>
         <LineChart data={pageData}>
@@ -423,10 +395,7 @@ export const TallTooltipInNarrowChart = {
           <Line dataKey="uv" fill="green" />
           <Line dataKey="pv" fill="red" />
           <Line dataKey="amt" fill="amt" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );
@@ -439,7 +408,7 @@ export const TallTooltipInNarrowChart = {
 };
 
 export const TooltipWithPortal = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [portalRef, setPortalRef] = useState<HTMLElement | null>(null);
 
     return (
@@ -449,10 +418,7 @@ export const TooltipWithPortal = {
             {portalRef && <Tooltip {...args} portal={portalRef} />}
             <Line dataKey="uv" fill="green" />
             <Line dataKey="pv" fill="red" />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </LineChart>
         </ResponsiveContainer>
         <div
@@ -495,7 +461,7 @@ const d1 = [
 ];
 
 export const RechartsAlphaTooltipBug5516Repro = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [, setRandomUnusedState] = useState(true);
 
     return (
@@ -511,10 +477,7 @@ export const RechartsAlphaTooltipBug5516Repro = {
             <LineChart data={d1} style={{ border: '1px solid black' }}>
               <Tooltip {...args} />
               <Line dataKey="Triggers" />
-              <RechartsHookInspector
-                position={context.rechartsInspectorPosition}
-                setPosition={context.rechartsSetInspectorPosition}
-              />
+              <RechartsHookInspector />
             </LineChart>
           </ResponsiveContainer>
         </div>
@@ -527,7 +490,7 @@ export const RechartsAlphaTooltipBug5516Repro = {
 };
 
 export const RechartsAlphaTooltipBug5516ReproButWithItemBasedTooltip = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const [, setRandomUnusedState] = useState(true);
 
     return (
@@ -543,10 +506,7 @@ export const RechartsAlphaTooltipBug5516ReproButWithItemBasedTooltip = {
             <BarChart data={d1} style={{ border: '1px solid black' }}>
               <Bar dataKey="Triggers" />
               <Tooltip {...args} />
-              <RechartsHookInspector
-                position={context.rechartsInspectorPosition}
-                setPosition={context.rechartsSetInspectorPosition}
-              />
+              <RechartsHookInspector />
             </BarChart>
           </ResponsiveContainer>
         </div>
@@ -560,7 +520,7 @@ export const RechartsAlphaTooltipBug5516ReproButWithItemBasedTooltip = {
 };
 
 export const RechartsTooltipBug5542Repro = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <div
         style={{
@@ -586,10 +546,7 @@ export const RechartsTooltipBug5542Repro = {
             <Legend />
             <Bar dataKey="pv" fill="#8884d8" />
             <Bar dataKey="uv" fill="#82ca9d" />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </BarChart>
         </div>
       </div>
@@ -602,7 +559,7 @@ export const RechartsTooltipBug5542Repro = {
 };
 
 export const TooltipWithNegativeOffset = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <ResponsiveContainer width="100%" height={400}>
         <ComposedChart data={pageData}>
@@ -610,10 +567,7 @@ export const TooltipWithNegativeOffset = {
           <YAxis />
           <Line dataKey="uv" />
           <Tooltip {...args} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/Area/AreaWithCustomDot.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Area/AreaWithCustomDot.stories.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import { ComposedChart, Area, ResponsiveContainer } from '../../../../../src';
 import { coordinateWithValueData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Area/Customised Dot',
@@ -22,7 +20,7 @@ const renderDot = (props: { cx: number; cy: number }) => {
 
 export const CustomizedDot = {
   id: 'test',
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
         <ComposedChart
@@ -37,10 +35,7 @@ export const CustomizedDot = {
           data={coordinateWithValueData}
         >
           <Area dataKey="y" isAnimationActive={false} dot={renderDot} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/Area/AreaWithCustomLabel.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Area/AreaWithCustomLabel.stories.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import { ComposedChart, Area, ResponsiveContainer } from '../../../../../src';
 import { coordinateWithValueData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Area/Customised Label',
@@ -21,7 +19,7 @@ const renderLabel = (props: { index: number; x: number; y: number }) => {
 };
 
 export const CustomizedLabel = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
         <ComposedChart
@@ -36,10 +34,7 @@ export const CustomizedLabel = {
           data={coordinateWithValueData}
         >
           <Area dataKey="y" isAnimationActive={false} label={renderLabel} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/Area/AreaWithFillPattern.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Area/AreaWithFillPattern.stories.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import { ComposedChart, Area, ResponsiveContainer } from '../../../../../src';
 import { coordinateWithValueData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Area/With Fill Pattern',
@@ -12,7 +10,7 @@ export default {
 const [surfaceWidth, surfaceHeight] = [600, 300];
 
 export const FillPattern = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
         <ComposedChart
@@ -36,10 +34,7 @@ export const FillPattern = {
           </defs>
           <Area type="monotone" dataKey="x" stroke="#8884d8" fillOpacity={1} fill="url(#left)" />
           <Area type="monotone" dataKey="y" stroke="#82ca9d" fillOpacity={1} fill="url(#right)" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/Bar/CustomizedEvent.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Bar/CustomizedEvent.stories.tsx
@@ -1,16 +1,14 @@
 import React, { useState } from 'react';
-import { Args } from '@storybook/react-vite';
 import { ComposedChart, Bar, ResponsiveContainer, Cell } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Bar/Customised Event',
 };
 
 export const CustomizedEvent = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const [activeIndex, setActiveIndex] = useState(1);
     const [surfaceWidth, surfaceHeight] = [600, 300];
     return (
@@ -33,10 +31,7 @@ export const CustomizedEvent = {
                 <Cell cursor="pointer" fill={index === activeIndex ? '#82ca9d' : '#8884d8'} key={`cell-${name}`} />
               ))}
             </Bar>
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </ComposedChart>
         </ResponsiveContainer>
       </>

--- a/storybook/stories/Examples/cartesian/Bar/CustomizedShape.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Bar/CustomizedShape.stories.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import { ComposedChart, Bar, ResponsiveContainer, Cell, BarProps } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Bar/Customised Shape',
 };
 
 export const CustomizedShape = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const getPath = (x: number, y: number, width: number, height: number) => {
       return `M${x},${y + height}C${x + width / 3},${y + height} ${x + width / 2},${y + height / 3}
   ${x + width / 2}, ${y}
@@ -55,10 +53,7 @@ export const CustomizedShape = {
               <Cell key={`cell-${name}`} fill={colors[index % 20]} />
             ))}
           </Bar>
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -66,7 +61,7 @@ export const CustomizedShape = {
 };
 
 export const FillGradient = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
 
     return (
@@ -94,10 +89,7 @@ export const FillGradient = {
           </defs>
           <Bar dataKey="uv" stroke="#8884d8" fillOpacity={1} fill="url(#colorUv)" />
           <Bar dataKey="pv" stroke="#82ca9d" fillOpacity={1} fill="url(#colorPv)" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );
@@ -105,7 +97,7 @@ export const FillGradient = {
 };
 
 export const FillPattern = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
 
     return (
@@ -131,10 +123,7 @@ export const FillPattern = {
           </defs>
           <Bar dataKey="uv" stroke="#8884d8" fillOpacity={1} fill="url(#star)" />
           <Bar dataKey="pv" stroke="#82ca9d" fillOpacity={1} fill="url(#stripe)" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/Bar/FillPatternOrGradient.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Bar/FillPatternOrGradient.stories.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import { ComposedChart, Bar, ResponsiveContainer } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Bar/Fill with Gradient or Pattern',
 };
 
 export const Fill = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
 
     return (
@@ -41,10 +39,7 @@ export const Fill = {
           <Bar dataKey="uv" stroke="#8884d8" fillOpacity={1} fill="url(#colorUv)" />
           <Bar dataKey="pv" stroke="#82ca9d" fillOpacity={1} fill="url(#stripe)" />
           <Bar dataKey="amt" stroke="#8884d8" fillOpacity={1} fill="url(#star)" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/Bar/StackedAndUnstacked.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Bar/StackedAndUnstacked.stories.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import { ComposedChart, Bar, ResponsiveContainer } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Bar/Stacked And Unstacked',
 };
 export const StackedAndUnstacked = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
@@ -27,10 +25,7 @@ export const StackedAndUnstacked = {
           <Bar stackId="pv-uv" dataKey="uv" stroke="red" fill="red" />
           <Bar stackId="pv-uv" dataKey="pv" stroke="green" fill="green" />
           <Bar dataKey="amt" stroke="green" fill="green" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/Bar/WithBrushAndOnDragEnd.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Bar/WithBrushAndOnDragEnd.stories.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import { Brush, ResponsiveContainer, Bar, BarChart, XAxis, YAxis } from '../../../../../src';
 import { dateWithValueData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Bar/With Brush and onDragEnd',
@@ -15,7 +13,7 @@ interface BrushStartEndIndex {
 }
 
 export const WithBrushAndOnDragEnd = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const [dragIndexes, setDragIndexes] = React.useState<BrushStartEndIndex>({
       startIndex: 0,
       endIndex: dateWithValueData.length - 1,
@@ -43,10 +41,7 @@ export const WithBrushAndOnDragEnd = {
               }}
             />
             <Bar dataKey="value" />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </BarChart>
         </ResponsiveContainer>
       </div>

--- a/storybook/stories/Examples/cartesian/Brush/Brush.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Brush/Brush.stories.tsx
@@ -15,14 +15,13 @@ import {
 } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: Brush,
 };
 
 export const ControlledBrush = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (_args: Args) => {
     const [startIndex, setStartIndex] = useState<number | undefined>(2);
     const [endIndex, setEndIndex] = useState<number | undefined>(5);
 
@@ -41,10 +40,7 @@ export const ControlledBrush = {
               }}
               alwaysShowText
             />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </ComposedChart>
         </ResponsiveContainer>
         <input
@@ -70,7 +66,7 @@ export const ControlledBrush = {
 };
 
 export const PanoramicBrush = {
-  render: (_args: Args, context: RechartsStoryContext) => {
+  render: (_args: Args) => {
     return (
       <ComposedChart width={600} height={300} data={pageData} margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>
         <XAxis dataKey="name" />
@@ -89,10 +85,7 @@ export const PanoramicBrush = {
           </LineChart>
         </Brush>
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </ComposedChart>
     );
   },

--- a/storybook/stories/Examples/cartesian/Brush/BrushInSurface.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Brush/BrushInSurface.stories.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import { Brush, ResponsiveContainer, ComposedChart } from '../../../../../src';
 import { dateData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Brush/In Surface',
 };
 
 export const InSurface = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     interface BrushStartEndIndex {
       startIndex?: number;
       endIndex?: number;
@@ -77,10 +75,7 @@ export const InSurface = {
               gap={5}
               onChange={handleGapChange}
             />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </ComposedChart>
         </div>
       </ResponsiveContainer>

--- a/storybook/stories/Examples/cartesian/CartesianAxis/TickPositioning.stories.tsx
+++ b/storybook/stories/Examples/cartesian/CartesianAxis/TickPositioning.stories.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import { Line, LineChart, ResponsiveContainer, XAxis } from '../../../../../src';
 import { ticks } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Cartesian Axis/Tick Positioning',
 };
 
 export const TickPositioning = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const intervalOptions = [
       'preserveStart',
       'preserveEnd',
@@ -42,10 +40,7 @@ export const TickPositioning = {
               height={70}
             />
           ))}
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/Line/LineWithCustomDot.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Line/LineWithCustomDot.stories.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import { ComposedChart, Line, ResponsiveContainer } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Line/Customised Dot',
@@ -22,7 +20,7 @@ const renderDot = (props: { cx: number; cy: number }) => {
 };
 
 export const CustomizedDot = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <ResponsiveContainer width="100%" height={surfaceHeight}>
         <ComposedChart
@@ -37,10 +35,7 @@ export const CustomizedDot = {
           data={pageData}
         >
           <Line dataKey="uv" isAnimationActive={false} dot={renderDot} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/Line/LineWithCustomLabel.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Line/LineWithCustomLabel.stories.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { Args, StoryObj } from '@storybook/react-vite';
+import { StoryObj } from '@storybook/react-vite';
 import { within, expect } from 'storybook/test';
 import { pageData } from '../../../data';
 import { ComposedChart, Area, ResponsiveContainer } from '../../../../../src';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Line/Customised Label',
@@ -21,7 +20,7 @@ const renderLabel = (props: { index: number; x: number; y: number }) => {
 };
 
 export const CustomizedLabel: StoryObj = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
 
     return (
@@ -38,10 +37,7 @@ export const CustomizedLabel: StoryObj = {
           data={pageData}
         >
           <Area dataKey="uv" isAnimationActive={false} label={renderLabel} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/ReferenceArea/ReferenceAreaIfOverflow.stories.tsx
+++ b/storybook/stories/Examples/cartesian/ReferenceArea/ReferenceAreaIfOverflow.stories.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import { expect, within } from 'storybook/test';
-import { Args } from '@storybook/react-vite';
 import { ComposedChart, ReferenceArea, CartesianGrid, XAxis, YAxis, ResponsiveContainer } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Reference Area/If Overflow',
 };
 
 export const IfOverflow = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -35,10 +33,7 @@ export const IfOverflow = {
             strokeOpacity={0.3}
             ifOverflow="extendDomain"
           />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/ReferenceDot/ReferenceDotIfOverflow.stories.tsx
+++ b/storybook/stories/Examples/cartesian/ReferenceDot/ReferenceDotIfOverflow.stories.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import { expect, within } from 'storybook/test';
-import { Args } from '@storybook/react-vite';
 import { ComposedChart, ReferenceDot, CartesianGrid, XAxis, YAxis, ResponsiveContainer } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/Reference Dot/If Overflow',
 };
 
 export const IfOverflow = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -27,10 +25,7 @@ export const IfOverflow = {
           <XAxis dataKey="name" />
           <YAxis type="number" />
           <ReferenceDot ifOverflow="extendDomain" x="Page E" y={1700} r={100} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/ReferenceLine/ReferenceLineIfOverflow.stories.tsx
+++ b/storybook/stories/Examples/cartesian/ReferenceLine/ReferenceLineIfOverflow.stories.tsx
@@ -1,6 +1,5 @@
 import { expect, within } from 'storybook/test';
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import {
   ComposedChart,
   Line,
@@ -12,14 +11,13 @@ import {
 } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/ReferenceLine/ReferenceLineIfOverflow',
 };
 
 export const IfOverflow = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -36,10 +34,7 @@ export const IfOverflow = {
           <YAxis type="number" />
           <Line dataKey="uv" />
           <ReferenceLine ifOverflow="extendDomain" y={1700} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/ReferenceLine/ReferenceLineSegment.stories.tsx
+++ b/storybook/stories/Examples/cartesian/ReferenceLine/ReferenceLineSegment.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import {
   ComposedChart,
   Line,
@@ -11,14 +10,13 @@ import {
 } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   title: 'Examples/cartesian/ReferenceLine/ReferenceLineSegment',
 };
 
 export const Segment = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart
@@ -40,10 +38,7 @@ export const Segment = {
               { x: 'Page E', y: 1500 },
             ]}
           />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/XAxis/SolarSystem.stories.tsx
+++ b/storybook/stories/Examples/cartesian/XAxis/SolarSystem.stories.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from '../../../../../src';
 import { solarSystem } from '../../../data/solarSystem';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default { Component: XAxis };
 
-export const MassBarChart = (args: Args, context: RechartsStoryContext) => {
+export const MassBarChart = () => {
   return (
     <ResponsiveContainer width="100%" height={400}>
       <BarChart data={solarSystem} width={100} height={100}>
@@ -15,16 +13,13 @@ export const MassBarChart = (args: Args, context: RechartsStoryContext) => {
         <YAxis width={100} label={{ value: 'Mass [kg]', position: 'insideLeft', dx: 0, dy: 20, angle: -90 }} />
         <Bar dataKey="massKg" unit="kg" />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </BarChart>
     </ResponsiveContainer>
   );
 };
 
-export const MassBarChartCategoricalY = (args: Args, context: RechartsStoryContext) => {
+export const MassBarChartCategoricalY = () => {
   return (
     <ResponsiveContainer width="100%" height={400}>
       <BarChart data={solarSystem} width={100} height={100}>
@@ -36,16 +31,13 @@ export const MassBarChartCategoricalY = (args: Args, context: RechartsStoryConte
         />
         <Bar dataKey="massKg" unit="kg" />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </BarChart>
     </ResponsiveContainer>
   );
 };
 
-export const MassBarChartCustomYDomain = (args: Args, context: RechartsStoryContext) => {
+export const MassBarChartCustomYDomain = () => {
   return (
     <ResponsiveContainer width="100%" height={400}>
       <BarChart data={solarSystem} width={100} height={100}>
@@ -58,16 +50,13 @@ export const MassBarChartCustomYDomain = (args: Args, context: RechartsStoryCont
         />
         <Bar dataKey="massKg" unit="kg" />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </BarChart>
     </ResponsiveContainer>
   );
 };
 
-export const MassBarChartLogScale = (args: Args, context: RechartsStoryContext) => {
+export const MassBarChartLogScale = () => {
   return (
     <ResponsiveContainer width="100%" height={400}>
       <BarChart data={solarSystem} width={100} height={100}>
@@ -80,17 +69,14 @@ export const MassBarChartLogScale = (args: Args, context: RechartsStoryContext) 
         />
         <Bar dataKey="massKg" unit="kg" />
         <Tooltip />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </BarChart>
     </ResponsiveContainer>
   );
 };
 
 /* eslint-disable react/jsx-no-bind */
-export const MassBarChartCustomTicks = (args: Args, context: RechartsStoryContext) => {
+export const MassBarChartCustomTicks = () => {
   function kgToYottagram(value: number): string {
     // the data is defined in kg
     const yottagram = value / 1e24;
@@ -109,10 +95,7 @@ export const MassBarChartCustomTicks = (args: Args, context: RechartsStoryContex
         />
         <Bar dataKey="massKg" name="mass" unit=" yottagram" />
         <Tooltip formatter={kgToYottagram} />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </BarChart>
     </ResponsiveContainer>
   );

--- a/storybook/stories/Examples/cartesian/XAxis/XAxisWithCalculatedPadding.stories.tsx
+++ b/storybook/stories/Examples/cartesian/XAxis/XAxisWithCalculatedPadding.stories.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { Args } from '@storybook/react-vite';
 import { ComposedChart, XAxis } from '../../../../../src';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 import { XAxisProps } from '../../../API/props/XAxisProps';
 
 export default {
@@ -16,16 +14,13 @@ const data = [0, 2, 4, 6, 8, 10].map(value => {
 });
 
 export const WithCalculatedPadding = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     return (
       <div>
         <h4>default:</h4>
         <ComposedChart width={600} height={50} data={data}>
           <XAxis dataKey="x" type="number" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
 
         <h4>no-gap:</h4>

--- a/storybook/stories/Examples/cartesian/XAxis/XAxisWithCustomTicks.stories.tsx
+++ b/storybook/stories/Examples/cartesian/XAxis/XAxisWithCustomTicks.stories.tsx
@@ -3,7 +3,6 @@ import { Args } from '@storybook/react-vite';
 import { ComposedChart, XAxis, ResponsiveContainer } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 import { getStoryArgsFromArgsTypesObject } from '../../../API/props/utils';
 import { XAxisProps } from '../../../API/props/XAxisProps';
 
@@ -14,7 +13,7 @@ export default {
 };
 
 export const WithCustomTicks = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const customizedAxisTick = (props: { x: number; y: number; payload: { value: string } }) => {
       const { x, y, payload } = props;
       return (
@@ -30,10 +29,7 @@ export const WithCustomTicks = {
       <ResponsiveContainer width="100%" height={500}>
         <ComposedChart width={600} height={50} data={pageData}>
           <XAxis {...args} dataKey="name" tick={customizedAxisTick} />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/XAxis/XAxisWithDifferentDataTypes.stories.tsx
+++ b/storybook/stories/Examples/cartesian/XAxis/XAxisWithDifferentDataTypes.stories.tsx
@@ -3,7 +3,6 @@ import { Args } from '@storybook/react-vite';
 import { ComposedChart, XAxis } from '../../../../../src';
 import { coordinateWithValueData, dateWithValueData, pageData, timeData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 import { getStoryArgsFromArgsTypesObject } from '../../../API/props/utils';
 import { XAxisProps } from '../../../API/props/XAxisProps';
 
@@ -14,15 +13,12 @@ export default {
 };
 
 export const WithDifferentDataTypes = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <div>
         <ComposedChart width={600} height={50} data={pageData}>
           <XAxis dataKey="name" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
         <ComposedChart width={600} height={50} data={coordinateWithValueData}>
           <XAxis {...args} dataKey="x" domain={['auto', 'auto']} type="number" />

--- a/storybook/stories/Examples/cartesian/XAxis/XAxisWithMultipleAxes.stories.tsx
+++ b/storybook/stories/Examples/cartesian/XAxis/XAxisWithMultipleAxes.stories.tsx
@@ -5,7 +5,6 @@ import { Line, LineChart, Tooltip, XAxis } from '../../../../../src';
 import { XAxisProps } from '../../../API/props/XAxisProps';
 import { getStoryArgsFromArgsTypesObject } from '../../../API/props/utils';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: XAxis,
@@ -13,7 +12,7 @@ export default {
 };
 
 export const XAxisWithMultipleAxes = {
-  render: (args: Args, context: RechartsStoryContext) => (
+  render: (args: Args) => (
     <article style={{ display: 'flex', flexDirection: 'column' }}>
       <LineChart width={700} height={700} data={pageData}>
         <XAxis {...args} dataKey="name" xAxisId="a" orientation="top" height={40} />
@@ -25,10 +24,7 @@ export const XAxisWithMultipleAxes = {
         <Line dataKey="uv" xAxisId="b" />
         <Line dataKey="pv" xAxisId="c" />
         <Line dataKey="amt" xAxisId="d" />
-        <RechartsHookInspector
-          position={context.rechartsInspectorPosition}
-          setPosition={context.rechartsSetInspectorPosition}
-        />
+        <RechartsHookInspector />
       </LineChart>
       <p>
         {`When an AxisId is specified on all provided axes of one type (XAxis, YAxis, ZAxis), recharts requires a

--- a/storybook/stories/Examples/cartesian/XAxis/XAxisWithTickFormatter.stories.tsx
+++ b/storybook/stories/Examples/cartesian/XAxis/XAxisWithTickFormatter.stories.tsx
@@ -5,7 +5,6 @@ import { dateWithValueData } from '../../../data';
 import { getStoryArgsFromArgsTypesObject } from '../../../API/props/utils';
 import { XAxisProps } from '../../../API/props/XAxisProps';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: XAxis,
@@ -14,7 +13,7 @@ export default {
 };
 
 export const WithTickFormatter = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     const tickFormatter = (value: number) =>
       new Date(value).toLocaleDateString('en-US', {
         year: 'numeric',
@@ -36,10 +35,7 @@ export const WithTickFormatter = {
             tickFormatter={tickFormatter}
           />
           <Line dataKey="value" />
-          <RechartsHookInspector
-            position={context.rechartsInspectorPosition}
-            setPosition={context.rechartsSetInspectorPosition}
-          />
+          <RechartsHookInspector />
         </ComposedChart>
       </ResponsiveContainer>
     );

--- a/storybook/stories/Examples/cartesian/YAxis/XAxisIncludeHidden.stories.tsx
+++ b/storybook/stories/Examples/cartesian/YAxis/XAxisIncludeHidden.stories.tsx
@@ -1,9 +1,7 @@
 import React, { ComponentProps, useState } from 'react';
-import { Args } from '@storybook/react-vite';
 import { ComposedChart, XAxis, Bar, ResponsiveContainer, YAxis, Legend } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 import { getStoryArgsFromArgsTypesObject } from '../../../API/props/utils';
 import { YAxisProps } from '../../../API/props/YAxisProps';
 
@@ -14,7 +12,7 @@ export default {
 };
 
 export const WithIncludeHidden = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: () => {
     const allKeys = Object.keys(pageData[0]);
     const [activeKeys, setActiveKeys] = useState(allKeys);
 
@@ -39,10 +37,7 @@ export const WithIncludeHidden = {
             <Legend onClick={handleLegendClick} />
             <Bar dataKey="pv" fill="blue" hide={!activeKeys.includes('pv')} />
             <Bar dataKey="amt" fill="green" hide={!activeKeys.includes('amt')} />
-            <RechartsHookInspector
-              position={context.rechartsInspectorPosition}
-              setPosition={context.rechartsSetInspectorPosition}
-            />
+            <RechartsHookInspector />
           </ComposedChart>
         </ResponsiveContainer>
       </>

--- a/storybook/stories/Examples/cartesian/YAxis/YAxisMultipleAxes.stories.tsx
+++ b/storybook/stories/Examples/cartesian/YAxis/YAxisMultipleAxes.stories.tsx
@@ -5,7 +5,6 @@ import { pageData } from '../../../data';
 import { getStoryArgsFromArgsTypesObject } from '../../../API/props/utils';
 import { YAxisProps } from '../../../API/props/YAxisProps';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
-import type { RechartsStoryContext } from '../../../../storybook-addon-recharts/RechartsStoryContext';
 
 export default {
   component: YAxis,
@@ -14,7 +13,7 @@ export default {
 };
 
 export const WithLeftAndRightAxes = {
-  render: (args: Args, context: RechartsStoryContext) => {
+  render: (args: Args) => {
     return (
       <article style={{ display: 'flex', flexDirection: 'column' }}>
         <div style={{ width: '100%' }}>
@@ -32,10 +31,7 @@ export const WithLeftAndRightAxes = {
               <YAxis {...args} yAxisId="right-mirror" orientation="right" mirror tickCount={20} />
 
               <Tooltip />
-              <RechartsHookInspector
-                position={context.rechartsInspectorPosition}
-                setPosition={context.rechartsSetInspectorPosition}
-              />
+              <RechartsHookInspector />
             </ComposedChart>
           </ResponsiveContainer>
         </div>

--- a/storybook/storybook-addon-recharts/ManualAnimations.tsx
+++ b/storybook/storybook-addon-recharts/ManualAnimations.tsx
@@ -1,29 +1,57 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { AnimationManagerControlsContext, useRechartsInspectorState } from './RechartsInspectorDecorator';
 import { useAllAnimationManagers } from '../../test/animation/CompositeAnimationManager';
 import { MockAnimationManager } from '../../test/animation/MockProgressAnimationManager';
 
+const useAnimationProgress = (allAnimationManagers: Map<string, MockAnimationManager>) => {
+  const [progressMap, setProgressMap] = useState<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    setProgressMap(prev => {
+      const newMap = new Map<string, number>();
+      // eslint-disable-next-line no-restricted-syntax
+      for (const animationId of allAnimationManagers.keys()) {
+        newMap.set(animationId, prev.get(animationId) ?? 0);
+      }
+      return newMap;
+    });
+  }, [allAnimationManagers]);
+
+  const setProgress = async (progress: number, animationId?: string) => {
+    const safeProgress = Math.min(0.999, progress);
+    if (animationId) {
+      const manager = allAnimationManagers.get(animationId);
+      if (manager) {
+        await manager.setAnimationProgress(safeProgress);
+        setProgressMap(prev => new Map(prev).set(animationId, progress));
+      }
+    } else {
+      const promises: Promise<void>[] = [];
+      const newProgressMap = new Map(progressMap);
+      // eslint-disable-next-line no-restricted-syntax
+      for (const [id, manager] of allAnimationManagers.entries()) {
+        promises.push(manager.setAnimationProgress(safeProgress));
+        newProgressMap.set(id, progress);
+      }
+      await Promise.all(promises);
+      setProgressMap(newProgressMap);
+    }
+  };
+
+  return { progressMap, setProgress };
+};
+
 function SingleAnimationControl({
   animationId,
-  animationManager,
+  progress,
+  onProgressChange,
+  onComplete,
 }: {
   animationId: string;
-  animationManager: MockAnimationManager;
+  progress: number;
+  onProgressChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onComplete: (e: React.MouseEvent) => void;
 }) {
-  const [progress, setProgress] = useState(0);
-
-  const handleProgressChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = Number(e.target.value);
-    await animationManager.setAnimationProgress(Math.min(0.999, value));
-    setProgress(value);
-  };
-
-  const completeAnimation = async (e: React.MouseEvent) => {
-    e.preventDefault();
-    await animationManager.setAnimationProgress(1);
-    setProgress(1);
-  };
-
   const inputId = `animation-progress-${animationId}`;
 
   return (
@@ -34,13 +62,13 @@ function SingleAnimationControl({
         id={inputId}
         min={0}
         max={1}
-        step={0.1}
+        step={0.001}
         value={progress}
-        onChange={handleProgressChange}
+        onChange={onProgressChange}
         style={{ width: 200, marginLeft: 8 }}
       />
-      <span style={{ marginLeft: 8 }}>{progress * 100}%</span>
-      <button type="button" onClick={completeAnimation}>
+      <span style={{ marginLeft: 8, width: 40 }}>{Math.round(progress * 100)}%</span>
+      <button type="button" onClick={onComplete}>
         Finish animation
       </button>
     </div>
@@ -51,6 +79,7 @@ export function ManualAnimations() {
   const compositeAnimationManager = useContext(AnimationManagerControlsContext);
   const allAnimationManagers = useAllAnimationManagers(compositeAnimationManager);
   const { manualAnimationsEnabled } = useRechartsInspectorState();
+  const { progressMap, setProgress } = useAnimationProgress(allAnimationManagers);
 
   if (!manualAnimationsEnabled) {
     return null;
@@ -60,12 +89,46 @@ export function ManualAnimations() {
     return <p>No animations are active</p>;
   }
 
+  const handleProgressChange = (animationId: string) => async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    await setProgress(value, animationId);
+  };
+
+  const completeAnimation = (animationId: string) => async (e: React.MouseEvent) => {
+    e.preventDefault();
+    await setProgress(1, animationId);
+  };
+
+  const completeAll = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    await setProgress(1);
+  };
+
+  const resetAll = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    await setProgress(0);
+  };
+
   return (
     <form style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       <h3>Manual Animations</h3>
-      {Array.from(allAnimationManagers.entries()).map(([animationId, animationManager]) => (
-        <SingleAnimationControl key={animationId} animationId={animationId} animationManager={animationManager} />
+      {Array.from(allAnimationManagers.keys()).map(animationId => (
+        <SingleAnimationControl
+          key={animationId}
+          animationId={animationId}
+          progress={progressMap.get(animationId) ?? 0}
+          onProgressChange={handleProgressChange(animationId)}
+          onComplete={completeAnimation(animationId)}
+        />
       ))}
+      <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+        <button type="button" onClick={completeAll}>
+          Finish all animations
+        </button>
+        <button type="button" onClick={resetAll}>
+          Reset all animations
+        </button>
+      </div>
     </form>
   );
 }

--- a/storybook/storybook-addon-recharts/ManualAnimations.tsx
+++ b/storybook/storybook-addon-recharts/ManualAnimations.tsx
@@ -101,6 +101,11 @@ export function ManualAnimations() {
     await setProgress(1, animationId);
   };
 
+  const handleAllProgressChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    await setProgress(value);
+  };
+
   const completeAll = async (e: React.MouseEvent) => {
     e.preventDefault();
     await setProgress(1);
@@ -111,9 +116,22 @@ export function ManualAnimations() {
     await setProgress(0);
   };
 
+  const allProgressValues = Array.from(progressMap.values());
+  const averageProgress =
+    allProgressValues.length > 0 ? allProgressValues.reduce((sum, p) => sum + p, 0) / allProgressValues.length : 0;
+
   return (
     <form style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       <h3>Manual Animations</h3>
+      {allAnimationManagers.size > 1 && (
+        <SingleAnimationControl
+          animationId="all-animations"
+          label="All animations:"
+          progress={averageProgress}
+          onProgressChange={handleAllProgressChange}
+          onComplete={completeAll}
+        />
+      )}
       {Array.from(allAnimationManagers.keys()).map(animationId => (
         <SingleAnimationControl
           key={animationId}

--- a/storybook/storybook-addon-recharts/ManualAnimations.tsx
+++ b/storybook/storybook-addon-recharts/ManualAnimations.tsx
@@ -1,17 +1,19 @@
 import React, { useContext, useState } from 'react';
 import { AnimationManagerControlsContext, useRechartsInspectorState } from './RechartsInspectorDecorator';
+import { useAllAnimationManagers } from '../../test/animation/CompositeAnimationManager';
+import { MockAnimationManager } from '../../test/animation/MockProgressAnimationManager';
 
-export function ManualAnimations() {
+function SingleAnimationControl({
+  animationId,
+  animationManager,
+}: {
+  animationId: string;
+  animationManager: MockAnimationManager;
+}) {
   const [progress, setProgress] = useState(0);
-  const animationManager = useContext(AnimationManagerControlsContext);
-  const { manualAnimationsEnabled } = useRechartsInspectorState();
 
   const handleProgressChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(e.target.value);
-    /*
-     * If we actually set the value to 1 then the animationManager automatically jumps to the next callback
-     * and we can't rewind anymore so let's stop at 0.999
-     */
     await animationManager.setAnimationProgress(Math.min(0.999, value));
     setProgress(value);
   };
@@ -22,29 +24,46 @@ export function ManualAnimations() {
     setProgress(1);
   };
 
-  if (!manualAnimationsEnabled) {
-    return null;
-  }
   return (
-    <form>
-      <h3>Manual Animations</h3>
-      <label htmlFor="animation-progress">
-        Animation Progress:
-        <input
-          type="range"
-          id="animation-progress"
-          min={0}
-          max={1}
-          step={0.1}
-          value={progress}
-          onChange={handleProgressChange}
-          style={{ width: 200, marginLeft: 8 }}
-        />
-        <span style={{ marginLeft: 8 }}>{progress * 100}%</span>
-      </label>
+    <div style={{ flexGrow: 1, display: 'flex', alignItems: 'center', gap: 8 }}>
+      <label htmlFor="animation-progress">Animation {animationId}:</label>
+      <input
+        type="range"
+        id="animation-progress"
+        min={0}
+        max={1}
+        step={0.1}
+        value={progress}
+        onChange={handleProgressChange}
+        style={{ width: 200, marginLeft: 8 }}
+      />
+      <span style={{ marginLeft: 8 }}>{progress * 100}%</span>
       <button type="button" onClick={completeAnimation}>
         Finish animation
       </button>
+    </div>
+  );
+}
+
+export function ManualAnimations() {
+  const compositeAnimationManager = useContext(AnimationManagerControlsContext);
+  const allAnimationManagers = useAllAnimationManagers(compositeAnimationManager);
+  const { manualAnimationsEnabled } = useRechartsInspectorState();
+
+  if (!manualAnimationsEnabled) {
+    return null;
+  }
+
+  if (allAnimationManagers.size === 0) {
+    return <p>No animations are active</p>;
+  }
+
+  return (
+    <form style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <h3>Manual Animations</h3>
+      {Array.from(allAnimationManagers.entries()).map(([animationId, animationManager]) => (
+        <SingleAnimationControl key={animationId} animationId={animationId} animationManager={animationManager} />
+      ))}
     </form>
   );
 }

--- a/storybook/storybook-addon-recharts/ManualAnimations.tsx
+++ b/storybook/storybook-addon-recharts/ManualAnimations.tsx
@@ -24,12 +24,14 @@ function SingleAnimationControl({
     setProgress(1);
   };
 
+  const inputId = `animation-progress-${animationId}`;
+
   return (
     <div style={{ flexGrow: 1, display: 'flex', alignItems: 'center', gap: 8 }}>
-      <label htmlFor="animation-progress">Animation {animationId}:</label>
+      <label htmlFor={inputId}>Animation {animationId}:</label>
       <input
         type="range"
-        id="animation-progress"
+        id={inputId}
         min={0}
         max={1}
         step={0.1}

--- a/storybook/storybook-addon-recharts/ManualAnimations.tsx
+++ b/storybook/storybook-addon-recharts/ManualAnimations.tsx
@@ -46,17 +46,19 @@ function SingleAnimationControl({
   progress,
   onProgressChange,
   onComplete,
+  label,
 }: {
   animationId: string;
   progress: number;
   onProgressChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onComplete: (e: React.MouseEvent) => void;
+  label: string;
 }) {
   const inputId = `animation-progress-${animationId}`;
 
   return (
     <div style={{ flexGrow: 1, display: 'flex', alignItems: 'center', gap: 8 }}>
-      <label htmlFor={inputId}>Animation {animationId}:</label>
+      <label htmlFor={inputId}>{label}</label>
       <input
         type="range"
         id={inputId}
@@ -116,6 +118,7 @@ export function ManualAnimations() {
         <SingleAnimationControl
           key={animationId}
           animationId={animationId}
+          label={`Animation ${animationId}:`}
           progress={progressMap.get(animationId) ?? 0}
           onProgressChange={handleProgressChange(animationId)}
           onComplete={completeAnimation(animationId)}

--- a/storybook/storybook-addon-recharts/ManualAnimations.tsx
+++ b/storybook/storybook-addon-recharts/ManualAnimations.tsx
@@ -1,16 +1,10 @@
-import React, { useState } from 'react';
-import { AnimationManagerContext } from '../../src/animation/useAnimationManager';
-import { CompositeAnimationManager } from '../../test/animation/CompositeAnimationManager';
+import React, { useContext, useState } from 'react';
+import { AnimationManagerControlsContext, useRechartsInspectorState } from './RechartsInspectorDecorator';
 
-type Props = {
-  isEnabled: boolean;
-  children: React.ReactNode;
-};
-
-const animationManager = new CompositeAnimationManager();
-
-export function ManualAnimations({ isEnabled, children }: Props) {
+export function ManualAnimations() {
   const [progress, setProgress] = useState(0);
+  const animationManager = useContext(AnimationManagerControlsContext);
+  const { manualAnimationsEnabled } = useRechartsInspectorState();
 
   const handleProgressChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(e.target.value);
@@ -28,39 +22,29 @@ export function ManualAnimations({ isEnabled, children }: Props) {
     setProgress(1);
   };
 
-  if (!isEnabled) {
-    return children;
+  if (!manualAnimationsEnabled) {
+    return null;
   }
   return (
-    <AnimationManagerContext.Provider value={animationManager.factory}>
-      {/* div to force vertical stacking. Comes with some basic styling so that it allows ResponsiveContainer to render */}
-      <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
-        {children}
-        <form>
-          <h3>Manual Animations</h3>
-          <p>
-            Use the buttons below to control the animations manually. This is useful for testing and debugging
-            animations in Recharts.
-          </p>
-          <label htmlFor="animation-progress">
-            Animation Progress:
-            <input
-              type="range"
-              id="animation-progress"
-              min={0}
-              max={1}
-              step={0.1}
-              value={progress}
-              onChange={handleProgressChange}
-              style={{ width: 200, marginLeft: 8 }}
-            />
-            <span style={{ marginLeft: 8 }}>{progress * 100}%</span>
-          </label>
-          <button type="button" onClick={completeAnimation}>
-            Finish animation
-          </button>
-        </form>
-      </div>
-    </AnimationManagerContext.Provider>
+    <form>
+      <h3>Manual Animations</h3>
+      <label htmlFor="animation-progress">
+        Animation Progress:
+        <input
+          type="range"
+          id="animation-progress"
+          min={0}
+          max={1}
+          step={0.1}
+          value={progress}
+          onChange={handleProgressChange}
+          style={{ width: 200, marginLeft: 8 }}
+        />
+        <span style={{ marginLeft: 8 }}>{progress * 100}%</span>
+      </label>
+      <button type="button" onClick={completeAnimation}>
+        Finish animation
+      </button>
+    </form>
   );
 }

--- a/storybook/storybook-addon-recharts/RechartsHookInspector.tsx
+++ b/storybook/storybook-addon-recharts/RechartsHookInspector.tsx
@@ -9,6 +9,7 @@ import { ChartSizeDimensions } from '../ChartSizeDimensions';
 import { ChartInspectorProps } from './inspectors/types';
 import { OffsetShower } from './inspectors/OffsetShower';
 import { PlotAreaShower } from './inspectors/PlotAreaShower';
+import { useRechartsInspectorState } from './RechartsInspectorDecorator';
 
 function Controls({
   defaultOpened,
@@ -53,8 +54,6 @@ const overlaysThatNeedBlanket = ['useChartWidth, useChartHeight', 'useOffset', '
 
 export function RechartsHookInspector({
   defaultOpened,
-  position,
-  setPosition,
 }: {
   defaultOpened?: string;
   position: Position | undefined;
@@ -63,6 +62,7 @@ export function RechartsHookInspector({
   const layout = useChartLayout();
   const [enabledOverlays, setEnabledOverlays] = useState<ReadonlyArray<string>>(defaultOpened ? [defaultOpened] : []);
   const [openedFromStart, setOpenedFromStart] = useState<boolean>(defaultOpened !== undefined);
+  const { position, setPosition } = useRechartsInspectorState();
 
   useEffect(() => {
     if (position == null && defaultOpened !== undefined && typeof setPosition === 'function') {

--- a/storybook/storybook-addon-recharts/RechartsHookInspector.tsx
+++ b/storybook/storybook-addon-recharts/RechartsHookInspector.tsx
@@ -52,13 +52,7 @@ function Blanket() {
 
 const overlaysThatNeedBlanket = ['useChartWidth, useChartHeight', 'useOffset', 'usePlotArea'];
 
-export function RechartsHookInspector({
-  defaultOpened,
-}: {
-  defaultOpened?: string;
-  position: Position | undefined;
-  setPosition: (newPosition: Position) => void;
-}) {
+export function RechartsHookInspector({ defaultOpened }: { defaultOpened?: string }) {
   const layout = useChartLayout();
   const [enabledOverlays, setEnabledOverlays] = useState<ReadonlyArray<string>>(defaultOpened ? [defaultOpened] : []);
   const [openedFromStart, setOpenedFromStart] = useState<boolean>(defaultOpened !== undefined);

--- a/storybook/storybook-addon-recharts/RechartsHookInspector.tsx
+++ b/storybook/storybook-addon-recharts/RechartsHookInspector.tsx
@@ -10,6 +10,7 @@ import { ChartInspectorProps } from './inspectors/types';
 import { OffsetShower } from './inspectors/OffsetShower';
 import { PlotAreaShower } from './inspectors/PlotAreaShower';
 import { useRechartsInspectorState } from './RechartsInspectorDecorator';
+import { ManualAnimations } from './ManualAnimations';
 
 function Controls({
   defaultOpened,
@@ -28,13 +29,14 @@ function Controls({
     <>
       <RechartsStorybookAddonActionBar position={position} setPosition={setPosition} />
       <Component setEnabledOverlays={setEnabledOverlays} defaultOpened={defaultOpened} />
+      <ManualAnimations />
     </>,
     document.querySelector('#recharts-hook-inspector-portal'),
   );
 }
 
 /**
- * Blanket component is an svg component that darkens the background a little bit.
+ * Blanket component is a svg component that darkens the background a little bit.
  * @constructor
  */
 function Blanket() {

--- a/storybook/storybook-addon-recharts/RechartsInspectorDecorator.tsx
+++ b/storybook/storybook-addon-recharts/RechartsInspectorDecorator.tsx
@@ -58,6 +58,9 @@ export const RechartsInspectorDecorator = (Story: StoryFn) => {
       setGlobals({
         [PARAM_POSITION_KEY]: newPosition,
       });
+      if (newPosition === 'hidden') {
+        setManualAnimationsEnabled(false);
+      }
     },
     [position, setGlobals],
   );

--- a/storybook/storybook-addon-recharts/RechartsInspectorDecorator.tsx
+++ b/storybook/storybook-addon-recharts/RechartsInspectorDecorator.tsx
@@ -1,9 +1,30 @@
-import React, { useCallback } from 'react';
+import React, { createContext, useCallback } from 'react';
 import { StoryFn } from '@storybook/react-vite';
 import { useGlobals } from 'storybook/preview-api';
+import { noop } from 'es-toolkit';
 import { PARAM_POSITION_KEY, Position } from './constants';
 import { HookInspectorLayout } from './HookInspectorWrapper';
 import { RechartsContextProperties } from './RechartsStoryContext';
+import { CompositeAnimationManager } from '../../test/animation/CompositeAnimationManager';
+import { AnimationManagerContext } from '../../src/animation/useAnimationManager';
+
+const animationManager = new CompositeAnimationManager();
+
+type RechartsInspectorState = {
+  enabled: boolean;
+  position: Position;
+  setPosition: (newPosition: Position) => void;
+};
+
+const RechartsInspectorContext = createContext<RechartsInspectorState>({
+  enabled: false,
+  position: 'hidden',
+  setPosition: noop,
+});
+
+export const useRechartsInspectorState = () => {
+  return React.useContext(RechartsInspectorContext);
+};
 
 export const RechartsInspectorDecorator = (Story: StoryFn) => {
   const [globals, setGlobals] = useGlobals();
@@ -28,8 +49,14 @@ export const RechartsInspectorDecorator = (Story: StoryFn) => {
   };
 
   return (
-    <HookInspectorLayout position={position}>
-      <Story {...context} />
-    </HookInspectorLayout>
+    <RechartsInspectorContext.Provider
+      value={{ enabled: position !== 'hidden' && position != null, position, setPosition }}
+    >
+      <AnimationManagerContext.Provider value={animationManager.factory}>
+        <HookInspectorLayout position={position}>
+          <Story {...context} />
+        </HookInspectorLayout>
+      </AnimationManagerContext.Provider>
+    </RechartsInspectorContext.Provider>
   );
 };

--- a/storybook/storybook-addon-recharts/RechartsInspectorDecorator.tsx
+++ b/storybook/storybook-addon-recharts/RechartsInspectorDecorator.tsx
@@ -2,11 +2,12 @@ import React, { createContext, useCallback } from 'react';
 import { StoryFn } from '@storybook/react-vite';
 import { useGlobals } from 'storybook/preview-api';
 import { noop } from 'es-toolkit';
-import { PARAM_POSITION_KEY, Position } from './constants';
+import { PARAM_MANUAL_ANIMATIONS_KEY, PARAM_POSITION_KEY, Position } from './constants';
 import { HookInspectorLayout } from './HookInspectorWrapper';
 import { RechartsContextProperties } from './RechartsStoryContext';
 import { CompositeAnimationManager } from '../../test/animation/CompositeAnimationManager';
 import { AnimationManagerContext } from '../../src/animation/useAnimationManager';
+import { createDefaultAnimationManager } from '../../src/animation/createDefaultAnimationManager';
 
 const animationManager = new CompositeAnimationManager();
 
@@ -14,13 +15,19 @@ type RechartsInspectorState = {
   enabled: boolean;
   position: Position;
   setPosition: (newPosition: Position) => void;
+  manualAnimationsEnabled: boolean;
+  setManualAnimationsEnabled: (isEnabled: boolean) => void;
 };
 
 const RechartsInspectorContext = createContext<RechartsInspectorState>({
   enabled: false,
   position: 'hidden',
   setPosition: noop,
+  manualAnimationsEnabled: false,
+  setManualAnimationsEnabled: noop,
 });
+
+export const AnimationManagerControlsContext = createContext(animationManager);
 
 export const useRechartsInspectorState = () => {
   return React.useContext(RechartsInspectorContext);
@@ -29,6 +36,19 @@ export const useRechartsInspectorState = () => {
 export const RechartsInspectorDecorator = (Story: StoryFn) => {
   const [globals, setGlobals] = useGlobals();
   const position = globals[PARAM_POSITION_KEY];
+  const manualAnimationsEnabled = globals[PARAM_MANUAL_ANIMATIONS_KEY];
+
+  const setManualAnimationsEnabled = useCallback(
+    (isEnabled: boolean) => {
+      if (isEnabled === manualAnimationsEnabled) {
+        return;
+      }
+      setGlobals({
+        [PARAM_MANUAL_ANIMATIONS_KEY]: isEnabled,
+      });
+    },
+    [manualAnimationsEnabled, setGlobals],
+  );
 
   const setPosition = useCallback(
     (newPosition: Position) => {
@@ -49,14 +69,24 @@ export const RechartsInspectorDecorator = (Story: StoryFn) => {
   };
 
   return (
-    <RechartsInspectorContext.Provider
-      value={{ enabled: position !== 'hidden' && position != null, position, setPosition }}
-    >
-      <AnimationManagerContext.Provider value={animationManager.factory}>
-        <HookInspectorLayout position={position}>
-          <Story {...context} />
-        </HookInspectorLayout>
+    <AnimationManagerControlsContext.Provider value={animationManager}>
+      <AnimationManagerContext.Provider
+        value={manualAnimationsEnabled ? animationManager.factory : createDefaultAnimationManager}
+      >
+        <RechartsInspectorContext.Provider
+          value={{
+            enabled: position !== 'hidden' && position != null,
+            position,
+            setPosition,
+            manualAnimationsEnabled,
+            setManualAnimationsEnabled,
+          }}
+        >
+          <HookInspectorLayout position={position}>
+            <Story {...context} />
+          </HookInspectorLayout>
+        </RechartsInspectorContext.Provider>
       </AnimationManagerContext.Provider>
-    </RechartsInspectorContext.Provider>
+    </AnimationManagerControlsContext.Provider>
   );
 };

--- a/storybook/storybook-addon-recharts/action-bar/HookInspectorLayoutSwitcher.tsx
+++ b/storybook/storybook-addon-recharts/action-bar/HookInspectorLayoutSwitcher.tsx
@@ -51,7 +51,7 @@ export function HookInspectorLayoutSwitcher({ position, setPosition }: LayoutSwi
       <RechartsHookInspectorButton
         isActive={manualAnimationsEnabled}
         onClick={() => setManualAnimationsEnabled(!manualAnimationsEnabled)}
-        title="Move to east"
+        title="Toggle manual animations"
       >
         <VideoIcon />
       </RechartsHookInspectorButton>

--- a/storybook/storybook-addon-recharts/action-bar/HookInspectorLayoutSwitcher.tsx
+++ b/storybook/storybook-addon-recharts/action-bar/HookInspectorLayoutSwitcher.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { CloseIcon } from '@storybook/icons';
+import { CloseIcon, VideoIcon } from '@storybook/icons';
 import { Position } from '../constants';
 import { LayoutBarIcon } from './LayoutBarIcon';
 import { RechartsHookInspectorButton } from './RechartsHookInspectorButton';
 import './actionbar.css';
+import { useRechartsInspectorState } from '../RechartsInspectorDecorator';
 
 export type LayoutSwitcherProps = {
   position: Position;
@@ -15,6 +16,7 @@ function Separator() {
 }
 
 export function HookInspectorLayoutSwitcher({ position, setPosition }: LayoutSwitcherProps) {
+  const { manualAnimationsEnabled, setManualAnimationsEnabled } = useRechartsInspectorState();
   return (
     <>
       <RechartsHookInspectorButton
@@ -44,6 +46,14 @@ export function HookInspectorLayoutSwitcher({ position, setPosition }: LayoutSwi
         title="Move to east"
       >
         <LayoutBarIcon direction="EAST" />
+      </RechartsHookInspectorButton>
+      <Separator />
+      <RechartsHookInspectorButton
+        isActive={manualAnimationsEnabled}
+        onClick={() => setManualAnimationsEnabled(!manualAnimationsEnabled)}
+        title="Move to east"
+      >
+        <VideoIcon />
       </RechartsHookInspectorButton>
       <Separator />
       <RechartsHookInspectorButton

--- a/storybook/storybook-addon-recharts/constants.ts
+++ b/storybook/storybook-addon-recharts/constants.ts
@@ -3,3 +3,5 @@ export type Position = 'NORTH' | 'SOUTH' | 'WEST' | 'EAST' | 'hidden';
 export const DEFAULT_POSITION: Position = 'NORTH';
 
 export const PARAM_POSITION_KEY = 'storybook-addon-recharts-position';
+
+export const PARAM_MANUAL_ANIMATIONS_KEY = 'storybook-addon-recharts-manual-animations';

--- a/storybook/storybook-addon-recharts/preview.tsx
+++ b/storybook/storybook-addon-recharts/preview.tsx
@@ -1,6 +1,6 @@
 import type { Renderer, ProjectAnnotations } from 'storybook/internal/types';
 import { RechartsInspectorDecorator } from './RechartsInspectorDecorator';
-import { PARAM_POSITION_KEY } from './constants';
+import { PARAM_MANUAL_ANIMATIONS_KEY, PARAM_POSITION_KEY } from './constants';
 
 const preview: ProjectAnnotations<Renderer> = {
   decorators: [RechartsInspectorDecorator],
@@ -13,6 +13,7 @@ const preview: ProjectAnnotations<Renderer> = {
      * but also allow users to hide it.
      */
     [PARAM_POSITION_KEY]: undefined,
+    [PARAM_MANUAL_ANIMATIONS_KEY]: false,
   },
 };
 

--- a/storybook/storybook-addon-recharts/register.tsx
+++ b/storybook/storybook-addon-recharts/register.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect } from 'react';
 import { addons, types, useGlobals, useStorybookApi } from 'storybook/manager-api';
 import { IconButton } from 'storybook/internal/components';
 import hookIcon from './hookIcon.svg';
-import { DEFAULT_POSITION, PARAM_POSITION_KEY } from './constants';
+import { DEFAULT_POSITION, PARAM_MANUAL_ANIMATIONS_KEY, PARAM_POSITION_KEY } from './constants';
 
 const ADDON_ID = 'storybook/storybook-addon-recharts/tool';
 
@@ -17,6 +17,11 @@ function HookInspectorToolToggle() {
     updateGlobals({
       [PARAM_POSITION_KEY]: isActive ? 'hidden' : DEFAULT_POSITION,
     });
+    if (!isActive) {
+      updateGlobals({
+        [PARAM_MANUAL_ANIMATIONS_KEY]: false, // Reset manual animations when closing the inspector
+      });
+    }
   }, [isActive, updateGlobals]);
 
   useEffect(() => {

--- a/test/animation/Animate.progress.spec.tsx
+++ b/test/animation/Animate.progress.spec.tsx
@@ -8,7 +8,7 @@ describe('Animate progress', () => {
   describe('when child is a function', () => {
     describe('with from, to as objects', () => {
       it('should call the function child with the current style', async () => {
-        const animationManager = new MockProgressAnimationManager();
+        const animationManager = new MockProgressAnimationManager('1');
         const child = vi.fn();
 
         render(
@@ -39,7 +39,7 @@ describe('Animate progress', () => {
 
     describe('with from, to as numbers', () => {
       it('should call the function child with the current style (but it does not)', async () => {
-        const animationManager = new MockProgressAnimationManager();
+        const animationManager = new MockProgressAnimationManager('1');
         const child = vi.fn();
 
         render(
@@ -70,7 +70,7 @@ describe('Animate progress', () => {
 
     describe('with from, to as strings', () => {
       it('should call the function child with the current style (but it does not)', async () => {
-        const animationManager = new MockProgressAnimationManager();
+        const animationManager = new MockProgressAnimationManager('1');
         const child = vi.fn();
 
         render(
@@ -105,7 +105,7 @@ describe('Animate progress', () => {
 
     describe('with from, to as CSS transforms', () => {
       it('should call the function child with the current style (but it does not)', async () => {
-        const animationManager = new MockProgressAnimationManager();
+        const animationManager = new MockProgressAnimationManager('1');
         const child = vi.fn();
 
         const transformOrigin = `100px 50px`;
@@ -148,7 +148,7 @@ describe('Animate progress', () => {
       });
 
       it('should clone the child with the current style (but it does not)', async () => {
-        const animationManager = new MockProgressAnimationManager();
+        const animationManager = new MockProgressAnimationManager('1');
         const transformOrigin = `100px 50px`;
 
         const { container } = render(
@@ -172,7 +172,7 @@ describe('Animate progress', () => {
 
     describe('when "to" changes in the middle of the animation', () => {
       it('should update the child with the new style and unfortunately it jumps in the middle', async () => {
-        const animationManager = new MockProgressAnimationManager();
+        const animationManager = new MockProgressAnimationManager('');
         const child = vi.fn();
 
         const { rerender } = render(

--- a/test/animation/CSSTransitionAnimate.timing.spec.tsx
+++ b/test/animation/CSSTransitionAnimate.timing.spec.tsx
@@ -26,7 +26,7 @@ describe('CSSTransitionAnimate timing', () => {
         expect.assertions(2);
         const childFunction = vi.fn();
         render(
-          <CSSTransitionAnimate from="1" to="0" attributeName="opacity" duration={500}>
+          <CSSTransitionAnimate animationId="1" from="1" to="0" attributeName="opacity" duration={500}>
             {childFunction}
           </CSSTransitionAnimate>,
         );
@@ -53,6 +53,7 @@ describe('CSSTransitionAnimate timing', () => {
 
         render(
           <CSSTransitionAnimate
+            animationId="1"
             from="1"
             to="0"
             attributeName="opacity"
@@ -81,6 +82,7 @@ describe('CSSTransitionAnimate timing', () => {
 
         render(
           <CSSTransitionAnimate
+            animationId="1"
             from="scaleY(0)"
             to="scaleY(1)"
             attributeName="transform"
@@ -114,6 +116,7 @@ describe('CSSTransitionAnimate timing', () => {
 
         render(
           <CSSTransitionAnimate
+            animationId="1"
             from="scaleY(0)"
             to="scaleY(1)"
             attributeName="transform"
@@ -141,6 +144,7 @@ describe('CSSTransitionAnimate timing', () => {
 
         const { rerender } = render(
           <CSSTransitionAnimate
+            animationId="1"
             from="1"
             to="0"
             attributeName="opacity"
@@ -166,6 +170,7 @@ describe('CSSTransitionAnimate timing', () => {
 
         render(
           <CSSTransitionAnimate
+            animationId="1"
             from="1"
             to="0"
             attributeName="opacity"
@@ -192,6 +197,7 @@ describe('CSSTransitionAnimate timing', () => {
 
         render(
           <CSSTransitionAnimate
+            animationId="1"
             from="1"
             to="0"
             attributeName="opacity"
@@ -211,12 +217,13 @@ describe('CSSTransitionAnimate timing', () => {
         expect(child).toHaveBeenCalledTimes(1);
       });
 
-      it('should restart animation when isActive changes to true', async () => {
+      it('should restart animation when isActive changes to true via rerender', async () => {
         const animationManager = new MockTickingAnimationManager();
         const child = vi.fn();
 
         const { rerender } = render(
           <CSSTransitionAnimate
+            animationId="1"
             from="1"
             to="0"
             attributeName="opacity"
@@ -238,6 +245,7 @@ describe('CSSTransitionAnimate timing', () => {
         // Now we change isActive to true
         rerender(
           <CSSTransitionAnimate
+            animationId="1"
             from="1"
             to="0"
             attributeName="opacity"
@@ -268,6 +276,7 @@ describe('CSSTransitionAnimate timing', () => {
           return (
             <>
               <CSSTransitionAnimate
+                animationId="1"
                 from="1"
                 to="0"
                 attributeName="opacity"
@@ -316,6 +325,7 @@ describe('CSSTransitionAnimate timing', () => {
 
         const { rerender } = render(
           <CSSTransitionAnimate
+            animationId="1"
             from="1"
             to="0"
             attributeName="opacity"
@@ -338,6 +348,7 @@ describe('CSSTransitionAnimate timing', () => {
 
         rerender(
           <CSSTransitionAnimate
+            animationId="1"
             from="0.7"
             to="0.3"
             attributeName="opacity"
@@ -366,6 +377,7 @@ describe('CSSTransitionAnimate timing', () => {
 
         const { rerender } = render(
           <CSSTransitionAnimate
+            animationId="1"
             from="1"
             to="0"
             attributeName="opacity"
@@ -386,6 +398,7 @@ describe('CSSTransitionAnimate timing', () => {
 
         rerender(
           <CSSTransitionAnimate
+            animationId="1"
             from="0.7"
             to="0.3"
             attributeName="opacity"
@@ -403,6 +416,58 @@ describe('CSSTransitionAnimate timing', () => {
 
         // however, the child should be rerendered with the fresh "from" state so this looks like a bug
         expect(child).toHaveBeenLastCalledWith({ opacity: '1' });
+        expect(child).toHaveBeenCalledTimes(2);
+      });
+
+      it('should start animation on rerender if canBegin changes from false to true', () => {
+        const animationManager = new MockTickingAnimationManager();
+        const child = vi.fn();
+
+        const { rerender } = render(
+          <CSSTransitionAnimate
+            animationId="1"
+            from="1"
+            to="0"
+            attributeName="opacity"
+            duration={500}
+            canBegin={false}
+            onAnimationStart={handleAnimationStart}
+            animationManager={animationManager}
+          >
+            {child}
+          </CSSTransitionAnimate>,
+        );
+
+        animationManager.assertQueue(null);
+
+        expect(handleAnimationStart).not.toHaveBeenCalled();
+        expect(child).toHaveBeenLastCalledWith({ opacity: '1' });
+        expect(child).toHaveBeenCalledTimes(1);
+
+        rerender(
+          <CSSTransitionAnimate
+            animationId="1"
+            from="0.7"
+            to="0.3"
+            attributeName="opacity"
+            duration={500}
+            canBegin
+            onAnimationStart={handleAnimationStart}
+            animationManager={animationManager}
+          >
+            {child}
+          </CSSTransitionAnimate>,
+        );
+
+        // queue should be populated with the animation steps
+        animationManager.assertQueue(['[function handleAnimationStart]', 0, '0.3', 500, '[function onAnimationEnd]']);
+
+        expect(handleAnimationStart).toHaveBeenCalledTimes(0);
+        /*
+         * now the child should be rerendered with the fresh "from" state, using the latest "from" value - NOT the one from before when canBegin was false
+         * buuuut it uses the old "from" value, which is a bug. I suppose we can live with it for now?
+         */
+        expect(child).toHaveBeenLastCalledWith({ opacity: '1', transition: 'opacity 500ms ease' });
         expect(child).toHaveBeenCalledTimes(2);
       });
     });

--- a/test/animation/CompositeAnimationManager.ts
+++ b/test/animation/CompositeAnimationManager.ts
@@ -69,7 +69,7 @@ export class CompositeAnimationManager implements MockAnimationManager {
       this.animationManagers.delete(animationId);
       this.notifySubscribers();
     };
-    const manager = new MockProgressAnimationManager(onStop);
+    const manager = new MockProgressAnimationManager(animationId, onStop);
     this.animationManagers.set(animationId, manager);
     this.notifySubscribers();
     return manager;

--- a/test/animation/CompositeAnimationManager.ts
+++ b/test/animation/CompositeAnimationManager.ts
@@ -65,7 +65,11 @@ export class CompositeAnimationManager implements MockAnimationManager {
   }
 
   public factory: AnimationManagerFactory = (animationId: string): AnimationManager => {
-    const manager = new MockProgressAnimationManager();
+    const onStop = () => {
+      this.animationManagers.delete(animationId);
+      this.notifySubscribers();
+    };
+    const manager = new MockProgressAnimationManager(onStop);
     this.animationManagers.set(animationId, manager);
     this.notifySubscribers();
     return manager;

--- a/test/animation/JavascriptAnimate.progress.spec.tsx
+++ b/test/animation/JavascriptAnimate.progress.spec.tsx
@@ -7,11 +7,11 @@ import { JavascriptAnimate } from '../../src/animation/JavascriptAnimate';
 
 describe('JavascriptAnimate progress', () => {
   it('should call the function child with the current time', async () => {
-    const animationManager = new MockProgressAnimationManager();
+    const animationManager = new MockProgressAnimationManager('1');
     const child = vi.fn();
 
     render(
-      <JavascriptAnimate easing="linear" duration={500} animationManager={animationManager}>
+      <JavascriptAnimate animationId="1" easing="linear" duration={500} animationManager={animationManager}>
         {child}
       </JavascriptAnimate>,
     );
@@ -31,11 +31,11 @@ describe('JavascriptAnimate progress', () => {
 
   describe('when easing changes in the middle of the animation', () => {
     it('should update the child with the new time and unfortunately it jumps in the middle', async () => {
-      const animationManager = new MockProgressAnimationManager();
+      const animationManager = new MockProgressAnimationManager('1');
       const child = vi.fn();
 
       const { rerender } = render(
-        <JavascriptAnimate easing="linear" duration={500} animationManager={animationManager}>
+        <JavascriptAnimate animationId="1" easing="linear" duration={500} animationManager={animationManager}>
           {child}
         </JavascriptAnimate>,
       );
@@ -49,7 +49,7 @@ describe('JavascriptAnimate progress', () => {
 
       // Change "to" in the middle of the animation
       rerender(
-        <JavascriptAnimate easing="ease-out" duration={500} animationManager={animationManager}>
+        <JavascriptAnimate animationId="1" easing="ease-out" duration={500} animationManager={animationManager}>
           {child}
         </JavascriptAnimate>,
       );

--- a/test/animation/JavascriptAnimate.timing.spec.tsx
+++ b/test/animation/JavascriptAnimate.timing.spec.tsx
@@ -25,6 +25,7 @@ describe('JavascriptAnimate timing', () => {
 
       render(
         <JavascriptAnimate
+          animationId="1"
           duration={500}
           onAnimationStart={handleAnimationStart}
           onAnimationEnd={handleAnimationEnd}
@@ -49,6 +50,7 @@ describe('JavascriptAnimate timing', () => {
 
       render(
         <JavascriptAnimate
+          animationId="1"
           duration={500}
           canBegin={false}
           onAnimationStart={handleAnimationStart}
@@ -70,6 +72,7 @@ describe('JavascriptAnimate timing', () => {
 
       render(
         <JavascriptAnimate
+          animationId="1"
           duration={500}
           isActive={false}
           onAnimationStart={handleAnimationStart}
@@ -91,7 +94,7 @@ describe('JavascriptAnimate timing', () => {
       const childFunction = vi.fn();
 
       render(
-        <JavascriptAnimate duration={500} animationManager={animationManager}>
+        <JavascriptAnimate animationId="1" duration={500} animationManager={animationManager}>
           {childFunction}
         </JavascriptAnimate>,
       );
@@ -113,6 +116,7 @@ describe('JavascriptAnimate timing', () => {
 
       render(
         <JavascriptAnimate
+          animationId="1"
           duration={500}
           onAnimationStart={handleAnimationStart}
           onAnimationEnd={handleAnimationEnd}
@@ -192,6 +196,7 @@ describe('JavascriptAnimate timing', () => {
 
       render(
         <JavascriptAnimate
+          animationId="1"
           duration={500}
           canBegin={false}
           onAnimationStart={handleAnimationStart}
@@ -214,6 +219,7 @@ describe('JavascriptAnimate timing', () => {
 
       render(
         <JavascriptAnimate
+          animationId="1"
           duration={500}
           isActive={false}
           onAnimationStart={handleAnimationStart}
@@ -236,6 +242,7 @@ describe('JavascriptAnimate timing', () => {
 
       const { rerender } = render(
         <JavascriptAnimate
+          animationId="1"
           duration={500}
           isActive={false}
           onAnimationStart={handleAnimationStart}
@@ -254,6 +261,7 @@ describe('JavascriptAnimate timing', () => {
       // Now we change isActive to true
       rerender(
         <JavascriptAnimate
+          animationId="1"
           duration={500}
           isActive
           onAnimationStart={handleAnimationStart}
@@ -325,6 +333,7 @@ describe('JavascriptAnimate timing', () => {
         return (
           <>
             <JavascriptAnimate
+              animationId="1"
               duration={500}
               isActive={isActive}
               onAnimationStart={handleAnimationStart}
@@ -391,6 +400,7 @@ describe('JavascriptAnimate timing', () => {
 
       const { rerender } = render(
         <JavascriptAnimate
+          animationId="1"
           duration={500}
           isActive={false}
           onAnimationStart={handleAnimationStart}
@@ -410,6 +420,7 @@ describe('JavascriptAnimate timing', () => {
 
       rerender(
         <JavascriptAnimate
+          animationId="1"
           duration={500}
           isActive={false}
           onAnimationStart={handleAnimationStart}
@@ -433,6 +444,7 @@ describe('JavascriptAnimate timing', () => {
 
       const { rerender } = render(
         <JavascriptAnimate
+          animationId="1"
           duration={500}
           canBegin={false}
           onAnimationStart={handleAnimationStart}
@@ -450,6 +462,7 @@ describe('JavascriptAnimate timing', () => {
 
       rerender(
         <JavascriptAnimate
+          animationId="1"
           duration={500}
           canBegin={false}
           onAnimationStart={handleAnimationStart}

--- a/test/animation/MockProgressAnimationManager.ts
+++ b/test/animation/MockProgressAnimationManager.ts
@@ -50,14 +50,17 @@ export class MockProgressAnimationManager
 {
   private readonly onStop?: () => void;
 
-  constructor(onStop?: () => void) {
+  constructor(
+    private animationId: string,
+    onStop?: () => void,
+  ) {
     super();
     this.onStop = onStop;
   }
 
   async setAnimationProgress(percent: number): Promise<void> {
     if (this.queue === null || this.queue.length === 0) {
-      throw new Error('Queue is empty');
+      throw new Error(`[${this.animationId}] Queue is empty`);
     }
     if (percent < 0) {
       throw new Error('Percent must be greater than or equal to 0');
@@ -135,6 +138,7 @@ export class MockProgressAnimationManager
     if (this.isPrimed) {
       return;
     }
+    this.isPrimed = true;
 
     /*
      * We don't really have a good way to check which function is the easing function.
@@ -151,8 +155,6 @@ export class MockProgressAnimationManager
      * to kickstart and set up its internal state.
      */
     await this.triggerNextTimeout(this.firstTick);
-
-    this.isPrimed = true;
   }
 
   /**
@@ -166,7 +168,7 @@ export class MockProgressAnimationManager
    */
   private async peekAnimationDuration(): Promise<number> {
     if (this.queue === null || this.queue.length === 0) {
-      throw new Error('Queue is empty');
+      throw new Error(`[${this.animationId}] Queue is empty`);
     }
 
     await this.prime();
@@ -175,7 +177,7 @@ export class MockProgressAnimationManager
 
     if (typeof animationDuration !== 'number') {
       throw new Error(
-        `We assume the first item in the queue is the animation duration.
+        `[${this.animationId}] We assume the first item in the queue is the animation duration.
         Found: [${typeof animationDuration}] instead.
         This probably means you are calling this method at a wrong time.`,
       );

--- a/test/animation/MockProgressAnimationManager.ts
+++ b/test/animation/MockProgressAnimationManager.ts
@@ -48,6 +48,13 @@ export class MockProgressAnimationManager
   extends MockAbstractAnimationManager
   implements AnimationManager, MockAnimationManager
 {
+  private readonly onStop?: () => void;
+
+  constructor(onStop?: () => void) {
+    super();
+    this.onStop = onStop;
+  }
+
   async setAnimationProgress(percent: number): Promise<void> {
     if (this.queue === null || this.queue.length === 0) {
       throw new Error('Queue is empty');
@@ -85,7 +92,9 @@ export class MockProgressAnimationManager
       await this.setAnimationProgress(1);
     }
 
-    return this.poll(this.queue.length);
+    const result = this.poll(this.queue.length);
+    this.onStop?.();
+    return result;
   }
 
   start(queue: ReactSmoothQueue) {
@@ -98,6 +107,7 @@ export class MockProgressAnimationManager
     super.stop();
     this.isPrimed = false; // Reset the primed state when stopping the queue
     this.animationProgress = 0; // Reset the animation progress when stopping a queue
+    this.onStop?.();
   }
 
   private isPrimed: boolean = false;

--- a/test/cartesian/Scatter.spec.tsx
+++ b/test/cartesian/Scatter.spec.tsx
@@ -215,13 +215,13 @@ describe('<Scatter />', () => {
   });
 
   describe('state integration', () => {
-    it('should publish its configuration to redux store', () => {
+    it('should publish its configuration to redux store, and update it when the props change', () => {
       const settingsSpy = vi.fn();
       const Comp = (): null => {
         settingsSpy(useAppSelector(selectUnfilteredCartesianItems));
         return null;
       };
-      render(
+      const { rerender } = render(
         <ScatterChart height={400} width={400}>
           <Scatter data={data} dataKey="cx" xAxisId="xaxis id" yAxisId="yaxis id" zAxisId="zaxis id" />
           <Customized component={<Comp />} />
@@ -243,6 +243,20 @@ describe('<Scatter />', () => {
       };
       expect(settingsSpy).toHaveBeenLastCalledWith([expected]);
       expect(settingsSpy).toHaveBeenCalledTimes(3);
+
+      rerender(
+        <ScatterChart height={400} width={400}>
+          <Scatter data={data} dataKey="cx" xAxisId="xaxis id" yAxisId="yaxis id" zAxisId="zaxis id" name="new name" />
+          <Customized component={<Comp />} />
+        </ScatterChart>,
+      );
+
+      const expectedWithName: ScatterSettings = {
+        ...expected,
+        name: 'new name',
+      };
+      expect(settingsSpy).toHaveBeenLastCalledWith([expectedWithName]);
+      expect(settingsSpy).toHaveBeenCalledTimes(6);
     });
   });
 

--- a/test/helper/useEffectDebug.ts
+++ b/test/helper/useEffectDebug.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef, EffectCallback, DependencyList } from 'react';
+
+/*
+ * https://stackoverflow.com/a/59843241
+ */
+
+const usePrevious = <T>(value: T | null): T | null => {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
+export const useEffectDebug = (
+  debuggerName: string,
+  effectHook: EffectCallback,
+  dependencies: DependencyList,
+  dependencyNames: string[] = [],
+): void => {
+  const previousDeps = usePrevious(dependencies);
+
+  if (previousDeps === null) {
+    const changedDeps = dependencies.reduce(
+      (accum, dependency, index) => {
+        const keyName = dependencyNames[index] || index;
+        return {
+          ...accum,
+          [keyName]: dependency,
+        };
+      },
+      {} as Record<string, any>,
+    );
+    console.log('[use-effect-debugger]', debuggerName, 'initial render', changedDeps);
+  } else {
+    const changedDeps = dependencies.reduce(
+      (accum, dependency, index) => {
+        if (dependency !== previousDeps[index]) {
+          const keyName = dependencyNames[index] || index;
+          return {
+            ...accum,
+            [keyName]: {
+              before: previousDeps[index],
+              after: dependency,
+            },
+          };
+        }
+
+        return accum;
+      },
+      {} as Record<string, { before: any; after: any }>,
+    );
+
+    const changedKeys = Object.keys(changedDeps);
+
+    if (changedKeys.length) {
+      const prev = Object.fromEntries(changedKeys.map(key => [key, changedDeps[key].before]));
+      const curr = Object.fromEntries(changedKeys.map(key => [key, changedDeps[key].after]));
+      // eslint-disable-next-line no-console
+      console.log('[use-effect-debugger]', debuggerName, changedKeys.join(', '), {
+        prev,
+        curr,
+      });
+    }
+  }
+
+  useEffect(effectHook, dependencies);
+};

--- a/test/helper/useEffectDebug.ts
+++ b/test/helper/useEffectDebug.ts
@@ -60,7 +60,7 @@ export const useEffectDebug = (
     if (changedKeys.length) {
       const prev = Object.fromEntries(
         changedKeys.map(key => {
-          if (key in changedKeys) {
+          if (key in changedDeps) {
             return [key, changedDeps[key].before];
           }
           return [key, undefined];

--- a/test/helper/useWhyDidYouRender.ts
+++ b/test/helper/useWhyDidYouRender.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * This hook is used to log component re-renders in development mode.
+ * It is useful for debugging performance issues and understanding why a component is re-rendering.
+ * It should only be used in development mode and not in production.
+ * @param componentName The name of the component to log
+ * @param props The props of the component
+ * @param hooks Optional hooks or other properties to observe for changes
+ * @returns void
+ */
+export function useWhyDidYouRender<T extends Record<string, any>>(
+  componentName: string,
+  props: T,
+  hooks?: Record<string, any>,
+): void {
+  const previousProps = useRef<T>();
+  const previousHooks = useRef<Record<string, any>>();
+
+  useEffect(() => {
+    const allProps = { ...props, ...hooks };
+    if (previousProps.current) {
+      const previousAllProps = { ...previousProps.current, ...previousHooks.current };
+      const allKeys = Object.keys({ ...allProps, ...previousAllProps });
+      const changesObj: Record<string, { from: any; to: any }> = {};
+      allKeys.forEach(key => {
+        if (previousAllProps[key] !== allProps[key]) {
+          changesObj[key] = {
+            from: previousAllProps[key],
+            to: allProps[key],
+          };
+        }
+      });
+
+      const changedKeys = Object.keys(changesObj);
+
+      if (changedKeys.length) {
+        const prev = Object.fromEntries(changedKeys.map(key => [key, previousAllProps[key]]));
+        const curr = Object.fromEntries(changedKeys.map(key => [key, allProps[key]]));
+        // eslint-disable-next-line no-console
+        console.log('[why-did-you-render?]', componentName, Object.keys(changesObj).join(', '), {
+          prev,
+          curr,
+        });
+      }
+    }
+
+    previousProps.current = props;
+    previousHooks.current = hooks;
+  });
+}

--- a/test/shape/Rectangle.animation.spec.tsx
+++ b/test/shape/Rectangle.animation.spec.tsx
@@ -310,8 +310,8 @@ describe('Rectangle animation', () => {
         it('should animate stroke-dasharray', async () => {
           const { container, animationManager } = renderTestCase();
           expect(await expectAnimatedStrokeDasharray(container, animationManager)).toEqual([
-            'transition: stroke-dasharray 1500ms ease; stroke-dasharray: 0px 1234px;',
-            'transition: stroke-dasharray 1500ms ease; stroke-dasharray: 1234px 0px;',
+            'stroke-dasharray: 0px 1px; transition: stroke-dasharray 1500ms ease;',
+            'stroke-dasharray: 1234px 0px; transition: stroke-dasharray 1500ms ease;',
           ]);
         });
       });


### PR DESCRIPTION
## Description

Couple of changes here:

1. The storybook animation manager now allows controlling multiple simultaneous animations
2. RechartsHookInspector now reads its props from React context (this was not possible in storybook 8 but now it is!) so we don't need to pass position and setPosition everywhere
3. ManualAnimations are now included in RechartsHookInspector so they come by default with every story, no extra boilerplate

## Related Issue

https://github.com/recharts/recharts/issues/5914

## Motivation and Context

Want to debug animations

## Screenshots (if appropriate):


https://github.com/user-attachments/assets/da00242c-0479-4549-b156-137899df681c


