### PR TITLE
Optimize Bar component rendering when activeBar is falsy

### DIFF
--- a/src/shape/Rectangle.tsx
+++ b/src/shape/Rectangle.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Rectangle
  */
 import * as React from 'react';
-import { SVGProps, useEffect, useRef, useState } from 'react';
+import { SVGProps, useEffect, useMemo, useRef, useState } from 'react';
 import { clsx } from 'clsx';
 import { AnimationDuration } from '../util/types';
 import { filterProps } from '../util/ReactUtils';
@@ -128,7 +128,8 @@ export const Rectangle: React.FC<Props> = rectangleProps => {
   const prevHeightRef = useRef<number>(height);
   const prevXRef = useRef<number>(x);
   const prevYRef = useRef<number>(y);
-  const animationId = useAnimationId(rectangleProps, 'rectangle-');
+  const animationIdInput = useMemo(() => ({ x, y, width, height, radius }), [x, y, width, height, radius]);
+  const animationId = useAnimationId(animationIdInput, 'rectangle-');
 
   if (x !== +x || y !== +y || width !== +width || height !== +height || width === 0 || height === 0) {
     return null;

--- a/src/util/svgPropertiesNoEvents.ts
+++ b/src/util/svgPropertiesNoEvents.ts
@@ -319,14 +319,14 @@ export function isSvgElementPropKey(key: PropertyKey): boolean {
   return allowedSvgKeys.includes(key);
 }
 
+export type SVGPropsNoEvents<T> = Pick<T, Extract<keyof T, SVGElementPropKeysType>>;
+
 /**
  * Filters an object to only include SVG properties. Removes all event handlers too.
  * @param obj - The object to filter
  * @returns A new object containing only valid SVG properties, excluding event handlers.
  */
-export function svgPropertiesNoEvents<T extends Record<string, any>>(
-  obj: T,
-): Pick<T, Extract<keyof T, SVGElementPropKeysType>> {
+export function svgPropertiesNoEvents<T extends Record<string, any>>(obj: T): SVGPropsNoEvents<T> {
   const filteredEntries = Object.entries(obj).filter(([key]) => isSvgElementPropKey(key));
-  return Object.fromEntries(filteredEntries) as Pick<T, Extract<keyof T, SVGElementPropKeysType>>;
+  return Object.fromEntries(filteredEntries) as SVGPropsNoEvents<T>;
 }


### PR DESCRIPTION
## Description

Do not read which index is active if we know we will never use this information anyway.

This optimizes the chart when `activeBar` is falsy. It remains slow when `activeBar` is set! But it is the same slow in 2.x.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/6267

## How Has This Been Tested?

### Exhibit A, before any changes

Mouse hover - 177m jank

Lot of time spent in rendering Rectangle - updateFunctionComponent 41% (256ms)

Chart takes about 4 seconds to load before it's interactive.

### Exhibit B: with optimized animation ID dependencies

Only generate new animation IDs when props that actually animate change.

Mouse hover - 50-110ms jank

updateFunctionComponent still high 52% (539ms)

Feels about the same in the browser, no subjective improvement.

4.5s to interactive.

### Exhibit C: with hooks extracted to child component

introduce `BarRectangleWithActiveState` that calls the selectActiveTooltipIndex selector in a child, not in a loop.

Mouse hover - 50-110ms jank

updateFunctionComponent still high - 46% 416ms

This subjectively feels faster but profile says it's about the same.

3.9s to interactive.

### Exhibit D: do not call hooks if active prop is not set

Adds BarRectangleNeverActive so that we never call any hooks if `activeBar` prop is falsy.

Looks like a jackpot, the Tooltip is as smooth as it gets on my 60fps screen.

Mouse hover - no jank

updateFunctionComponent Rectangle went away - it never updates at all. The Tooltip is still there, that has to stay.

3.8s to interactive, this didn't get any better.

Okay I'm happy with this. The chart remains slow with `activeBar` prop but that's the same in 2.x so it's not a regression anymore.
