### PR TITLE
Allow rendering Labels as nested children in XAxis and YAxis

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -9,7 +9,7 @@ import { clsx } from 'clsx';
 import { shallowEqual } from '../util/ShallowEqual';
 import { Layer } from '../container/Layer';
 import { Text } from '../component/Text';
-import { Label } from '../component/Label';
+import { CartesianLabelContextProvider, ImplicitLabelType, CartesianLabelFromLabelProp } from '../component/Label';
 import { isNumber } from '../util/DataUtils';
 import {
   CartesianViewBox,
@@ -47,7 +47,7 @@ export interface CartesianAxisProps {
   mirror?: boolean;
   tickMargin?: number;
   hide?: boolean;
-  label?: any;
+  label?: ImplicitLabelType;
   /** Padding information passed to custom tick components */
   padding?: XAxisPadding | YAxisPadding;
 
@@ -375,7 +375,15 @@ export class CartesianAxis extends Component<Props, IState> {
       >
         {axisLine && this.renderAxisLine()}
         {this.renderTicks(this.state.fontSize, this.state.letterSpacing, ticks)}
-        {Label.renderCallByParent(this.props)}
+        <CartesianLabelContextProvider
+          x={this.props.x}
+          y={this.props.y}
+          width={this.props.width}
+          height={this.props.height}
+        >
+          <CartesianLabelFromLabelProp label={this.props.label} />
+          {this.props.children}
+        </CartesianLabelContextProvider>
       </Layer>
     );
   }

--- a/storybook/stories/API/cartesian/XAxis.stories.tsx
+++ b/storybook/stories/API/cartesian/XAxis.stories.tsx
@@ -1,6 +1,16 @@
 import React from 'react';
 import { Args } from '@storybook/react-vite';
-import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from '../../../../src';
+import {
+  CartesianGrid,
+  Label,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from '../../../../src';
 import { coordinateWithValueData } from '../../data';
 import { XAxisProps } from '../props/XAxisProps';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
@@ -36,7 +46,7 @@ export const API = {
     tickMargin: 20,
     angle: 45,
     height: 70,
-    label: { value: 'The Axis Label', position: 'insideBottomRight' },
+    label: { value: 'The Axis Label insideBottomRight', position: 'insideBottomRight' },
   },
 };
 
@@ -47,7 +57,6 @@ export const API = {
  */
 const CustomXAxisTickWithPadding = (props: any) => {
   const { x, y, payload, padding } = props;
-
   return (
     <g transform={`translate(${x},${y})`}>
       <text x={0} y={0} dy={16} textAnchor="middle" fill="#666" fontSize="12">
@@ -80,11 +89,21 @@ export const CustomTickWithPadding = {
       { name: 'Jun', value: 239, category: 'F' },
     ];
 
+    const CustomLabels = () => (
+      <>
+        <Label position="insideTopLeft">Label insideTopLeft</Label>
+        <Label position="insideTopRight">Label insideTopRight</Label>
+        <Label position="insideTop">Label insideTop</Label>
+      </>
+    );
+
     return (
       <ResponsiveContainer width="100%" height={500}>
         <LineChart data={sampleData}>
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis {...args} dataKey="name" tick={<CustomXAxisTickWithPadding />} height={80} />
+          <XAxis {...args} dataKey="name" tick={<CustomXAxisTickWithPadding />} height={80}>
+            <CustomLabels />
+          </XAxis>
           <YAxis />
           <Line type="monotone" dataKey="value" stroke="#8884d8" />
           <Tooltip />

--- a/test-vr/playwright-ct.config.ts
+++ b/test-vr/playwright-ct.config.ts
@@ -23,6 +23,10 @@ export default defineConfig({
   outputDir: '/recharts/test-vr/test-results',
   /* Maximum time one test can run for. */
   timeout: 10 * 1000,
+  expect: {
+    /* https://playwright.dev/docs/test-timeouts */
+    timeout: 10 * 1000,
+  },
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
## Description

Instead of parsing array of children, pass the viewBox in React context where Label can read it.

## Related Issue

https://github.com/recharts/recharts/issues/6156

https://github.com/recharts/recharts/issues/5768

## Motivation and Context

Removing findAllByType

## How Has This Been Tested?

VR tests, storybook

## Screenshots (if appropriate):

No visual difference

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes
