### PR TITLE
Remove redundant `Rectangle` import (and fix linter warning in the same file)

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Key, MutableRefObject, PureComponent, ReactElement, ReactNode, useCallback, useRef, useState } from 'react';
 import { clsx } from 'clsx';
 import { Series } from 'victory-vendor/d3-shape';
-import { Rectangle, Props as RectangleProps } from '../shape/Rectangle';
+import { Props as RectangleProps } from '../shape/Rectangle';
 import { Layer } from '../container/Layer';
 import { ErrorBarDataItem, ErrorBarDataPointFormatter } from './ErrorBar';
 import { Cell } from '../component/Cell';

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -286,7 +286,7 @@ function BarBackground(props: BarBackgroundProps) {
           className: 'recharts-bar-background-rectangle',
         };
 
-        return <BarRectangle key={`background-bar-${i}`} {...barRectangleProps} />;
+        return <BarRectangle key={`background-bar-${barRectangleProps.index}`} {...barRectangleProps} />;
       })}
     </>
   );


### PR DESCRIPTION
## Description

The src/cartesian/Bar.tsx module has a redundant import of the <Rectangle /> component, that gets overwritten by the module-scoped Rectangle data type. This doesn't break any code, but e.g. tsup fails to parse the project without removing it.

## Motivation and Context

No change to the package behavior, this is just a quality-of-life improvement to allow tsup to compile typedefs.

## How Has This Been Tested?

Unit tests and linter run and pass

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes
