### PR TITLE
Ranged Radar chart animation

### DIFF
--- a/src/shape/Polygon.tsx
+++ b/src/shape/Polygon.tsx
@@ -11,7 +11,7 @@ const isValidatePoint = (point: Coordinate) => {
   return point && point.x === +point.x && point.y === +point.y;
 };
 
-const getParsedPoints = (points: Coordinate[] = []) => {
+const getParsedPoints = (points: ReadonlyArray<Coordinate> = []) => {
   let segmentPoints: Coordinate[][] = [[]];
 
   points.forEach(entry => {
@@ -34,7 +34,7 @@ const getParsedPoints = (points: Coordinate[] = []) => {
   return segmentPoints;
 };
 
-const getSinglePolygonPath = (points: Coordinate[], connectNulls?: boolean) => {
+const getSinglePolygonPath = (points: ReadonlyArray<Coordinate>, connectNulls?: boolean) => {
   let segmentPoints = getParsedPoints(points);
 
   if (connectNulls) {
@@ -56,19 +56,23 @@ const getSinglePolygonPath = (points: Coordinate[], connectNulls?: boolean) => {
   return segmentPoints.length === 1 ? `${polygonPath}Z` : polygonPath;
 };
 
-const getRanglePath = (points: Coordinate[], baseLinePoints: Coordinate[], connectNulls?: boolean) => {
+const getRanglePath = (
+  points: ReadonlyArray<Coordinate>,
+  baseLinePoints: ReadonlyArray<Coordinate>,
+  connectNulls?: boolean,
+) => {
   const outerPath = getSinglePolygonPath(points, connectNulls);
 
   return `${outerPath.slice(-1) === 'Z' ? outerPath.slice(0, -1) : outerPath}L${getSinglePolygonPath(
-    baseLinePoints.reverse(),
+    Array.from(baseLinePoints).reverse(),
     connectNulls,
   ).slice(1)}`;
 };
 
 interface PolygonProps {
   className?: string;
-  points?: Coordinate[];
-  baseLinePoints?: Coordinate[];
+  points?: ReadonlyArray<Coordinate>;
+  baseLinePoints?: ReadonlyArray<Coordinate>;
   connectNulls?: boolean;
 }
 


### PR DESCRIPTION
## Description

Ranged Radar animations were explicitly disabled in 2.x: https://github.com/recharts/recharts/blob/2.x/src/polar/Radar.tsx#L339 and I never noticed until I removed the condition in https://github.com/recharts/recharts/pull/6232.

Instead of adding the condition back let's add animation for ranged radar charts too.

## Related Issue

https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=2719

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/2b6ac6aa-efa0-4311-89c1-e253416b56f6

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes
