### PR TITLE
Codex/add explicit return types and argument types

### DIFF
--- a/src/animation/JavascriptAnimate.tsx
+++ b/src/animation/JavascriptAnimate.tsx
@@ -37,7 +37,7 @@ type TimeAsObject = {
 const from: TimeAsObject = { t: 0 };
 const to: TimeAsObject = { t: 1 };
 
-export function JavascriptAnimate(outsideProps: JavascriptAnimateProps) {
+export function JavascriptAnimate(outsideProps: JavascriptAnimateProps): React.ReactNode {
   const props = resolveDefaultProps(outsideProps, defaultJavascriptAnimateProps);
   const { isActive, canBegin, duration, easing, begin, onAnimationEnd, onAnimationStart, children } = props;
 

--- a/src/component/Cursor.tsx
+++ b/src/component/Cursor.tsx
@@ -40,7 +40,7 @@ export type CursorConnectedProps = CursorProps & {
   chartName: string;
 };
 
-export function CursorInternal(props: CursorConnectedProps) {
+export function CursorInternal(props: CursorConnectedProps): ReactElement | null {
   const { coordinate, payload, index, offset, tooltipAxisBandSize, layout, cursor, tooltipEventType, chartName } =
     props;
 
@@ -101,7 +101,7 @@ export function CursorInternal(props: CursorConnectedProps) {
  * It usually shows together with a tooltip
  * to emphasise which part of the chart does the tooltip refer to.
  */
-export function Cursor(props: CursorProps) {
+export function Cursor(props: CursorProps): ReactElement {
   const tooltipAxisBandSize = useTooltipAxisBandSize();
   const offset = useOffsetInternal();
   const layout = useChartLayout();

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -97,7 +97,7 @@ export const CartesianLabelContextProvider = ({
   width: number;
   height: number;
   children: ReactNode;
-}) => {
+}): ReactElement => {
   const viewBox: CartesianViewBoxRequired = useMemo(
     () => ({
       x,
@@ -110,7 +110,7 @@ export const CartesianLabelContextProvider = ({
   return <CartesianLabelContext.Provider value={viewBox}>{children}</CartesianLabelContext.Provider>;
 };
 
-const useCartesianLabelContext = () => {
+const useCartesianLabelContext = (): CartesianViewBox | null => {
   const labelChildContext = useContext(CartesianLabelContext);
   const chartContext = useViewBox();
   return labelChildContext || chartContext;
@@ -129,7 +129,7 @@ export const PolarLabelContextProvider = ({
   children,
 }: PolarViewBoxRequired & {
   children: ReactNode;
-}) => {
+}): ReactElement => {
   const viewBox: PolarViewBoxRequired = useMemo(
     () => ({
       cx,
@@ -145,13 +145,13 @@ export const PolarLabelContextProvider = ({
   return <PolarLabelContext.Provider value={viewBox}>{children}</PolarLabelContext.Provider>;
 };
 
-export const usePolarLabelContext = () => {
+export const usePolarLabelContext = (): PolarViewBoxRequired | null => {
   const labelChildContext = useContext(PolarLabelContext);
   const chartContext = useAppSelector(selectPolarViewBox);
   return labelChildContext || chartContext;
 };
 
-const getLabel = (props: Props) => {
+const getLabel = (props: Props): ReactNode => {
   const { value, formatter } = props;
   const label = isNullish(props.children) ? value : props.children;
 
@@ -166,7 +166,7 @@ export const isLabelContentAFunction = (content: unknown): content is (props: Pr
   return content != null && typeof content === 'function';
 };
 
-const getDeltaAngle = (startAngle: number, endAngle: number) => {
+const getDeltaAngle = (startAngle: number, endAngle: number): number => {
   const sign = mathSign(endAngle - startAngle);
   const deltaAngle = Math.min(Math.abs(endAngle - startAngle), 360);
 
@@ -178,7 +178,7 @@ const renderRadialLabel = (
   label: ReactNode,
   attrs: SVGProps<SVGTextElement>,
   viewBox: PolarViewBox,
-) => {
+): ReactElement => {
   const { position, offset, className } = labelProps;
   const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, clockWise } = viewBox;
   const radius = (innerRadius + outerRadius) / 2;
@@ -216,7 +216,11 @@ const renderRadialLabel = (
   );
 };
 
-const getAttrsOfPolarLabel = (viewBox: PolarViewBox, offset: Props['offset'], position: Props['position']) => {
+const getAttrsOfPolarLabel = (
+  viewBox: PolarViewBox,
+  offset: Props['offset'],
+  position: Props['position'],
+): SVGProps<SVGTextElement> & { verticalAnchor: 'start' | 'middle' | 'end' } => {
   const { cx, cy, innerRadius, outerRadius, startAngle, endAngle } = viewBox as PolarViewBox;
   const midAngle = (startAngle + endAngle) / 2;
 
@@ -269,7 +273,10 @@ const getAttrsOfPolarLabel = (viewBox: PolarViewBox, offset: Props['offset'], po
   };
 };
 
-const getAttrsOfCartesianLabel = (props: Props, viewBox: CartesianViewBox) => {
+const getAttrsOfCartesianLabel = (
+  props: Props,
+  viewBox: CartesianViewBox,
+): SVGProps<SVGTextElement> & { verticalAnchor: 'start' | 'middle' | 'end'; width?: number; height?: number } => {
   const { parentViewBox, offset, position } = props;
   const { x, y, width, height } = viewBox;
 
@@ -475,7 +482,7 @@ const getAttrsOfCartesianLabel = (props: Props, viewBox: CartesianViewBox) => {
 const isPolar = (viewBox: CartesianViewBox | PolarViewBox): viewBox is PolarViewBox =>
   'cx' in viewBox && isNumber(viewBox.cx);
 
-export function Label({ offset = 5, ...restProps }: Props) {
+export function Label({ offset = 5, ...restProps }: Props): ReactElement | null {
   const props = { offset, ...restProps };
   const {
     viewBox: viewBoxFromProps,
@@ -610,7 +617,11 @@ export const parseViewBox = (props: any): ViewBox => {
   return undefined;
 };
 
-const parseLabel = (label: ImplicitLabelType, viewBox: ViewBox, labelRef?: React.RefObject<Element>) => {
+const parseLabel = (
+  label: ImplicitLabelType,
+  viewBox: ViewBox,
+  labelRef?: React.RefObject<Element>,
+): ReactElement | null => {
   if (!label) {
     return null;
   }
@@ -646,13 +657,13 @@ const parseLabel = (label: ImplicitLabelType, viewBox: ViewBox, labelRef?: React
 
 Label.parseViewBox = parseViewBox;
 
-export function CartesianLabelFromLabelProp({ label }: { label: ImplicitLabelType }) {
+export function CartesianLabelFromLabelProp({ label }: { label: ImplicitLabelType }): ReactElement | null {
   const viewBox = useCartesianLabelContext();
 
   return parseLabel(label, viewBox) || null;
 }
 
-export function PolarLabelFromLabelProp({ label }: { label: ImplicitLabelType }) {
+export function PolarLabelFromLabelProp({ label }: { label: ImplicitLabelType }): ReactElement | null {
   const viewBox = usePolarLabelContext();
 
   return parseLabel(label, viewBox) || null;

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CSSProperties, PureComponent, useEffect } from 'react';
+import { CSSProperties, PureComponent, useEffect, ReactElement } from 'react';
 import { createPortal } from 'react-dom';
 import { useLegendPortal } from '../context/legendPortalContext';
 import { DefaultLegendContent, LegendPayload, Props as DefaultProps } from './DefaultLegendContent';
@@ -13,7 +13,7 @@ import { useChartHeight, useChartWidth, useMargin } from '../context/chartLayout
 import { LegendSettings, setLegendSettings, setLegendSize } from '../state/legendSlice';
 import { useAppDispatch } from '../state/hooks';
 
-function defaultUniqBy(entry: LegendPayload) {
+function defaultUniqBy(entry: LegendPayload): unknown {
   return entry.value;
 }
 
@@ -24,7 +24,7 @@ type ContentProps = Props & {
   contextPayload: ReadonlyArray<LegendPayload>;
 };
 
-function LegendContent(props: ContentProps) {
+function LegendContent(props: ContentProps): ReactElement {
   const { contextPayload, ...otherProps } = props;
   const finalPayload = getUniqPayload(contextPayload, props.payloadUniqBy, defaultUniqBy);
   const contentProps = {
@@ -55,7 +55,7 @@ function getDefaultPosition(
   chartWidth: number,
   chartHeight: number,
   box: ElementOffset,
-) {
+): CSSProperties {
   const { layout, align, verticalAlign } = props;
   let hPos, vPos;
 
@@ -127,7 +127,7 @@ function LegendSizeDispatcher(props: Size): null {
   return null;
 }
 
-function LegendWrapper(props: Props) {
+function LegendWrapper(props: Props): React.ReactPortal | null {
   const contextPayload = useLegendPayload();
   const legendPortalFromContext = useLegendPortal();
   const margin = useMargin();
@@ -214,7 +214,7 @@ export class Legend extends PureComponent<Props, State> {
     return null;
   }
 
-  public render() {
+  public render(): ReactElement {
     return <LegendWrapper {...this.props} />;
   }
 }

--- a/src/state/RechartsStoreProvider.tsx
+++ b/src/state/RechartsStoreProvider.tsx
@@ -12,7 +12,11 @@ type RechartsStoreProviderProps = {
   reduxStoreName?: string;
 };
 
-export function RechartsStoreProvider({ preloadedState, children, reduxStoreName }: RechartsStoreProviderProps) {
+export function RechartsStoreProvider({
+  preloadedState,
+  children,
+  reduxStoreName,
+}: RechartsStoreProviderProps): ReactNode {
   const isPanorama = useIsPanorama();
   /*
    * Why the ref? Redux official documentation recommends to use store as a singleton,

--- a/src/state/reduxDevtoolsJsonStringifyReplacer.ts
+++ b/src/state/reduxDevtoolsJsonStringifyReplacer.ts
@@ -1,4 +1,4 @@
-export function reduxDevtoolsJsonStringifyReplacer(_key: string, value: unknown) {
+export function reduxDevtoolsJsonStringifyReplacer(_key: string, value: unknown): unknown {
   if (value instanceof HTMLElement) {
     return `HTMLElement <${value.tagName} class="${value.className}">`;
   }

--- a/src/util/ActiveShapeUtils.tsx
+++ b/src/util/ActiveShapeUtils.tsx
@@ -31,7 +31,10 @@ export type ShapeProps<OptionType, ExtraProps, ShapePropsType> = {
   propTransformer?: (option: OptionType, props: unknown) => ShapePropsType;
 } & ExtraProps;
 
-function defaultPropTransformer<OptionType, ExtraProps, ShapePropsType>(option: OptionType, props: ExtraProps) {
+function defaultPropTransformer<OptionType, ExtraProps, ShapePropsType>(
+  option: OptionType,
+  props: ExtraProps,
+): ShapePropsType {
   return {
     ...props,
     ...option,
@@ -81,7 +84,7 @@ export function Shape<OptionType, ExtraProps, ShapePropsType extends React.JSX.I
   activeClassName = 'recharts-active-shape',
   isActive,
   ...props
-}: ShapeProps<OptionType, ExtraProps, ShapePropsType>) {
+}: ShapeProps<OptionType, ExtraProps, ShapePropsType>): React.JSX.Element {
   let shape: React.JSX.Element;
 
   if (isValidElement(option)) {

--- a/src/util/BarUtils.tsx
+++ b/src/util/BarUtils.tsx
@@ -46,7 +46,7 @@ export type BarRectangleProps = {
   height?: number;
 } & Omit<BarProps, 'onAnimationStart' | 'onAnimationEnd'>;
 
-export function BarRectangle(props: BarRectangleProps) {
+export function BarRectangle(props: BarRectangleProps): React.JSX.Element {
   return (
     <Shape
       shapeType="rectangle"
@@ -65,9 +65,11 @@ export type MinPointSize = number | ((value: number | undefined | null, index: n
  * @param defaultValue default minPointSize
  * @returns minPointSize
  */
-export const minPointSizeCallback =
-  (minPointSize: MinPointSize, defaultValue = 0) =>
-  (value: unknown, index: number): number => {
+export const minPointSizeCallback = (
+  minPointSize: MinPointSize,
+  defaultValue = 0,
+): ((value: unknown, index: number) => number) => {
+  return (value: unknown, index: number): number => {
     if (isNumber(minPointSize)) return minPointSize;
     const isValueNumberOrNil = isNumber(value) || isNullish(value);
     if (isValueNumberOrNil) {
@@ -80,3 +82,4 @@ export const minPointSizeCallback =
     );
     return defaultValue;
   };
+};

--- a/src/util/CartesianUtils.ts
+++ b/src/util/CartesianUtils.ts
@@ -123,7 +123,7 @@ export const createLabeledScales = (options: Record<string, any>): LabeledScales
 /** Normalizes the angle so that 0 <= angle < 180.
  * @param {number} angle Angle in degrees.
  * @return {number} the normalized angle with a value of at least 0 and never greater or equal to 180. */
-export function normalizeAngle(angle: number) {
+export function normalizeAngle(angle: number): number {
   return ((angle % 180) + 180) % 180;
 }
 

--- a/src/util/CartesianUtils.ts
+++ b/src/util/CartesianUtils.ts
@@ -1,6 +1,9 @@
 import { Coordinate, Size } from './types';
 
-export const rectWithPoints = ({ x: x1, y: y1 }: Coordinate, { x: x2, y: y2 }: Coordinate) => ({
+export const rectWithPoints = (
+  { x: x1, y: y1 }: Coordinate,
+  { x: x2, y: y2 }: Coordinate,
+): { x: number; y: number; width: number; height: number } => ({
   x: Math.min(x1, x2),
   y: Math.min(y1, y2),
   width: Math.abs(x2 - x1),
@@ -12,8 +15,17 @@ export const rectWithPoints = ({ x: x1, y: y1 }: Coordinate, { x: x2, y: y2 }: C
  * @param  {Object} coords     x1, x2, y1, and y2
  * @return {Object} object
  */
-export const rectWithCoords = ({ x1, y1, x2, y2 }: { x1: number; y1: number; x2: number; y2: number }) =>
-  rectWithPoints({ x: x1, y: y1 }, { x: x2, y: y2 });
+export const rectWithCoords = ({
+  x1,
+  y1,
+  x2,
+  y2,
+}: {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}): { x: number; y: number; width: number; height: number } => rectWithPoints({ x: x1, y: y1 }, { x: x2, y: y2 });
 
 export class ScaleHelper {
   static EPS = 1e-4;
@@ -132,7 +144,7 @@ export function normalizeAngle(angle: number): number {
  * @param {number} angle Angle in degrees in which the text is displayed.
  * @return {number} The width of the largest horizontal line that fits inside a rectangle that is displayed at an angle.
  */
-export const getAngledRectangleWidth = ({ width, height }: Size, angle: number | undefined = 0) => {
+export const getAngledRectangleWidth = ({ width, height }: Size, angle: number | undefined = 0): number => {
   // Ensure angle is >= 0 && < 180
   const normalizedAngle = normalizeAngle(angle);
   const angleRadians = (normalizedAngle * Math.PI) / 180;

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -187,7 +187,7 @@ export const appendOffsetOfLegend = (
   return offset;
 };
 
-export const isCategoricalAxis = (layout: LayoutType, axisType: AxisType) =>
+export const isCategoricalAxis = (layout: LayoutType, axisType: AxisType): boolean =>
   (layout === 'horizontal' && axisType === 'xAxis') ||
   (layout === 'vertical' && axisType === 'yAxis') ||
   (layout === 'centric' && axisType === 'angleAxis') ||
@@ -352,7 +352,7 @@ export const getTicksOfAxis = (
 };
 
 const EPS = 1e-4;
-export const checkDomainOfScale = (scale: any) => {
+export const checkDomainOfScale = (scale: any): void => {
   const domain = scale.domain();
 
   if (!domain || domain.length <= 2) {

--- a/src/util/CssPrefixUtils.ts
+++ b/src/util/CssPrefixUtils.ts
@@ -1,6 +1,6 @@
 const PREFIX_LIST = ['Webkit', 'Moz', 'O', 'ms'];
 
-export const generatePrefixStyle = (name: string, value: string) => {
+export const generatePrefixStyle = (name: string, value: string): Record<string, string> | undefined => {
   if (!name) {
     return undefined;
   }

--- a/src/util/DOMUtils.ts
+++ b/src/util/DOMUtils.ts
@@ -127,7 +127,7 @@ export const clearStringCache = (): void => {
  * Get cache statistics for debugging purposes.
  * @returns Cache statistics including size and max size
  */
-export const getStringCacheStats = () => ({
+export const getStringCacheStats = (): { size: number; maxSize: number } => ({
   size: stringCache.size(),
   maxSize: currentConfig.cacheSize,
 });

--- a/src/util/DataUtils.ts
+++ b/src/util/DataUtils.ts
@@ -1,6 +1,6 @@
 import get from 'es-toolkit/compat/get';
 
-export const mathSign = (value: number) => {
+export const mathSign = (value: number): number => {
   if (value === 0) {
     return 0;
   }
@@ -25,7 +25,7 @@ export const isNumber = (value: unknown): value is number =>
 export const isNumOrStr = (value: unknown): value is number | string => isNumber(value) || typeof value === 'string';
 
 let idCounter = 0;
-export const uniqueId = (prefix?: string) => {
+export const uniqueId = (prefix?: string): string => {
   const id = ++idCounter;
 
   return `${prefix || ''}${id}`;
@@ -44,7 +44,7 @@ export const getPercentValue = (
   totalValue: number | undefined,
   defaultValue = 0,
   validate = false,
-) => {
+): number => {
   if (!isNumber(percent) && typeof percent !== 'string') {
     return defaultValue;
   }
@@ -99,7 +99,10 @@ export const hasDuplicate = (ary: ReadonlyArray<unknown>): boolean => {
  *  @param numberB The second number
  *  @return A function that returns the interpolated number
  */
-export const interpolateNumber = (numberA: number | undefined, numberB: number | undefined) => {
+export const interpolateNumber = (
+  numberA: number | undefined,
+  numberB: number | undefined,
+): ((t: number) => number) | (() => number | undefined) => {
   if (isNumber(numberA) && isNumber(numberB)) {
     return (t: number) => numberA + t * (numberB - numberA);
   }
@@ -137,7 +140,9 @@ export function findEntryInArray<T>(
  * @param {Array} data The array of points
  * @returns {Object} The domain of x, and the parameter of linear function
  */
-export const getLinearRegression = (data: ReadonlyArray<{ cx?: number; cy?: number }>) => {
+export const getLinearRegression = (
+  data: ReadonlyArray<{ cx?: number; cy?: number }>,
+): { xmin: number; xmax: number; a: number; b: number } | null => {
   if (!data || !data.length) {
     return null;
   }

--- a/src/util/FunnelUtils.tsx
+++ b/src/util/FunnelUtils.tsx
@@ -26,6 +26,6 @@ export function typeGuardTrapezoidProps(option: SVGProps<SVGPathElement>, props:
 
 export type FunnelTrapezoidProps = { option: FunnelProps['activeShape'] } & FunnelTrapezoidItem;
 
-export function FunnelTrapezoid(props: FunnelTrapezoidProps) {
+export function FunnelTrapezoid(props: FunnelTrapezoidProps): React.JSX.Element {
   return <Shape shapeType="trapezoid" propTransformer={typeGuardTrapezoidProps} {...props} />;
 }

--- a/src/util/LogUtils.ts
+++ b/src/util/LogUtils.ts
@@ -1,7 +1,7 @@
 /* eslint no-console: 0 */
 const isDev = process.env.NODE_ENV !== 'production';
 
-export const warn = (condition: boolean, format: string, ...args: any[]) => {
+export const warn = (condition: boolean, format: string, ...args: any[]): void => {
   if (isDev && typeof console !== 'undefined' && console.warn) {
     if (format === undefined) {
       console.warn('LogUtils requires an error message argument');

--- a/src/util/PolarUtils.ts
+++ b/src/util/PolarUtils.ts
@@ -3,9 +3,9 @@ import { Coordinate, RangeObj, PolarViewBoxRequired, ChartOffsetInternal } from 
 
 export const RADIAN = Math.PI / 180;
 
-export const degreeToRadian = (angle: number) => (angle * Math.PI) / 180;
+export const degreeToRadian = (angle: number): number => (angle * Math.PI) / 180;
 
-export const radianToDegree = (angleInRadian: number) => (angleInRadian * 180) / Math.PI;
+export const radianToDegree = (angleInRadian: number): number => (angleInRadian * 180) / Math.PI;
 
 export const polarToCartesian = (cx: number, cy: number, radius: number, angle: number): Coordinate => ({
   x: cx + Math.cos(-RADIAN * angle) * radius,
@@ -24,20 +24,23 @@ export const getMaxRadius = (
     height: 0,
     brushBottom: 0,
   },
-) =>
+): number =>
   Math.min(
     Math.abs(width - (offset.left || 0) - (offset.right || 0)),
     Math.abs(height - (offset.top || 0) - (offset.bottom || 0)),
   ) / 2;
 
-export const distanceBetweenPoints = (point: Coordinate, anotherPoint: Coordinate) => {
+export const distanceBetweenPoints = (point: Coordinate, anotherPoint: Coordinate): number => {
   const { x: x1, y: y1 } = point;
   const { x: x2, y: y2 } = anotherPoint;
 
   return Math.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2);
 };
 
-export const getAngleOfPoint = ({ x, y }: Coordinate, { cx, cy }: PolarViewBoxRequired) => {
+export const getAngleOfPoint = (
+  { x, y }: Coordinate,
+  { cx, cy }: PolarViewBoxRequired,
+): { radius: number; angle: number; angleInRadian?: number } => {
   const radius = distanceBetweenPoints({ x, y }, { x: cx, y: cy });
 
   if (radius <= 0) {
@@ -54,7 +57,13 @@ export const getAngleOfPoint = ({ x, y }: Coordinate, { cx, cy }: PolarViewBoxRe
   return { radius, angle: radianToDegree(angleInRadian), angleInRadian };
 };
 
-export const formatAngleOfSector = ({ startAngle, endAngle }: PolarViewBoxRequired) => {
+export const formatAngleOfSector = ({
+  startAngle,
+  endAngle,
+}: PolarViewBoxRequired): {
+  startAngle: number;
+  endAngle: number;
+} => {
   const startCnt = Math.floor(startAngle / 360);
   const endCnt = Math.floor(endAngle / 360);
   const min = Math.min(startCnt, endCnt);
@@ -65,7 +74,7 @@ export const formatAngleOfSector = ({ startAngle, endAngle }: PolarViewBoxRequir
   };
 };
 
-const reverseFormatAngleOfSector = (angle: number, { startAngle, endAngle }: PolarViewBoxRequired) => {
+const reverseFormatAngleOfSector = (angle: number, { startAngle, endAngle }: PolarViewBoxRequired): number => {
   const startCnt = Math.floor(startAngle / 360);
   const endCnt = Math.floor(endAngle / 360);
   const min = Math.min(startCnt, endCnt);
@@ -116,7 +125,7 @@ export const inRangeOfSector = ({ x, y }: Coordinate, viewBox: PolarViewBoxRequi
 
 export const getTickClassName = (
   tick?: SVGProps<SVGTextElement> | ReactElement<SVGElement> | ((props: any) => ReactElement<SVGElement>) | boolean,
-) =>
+): string =>
   !isValidElement(tick) && typeof tick !== 'function' && typeof tick !== 'boolean' && tick != null
     ? tick.className
     : '';

--- a/src/util/RadialBarUtils.tsx
+++ b/src/util/RadialBarUtils.tsx
@@ -35,6 +35,6 @@ export interface RadialBarSectorProps extends SectorProps {
   isActive?: boolean;
 }
 
-export function RadialBarSector(props: RadialBarSectorProps) {
+export function RadialBarSector(props: RadialBarSectorProps): React.JSX.Element {
   return <Shape shapeType="sector" propTransformer={typeGuardSectorProps} {...props} />;
 }

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -32,7 +32,7 @@ export const SCALE_TYPES = [
  * @param  {Object} Comp Specified Component
  * @return {String}      Display name of Component
  */
-export const getDisplayName = (Comp: React.ComponentType | string) => {
+export const getDisplayName = (Comp: React.ComponentType | string): string => {
   if (typeof Comp === 'string') {
     return Comp;
   }
@@ -161,7 +161,7 @@ export const filterProps = (
   props: Record<string, any> | Component | FunctionComponent | boolean | unknown,
   includeEvents: boolean,
   svgElementType?: FilteredSvgElementType,
-) => {
+): Record<string, any> | null => {
   if (!props || typeof props === 'function' || typeof props === 'boolean') {
     return null;
   }

--- a/src/util/ReduceCSSCalc.ts
+++ b/src/util/ReduceCSSCalc.ts
@@ -23,7 +23,7 @@ function convertToPx(value: number, unit: string): number {
 }
 
 class DecimalCSS {
-  static parse(str: string) {
+  static parse(str: string): DecimalCSS {
     const [, numStr, unit] = NUM_SPLIT_REGEX.exec(str) ?? [];
 
     return new DecimalCSS(parseFloat(numStr), unit ?? '');
@@ -51,7 +51,7 @@ class DecimalCSS {
     }
   }
 
-  add(other: DecimalCSS) {
+  add(other: DecimalCSS): DecimalCSS {
     if (this.unit !== other.unit) {
       return new DecimalCSS(NaN, '');
     }
@@ -59,7 +59,7 @@ class DecimalCSS {
     return new DecimalCSS(this.num + other.num, this.unit);
   }
 
-  subtract(other: DecimalCSS) {
+  subtract(other: DecimalCSS): DecimalCSS {
     if (this.unit !== other.unit) {
       return new DecimalCSS(NaN, '');
     }
@@ -67,7 +67,7 @@ class DecimalCSS {
     return new DecimalCSS(this.num - other.num, this.unit);
   }
 
-  multiply(other: DecimalCSS) {
+  multiply(other: DecimalCSS): DecimalCSS {
     if (this.unit !== '' && other.unit !== '' && this.unit !== other.unit) {
       return new DecimalCSS(NaN, '');
     }
@@ -75,7 +75,7 @@ class DecimalCSS {
     return new DecimalCSS(this.num * other.num, this.unit || other.unit);
   }
 
-  divide(other: DecimalCSS) {
+  divide(other: DecimalCSS): DecimalCSS {
     if (this.unit !== '' && other.unit !== '' && this.unit !== other.unit) {
       return new DecimalCSS(NaN, '');
     }
@@ -83,11 +83,11 @@ class DecimalCSS {
     return new DecimalCSS(this.num / other.num, this.unit || other.unit);
   }
 
-  toString() {
+  toString(): string {
     return `${this.num}${this.unit}`;
   }
 
-  isNaN() {
+  isNaN(): boolean {
     return isNan(this.num);
   }
 }

--- a/src/util/ScatterUtils.tsx
+++ b/src/util/ScatterUtils.tsx
@@ -11,7 +11,7 @@ export function ScatterSymbol({
 }: {
   option: ActiveShape<ScatterPointItem> | SymbolType;
   isActive: boolean;
-} & ScatterPointItem) {
+} & ScatterPointItem): React.JSX.Element {
   if (typeof option === 'string') {
     return <Shape option={<Symbols type={option} {...props} />} isActive={isActive} shapeType="symbols" {...props} />;
   }

--- a/src/util/ShallowEqual.ts
+++ b/src/util/ShallowEqual.ts
@@ -1,4 +1,4 @@
-export function shallowEqual(a: any, b: any) {
+export function shallowEqual<T extends Record<string, unknown>>(a: T, b: T): boolean {
   /* eslint-disable no-restricted-syntax */
   for (const key in a) {
     if ({}.hasOwnProperty.call(a, key) && (!{}.hasOwnProperty.call(b, key) || a[key] !== b[key])) {

--- a/src/util/TickUtils.ts
+++ b/src/util/TickUtils.ts
@@ -2,13 +2,17 @@ import { getAngledRectangleWidth } from './CartesianUtils';
 import { getEveryNthWithCondition } from './getEveryNthWithCondition';
 import { Size, CartesianTickItem, CartesianViewBoxRequired } from './types';
 
-export function getAngledTickWidth(contentSize: Size, unitSize: Size, angle: number) {
+export function getAngledTickWidth(contentSize: Size, unitSize: Size, angle: number): number {
   const size = { width: contentSize.width + unitSize.width, height: contentSize.height + unitSize.height };
 
   return getAngledRectangleWidth(size, angle);
 }
 
-export function getTickBoundaries(viewBox: CartesianViewBoxRequired, sign: number, sizeKey: string) {
+export function getTickBoundaries(
+  viewBox: CartesianViewBoxRequired,
+  sign: number,
+  sizeKey: string,
+): { start: number; end: number } {
   const isWidth = sizeKey === 'width';
   const { x, y, width, height } = viewBox;
   if (sign === 1) {

--- a/src/util/isDomainSpecifiedByUser.ts
+++ b/src/util/isDomainSpecifiedByUser.ts
@@ -55,7 +55,7 @@ export function extendDomain(
 export function numericalDomainSpecifiedWithoutRequiringData(
   userDomain: AxisDomain | undefined,
   allowDataOverflow: boolean,
-) {
+): NumberDomain | undefined {
   if (!allowDataOverflow) {
     // Cannot compute data overflow if the data is not provided
     return undefined;

--- a/src/util/scale/getNiceTickValues.ts
+++ b/src/util/scale/getNiceTickValues.ts
@@ -14,7 +14,7 @@ import { getDigitCount, rangeStep } from './util/arithmetic';
  * @param  {Number} max       The maximum value
  * @return {Array} An interval
  */
-export const getValidInterval = ([min, max]: [number, number]) => {
+export const getValidInterval = ([min, max]: [number, number]): [number, number] => {
   let [validMin, validMax] = [min, max];
 
   // exchange
@@ -33,7 +33,7 @@ export const getValidInterval = ([min, max]: [number, number]) => {
  * @param  correctionFactor A correction factor
  * @return The step which is easy to understand between two ticks
  */
-export const getFormatStep = (roughStep: Decimal, allowDecimals: boolean, correctionFactor: number) => {
+export const getFormatStep = (roughStep: Decimal, allowDecimals: boolean, correctionFactor: number): Decimal => {
   if (roughStep.lte(0)) {
     return new Decimal(0);
   }
@@ -206,7 +206,11 @@ function getNiceTickValuesFn([min, max]: [number, number], tickCount = 6, allowD
  * @param allowDecimals Allow the ticks to be decimals or not
  * @return array of ticks
  */
-function getTickValuesFixedDomainFn([min, max]: readonly [number, number], tickCount: number, allowDecimals = true) {
+function getTickValuesFixedDomainFn(
+  [min, max]: readonly [number, number],
+  tickCount: number,
+  allowDecimals = true,
+): number[] {
   // More than two ticks should be return
   const [cormin, cormax] = getValidInterval([min, max]);
 
@@ -235,5 +239,5 @@ function getTickValuesFixedDomainFn([min, max]: readonly [number, number], tickC
   return min > max ? reverse(values) : values;
 }
 
-export const getNiceTickValues = memoize(getNiceTickValuesFn);
-export const getTickValuesFixedDomain = memoize(getTickValuesFixedDomainFn);
+export const getNiceTickValues: typeof getNiceTickValuesFn = memoize(getNiceTickValuesFn);
+export const getTickValuesFixedDomain: typeof getTickValuesFixedDomainFn = memoize(getTickValuesFixedDomainFn);

--- a/src/util/scale/util/arithmetic.ts
+++ b/src/util/scale/util/arithmetic.ts
@@ -15,7 +15,7 @@ import { curry } from './utils';
  * @param  {Number} value The number
  * @return {Integer}      Digit count
  */
-function getDigitCount(value: number) {
+function getDigitCount(value: number): number {
   let result;
 
   if (value === 0) {
@@ -60,7 +60,7 @@ function rangeStep(start: Decimal, end: Decimal, step: Decimal): Array<number> {
  * @param  {Number} t  A value in [0, 1]
  * @return {Number}    A value in the domain
  */
-const interpolateNumber = curry((a: number, b: number, t: number) => {
+const interpolateNumber = curry((a: number, b: number, t: number): number => {
   const newA = +a;
   const newB = +b;
 
@@ -75,7 +75,7 @@ const interpolateNumber = curry((a: number, b: number, t: number) => {
  * @param  {Number} x Can be considered as an output value after interpolation
  * @return {Number}   When x is in the range a ~ b, the return value is in [0, 1]
  */
-const uninterpolateNumber = curry((a: number, b: number, x: number) => {
+const uninterpolateNumber = curry((a: number, b: number, x: number): number => {
   let diff = b - +a;
 
   diff = diff || Infinity;
@@ -92,7 +92,7 @@ const uninterpolateNumber = curry((a: number, b: number, x: number) => {
  * @return {Number}   When x is in the interval a ~ b, the return value is in [0, 1].
  *                    When x is not in the interval a ~ b, it will be truncated to the interval a ~ b.
  */
-const uninterpolateTruncation = curry((a: number, b: number, x: number) => {
+const uninterpolateTruncation = curry((a: number, b: number, x: number): number => {
   let diff = b - +a;
 
   diff = diff || Infinity;

--- a/src/util/scale/util/utils.ts
+++ b/src/util/scale/util/utils.ts
@@ -1,13 +1,13 @@
-const identity = (i: any) => i;
+const identity = (i: any): any => i;
 
 export const PLACE_HOLDER = {
   '@@functional/placeholder': true,
 };
 
-const isPlaceHolder = (val: any) => val === PLACE_HOLDER;
+const isPlaceHolder = (val: any): boolean => val === PLACE_HOLDER;
 
-const curry0 = (fn: (...args: any[]) => any) =>
-  function _curried(...args: any[]) {
+const curry0 = (fn: (...args: any[]) => any): ((...args: any[]) => any) =>
+  function _curried(...args: any[]): any {
     if (args.length === 0 || (args.length === 1 && isPlaceHolder(args[0]))) {
       return _curried;
     }
@@ -15,12 +15,12 @@ const curry0 = (fn: (...args: any[]) => any) =>
     return fn(...args);
   };
 
-const curryN = (n: number, fn: (...args: any[]) => any) => {
+const curryN = (n: number, fn: (...args: any[]) => any): ((...args: any[]) => any) => {
   if (n === 1) {
     return fn;
   }
 
-  return curry0((...args: any[]) => {
+  return curry0((...args: any[]): any => {
     const argsLength = args.filter(arg => arg !== PLACE_HOLDER).length;
 
     if (argsLength >= n) {
@@ -29,7 +29,7 @@ const curryN = (n: number, fn: (...args: any[]) => any) => {
 
     return curryN(
       n - argsLength,
-      curry0((...restArgs: any[]) => {
+      curry0((...restArgs: any[]): any => {
         const newArgs = args.map(arg => (isPlaceHolder(arg) ? restArgs.shift() : arg));
 
         return fn(...newArgs, ...restArgs);
@@ -38,10 +38,10 @@ const curryN = (n: number, fn: (...args: any[]) => any) => {
   });
 };
 
-export const curry = (fn: (...args: any[]) => any) => curryN(fn.length, fn);
+export const curry = (fn: (...args: any[]) => any): ((...args: any[]) => any) => curryN(fn.length, fn);
 
-export const range = (begin: number, end: number) => {
-  const arr = [];
+export const range = (begin: number, end: number): number[] => {
+  const arr: number[] = [];
 
   for (let i = begin; i < end; ++i) {
     arr[i - begin] = i;
@@ -50,7 +50,7 @@ export const range = (begin: number, end: number) => {
   return arr;
 };
 
-export const map = curry((fn: (value: any, index: number, array: any[]) => unknown, arr: any[]) => {
+export const map: any = curry((fn: (value: any, index: number, array: any[]) => unknown, arr: any[]): any => {
   if (Array.isArray(arr)) {
     return arr.map(fn);
   }
@@ -60,7 +60,7 @@ export const map = curry((fn: (value: any, index: number, array: any[]) => unkno
     .map(fn);
 });
 
-export const compose = (...args: any[]) => {
+export const compose = (...args: any[]): ((...fnArgs: any[]) => any) => {
   if (!args.length) {
     return identity;
   }
@@ -70,7 +70,7 @@ export const compose = (...args: any[]) => {
   const firstFn = fns[0];
   const tailsFn = fns.slice(1);
 
-  return (...composeArgs: any[]) => tailsFn.reduce((res, fn) => fn(res), firstFn(...composeArgs));
+  return (...composeArgs: any[]): any => tailsFn.reduce((res, fn) => fn(res), firstFn(...composeArgs));
 };
 
 export const reverse = <T extends any[] | string>(arr: T): T => {

--- a/src/util/useElementOffset.ts
+++ b/src/util/useElementOffset.ts
@@ -50,7 +50,7 @@ export type SetElementOffset = (node: HTMLElement | null) => void;
 export function useElementOffset(extraDependencies: ReadonlyArray<unknown> = []): [ElementOffset, SetElementOffset] {
   const [lastBoundingBox, setLastBoundingBox] = useState<ElementOffset>({ height: 0, left: 0, top: 0, width: 0 });
   const updateBoundingBox = useCallback(
-    (node: HTMLDivElement | null) => {
+    (node: HTMLDivElement | null): void => {
       if (node != null) {
         const rect = node.getBoundingClientRect();
         const box: ElementOffset = {

--- a/src/util/useReportScale.ts
+++ b/src/util/useReportScale.ts
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Dispatch, SetStateAction } from 'react';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { selectContainerScale } from '../state/selectors/containerSelectors';
 import { setScale } from '../state/layoutSlice';
 import { isWellBehavedNumber } from './isWellBehavedNumber';
 
-export function useReportScale() {
+export function useReportScale(): Dispatch<SetStateAction<HTMLElement | null>> {
   const dispatch = useAppDispatch();
   const [ref, setRef] = useState<HTMLElement | null>(null);
   const scale = useAppSelector(selectContainerScale);


### PR DESCRIPTION
## Description

Codex Prompt: Add explicit return types to all methods and add explicit types to all method arguments where they are currently missing.

## Motivation and Context

Modern type inference is pretty sweet, but the more you rely on it in a static call graph the more expensive it becomes at compile time. Besides that, explicit types are pretty good documentation ;)

## How Has This Been Tested?

Compile time checking.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes
