### PR TITLE
type: add extensible type for LegendPayload interface

### DIFF
--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -33,6 +33,7 @@ export interface LegendPayload {
   payload?: {
     strokeDasharray?: number | string;
     value?: any;
+    [key: string]: any
   };
   formatter?: Formatter;
   inactive?: boolean;


### PR DESCRIPTION
## Description

changes on LegendPayload interface of payload property object. before: payload?: {
    strokeDasharray?: number | string;
    value?: any;
  };. this type doesn't accept custom properties.

now: payload?: {
    strokeDasharray?: number | string;
    value?: any;
    [key: string]: any
  };. this allows to pass any property setted without type errors.

## Motivation and Context

type error

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- type errors fixed

