### PR TITLE
fix: don't filter zero out of brush scaleValues

### DIFF
--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -510,7 +510,7 @@ class BrushWithState extends PureComponent<BrushWithStateProps, State> {
       const scaleValues = prevScale
         .domain()
         .map(entry => prevScale(entry))
-        .filter(Boolean);
+        .filter(value => value != null);
 
       return {
         prevData: data,

--- a/storybook/stories/Examples/cartesian/Brush/Brush.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Brush/Brush.stories.tsx
@@ -90,3 +90,21 @@ export const PanoramicBrush = {
     );
   },
 };
+
+export const NoChartBrush = {
+  render: (_args: Args) => {
+    return (
+      <ComposedChart width={600} height={300} data={pageData}>
+        <Brush>
+          <LineChart>
+            <ReferenceLine key="test" stroke="red" strokeOpacity="red" strokeWidth={3} strokeLinecap="round" y={1000} />
+            <CartesianGrid strokeDasharray="1 1" verticalPoints={[10, 20, 30]} horizontalPoints={[10, 20, 30]} />
+            <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} />
+            <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+          </LineChart>
+        </Brush>
+        <RechartsHookInspector />
+      </ComposedChart>
+    );
+  },
+};

--- a/test/cartesian/Brush.spec.tsx
+++ b/test/cartesian/Brush.spec.tsx
@@ -226,6 +226,39 @@ describe('<Brush />', () => {
     });
   });
 
+  test('Should not filter out the value 0 in scaleValues and cause indices to be off by 1', async () => {
+    const { container } = render(
+      <ComposedChart width={200} height={100} data={data.slice(0, 6)} margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
+        <Brush>
+          <LineChart>
+            <Line dataKey="name" dot isAnimationActive={false} />
+          </LineChart>
+        </Brush>
+      </ComposedChart>,
+    );
+    const traveller = container.querySelectorAll('.recharts-brush-traveller')[1] as SVGGElement;
+    expect(traveller).toBeDefined();
+    fireEvent.focus(traveller);
+
+    const text = container.querySelector('.recharts-brush-texts text[text-anchor="start"]') as SVGGElement;
+    expect(text.textContent).toBe('5');
+
+    fireEvent.keyDown(traveller, {
+      key: 'ArrowLeft',
+    });
+    await waitFor(() => {
+      expect(text.textContent).toBe('4');
+    });
+    fireEvent.keyDown(traveller, {
+      key: 'ArrowRight',
+    });
+
+    await waitFor(() => {
+      // there are 6 data points, left and then right should have index 5
+      expect(text.textContent).toBe('5');
+    });
+  });
+
   test("Don't render any travellers or slide when data is empty in simple Brush", () => {
     const { container } = render(
       <BarChart width={400} height={100} data={[]}>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
we were filtering out `0` which breaks Brush when the first `scaleValue` in the list happens to be 0. This usually works because our default margin adds value to the scale values to make the first one > 0

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/6308

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
bug fix

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit test, storybook

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes
