### PR TITLE
Enable dev tools via Global module instead of window

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -17,6 +17,7 @@ import { keyboardEventsMiddleware } from './keyboardEventsMiddleware';
 import { externalEventsMiddleware } from './externalEventsMiddleware';
 import { touchEventMiddleware } from './touchEventsMiddleware';
 import { errorBarReducer } from './errorBarSlice';
+import { Global } from '../util/Global';
 
 const rootReducer = combineReducers({
   brush: brushReducer,
@@ -53,7 +54,7 @@ export const createRechartsStore = (
         externalEventsMiddleware.middleware,
         touchEventMiddleware.middleware,
       ]),
-    devTools: !!window.RECHARTS_DEV_TOOLS_ENABLED && {
+    devTools: Global.devToolsEnabled && {
       serialize: {
         replacer: reduxDevtoolsJsonStringifyReplacer,
       },
@@ -64,9 +65,3 @@ export const createRechartsStore = (
 
 export type RechartsRootState = ReturnType<typeof rootReducer>;
 export type AppDispatch = Dispatch<Action>;
-
-declare global {
-  interface Window {
-    RECHARTS_DEV_TOOLS_ENABLED?: boolean;
-  }
-}

--- a/src/util/Global.ts
+++ b/src/util/Global.ts
@@ -2,5 +2,6 @@ const parseIsSsrByDefault = (): boolean =>
   !(typeof window !== 'undefined' && window.document && Boolean(window.document.createElement) && window.setTimeout);
 
 export const Global = {
+  devToolsEnabled: false,
   isSsr: parseIsSsrByDefault(),
 };

--- a/storybook/preview.ts
+++ b/storybook/preview.ts
@@ -1,5 +1,6 @@
 import { Decorator, Preview } from '@storybook/react-vite';
 import './global.css';
+import { Global } from '../src';
 
 const preview: Preview = {
   parameters: {
@@ -38,4 +39,4 @@ export default preview;
 export const decorators: Decorator[] = [];
 
 // Enable dev tools in the storybook:
-window.RECHARTS_DEV_TOOLS_ENABLED = true;
+Global.devToolsEnabled = true;


### PR DESCRIPTION
See https://github.com/recharts/recharts/pull/6264

Replaces `window.RECHARTS_DEV_TOOLS_ENABLED` with `Global.devToolsEnabled`