### PR TITLE
Polar context for Labels

### DIFF
--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react';
 import { clsx } from 'clsx';
 import { Text } from './Text';
-import { findAllByType, filterProps } from '../util/ReactUtils';
+import { filterProps } from '../util/ReactUtils';
 import { isNumOrStr, isNumber, isPercent, getPercentValue, uniqueId, mathSign, isNullish } from '../util/DataUtils';
 import { polarToCartesian } from '../util/PolarUtils';
 import {
@@ -644,46 +644,7 @@ const parseLabel = (label: ImplicitLabelType, viewBox: ViewBox, labelRef?: React
   return null;
 };
 
-/**
- * @deprecated do not use as it relies on direct child access. Instead, use `CartesianLabelFromLabelProp`.
- * @param parentProps - The props of the parent component that contains the label.
- * @param viewBox - The viewBox to be used for the label.
- * @param checkPropsLabel - Whether to check the `label` prop of the parent component.
- * @returns An array of React elements representing the labels, or null if no labels are found
- */
-const renderCallByParent = (
-  parentProps: {
-    children?: ReactNode;
-    label?: unknown;
-    labelRef?: React.RefObject<Element>;
-  },
-  viewBox?: ViewBox,
-  checkPropsLabel = true,
-): ReactElement[] | null => {
-  if (!parentProps || (!parentProps.children && checkPropsLabel && !parentProps.label)) {
-    return null;
-  }
-  const { children, labelRef } = parentProps;
-  const parentViewBox = parseViewBox(parentProps);
-
-  const explicitChildren = findAllByType(children, Label).map((child, index) => {
-    return cloneElement(child, {
-      viewBox: viewBox || parentViewBox,
-      // eslint-disable-next-line react/no-array-index-key
-      key: `label-${index}`,
-    });
-  });
-
-  if (!checkPropsLabel) {
-    return explicitChildren;
-  }
-  const implicitLabel = parseLabel(parentProps.label, viewBox || parentViewBox, labelRef);
-
-  return [implicitLabel, ...explicitChildren];
-};
-
 Label.parseViewBox = parseViewBox;
-Label.renderCallByParent = renderCallByParent;
 
 export function CartesianLabelFromLabelProp({ label }: { label: ImplicitLabelType }) {
   const viewBox = useCartesianLabelContext();

--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -5,13 +5,14 @@ import minBy from 'es-toolkit/compat/minBy';
 
 import { clsx } from 'clsx';
 import { Text } from '../component/Text';
-import { Label } from '../component/Label';
+import { PolarLabelContextProvider, PolarLabelFromLabelProp } from '../component/Label';
 import { Layer } from '../container/Layer';
 import { getTickClassName, polarToCartesian } from '../util/PolarUtils';
 import {
   adaptEventsOfChild,
   BaseAxisProps,
   Coordinate,
+  PolarViewBoxRequired,
   PresentationAttributesAdaptChildEvent,
   TickItem,
 } from '../util/types';
@@ -22,15 +23,6 @@ import { selectPolarAxisScale, selectPolarAxisTicks } from '../state/selectors/p
 import { selectPolarViewBox } from '../state/selectors/polarAxisSelectors';
 import { defaultPolarRadiusAxisProps } from './defaultPolarRadiusAxisProps';
 import { svgPropertiesNoEvents } from '../util/svgPropertiesNoEvents';
-
-type PolarRadiusViewBox = {
-  cx: number;
-  cy: number;
-  startAngle: number;
-  endAngle: number;
-  innerRadius: number;
-  outerRadius: number;
-};
 
 type TickOrientation = 'left' | 'right' | 'middle';
 
@@ -91,7 +83,7 @@ const getTickTextAnchor = (orientation: TickOrientation): string => {
   return textAnchor;
 };
 
-const getViewBox = (angle: number, cx: number, cy: number, ticks: ReadonlyArray<TickItem>): PolarRadiusViewBox => {
+const getViewBox = (angle: number, cx: number, cy: number, ticks: ReadonlyArray<TickItem>): PolarViewBoxRequired => {
   const maxRadiusTick = maxBy(ticks, (entry: TickItem) => entry.coordinate || 0);
   const minRadiusTick = minBy(ticks, (entry: TickItem) => entry.coordinate || 0);
 
@@ -102,6 +94,7 @@ const getViewBox = (angle: number, cx: number, cy: number, ticks: ReadonlyArray<
     endAngle: angle,
     innerRadius: minRadiusTick.coordinate || 0,
     outerRadius: maxRadiusTick.coordinate || 0,
+    clockWise: false,
   };
 };
 
@@ -204,7 +197,10 @@ export const PolarRadiusAxisWrapper: FunctionComponent<Props> = (defaultsAndInpu
     <Layer className={clsx('recharts-polar-radius-axis', AXIS_TYPE, props.className)}>
       {axisLine && renderAxisLine(props, ticks)}
       {tick && renderTicks(props, ticks)}
-      {Label.renderCallByParent(props, getViewBox(props.angle, props.cx, props.cy, ticks))}
+      <PolarLabelContextProvider {...getViewBox(props.angle, props.cx, props.cy, ticks)}>
+        <PolarLabelFromLabelProp label={props.label} />
+        {props.children}
+      </PolarLabelContextProvider>
     </Layer>
   );
 };

--- a/src/state/selectors/polarAxisSelectors.ts
+++ b/src/state/selectors/polarAxisSelectors.ts
@@ -190,7 +190,7 @@ export const selectPolarViewBox: (state: RechartsRootState) => PolarViewBoxRequi
       outerRadius,
       startAngle,
       endAngle,
-      clockWise: false,
+      clockWise: false, // this property look useful, why not use it?
     };
   },
 );

--- a/storybook/stories/API/polar/PolarRadiusAxis.mdx
+++ b/storybook/stories/API/polar/PolarRadiusAxis.mdx
@@ -4,9 +4,8 @@ import * as PolarRadiusAxisStories from './PolarRadiusAxis.stories';
 # PolarRadiusAxis
 <Meta of={PolarRadiusAxisStories} />
 
-<Canvas>
-  <Story name="API" of={PolarRadiusAxisStories} />
-</Canvas>
+<Canvas of={PolarRadiusAxisStories.API} layout='padded' />
+
 ## Parent Component
 
 The PolarRadiusAxis can be used within a `<RadarChart />` or `<RadialBarChart />`.

--- a/storybook/stories/API/polar/Radar.mdx
+++ b/storybook/stories/API/polar/Radar.mdx
@@ -1,7 +1,9 @@
-import { ArgTypes } from '@storybook/addon-docs/blocks';
+import { ArgTypes, Canvas } from '@storybook/addon-docs/blocks';
 import * as RadarStories from './Radar.stories';
 
 # Radar
+
+<Canvas of={RadarStories.General} layout='padded' />
 
 ## Parent Component
 

--- a/storybook/stories/API/polar/RadialBar.mdx
+++ b/storybook/stories/API/polar/RadialBar.mdx
@@ -5,9 +5,7 @@ import * as ComponentStories from './RadialBar.stories';
 
 <Meta of={ComponentStories} />
 
-<Canvas>
-  <Story name="API" of={ComponentStories} />
-</Canvas>
+<Canvas of={ComponentStories.API} layout='padded'/>
 
 ## Parent Component
 


### PR DESCRIPTION
## Description

Add PolarLabelContext, use it to set Label context in PolarRadiusAxis, remove unused Label.renderCallByParent

## Related Issue

https://github.com/recharts/recharts/issues/5768 571 errors -> 569

This should also somehow help with the problem where we wanted to set default props for label in YAxis.

It also allows Labels as a nested component inside of PolarRadiusAxis but I can't recall anyone asked for that.

## Motivation and Context

Removes one of the usages of `findAllByType`

## How Has This Been Tested?

VR test
