### PR TITLE
fix: allow brush travelers to be controled by keys after mouse interaction

### DIFF
--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -743,17 +743,23 @@ class BrushWithState extends PureComponent<BrushWithStateProps, State> {
   }
 
   handleTravellerMoveKeyboard = (direction: 1 | -1, id: BrushTravellerId) => {
-    const { data, gap } = this.props;
+    const { data, gap, startIndex, endIndex } = this.props;
     // scaleValues are a list of coordinates. For example: [65, 250, 435, 620, 805, 990].
     const { scaleValues, startX, endX } = this.state;
     if (scaleValues == null) {
       return;
     }
-    // currentScaleValue refers to which coordinate the current traveller should be placed at.
-    const currentScaleValue = this.state[id];
 
-    const currentIndex = scaleValues.indexOf(currentScaleValue);
-    if (currentIndex === -1) {
+    // unless we search for the closest scaleValue to the current coordinate
+    // we need to move travelers via index when using the keyboard
+    let currentIndex: number = -1;
+    if (id === 'startX') {
+      currentIndex = startIndex;
+    } else if (id === 'endX') {
+      currentIndex = endIndex;
+    }
+
+    if (currentIndex < 0 || currentIndex >= data.length) {
       return;
     }
 

--- a/test/cartesian/Brush.spec.tsx
+++ b/test/cartesian/Brush.spec.tsx
@@ -415,6 +415,43 @@ describe('<Brush />', () => {
       });
     });
 
+    test('Travellers should move when valid keyboard events are fired AFTER mouse interaction', async () => {
+      const { container } = render(
+        <BarChart width={400} height={100} data={data}>
+          <Brush dataKey="value" x={100} y={50} width={400} height={40} />
+        </BarChart>,
+      );
+
+      const traveller = container.querySelector('.recharts-brush-traveller') as SVGGElement;
+
+      fireEvent.mouseDown(traveller);
+      fireEvent.mouseMove(traveller, { clientX: 30 });
+      fireEvent.mouseUp(traveller);
+
+      fireEvent.focus(traveller);
+
+      await waitFor(() => {
+        expect(container.querySelector('.recharts-brush-texts')).not.toBeNull();
+      });
+
+      const text = container.querySelector('.recharts-brush-texts text[text-anchor="end"]') as SVGGElement;
+      expect(text?.textContent).toBe('10');
+
+      fireEvent.keyDown(traveller, {
+        key: 'ArrowRight',
+      });
+      await waitFor(() => {
+        expect(text.textContent).toBe('20');
+      });
+
+      fireEvent.keyDown(traveller, {
+        key: 'ArrowLeft',
+      });
+      await waitFor(() => {
+        expect(text.textContent).toBe('10');
+      });
+    });
+
     const ControlledPanoramicBrush = () => {
       const [startIndex, setStartIndex] = useState<number | undefined>(3);
       const [endIndex, setEndIndex] = useState<number | undefined>(data.length - 1);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
We were taking the scale value of the current X of the brush even if that X value was in the middle of two actual Brush scale values and trying to find it in the list of real scale values

Instead we should just be able to rely on indices since we're just updating the index anyways.

Now you can tab to chart, move travelers, move travelers with the mouse, tab to chart, and the travelers will continue to move with the keyboard wheras before the would not

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fix https://github.com/recharts/recharts/issues/6265

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
fix https://github.com/recharts/recharts/issues/6265

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* red green unit test
* locally in storybook

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes
