### PR TITLE
ResponsiveContainer uses context instead of element cloning

### DIFF
--- a/src/chart/CartesianChart.tsx
+++ b/src/chart/CartesianChart.tsx
@@ -9,7 +9,6 @@ import { CartesianChartProps, Margin, TooltipEventType } from '../util/types';
 import { TooltipPayloadSearcher } from '../state/tooltipSlice';
 import { CategoricalChart } from './CategoricalChart';
 import { resolveDefaultProps } from '../util/resolveDefaultProps';
-import { isPositiveNumber } from '../util/isWellBehavedNumber';
 
 const defaultMargin: Margin = { top: 5, right: 5, bottom: 5, left: 5 };
 
@@ -44,10 +43,6 @@ export const CartesianChart = forwardRef<SVGSVGElement, CartesianChartOptions>(f
   const rootChartProps = resolveDefaultProps(props.categoricalChartProps, defaultProps);
 
   const { width, height, ...otherCategoricalProps } = rootChartProps;
-
-  if (!isPositiveNumber(width) || !isPositiveNumber(height)) {
-    return null;
-  }
 
   const {
     chartName,
@@ -85,7 +80,7 @@ export const CartesianChart = forwardRef<SVGSVGElement, CartesianChartOptions>(f
         syncMethod={rootChartProps.syncMethod}
         className={rootChartProps.className}
       />
-      <CategoricalChart {...otherCategoricalProps} width={width} height={height} ref={ref} />
+      <CategoricalChart {...otherCategoricalProps} ref={ref} />
     </RechartsStoreProvider>
   );
 });

--- a/src/chart/CategoricalChart.tsx
+++ b/src/chart/CategoricalChart.tsx
@@ -5,48 +5,44 @@ import { RechartsWrapper } from './RechartsWrapper';
 import { ClipPathProvider } from '../container/ClipPathProvider';
 import { CartesianChartProps } from '../util/types';
 import { svgPropertiesNoEvents } from '../util/svgPropertiesNoEvents';
+import { useChartHeight, useChartWidth } from '../context/chartLayoutContext';
 
-type CategoricalChartRequiredProps = CartesianChartProps & {
-  width: NonNullable<CartesianChartProps['width']>;
-  height: NonNullable<CartesianChartProps['height']>;
-};
+export const CategoricalChart = forwardRef<SVGSVGElement, CartesianChartProps>((props: CartesianChartProps, ref) => {
+  const { children, className, style, compact, title, desc, ...others } = props;
+  const width = useChartWidth();
+  const height = useChartHeight();
+  const attrs = svgPropertiesNoEvents(others);
 
-export const CategoricalChart = forwardRef<SVGSVGElement, CategoricalChartRequiredProps>(
-  (props: CategoricalChartRequiredProps, ref) => {
-    const { children, className, width, height, style, compact, title, desc, ...others } = props;
-    const attrs = svgPropertiesNoEvents(others);
-
-    // The "compact" mode is used as the panorama within Brush
-    if (compact) {
-      return (
-        <RootSurface otherAttributes={attrs} title={title} desc={desc}>
-          {children}
-        </RootSurface>
-      );
-    }
-
+  // The "compact" mode is used as the panorama within Brush
+  if (compact) {
     return (
-      <RechartsWrapper
-        className={className}
-        style={style}
-        width={width}
-        height={height}
-        onClick={props.onClick}
-        onMouseLeave={props.onMouseLeave}
-        onMouseEnter={props.onMouseEnter}
-        onMouseMove={props.onMouseMove}
-        onMouseDown={props.onMouseDown}
-        onMouseUp={props.onMouseUp}
-        onContextMenu={props.onContextMenu}
-        onDoubleClick={props.onDoubleClick}
-        onTouchStart={props.onTouchStart}
-        onTouchMove={props.onTouchMove}
-        onTouchEnd={props.onTouchEnd}
-      >
-        <RootSurface otherAttributes={attrs} title={title} desc={desc} ref={ref}>
-          <ClipPathProvider>{children}</ClipPathProvider>
-        </RootSurface>
-      </RechartsWrapper>
+      <RootSurface otherAttributes={attrs} title={title} desc={desc}>
+        {children}
+      </RootSurface>
     );
-  },
-);
+  }
+
+  return (
+    <RechartsWrapper
+      className={className}
+      style={style}
+      width={width}
+      height={height}
+      onClick={props.onClick}
+      onMouseLeave={props.onMouseLeave}
+      onMouseEnter={props.onMouseEnter}
+      onMouseMove={props.onMouseMove}
+      onMouseDown={props.onMouseDown}
+      onMouseUp={props.onMouseUp}
+      onContextMenu={props.onContextMenu}
+      onDoubleClick={props.onDoubleClick}
+      onTouchStart={props.onTouchStart}
+      onTouchMove={props.onTouchMove}
+      onTouchEnd={props.onTouchEnd}
+    >
+      <RootSurface otherAttributes={attrs} title={title} desc={desc} ref={ref}>
+        <ClipPathProvider>{children}</ClipPathProvider>
+      </RootSurface>
+    </RechartsWrapper>
+  );
+});

--- a/src/chart/PolarChart.tsx
+++ b/src/chart/PolarChart.tsx
@@ -10,7 +10,6 @@ import { Margin, PolarChartProps, TooltipEventType } from '../util/types';
 import { TooltipPayloadSearcher } from '../state/tooltipSlice';
 import { CategoricalChart } from './CategoricalChart';
 import { resolveDefaultProps } from '../util/resolveDefaultProps';
-import { isPositiveNumber } from '../util/isWellBehavedNumber';
 
 const defaultMargin: Margin = { top: 5, right: 5, bottom: 5, left: 5 };
 
@@ -66,10 +65,6 @@ export const PolarChart = forwardRef<SVGSVGElement, PolarChartOptions>(function 
 
   const { width, height, layout, ...otherCategoricalProps } = polarChartProps;
 
-  if (!isPositiveNumber(width) || !isPositiveNumber(height)) {
-    return null;
-  }
-
   const { chartName, defaultTooltipEventType, validateTooltipEventTypes, tooltipPayloadSearcher } = props;
 
   const options: ChartOptions = {
@@ -103,7 +98,7 @@ export const PolarChart = forwardRef<SVGSVGElement, PolarChartOptions>(function 
         innerRadius={polarChartProps.innerRadius}
         outerRadius={polarChartProps.outerRadius}
       />
-      <CategoricalChart width={width} height={height} {...otherCategoricalProps} ref={ref} />
+      <CategoricalChart {...otherCategoricalProps} ref={ref} />
     </RechartsStoreProvider>
   );
 });

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -819,108 +819,16 @@ const sankeyDefaultProps = {
 
 type PropsWithResolvedDefaults = RequiresDefaultProps<Props, typeof sankeyDefaultProps>;
 
-function SankeyImpl(
-  props: PropsWithResolvedDefaults & {
-    links: ReadonlyArray<SankeyLink>;
-    modifiedNodes: NodeProps[];
-    modifiedLinks: LinkProps[];
-  },
-) {
-  const { className, style, children, links, ...others } = props;
-  const { link, dataKey, node, onMouseEnter, onMouseLeave, onClick, modifiedNodes, modifiedLinks } = props;
-
-  const tooltipPortal: Ref<HTMLDivElement | null> = useRef<HTMLDivElement | null>(null);
-
-  const attrs = svgPropertiesNoEvents(others);
-
-  const width = useChartWidth();
-  const height = useChartHeight();
-
-  const handleMouseEnter = useCallback(
-    (item: NodeProps | LinkProps, type: SankeyElementType, e: MouseEvent) => {
-      if (onMouseEnter) {
-        onMouseEnter(item, type, e);
-      }
-    },
-    [onMouseEnter],
-  );
-
-  const handleMouseLeave = useCallback(
-    (item: NodeProps | LinkProps, type: SankeyElementType, e: MouseEvent) => {
-      if (onMouseLeave) {
-        onMouseLeave(item, type, e);
-      }
-    },
-    [onMouseLeave],
-  );
-
-  const handleClick = useCallback(
-    (item: NodeProps | LinkProps, type: SankeyElementType, e: MouseEvent) => {
-      if (onClick) {
-        onClick(item, type, e);
-      }
-    },
-    [onClick],
-  );
-
-  if (!isPositiveNumber(width) || !isPositiveNumber(height)) {
-    return null;
-  }
-
-  return (
-    <TooltipPortalContext.Provider value={tooltipPortal.current}>
-      <RechartsWrapper
-        className={className}
-        style={style}
-        width={width}
-        height={height}
-        ref={tooltipPortal}
-        onMouseEnter={undefined}
-        onMouseLeave={undefined}
-        onClick={undefined}
-        onMouseMove={undefined}
-        onMouseDown={undefined}
-        onMouseUp={undefined}
-        onContextMenu={undefined}
-        onDoubleClick={undefined}
-        onTouchStart={undefined}
-        onTouchMove={undefined}
-        onTouchEnd={undefined}
-      >
-        <Surface {...attrs} width={width} height={height}>
-          {children}
-          <AllSankeyLinkElements
-            links={links}
-            modifiedLinks={modifiedLinks}
-            linkContent={link}
-            dataKey={dataKey}
-            onMouseEnter={(linkProps: LinkProps, e: MouseEvent) => handleMouseEnter(linkProps, 'link', e)}
-            onMouseLeave={(linkProps: LinkProps, e: MouseEvent) => handleMouseLeave(linkProps, 'link', e)}
-            onClick={(linkProps: LinkProps, e: MouseEvent) => handleClick(linkProps, 'link', e)}
-          />
-          <AllNodeElements
-            modifiedNodes={modifiedNodes}
-            nodeContent={node}
-            dataKey={dataKey}
-            onMouseEnter={(nodeProps: NodeProps, e: MouseEvent) => handleMouseEnter(nodeProps, 'node', e)}
-            onMouseLeave={(nodeProps: NodeProps, e: MouseEvent) => handleMouseLeave(nodeProps, 'node', e)}
-            onClick={(nodeProps: NodeProps, e: MouseEvent) => handleClick(nodeProps, 'node', e)}
-          />
-        </Surface>
-      </RechartsWrapper>
-    </TooltipPortalContext.Provider>
-  );
-}
-
-export function Sankey(outsideProps: Props) {
-  const props: PropsWithResolvedDefaults = resolveDefaultProps(outsideProps, sankeyDefaultProps);
+function SankeyImpl(props: PropsWithResolvedDefaults) {
+  const { className, style, children, ...others } = props;
   const {
-    data,
-    width,
-    height,
-    className,
     link,
+    dataKey,
     node,
+    onMouseEnter,
+    onMouseLeave,
+    onClick,
+    data,
     iterations,
     nodeWidth,
     nodePadding,
@@ -928,6 +836,13 @@ export function Sankey(outsideProps: Props) {
     linkCurvature,
     margin,
   } = props;
+
+  const tooltipPortal: Ref<HTMLDivElement | null> = useRef<HTMLDivElement | null>(null);
+
+  const attrs = svgPropertiesNoEvents(others);
+
+  const width = useChartWidth();
+  const height = useChartHeight();
 
   const { links, modifiedLinks, modifiedNodes } = useMemo(() => {
     if (!data || !width || !height || width <= 0 || height <= 0) {
@@ -969,17 +884,95 @@ export function Sankey(outsideProps: Props) {
     };
   }, [data, width, height, margin, iterations, nodeWidth, nodePadding, sort, link, node, linkCurvature]);
 
+  const handleMouseEnter = useCallback(
+    (item: NodeProps | LinkProps, type: SankeyElementType, e: MouseEvent) => {
+      if (onMouseEnter) {
+        onMouseEnter(item, type, e);
+      }
+    },
+    [onMouseEnter],
+  );
+
+  const handleMouseLeave = useCallback(
+    (item: NodeProps | LinkProps, type: SankeyElementType, e: MouseEvent) => {
+      if (onMouseLeave) {
+        onMouseLeave(item, type, e);
+      }
+    },
+    [onMouseLeave],
+  );
+
+  const handleClick = useCallback(
+    (item: NodeProps | LinkProps, type: SankeyElementType, e: MouseEvent) => {
+      if (onClick) {
+        onClick(item, type, e);
+      }
+    },
+    [onClick],
+  );
+
   if (!isPositiveNumber(width) || !isPositiveNumber(height) || !data || !data.links || !data.nodes) {
     return null;
   }
 
   return (
+    <>
+      <SetComputedData computedData={{ links: modifiedLinks, nodes: modifiedNodes }} />
+      <TooltipPortalContext.Provider value={tooltipPortal.current}>
+        <RechartsWrapper
+          className={className}
+          style={style}
+          width={width}
+          height={height}
+          ref={tooltipPortal}
+          onMouseEnter={undefined}
+          onMouseLeave={undefined}
+          onClick={undefined}
+          onMouseMove={undefined}
+          onMouseDown={undefined}
+          onMouseUp={undefined}
+          onContextMenu={undefined}
+          onDoubleClick={undefined}
+          onTouchStart={undefined}
+          onTouchMove={undefined}
+          onTouchEnd={undefined}
+        >
+          <Surface {...attrs} width={width} height={height}>
+            {children}
+            <AllSankeyLinkElements
+              links={links}
+              modifiedLinks={modifiedLinks}
+              linkContent={link}
+              dataKey={dataKey}
+              onMouseEnter={(linkProps: LinkProps, e: MouseEvent) => handleMouseEnter(linkProps, 'link', e)}
+              onMouseLeave={(linkProps: LinkProps, e: MouseEvent) => handleMouseLeave(linkProps, 'link', e)}
+              onClick={(linkProps: LinkProps, e: MouseEvent) => handleClick(linkProps, 'link', e)}
+            />
+            <AllNodeElements
+              modifiedNodes={modifiedNodes}
+              nodeContent={node}
+              dataKey={dataKey}
+              onMouseEnter={(nodeProps: NodeProps, e: MouseEvent) => handleMouseEnter(nodeProps, 'node', e)}
+              onMouseLeave={(nodeProps: NodeProps, e: MouseEvent) => handleMouseLeave(nodeProps, 'node', e)}
+              onClick={(nodeProps: NodeProps, e: MouseEvent) => handleClick(nodeProps, 'node', e)}
+            />
+          </Surface>
+        </RechartsWrapper>
+      </TooltipPortalContext.Provider>
+    </>
+  );
+}
+
+export function Sankey(outsideProps: Props) {
+  const props: PropsWithResolvedDefaults = resolveDefaultProps(outsideProps, sankeyDefaultProps);
+  const { width, height, className } = props;
+
+  return (
     <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={className ?? 'Sankey'}>
       <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={props} />
-      <SetComputedData computedData={{ links: modifiedLinks, nodes: modifiedNodes }} />
       <ReportChartSize width={width} height={height} />
       <ReportChartMargin margin={defaultSankeyMargin} />
-      <SankeyImpl {...props} links={links} modifiedLinks={modifiedLinks} modifiedNodes={modifiedNodes} />
+      <SankeyImpl {...props} />
     </RechartsStoreProvider>
   );
 }

--- a/src/chart/SunburstChart.tsx
+++ b/src/chart/SunburstChart.tsx
@@ -8,7 +8,7 @@ import { Layer } from '../container/Layer';
 import { Sector } from '../shape/Sector';
 import { Text } from '../component/Text';
 import { polarToCartesian } from '../util/PolarUtils';
-import { ReportChartMargin, ReportChartSize } from '../context/chartLayoutContext';
+import { ReportChartMargin, ReportChartSize, useChartHeight, useChartWidth } from '../context/chartLayoutContext';
 import { TooltipPortalContext } from '../context/tooltipPortalContext';
 import { RechartsWrapper } from './RechartsWrapper';
 import {
@@ -181,8 +181,6 @@ const SunburstChartImpl = ({
   className,
   data,
   children,
-  width,
-  height,
   padding = 2,
   dataKey = 'value',
   nameKey = 'name',
@@ -191,9 +189,9 @@ const SunburstChartImpl = ({
   fill = '#333',
   stroke = '#FFF',
   textOptions = defaultTextProps,
-  outerRadius = Math.min(width, height) / 2,
-  cx = width / 2,
-  cy = height / 2,
+  outerRadius: outerRadiusFromProps,
+  cx: cxFromProps,
+  cy: cyFromProps,
   startAngle = 0,
   endAngle = 360,
   onClick,
@@ -201,6 +199,13 @@ const SunburstChartImpl = ({
   onMouseLeave,
 }: SunburstChartProps) => {
   const dispatch = useAppDispatch();
+
+  const width = useChartWidth();
+  const height = useChartHeight();
+
+  const outerRadius = outerRadiusFromProps ?? Math.min(width, height) / 2;
+  const cx = cxFromProps ?? width / 2;
+  const cy = cyFromProps ?? height / 2;
 
   const rScale = scaleLinear([0, data[dataKey]], [0, endAngle]);
   const treeDepth = getMaxDepthOf(data);

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -13,7 +13,7 @@ import { isNan, uniqueId } from '../util/DataUtils';
 import { getStringSize } from '../util/DOMUtils';
 import { Global } from '../util/Global';
 import { AnimationDuration, AnimationTiming, DataKey, Margin, RectanglePosition } from '../util/types';
-import { ReportChartMargin, ReportChartSize } from '../context/chartLayoutContext';
+import { ReportChartMargin, ReportChartSize, useChartHeight, useChartWidth } from '../context/chartLayoutContext';
 import { TooltipPortalContext } from '../context/tooltipPortalContext';
 import { RechartsWrapper } from './RechartsWrapper';
 import {
@@ -938,15 +938,16 @@ class TreemapWithState extends PureComponent<InternalTreemapProps, State> {
 
 function TreemapDispatchInject(props: Props) {
   const dispatch = useAppDispatch();
-  return <TreemapWithState {...props} dispatch={dispatch} />;
+  const width = useChartWidth();
+  const height = useChartHeight();
+  if (!isPositiveNumber(width) || !isPositiveNumber(height)) {
+    return null;
+  }
+  return <TreemapWithState {...props} width={width} height={height} dispatch={dispatch} />;
 }
 
 export function Treemap(props: Props) {
   const { width, height } = props;
-
-  if (!isPositiveNumber(width) || !isPositiveNumber(height)) {
-    return null;
-  }
 
   return (
     <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={props.className ?? 'Treemap'}>

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -26,10 +26,12 @@ export interface Props {
   aspect?: number;
   /**
    * The width of the container. If a percentage string is specified, it is calculated responsive to the width of the parent element.
+   * @default '100%'
    */
   width?: Percent | number;
   /**
    * The height of the container. If a percentage string is specified, it is calculated responsive to the height of the parent element.
+   * @default '100%'
    */
   height?: Percent | number;
   /**

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -7,6 +7,7 @@ import { selectChartOffsetInternal, selectChartViewBox } from '../state/selector
 import { selectChartHeight, selectChartWidth } from '../state/selectors/containerSelectors';
 import { useIsPanorama } from './PanoramaContext';
 import { selectBrushDimensions, selectBrushSettings } from '../state/selectors/brushSelectors';
+import { useResponsiveContainerContext } from '../component/ResponsiveContainer';
 
 export const useViewBox = (): CartesianViewBoxRequired | undefined => {
   const panorama = useIsPanorama();
@@ -111,9 +112,31 @@ export const useChartLayout = () => useAppSelector(selectChartLayout);
 export const ReportChartSize = (props: Size): null => {
   const dispatch = useAppDispatch();
 
+  const { width: widthFromProps, height: heightFromProps } = props;
+  const responsiveContainerCalculations = useResponsiveContainerContext();
+
+  let width = widthFromProps;
+  let height = heightFromProps;
+
+  if (responsiveContainerCalculations) {
+    /*
+     * In case we receive width and height from ResponsiveContainer,
+     * we will always prefer those.
+     * Only in case ResponsiveContainer does not provide width or height,
+     * we will fall back to the explicitly provided width and height.
+     *
+     * This to me feels backwards - we should allow override by the more specific props on individual charts, right?
+     * But this is 3.x behaviour, so let's keep it for backwards compatibility.
+     *
+     * We can change this in 4.x if we want to.
+     */
+    width = responsiveContainerCalculations.width > 0 ? responsiveContainerCalculations.width : widthFromProps;
+    height = responsiveContainerCalculations.height > 0 ? responsiveContainerCalculations.height : heightFromProps;
+  }
+
   useEffect(() => {
-    dispatch(setChartSize(props));
-  }, [dispatch, props]);
+    dispatch(setChartSize({ width, height }));
+  }, [dispatch, width, height]);
 
   return null;
 };

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -112,6 +112,14 @@ export const useChartLayout = () => useAppSelector(selectChartLayout);
 export const ReportChartSize = (props: Size): null => {
   const dispatch = useAppDispatch();
 
+  /*
+   * Skip dispatching properties in panorama chart for two reasons:
+   * 1. The root chart should be deciding on these properties, and
+   * 2. Brush reads these properties from redux store, and so they must remain stable
+   *      to avoid circular dependency and infinite re-rendering.
+   */
+  const isPanorama = useIsPanorama();
+
   const { width: widthFromProps, height: heightFromProps } = props;
   const responsiveContainerCalculations = useResponsiveContainerContext();
 
@@ -135,8 +143,10 @@ export const ReportChartSize = (props: Size): null => {
   }
 
   useEffect(() => {
-    dispatch(setChartSize({ width, height }));
-  }, [dispatch, width, height]);
+    if (!isPanorama) {
+      dispatch(setChartSize({ width, height }));
+    }
+  }, [dispatch, isPanorama, width, height]);
 
   return null;
 };

--- a/src/state/ReportMainChartProps.tsx
+++ b/src/state/ReportMainChartProps.tsx
@@ -1,8 +1,10 @@
-import { useEffect } from 'react';
+import * as React from 'react';
+import { ReactNode, useEffect } from 'react';
 import { LayoutType, Margin } from '../util/types';
 import { useIsPanorama } from '../context/PanoramaContext';
-import { setChartSize, setLayout, setMargin } from './layoutSlice';
+import { setLayout, setMargin } from './layoutSlice';
 import { useAppDispatch } from './hooks';
+import { ReportChartSize } from '../context/chartLayoutContext';
 
 /**
  * "Main" props are props that are only accepted on the main chart,
@@ -15,7 +17,7 @@ type MainChartProps = {
   margin: Partial<Margin>;
 };
 
-export function ReportMainChartProps({ layout, width, height, margin }: MainChartProps): null {
+export function ReportMainChartProps({ layout, width, height, margin }: MainChartProps): ReactNode {
   const dispatch = useAppDispatch();
 
   /*
@@ -34,9 +36,8 @@ export function ReportMainChartProps({ layout, width, height, margin }: MainChar
   useEffect(() => {
     if (!isPanorama) {
       dispatch(setLayout(layout));
-      dispatch(setChartSize({ width, height }));
       dispatch(setMargin(margin));
     }
   }, [dispatch, isPanorama, layout, width, height, margin]);
-  return null;
+  return <ReportChartSize width={width} height={height} />;
 }

--- a/storybook/stories/API/cartesian/CartesianAxis.stories.tsx
+++ b/storybook/stories/API/cartesian/CartesianAxis.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Args } from '@storybook/react-vite';
-import { CartesianAxis, ResponsiveContainer, Surface } from '../../../../src';
+import { CartesianAxis, Surface } from '../../../../src';
 import { ticks } from '../../data';
 
 const GeneralProps: Args = {
@@ -178,28 +178,26 @@ export const API = {
   render: (args: Record<string, any>) => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
     return (
-      <ResponsiveContainer width="100%" height={surfaceHeight}>
-        <Surface
-          width={surfaceWidth}
-          height={surfaceHeight}
+      <Surface
+        width={surfaceWidth}
+        height={surfaceHeight}
+        viewBox={{
+          x: 0,
+          y: 0,
+          width: surfaceWidth,
+          height: surfaceHeight,
+        }}
+      >
+        <CartesianAxis
           viewBox={{
             x: 0,
             y: 0,
             width: surfaceWidth,
             height: surfaceHeight,
           }}
-        >
-          <CartesianAxis
-            viewBox={{
-              x: 0,
-              y: 0,
-              width: surfaceWidth,
-              height: surfaceHeight,
-            }}
-            {...args}
-          />
-        </Surface>
-      </ResponsiveContainer>
+          {...args}
+        />
+      </Surface>
     );
   },
   args: {

--- a/storybook/stories/API/chart/ComposedChart.stories.tsx
+++ b/storybook/stories/API/chart/ComposedChart.stories.tsx
@@ -144,9 +144,9 @@ export const LineBarAreaScatterTimeScale = {
       });
     };
     return (
-      <ResponsiveContainer width="100%" height={500}>
-        <div style={{ width: '600px', margin: 'auto' }}>
-          <p>A ComposedChart of time scale</p>
+      <div style={{ width: '600px' }}>
+        <p>A ComposedChart of time scale</p>
+        <ResponsiveContainer width="100%" height={500}>
           <div className="composed-chart-wrapper">
             <Composed
               width={600}
@@ -177,8 +177,8 @@ export const LineBarAreaScatterTimeScale = {
               <RechartsHookInspector />
             </Composed>
           </div>
-        </div>
-      </ResponsiveContainer>
+        </ResponsiveContainer>
+      </div>
     );
   },
   args: {

--- a/storybook/stories/API/component/Text.stories.tsx
+++ b/storybook/stories/API/component/Text.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ResponsiveContainer, Surface, Text } from '../../../../src';
+import { Surface, Text } from '../../../../src';
 import { TextProps } from '../props/TextProps';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 
@@ -13,12 +13,10 @@ export default {
 export const API = {
   render: (args: Record<string, any>) => {
     return (
-      <ResponsiveContainer width={500} height={300}>
-        <Surface width={500} height={80}>
-          <Text {...args}>{args.content}</Text>
-          <RechartsHookInspector />
-        </Surface>
-      </ResponsiveContainer>
+      <Surface width={500} height={300}>
+        <Text {...args}>{args.content}</Text>
+        <RechartsHookInspector />
+      </Surface>
     );
   },
   args: {

--- a/storybook/stories/API/polar/PolarGrid.stories.tsx
+++ b/storybook/stories/API/polar/PolarGrid.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Args } from '@storybook/react-vite';
-import { PolarGrid, ResponsiveContainer, Surface } from '../../../../src';
+import { PolarGrid, Surface } from '../../../../src';
 
 const GeneralProps: Args = {
   cx: {
@@ -65,20 +65,18 @@ const [surfaceWidth, surfaceHeight] = [500, 500];
 export const Simple = {
   render: (args: Record<string, any>) => {
     return (
-      <ResponsiveContainer width="100%" height={surfaceHeight}>
-        <Surface
-          width={surfaceWidth}
-          height={surfaceHeight}
-          viewBox={{
-            x: 0,
-            y: 0,
-            width: surfaceWidth,
-            height: surfaceHeight,
-          }}
-        >
-          <PolarGrid cx={250} cy={250} innerRadius={0} outerRadius={200} {...args} />
-        </Surface>
-      </ResponsiveContainer>
+      <Surface
+        width={surfaceWidth}
+        height={surfaceHeight}
+        viewBox={{
+          x: 0,
+          y: 0,
+          width: surfaceWidth,
+          height: surfaceHeight,
+        }}
+      >
+        <PolarGrid cx={250} cy={250} innerRadius={0} outerRadius={200} {...args} />
+      </Surface>
     );
   },
   args: {

--- a/storybook/stories/Examples/cartesian/Brush/BrushInSurface.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Brush/BrushInSurface.stories.tsx
@@ -14,7 +14,6 @@ export const InSurface = {
       endIndex?: number;
     }
 
-    const [surfaceWidth, surfaceHeight] = [600, 500];
     const [simple, setSimple] = React.useState<BrushStartEndIndex>({
       startIndex: 0,
       endIndex: dateData.length - 1,
@@ -48,36 +47,34 @@ export const InSurface = {
     };
 
     return (
-      <ResponsiveContainer width="100%" height={surfaceHeight}>
-        <div style={{ margin: 'auto', width: surfaceWidth }}>
-          <p>Simple Brush</p>
-          <ComposedChart data={dateData} width={surfaceWidth} height={200}>
-            <Brush
-              startIndex={simple.startIndex}
-              endIndex={simple.endIndex}
-              x={100}
-              y={50}
-              width={400}
-              height={40}
-              onChange={handleChange}
-              traveller={renderTraveller}
-            />
-          </ComposedChart>
-          <p>Brush has specified gap</p>
-          <ComposedChart width={surfaceWidth} height={200} data={dateData}>
-            <Brush
-              startIndex={gap.startIndex}
-              endIndex={gap.endIndex}
-              x={100}
-              y={50}
-              width={400}
-              height={40}
-              gap={5}
-              onChange={handleGapChange}
-            />
-            <RechartsHookInspector />
-          </ComposedChart>
-        </div>
+      <ResponsiveContainer width="100%" height={200}>
+        <p>Simple Brush</p>
+        <ComposedChart data={dateData}>
+          <Brush
+            startIndex={simple.startIndex}
+            endIndex={simple.endIndex}
+            x={100}
+            y={50}
+            width={400}
+            height={40}
+            onChange={handleChange}
+            traveller={renderTraveller}
+          />
+        </ComposedChart>
+        <p>Brush has specified gap</p>
+        <ComposedChart data={dateData}>
+          <Brush
+            startIndex={gap.startIndex}
+            endIndex={gap.endIndex}
+            x={100}
+            y={50}
+            width={400}
+            height={40}
+            gap={5}
+            onChange={handleGapChange}
+          />
+          <RechartsHookInspector />
+        </ComposedChart>
       </ResponsiveContainer>
     );
   },

--- a/storybook/stories/Examples/cartesian/CartesianAxis/MultipleAxes.stories.tsx
+++ b/storybook/stories/Examples/cartesian/CartesianAxis/MultipleAxes.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CartesianAxis, Label, ResponsiveContainer, Surface } from '../../../../../src';
+import { CartesianAxis, Label, Surface } from '../../../../../src';
 import { ticks } from '../../../data';
 
 export default {
@@ -10,74 +10,72 @@ export const MultipleAxes = {
   render: () => {
     const [surfaceWidth, surfaceHeight] = [600, 300];
     return (
-      <ResponsiveContainer width="100%" height={surfaceHeight}>
-        <Surface
-          width={surfaceWidth}
-          height={surfaceHeight}
+      <Surface
+        width={surfaceWidth}
+        height={surfaceHeight}
+        viewBox={{
+          x: 0,
+          y: 0,
+          width: surfaceWidth,
+          height: surfaceHeight,
+        }}
+      >
+        <CartesianAxis
+          orientation="bottom"
+          y={100}
+          width={400}
+          height={50}
           viewBox={{
             x: 0,
             y: 0,
-            width: surfaceWidth,
-            height: surfaceHeight,
+            width: 500,
+            height: 500,
           }}
+          ticks={ticks}
+          label="test"
         >
-          <CartesianAxis
-            orientation="bottom"
-            y={100}
-            width={400}
-            height={50}
-            viewBox={{
-              x: 0,
-              y: 0,
-              width: 500,
-              height: 500,
-            }}
-            ticks={ticks}
-            label="test"
-          >
-            <Label>测试</Label>
-          </CartesianAxis>
-          <CartesianAxis
-            orientation="top"
-            y={200}
-            width={400}
-            height={50}
-            viewBox={{
-              x: 0,
-              y: 0,
-              width: 500,
-              height: 500,
-            }}
-            ticks={ticks}
-          />
-          <CartesianAxis
-            orientation="left"
-            x={50}
-            width={50}
-            height={400}
-            viewBox={{
-              x: 0,
-              y: 0,
-              width: 500,
-              height: 500,
-            }}
-            ticks={ticks}
-          />
-          <CartesianAxis
-            orientation="right"
-            x={150}
-            width={50}
-            height={400}
-            viewBox={{
-              x: 0,
-              y: 0,
-              width: 500,
-              height: 500,
-            }}
-            ticks={ticks}
-          />
-        </Surface>
-      </ResponsiveContainer>
+          <Label>测试</Label>
+        </CartesianAxis>
+        <CartesianAxis
+          orientation="top"
+          y={200}
+          width={400}
+          height={50}
+          viewBox={{
+            x: 0,
+            y: 0,
+            width: 500,
+            height: 500,
+          }}
+          ticks={ticks}
+        />
+        <CartesianAxis
+          orientation="left"
+          x={50}
+          width={50}
+          height={400}
+          viewBox={{
+            x: 0,
+            y: 0,
+            width: 500,
+            height: 500,
+          }}
+          ticks={ticks}
+        />
+        <CartesianAxis
+          orientation="right"
+          x={150}
+          width={50}
+          height={400}
+          viewBox={{
+            x: 0,
+            y: 0,
+            width: 500,
+            height: 500,
+          }}
+          ticks={ticks}
+        />
+      </Surface>
     );
   },
 };

--- a/test/chart/Treemap.spec.tsx
+++ b/test/chart/Treemap.spec.tsx
@@ -269,8 +269,8 @@ describe('<Treemap />', () => {
       });
       expect(sizeSpy).toHaveBeenLastCalledWith({ width: 100, height: 50 });
       expect(viewBoxSpy).toHaveBeenLastCalledWith({ x: 0, y: 0, width: 100, height: 50 });
-      expect(sizeSpy).toHaveBeenCalledTimes(3);
-      expect(viewBoxSpy).toHaveBeenCalledTimes(3);
+      expect(sizeSpy).toHaveBeenCalledTimes(1);
+      expect(viewBoxSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should not throw if axes are provided - they are not an allowed child', () => {

--- a/test/component/ResponsiveContainer.spec.tsx
+++ b/test/component/ResponsiveContainer.spec.tsx
@@ -164,9 +164,13 @@ describe('<ResponsiveContainer />', () => {
       </ResponsiveContainer>,
     );
 
+    act(() => {
+      notifyResizeObserverChange([{ contentRect: { width: 10, height: 10 } }]);
+    });
+
     const testDivBefore = screen.getByTestId('inside');
     assertNotNull(testDivBefore);
-    expect(testDivBefore).toHaveStyle({ width: '0px', height: '200px' });
+    expect(testDivBefore).toHaveStyle({ width: '10px', height: '200px' });
 
     act(() => {
       notifyResizeObserverChange([{ contentRect: { width: 100, height: 100 } }]);
@@ -185,9 +189,14 @@ describe('<ResponsiveContainer />', () => {
       </ResponsiveContainer>,
     );
 
+    act(() => {
+      notifyResizeObserverChange([{ contentRect: { width: 10, height: 10 } }]);
+      vi.advanceTimersByTime(300);
+    });
+
     const testDivBefore = screen.getByTestId('inside');
     assertNotNull(testDivBefore);
-    expect(testDivBefore).toHaveStyle({ width: '0px', height: '200px' });
+    expect(testDivBefore).toHaveStyle({ width: '10px', height: '200px' });
 
     act(() => {
       notifyResizeObserverChange([{ contentRect: { width: 50, height: 50 } }]);
@@ -196,7 +205,7 @@ describe('<ResponsiveContainer />', () => {
     const testDivInBetween = screen.getByTestId('inside');
     assertNotNull(testDivInBetween);
     // should still be the same since we haven't advanced the timers yet
-    expect(testDivInBetween).toHaveStyle({ width: '0px', height: '200px' });
+    expect(testDivInBetween).toHaveStyle({ width: '10px', height: '200px' });
 
     // advance time by 100ms, should still be the same
     act(() => {
@@ -204,7 +213,7 @@ describe('<ResponsiveContainer />', () => {
     });
     const testDivAfter100ms = screen.getByTestId('inside');
     assertNotNull(testDivAfter100ms);
-    expect(testDivAfter100ms).toHaveStyle({ width: '0px', height: '200px' });
+    expect(testDivAfter100ms).toHaveStyle({ width: '10px', height: '200px' });
 
     // advance time by another 100ms (total of 200ms) and now it should resize
     act(() => {
@@ -411,19 +420,20 @@ describe('<ResponsiveContainer />', () => {
       childRenderSpy(width, height);
       return null;
     }
-    console.log('render 1');
     render(
       <ResponsiveContainer>
         <Child />
       </ResponsiveContainer>,
     );
+    act(() => {
+      notifyResizeObserverChange([{ contentRect: { width: 10, height: 10 } }]);
+    });
 
     expect(childRenderSpy).toHaveBeenCalledTimes(1);
-    expect(childRenderSpy).toHaveBeenLastCalledWith(0, 0);
+    expect(childRenderSpy).toHaveBeenLastCalledWith(10, 10);
     childRenderSpy.mockClear();
 
     act(() => {
-      console.log('render 2');
       notifyResizeObserverChange([{ contentRect: { width: 100, height: 100 } }]);
     });
 
@@ -431,7 +441,6 @@ describe('<ResponsiveContainer />', () => {
     childRenderSpy.mockClear();
 
     act(() => {
-      console.log('render 3');
       notifyResizeObserverChange([{ contentRect: { width: 100, height: 100 } }]);
     });
 
@@ -439,14 +448,12 @@ describe('<ResponsiveContainer />', () => {
 
     // What if size is slightly different but rounds to the same?
     act(() => {
-      console.log('render 4');
       notifyResizeObserverChange([{ contentRect: { width: 100.4, height: 100.4 } }]);
     });
     expect(childRenderSpy).not.toHaveBeenCalled();
 
     // And now with a different rounded value
     act(() => {
-      console.log('render 5');
       notifyResizeObserverChange([{ contentRect: { width: 101, height: 101 } }]);
     });
     expect(childRenderSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Description

Couple of implications here:

1. ResponsiveContainer children now can be arbitrarily nested, the chart no longer needs to be a direct descendant
2. ResponsiveContainer no longer responsives all children. It used to inject width, height into anything, including <div> and <Surface>, it doesn't do that anymore. Some of our stories are affected by this
3. No more typescript ignore necessary

Next PR: include the ResponsiveContainer in all charts, out of the box