### PR TITLE
test: handle floating promises

### DIFF
--- a/test/cartesian/Brush.spec.tsx
+++ b/test/cartesian/Brush.spec.tsx
@@ -93,7 +93,7 @@ describe('<Brush />', () => {
     });
   });
 
-  test('Render 2 travelers and 1 slide in simple Brush', () => {
+  test('Render 2 travelers and 1 slide in simple Brush', async () => {
     const { container } = render(
       <BarChart width={400} height={100} data={data}>
         <Brush dataKey="value" x={100} y={50} width={400} height={40} />
@@ -128,7 +128,7 @@ describe('<Brush />', () => {
     // this is using X in pixels, not value, why? Doesn't sound very accessible
     expect(traveller1.getAttribute('aria-valuenow')).toBe('100');
     expect(traveller1.getAttribute('style')).toBe('cursor: col-resize;');
-    expect(traveller1.innerHTML).toMatchFileSnapshot('snapshots/brush-traveller1.svg');
+    await expect(traveller1.innerHTML).toMatchFileSnapshot('snapshots/brush-traveller1.svg');
 
     const traveller2 = allTravellers[1];
     expect(traveller2.getAttributeNames()).toEqual([
@@ -147,7 +147,7 @@ describe('<Brush />', () => {
     // this is using X in pixels, not value, why? Doesn't sound very accessible
     expect(traveller2.getAttribute('aria-valuenow')).toBe('495');
     expect(traveller2.getAttribute('style')).toBe('cursor: col-resize;');
-    expect(traveller2.innerHTML).toMatchFileSnapshot('snapshots/brush-traveller2.svg');
+    await expect(traveller2.innerHTML).toMatchFileSnapshot('snapshots/brush-traveller2.svg');
   });
 
   test('custom traveller Element should receive extra sneaky props', () => {

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -3553,7 +3553,7 @@ describe('<BarChart />', () => {
       expect(tooltips4[1]).not.toBeVisible();
     });
 
-    it('should render two connected charts when given same syncId', () => {
+    it('should render two connected charts when given same syncId', async () => {
       const { container } = render(
         <>
           <BarChart syncId={1} width={100} height={50} data={data}>
@@ -3591,8 +3591,8 @@ describe('<BarChart />', () => {
       fireEvent.mouseOut(barCharts[0]);
       const tooltips3 = container.querySelectorAll('.recharts-tooltip-wrapper');
       // TODO: remove these waits. Right now with both Context and Redux there are too many re-renders.
-      waitFor(() => expect(tooltips3[0]).not.toBeVisible());
-      waitFor(() => expect(tooltips3[1]).not.toBeVisible());
+      await waitFor(() => expect(tooltips3[0]).not.toBeVisible());
+      await waitFor(() => expect(tooltips3[1]).not.toBeVisible());
 
       fireEvent.mouseOut(barCharts[1]);
       const tooltips4 = container.querySelectorAll('.recharts-tooltip-wrapper');

--- a/test/component/TooltipBoundingBox.spec.tsx
+++ b/test/component/TooltipBoundingBox.spec.tsx
@@ -53,9 +53,9 @@ describe('TooltipBoundingBox', () => {
     expect(screen.getByText('Hello world!')).not.toBeVisible();
   });
 
-  it('should hide children when dismissed using Escape key', () => {
+  it('should hide children when dismissed using Escape key', async () => {
     render(<TooltipBoundingBox {...defaultProps} active={false} />);
-    userEvent.keyboard('{Escape}');
+    await userEvent.keyboard('{Escape}');
     expect(screen.getByText('Hello world!')).toBeInTheDocument();
     expect(screen.getByText('Hello world!')).not.toBeVisible();
   });


### PR DESCRIPTION
## Description

Codex attempted to fix any floating promises

See https://typescript-eslint.io/rules/no-floating-promises/

Probably not required, but it looks like it might be good hygiene.  It's possible the floating promises could cause flaky test behavior.

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes
