### PR TITLE
Simplify rendering components with and without animation

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -544,17 +544,19 @@ function AreaWithAnimation({
         }
         return (
           <Layer>
-            <defs>
-              <clipPath id={`animationClipPath-${clipPathId}`}>
-                <ClipRect
-                  alpha={t}
-                  points={points}
-                  baseLine={baseLine}
-                  layout={props.layout}
-                  strokeWidth={props.strokeWidth}
-                />
-              </clipPath>
-            </defs>
+            {isAnimationActive && (
+              <defs>
+                <clipPath id={`animationClipPath-${clipPathId}`}>
+                  <ClipRect
+                    alpha={t}
+                    points={points}
+                    baseLine={baseLine}
+                    layout={props.layout}
+                    strokeWidth={props.strokeWidth}
+                  />
+                </clipPath>
+              </defs>
+            )}
             <Layer clipPath={`url(#animationClipPath-${clipPathId})`}>
               <StaticArea
                 points={points}
@@ -577,8 +579,6 @@ function AreaWithAnimation({
  * It also holds the state of the animation.
  */
 function RenderArea({ needClip, clipPathId, props }: { needClip: boolean; clipPathId: string; props: InternalProps }) {
-  const { points, baseLine, isAnimationActive } = props;
-
   /*
    * These two must be refs, not state!
    * Because we want to store the most recent shape of the animation in case we have to interrupt the animation;
@@ -590,39 +590,13 @@ function RenderArea({ needClip, clipPathId, props }: { needClip: boolean; clipPa
   const previousPointsRef = useRef<ReadonlyArray<AreaPointItem> | null>(null);
   const previousBaselineRef = useRef<InternalProps['baseLine'] | null>();
 
-  const prevPoints = previousPointsRef.current;
-  const prevBaseLine = previousBaselineRef.current;
-
-  if (
-    isAnimationActive &&
-    /*
-     * Here it's important that we unmount of AreaWithAnimation in case points are undefined
-     * - this will make sure to interrupt the animation if it's running.
-     * We still get to keep the last shape of the animation in the refs above.
-     */
-    points &&
-    points.length &&
-    (prevPoints !== points || prevBaseLine !== baseLine)
-  ) {
-    return (
-      <AreaWithAnimation
-        needClip={needClip}
-        clipPathId={clipPathId}
-        props={props}
-        previousPointsRef={previousPointsRef}
-        previousBaselineRef={previousBaselineRef}
-      />
-    );
-  }
-
   return (
-    <StaticArea
-      points={points}
-      baseLine={baseLine}
+    <AreaWithAnimation
       needClip={needClip}
       clipPathId={clipPathId}
       props={props}
-      showLabels
+      previousPointsRef={previousPointsRef}
+      previousBaselineRef={previousBaselineRef}
     />
   );
 }

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -469,19 +469,9 @@ function RectanglesWithAnimation({
 }
 
 function RenderRectangles(props: InternalProps) {
-  const { data, isAnimationActive } = props;
   const previousRectanglesRef = useRef<ReadonlyArray<BarRectangleItem> | null>(null);
 
-  if (
-    isAnimationActive &&
-    data &&
-    data.length &&
-    (previousRectanglesRef.current == null || previousRectanglesRef.current !== data)
-  ) {
-    return <RectanglesWithAnimation previousRectanglesRef={previousRectanglesRef} props={props} />;
-  }
-
-  return <BarRectangles props={props} data={data} showLabels />;
+  return <RectanglesWithAnimation previousRectanglesRef={previousRectanglesRef} props={props} />;
 }
 
 const defaultMinPointSize: number = 0;
@@ -507,7 +497,7 @@ const errorBarDataPointFormatter: ErrorBarDataPointFormatter = (
 class BarWithState extends PureComponent<InternalProps> {
   render() {
     const { hide, data, dataKey, className, xAxisId, yAxisId, needClip, background, id } = this.props;
-    if (hide) {
+    if (hide || data == null) {
       return null;
     }
 

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -208,7 +208,7 @@ function TrapezoidsWithAnimation({
   } = props;
   const prevTrapezoids = previousTrapezoidsRef.current;
 
-  const [isAnimating, setIsAnimating] = useState(true);
+  const [isAnimating, setIsAnimating] = useState(false);
 
   const animationId = useAnimationId(trapezoids, 'recharts-funnel-');
 
@@ -292,15 +292,9 @@ function TrapezoidsWithAnimation({
 }
 
 function RenderTrapezoids(props: InternalProps) {
-  const { trapezoids, isAnimationActive } = props;
-
   const previousTrapezoidsRef = useRef<ReadonlyArray<FunnelTrapezoidItem> | null>(null);
-  const prevTrapezoids = previousTrapezoidsRef.current;
 
-  if (isAnimationActive && trapezoids && trapezoids.length && (!prevTrapezoids || prevTrapezoids !== trapezoids)) {
-    return <TrapezoidsWithAnimation props={props} previousTrapezoidsRef={previousTrapezoidsRef} />;
-  }
-  return <FunnelTrapezoids trapezoids={trapezoids} allOtherFunnelProps={props} showLabels />;
+  return <TrapezoidsWithAnimation props={props} previousTrapezoidsRef={previousTrapezoidsRef} />;
 }
 
 const getRealWidthHeight = (customWidth: number | string | undefined, offset: ChartOffsetInternal) => {

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -413,12 +413,15 @@ function CurveWithAnimation({
         const lengthInterpolated = interpolate(startingPoint, totalLength + startingPoint, t);
         const curLength = Math.min(lengthInterpolated, totalLength);
         let currentStrokeDasharray;
-
-        if (strokeDasharray) {
-          const lines = `${strokeDasharray}`.split(/[,\s]+/gim).map(num => parseFloat(num));
-          currentStrokeDasharray = getStrokeDasharray(curLength, totalLength, lines);
+        if (isAnimationActive) {
+          if (strokeDasharray) {
+            const lines = `${strokeDasharray}`.split(/[,\s]+/gim).map(num => parseFloat(num));
+            currentStrokeDasharray = getStrokeDasharray(curLength, totalLength, lines);
+          } else {
+            currentStrokeDasharray = generateSimpleStrokeDasharray(totalLength, curLength);
+          }
         } else {
-          currentStrokeDasharray = generateSimpleStrokeDasharray(totalLength, curLength);
+          currentStrokeDasharray = strokeDasharray == null ? undefined : String(strokeDasharray);
         }
 
         if (prevPoints) {
@@ -513,26 +516,19 @@ function CurveWithAnimation({
 }
 
 function RenderCurve({ clipPathId, props }: { clipPathId: string; props: InternalProps }) {
-  const { points, isAnimationActive } = props;
   const previousPointsRef = useRef<ReadonlyArray<LinePointItem> | null>(null);
   const longestAnimatedLengthRef = useRef<number>(0);
   const pathRef = useRef<SVGPathElement | null>(null);
 
-  const prevPoints = previousPointsRef.current;
-
-  if (isAnimationActive && points && points.length && prevPoints !== points) {
-    return (
-      <CurveWithAnimation
-        props={props}
-        clipPathId={clipPathId}
-        previousPointsRef={previousPointsRef}
-        longestAnimatedLengthRef={longestAnimatedLengthRef}
-        pathRef={pathRef}
-      />
-    );
-  }
-
-  return <StaticCurve props={props} points={points} clipPathId={clipPathId} pathRef={pathRef} showLabels />;
+  return (
+    <CurveWithAnimation
+      props={props}
+      clipPathId={clipPathId}
+      previousPointsRef={previousPointsRef}
+      longestAnimatedLengthRef={longestAnimatedLengthRef}
+      pathRef={pathRef}
+    />
+  );
 }
 
 const errorBarDataPointFormatter: ErrorBarDataPointFormatter = (

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -344,19 +344,6 @@ function SymbolsWithAnimation({
   );
 }
 
-function RenderSymbols(props: InternalProps) {
-  const { points, isAnimationActive } = props;
-  const previousPointsRef = useRef<ReadonlyArray<ScatterPointItem> | null>(null);
-
-  const prevPoints = previousPointsRef.current;
-
-  if (isAnimationActive && points && points.length && (!prevPoints || prevPoints !== points)) {
-    return <SymbolsWithAnimation props={props} previousPointsRef={previousPointsRef} />;
-  }
-
-  return <ScatterSymbols points={points} allOtherScatterProps={props} showLabels />;
-}
-
 type InputRequiredToComputeTooltipEntrySettings = {
   dataKey?: DataKey<any> | undefined;
   points?: ReadonlyArray<ScatterPointItem>;
@@ -508,6 +495,7 @@ const errorBarDataPointFormatter = (
 
 function ScatterWithId(props: InternalProps) {
   const { hide, points, className, needClip, xAxisId, yAxisId, id, children } = props;
+  const previousPointsRef = useRef<ReadonlyArray<ScatterPointItem> | null>(null);
   if (hide) {
     return null;
   }
@@ -531,7 +519,7 @@ function ScatterWithId(props: InternalProps) {
         {children}
       </SetErrorBarContext>
       <Layer key="recharts-scatter-symbols">
-        <RenderSymbols {...props} />
+        <SymbolsWithAnimation props={props} previousPointsRef={previousPointsRef} />
       </Layer>
     </Layer>
   );
@@ -581,12 +569,9 @@ function ScatterImpl(props: Props) {
   if (needClip == null) {
     return null;
   }
-  /*
-   * Do not check if points is null here!
-   * It is important that the animation component receives `null` as points
-   * so that it can reset its internal state and start animating to new positions.
-   */
-  // if (points == null)
+  if (points == null) {
+    return null;
+  }
   return (
     <>
       <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={{ ...props, points }} />

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -319,7 +319,7 @@ function PolygonWithAnimation({
   } = props;
   const prevPoints = previousPointsRef.current;
   const animationId = useAnimationId(props, 'recharts-radar-');
-  const [isAnimating, setIsAnimating] = useState(true);
+  const [isAnimating, setIsAnimating] = useState(false);
 
   const handleAnimationEnd = useCallback(() => {
     if (typeof onAnimationEnd === 'function') {
@@ -386,15 +386,9 @@ function PolygonWithAnimation({
 }
 
 function RenderPolygon(props: Props) {
-  const { points, isAnimationActive, isRange } = props;
   const previousPointsRef = useRef<ReadonlyArray<RadarPoint> | undefined>(undefined);
-  const prevPoints = previousPointsRef.current;
 
-  if (isAnimationActive && points && points.length && !isRange && (!prevPoints || prevPoints !== points)) {
-    return <PolygonWithAnimation props={props} previousPointsRef={previousPointsRef} />;
-  }
-
-  return <StaticPolygon points={points} props={props} showLabels />;
+  return <PolygonWithAnimation props={props} previousPointsRef={previousPointsRef} />;
 }
 
 const defaultRadarProps: Partial<Props> = {
@@ -414,7 +408,7 @@ class RadarWithState extends PureComponent<Props> {
   render() {
     const { hide, className, points } = this.props;
 
-    if (hide) {
+    if (hide || points == null) {
       return null;
     }
 
@@ -439,7 +433,7 @@ class RadarWithState extends PureComponent<Props> {
 function RadarImpl(props: Props) {
   const isPanorama = useIsPanorama();
   const radarPoints = useAppSelector(state =>
-    selectRadarPoints(state, props.radiusAxisId, props.angleAxisId, isPanorama, props.dataKey),
+    selectRadarPoints(state, props.radiusAxisId, props.angleAxisId, isPanorama, props.id),
   );
 
   return (

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -144,7 +144,7 @@ function SectorsWithAnimation({
 
   const prevData = previousSectorsRef.current;
 
-  const [isAnimating, setIsAnimating] = useState(true);
+  const [isAnimating, setIsAnimating] = useState(false);
 
   const handleAnimationEnd = useCallback(() => {
     if (typeof onAnimationEnd === 'function') {
@@ -213,16 +213,9 @@ function SectorsWithAnimation({
 }
 
 function RenderSectors(props: RadialBarProps) {
-  const { data = [], isAnimationActive } = props;
-
   const previousSectorsRef = useRef<ReadonlyArray<RadialBarDataItem> | null>(null);
-  const prevData = previousSectorsRef.current;
 
-  if (isAnimationActive && data && data.length && (!prevData || prevData !== data)) {
-    return <SectorsWithAnimation props={props} previousSectorsRef={previousSectorsRef} />;
-  }
-
-  return <RadialBarSectors sectors={data} allOtherRadialBarProps={props} showLabels />;
+  return <SectorsWithAnimation props={props} previousSectorsRef={previousSectorsRef} />;
 }
 
 interface InternalRadialBarProps {

--- a/src/state/selectors/radarSelectors.ts
+++ b/src/state/selectors/radarSelectors.ts
@@ -12,6 +12,7 @@ import { selectChartLayout } from '../../context/chartLayoutContext';
 import { getBandSizeOfAxis, isCategoricalAxis, RechartsScale } from '../../util/ChartUtils';
 import { AngleAxisSettings, RadiusAxisSettings } from '../polarAxisSlice';
 import { selectUnfilteredPolarItems } from './polarSelectors';
+import { GraphicalItemId } from '../graphicalItemsSlice';
 
 const selectRadiusAxisScale = (state: RechartsRootState, radiusAxisId: AxisId): RechartsScale | undefined =>
   selectPolarAxisScale(state, 'radiusAxis', radiusAxisId);
@@ -111,20 +112,20 @@ export const selectAngleAxisWithScaleAndViewport: (
   },
 );
 
-const pickDataKey = (
+const pickId = (
   _state: RechartsRootState,
   _radiusAxisId: AxisId,
   _angleAxisId: AxisId,
   _isPanorama: boolean,
-  radarDataKey: DataKey<any> | undefined,
-): DataKey<any> | undefined => radarDataKey;
+  radarId: GraphicalItemId,
+): GraphicalItemId => radarId;
 
 const selectBandSizeOfAxis: (
   state: RechartsRootState,
   radiusAxisId: AxisId,
   angleAxisId: AxisId,
   isPanorama: boolean,
-  radarDataKey: DataKey<any> | undefined,
+  radarId: GraphicalItemId,
 ) => number | undefined = createSelector(
   [
     selectChartLayout,
@@ -152,23 +153,23 @@ const selectSynchronisedRadarDataKey: (
   _radiusAxisId: AxisId,
   _angleAxisId: AxisId,
   _isPanorama: boolean,
-  radarDataKey: DataKey<any> | undefined,
-) => DataKey<any> | undefined = createSelector(
-  [selectUnfilteredPolarItems, pickDataKey],
-  (graphicalItems, radarDataKey) => {
-    if (graphicalItems.some(pgis => pgis.type === 'radar' && radarDataKey === pgis.dataKey)) {
-      return radarDataKey;
-    }
+  radarId: GraphicalItemId,
+) => DataKey<any> | undefined = createSelector([selectUnfilteredPolarItems, pickId], (graphicalItems, radarId) => {
+  if (graphicalItems == null) {
     return undefined;
-  },
-);
+  }
+  // Find the radar item with the given radarId
+  const pgis = graphicalItems.find(item => item.type === 'radar' && radarId === item.id);
+  // If found, return its dataKey
+  return pgis?.dataKey;
+});
 
 export const selectRadarPoints: (
   state: RechartsRootState,
   radiusAxisId: AxisId,
   angleAxisId: AxisId,
   isPanorama: boolean,
-  radarDataKey: DataKey<any> | undefined,
+  radarId: GraphicalItemId,
 ) => RadarComposedData | undefined = createSelector(
   [
     selectRadiusAxisForRadar,

--- a/test/animation/JavascriptAnimate.timing.spec.tsx
+++ b/test/animation/JavascriptAnimate.timing.spec.tsx
@@ -76,6 +76,7 @@ describe('JavascriptAnimate timing', () => {
           duration={500}
           isActive={false}
           onAnimationStart={handleAnimationStart}
+          onAnimationEnd={handleAnimationEnd}
           animationManager={animationManager}
         >
           {() => <div className="test-wrapper" />}
@@ -85,7 +86,7 @@ describe('JavascriptAnimate timing', () => {
       await timeoutController.flushAllTimeouts();
 
       expect(handleAnimationStart).not.toHaveBeenCalled();
-      expect(handleAnimationStart).not.toHaveBeenCalled();
+      expect(handleAnimationEnd).not.toHaveBeenCalled();
     });
 
     it('should call children function with current time', async () => {

--- a/test/cartesian/Bar.animation.spec.tsx
+++ b/test/cartesian/Bar.animation.spec.tsx
@@ -193,6 +193,7 @@ describe('Bar animation', () => {
     it('should call onAnimationEnd callback when the animation ends', async () => {
       const { animationManager } = renderTestCase();
 
+      expect(onAnimationEnd).not.toHaveBeenCalled();
       await animationManager.setAnimationProgress(0.9);
       expect(onAnimationEnd).not.toHaveBeenCalled();
 

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -797,12 +797,12 @@ describe('<LineChart />', () => {
     expect(newLineDots[0].children).toHaveLength(3);
 
     // make sure the new first dot is the same as the old 2 dot, just in a new place
-    expect(lineDots[0].children[0]).toHaveAttribute('cx', margin.left.toString());
-    expect(lineDots[0].children[0]).toHaveAttribute('cy', '20');
+    expect(newLineDots[0].children[0]).toHaveAttribute('cx', margin.left.toString());
+    expect(newLineDots[0].children[0]).toHaveAttribute('cy', '20');
 
     // verify one of the dots that we expect to move when the brush happens
-    expect(lineDots[0].children[1]).toHaveAttribute('cx', '200');
-    expect(lineDots[0].children[1]).toHaveAttribute('cy', '126.66666666666667');
+    expect(newLineDots[0].children[1]).toHaveAttribute('cx', '200');
+    expect(newLineDots[0].children[1]).toHaveAttribute('cy', '126.66666666666667');
   });
 
   describe('Tooltip integration', () => {

--- a/test/polar/Pie.animation.spec.tsx
+++ b/test/polar/Pie.animation.spec.tsx
@@ -256,6 +256,7 @@ describe('Pie animation', () => {
     it('should call onAnimationEnd callback when the animation ends', async () => {
       const { animationManager } = renderTestCase();
 
+      expect(onAnimationEnd).not.toHaveBeenCalled();
       await animationManager.setAnimationProgress(0.9);
       expect(onAnimationEnd).not.toHaveBeenCalled();
 

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -486,7 +486,7 @@ describe('selectAxisDomain', () => {
       },
     ]);
     expect(domainSpy).toHaveBeenLastCalledWith([10, 20, 30, 40, 50, 60, 70, 80, 90]);
-    expect(domainSpy).toHaveBeenCalledTimes(3);
+    expect(domainSpy).toHaveBeenCalledTimes(2);
   });
 
   it('should return array indexes if there are multiple graphical items, and no explicit dataKey on the matching XAxis', () => {
@@ -551,7 +551,7 @@ describe('selectAxisDomain', () => {
       },
     ]);
     expect(domainSpy).toHaveBeenLastCalledWith([0, 1, 2, 3, 4, 5, 6, 7, 8]);
-    expect(domainSpy).toHaveBeenCalledTimes(3);
+    expect(domainSpy).toHaveBeenCalledTimes(2);
   });
 
   describe('XAxis with type = number', () => {
@@ -2703,7 +2703,7 @@ describe('selectErrorBarsSettings', () => {
             direction: 'x',
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(4);
       });
 
       it('should return YAxis error bars', () => {
@@ -2714,7 +2714,7 @@ describe('selectErrorBarsSettings', () => {
             direction: 'y',
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(4);
       });
     });
 

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -2534,7 +2534,7 @@ describe('selectErrorBarsSettings', () => {
             direction: 'x',
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should return YAxis error bars', () => {
@@ -2545,7 +2545,7 @@ describe('selectErrorBarsSettings', () => {
             direction: 'y',
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
     });
 

--- a/test/state/selectors/radarSelectors.spec.tsx
+++ b/test/state/selectors/radarSelectors.spec.tsx
@@ -18,7 +18,7 @@ import { exampleRadarData } from '../../_data';
 import { assertNotNull } from '../../helper/assertNotNull';
 
 describe('selectRadarPoints', () => {
-  const selector = (state: RechartsRootState) => selectRadarPoints(state, 0, 0, false, 'value');
+  const selector = (state: RechartsRootState) => selectRadarPoints(state, 0, 0, false, 'radar-value');
 
   shouldReturnUndefinedOutOfContext(selector);
   shouldReturnFromInitialState(selector, undefined);
@@ -31,7 +31,7 @@ describe('selectRadarPoints', () => {
     };
     render(
       <RadarChart width={500} height={500} data={exampleRadarData}>
-        <Radar dataKey="value" />
+        <Radar dataKey="value" id="radar-value" />
         <PolarAngleAxis dataKey="value" />
         <Comp />
       </RadarChart>,
@@ -168,8 +168,8 @@ describe('selectRadarPoints', () => {
 
   it('should return new data after interaction', () => {
     const spy = vi.fn();
-    const Comp = ({ dataKey }: { dataKey: string }): null => {
-      spy(useAppSelectorWithStableTest(state => selectRadarPoints(state, 0, 0, false, dataKey)));
+    const Comp = (): null => {
+      spy(useAppSelectorWithStableTest(state => selectRadarPoints(state, 0, 0, false, 'radar-value')));
       return null;
     };
     const TestCase = () => {
@@ -186,8 +186,8 @@ describe('selectRadarPoints', () => {
             </button>
           )}
           <RadarChart data={exampleRadarData} width={400} height={400}>
-            <Radar dataKey={dataKey} />
-            <Comp dataKey={dataKey} />
+            <Radar dataKey={dataKey} id="radar-value" />
+            <Comp />
           </RadarChart>
         </>
       );

--- a/test/state/selectors/selectors.spec.tsx
+++ b/test/state/selectors/selectors.spec.tsx
@@ -1236,7 +1236,7 @@ describe('selectTooltipState.tooltipItemPayloads', () => {
         <Pie data={[{ y: 10 }, { y: 20 }, { y: 30 }]} dataKey="y" />
       </PieChart>,
     );
-    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenCalledTimes(2);
     expectLastCalledWith(spy, [
       [
         [


### PR DESCRIPTION
## Description

We do not need separate component to check for `isAnimationActive` because `<JavascriptAnimation>` component does that internally already so we can just use that straight.

This change will make fixing https://github.com/recharts/recharts/issues/6215 easier because it means half the code now needs changing.

Refactor only, no functional change.

## Related Issue

https://github.com/recharts/recharts/issues/6215
