### PR TITLE
Make devTools registration opt-in (fixes #6250).

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -53,7 +53,7 @@ export const createRechartsStore = (
         externalEventsMiddleware.middleware,
         touchEventMiddleware.middleware,
       ]),
-    devTools: {
+    devTools: !!window.RECHARTS_DEV_TOOLS_ENABLED && {
       serialize: {
         replacer: reduxDevtoolsJsonStringifyReplacer,
       },
@@ -64,3 +64,9 @@ export const createRechartsStore = (
 
 export type RechartsRootState = ReturnType<typeof rootReducer>;
 export type AppDispatch = Dispatch<Action>;
+
+declare global {
+  interface Window {
+    RECHARTS_DEV_TOOLS_ENABLED?: boolean;
+  }
+}

--- a/storybook/preview.ts
+++ b/storybook/preview.ts
@@ -36,3 +36,6 @@ const preview: Preview = {
 export default preview;
 
 export const decorators: Decorator[] = [];
+
+// Enable dev tools in the storybook:
+window.RECHARTS_DEV_TOOLS_ENABLED = true;


### PR DESCRIPTION
## Description

Makes devTools-registration opt-in via global flag.

## Related Issue

#6250

## Motivation and Context

The [Redux DevTools](https://github.com/reduxjs/redux-devtools) browser extension does not handle multiple tabs with multiple registered stores well. They are all garbaged together in every instance of the opened dev tools.

You might have a production page open in one tab, showing a few recharts-charts. And then in another tab you have your own development software running, which uses redux for example, but doesn't even have any charts in it. But still you will get all the recharts store entries there.

For recharts developers using this, I would recommend using something like:

```
window.RECHARTS_DEV_TOOLS_ENABLED = process.env.NODE_ENV === 'development';
```

## How Has This Been Tested?

Used `pnpm patch` to patch recharts and see the effects in our app in the dev tools.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

This change only affects recharts-developers, not any chart implementation in the user-space.