### PR TITLE
Responsive container integrated with RechartsWrapper

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -417,7 +417,7 @@ const CartesianAxisComponent = forwardRef<CartesianAxisRef, InternalProps>((prop
   const { axisLine, width, height, className, hide, ticks, ...rest } = props;
   const [fontSize, setFontSize] = useState('');
   const [letterSpacing, setLetterSpacing] = useState('');
-  const tickRefs = useRef<Element[]>([]);
+  const tickRefs = useRef<HTMLCollectionOf<Element> | null>(null);
 
   useImperativeHandle(
     ref,
@@ -438,7 +438,7 @@ const CartesianAxisComponent = forwardRef<CartesianAxisRef, InternalProps>((prop
     (el: SVGElement | null) => {
       if (el) {
         const tickNodes = el.getElementsByClassName('recharts-cartesian-axis-tick-value');
-        tickRefs.current = Array.from(tickNodes);
+        tickRefs.current = tickNodes;
         const tick: Element | undefined = tickNodes[0];
 
         if (tick) {

--- a/src/chart/CartesianChart.tsx
+++ b/src/chart/CartesianChart.tsx
@@ -9,7 +9,6 @@ import { CartesianChartProps, Margin, TooltipEventType } from '../util/types';
 import { TooltipPayloadSearcher } from '../state/tooltipSlice';
 import { CategoricalChart } from './CategoricalChart';
 import { resolveDefaultProps } from '../util/resolveDefaultProps';
-import { ResponsiveContainer } from '../component/ResponsiveContainer';
 
 const defaultMargin: Margin = { top: 5, right: 5, bottom: 5, left: 5 };
 
@@ -22,6 +21,7 @@ const defaultProps = {
   margin: defaultMargin,
   reverseStackOrder: false,
   syncMethod: 'index',
+  responsive: false,
 } as const satisfies Partial<CartesianChartProps>;
 
 /**
@@ -43,8 +43,6 @@ export const CartesianChart = forwardRef<SVGSVGElement, CartesianChartOptions>(f
 ) {
   const rootChartProps = resolveDefaultProps(props.categoricalChartProps, defaultProps);
 
-  const { width, height, aspectRatio, ...otherCategoricalProps } = rootChartProps;
-
   const {
     chartName,
     defaultTooltipEventType,
@@ -62,28 +60,21 @@ export const CartesianChart = forwardRef<SVGSVGElement, CartesianChartOptions>(f
   };
 
   return (
-    <ResponsiveContainer width={width} height={height} aspect={aspectRatio}>
-      <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={categoricalChartProps.id ?? chartName}>
-        <ChartDataContextProvider chartData={categoricalChartProps.data} />
-        <ReportMainChartProps
-          width={width}
-          height={height}
-          layout={rootChartProps.layout}
-          margin={rootChartProps.margin}
-        />
-        <ReportChartProps
-          accessibilityLayer={rootChartProps.accessibilityLayer}
-          barCategoryGap={rootChartProps.barCategoryGap}
-          maxBarSize={rootChartProps.maxBarSize}
-          stackOffset={rootChartProps.stackOffset}
-          barGap={rootChartProps.barGap}
-          barSize={rootChartProps.barSize}
-          syncId={rootChartProps.syncId}
-          syncMethod={rootChartProps.syncMethod}
-          className={rootChartProps.className}
-        />
-        <CategoricalChart {...otherCategoricalProps} ref={ref} />
-      </RechartsStoreProvider>
-    </ResponsiveContainer>
+    <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={categoricalChartProps.id ?? chartName}>
+      <ChartDataContextProvider chartData={categoricalChartProps.data} />
+      <ReportMainChartProps layout={rootChartProps.layout} margin={rootChartProps.margin} />
+      <ReportChartProps
+        accessibilityLayer={rootChartProps.accessibilityLayer}
+        barCategoryGap={rootChartProps.barCategoryGap}
+        maxBarSize={rootChartProps.maxBarSize}
+        stackOffset={rootChartProps.stackOffset}
+        barGap={rootChartProps.barGap}
+        barSize={rootChartProps.barSize}
+        syncId={rootChartProps.syncId}
+        syncMethod={rootChartProps.syncMethod}
+        className={rootChartProps.className}
+      />
+      <CategoricalChart {...rootChartProps} ref={ref} />
+    </RechartsStoreProvider>
   );
 });

--- a/src/chart/CategoricalChart.tsx
+++ b/src/chart/CategoricalChart.tsx
@@ -5,20 +5,24 @@ import { RechartsWrapper } from './RechartsWrapper';
 import { ClipPathProvider } from '../container/ClipPathProvider';
 import { CartesianChartProps } from '../util/types';
 import { svgPropertiesNoEvents } from '../util/svgPropertiesNoEvents';
-import { useChartHeight, useChartWidth } from '../context/chartLayoutContext';
+import { ReportChartSize } from '../context/chartLayoutContext';
 
 export const CategoricalChart = forwardRef<SVGSVGElement, CartesianChartProps>((props: CartesianChartProps, ref) => {
-  const { children, className, style, compact, title, desc, ...others } = props;
-  const width = useChartWidth();
-  const height = useChartHeight();
+  const { width, height, responsive, children, className, style, compact, title, desc, ...others } = props;
   const attrs = svgPropertiesNoEvents(others);
 
-  // The "compact" mode is used as the panorama within Brush
+  /*
+   * The "compact" mode is used as the panorama within Brush.
+   * However because `compact` is a public prop, let's assume that it can render outside of Brush too.
+   */
   if (compact) {
     return (
-      <RootSurface otherAttributes={attrs} title={title} desc={desc}>
-        {children}
-      </RootSurface>
+      <>
+        <ReportChartSize width={width} height={height} />
+        <RootSurface otherAttributes={attrs} title={title} desc={desc}>
+          {children}
+        </RootSurface>
+      </>
     );
   }
 
@@ -28,6 +32,7 @@ export const CategoricalChart = forwardRef<SVGSVGElement, CartesianChartProps>((
       style={style}
       width={width}
       height={height}
+      responsive={responsive}
       onClick={props.onClick}
       onMouseLeave={props.onMouseLeave}
       onMouseEnter={props.onMouseEnter}

--- a/src/chart/PolarChart.tsx
+++ b/src/chart/PolarChart.tsx
@@ -10,7 +10,6 @@ import { Margin, PolarChartProps, TooltipEventType } from '../util/types';
 import { TooltipPayloadSearcher } from '../state/tooltipSlice';
 import { CategoricalChart } from './CategoricalChart';
 import { resolveDefaultProps } from '../util/resolveDefaultProps';
-import { ResponsiveContainer } from '../component/ResponsiveContainer';
 
 const defaultMargin: Margin = { top: 5, right: 5, bottom: 5, left: 5 };
 
@@ -26,6 +25,7 @@ const defaultProps = {
   reverseStackOrder: false,
   syncMethod: 'index',
   layout: 'radial',
+  responsive: false,
 } as const satisfies Partial<PolarChartProps>;
 
 /**
@@ -64,7 +64,7 @@ export const PolarChart = forwardRef<SVGSVGElement, PolarChartOptions>(function 
 ) {
   const polarChartProps = resolveDefaultProps(props.categoricalChartProps, defaultProps);
 
-  const { width, height, aspectRatio, layout, ...otherCategoricalProps } = polarChartProps;
+  const { layout, ...otherCategoricalProps } = polarChartProps;
 
   const { chartName, defaultTooltipEventType, validateTooltipEventTypes, tooltipPayloadSearcher } = props;
 
@@ -77,31 +77,29 @@ export const PolarChart = forwardRef<SVGSVGElement, PolarChartOptions>(function 
   };
 
   return (
-    <ResponsiveContainer width={width} height={height} aspect={aspectRatio}>
-      <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={polarChartProps.id ?? chartName}>
-        <ChartDataContextProvider chartData={polarChartProps.data} />
-        <ReportMainChartProps width={width} height={height} layout={layout} margin={polarChartProps.margin} />
-        <ReportChartProps
-          accessibilityLayer={polarChartProps.accessibilityLayer}
-          barCategoryGap={polarChartProps.barCategoryGap}
-          maxBarSize={polarChartProps.maxBarSize}
-          stackOffset={polarChartProps.stackOffset}
-          barGap={polarChartProps.barGap}
-          barSize={polarChartProps.barSize}
-          syncId={polarChartProps.syncId}
-          syncMethod={polarChartProps.syncMethod}
-          className={polarChartProps.className}
-        />
-        <ReportPolarOptions
-          cx={polarChartProps.cx}
-          cy={polarChartProps.cy}
-          startAngle={polarChartProps.startAngle}
-          endAngle={polarChartProps.endAngle}
-          innerRadius={polarChartProps.innerRadius}
-          outerRadius={polarChartProps.outerRadius}
-        />
-        <CategoricalChart {...otherCategoricalProps} ref={ref} />
-      </RechartsStoreProvider>
-    </ResponsiveContainer>
+    <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={polarChartProps.id ?? chartName}>
+      <ChartDataContextProvider chartData={polarChartProps.data} />
+      <ReportMainChartProps layout={layout} margin={polarChartProps.margin} />
+      <ReportChartProps
+        accessibilityLayer={polarChartProps.accessibilityLayer}
+        barCategoryGap={polarChartProps.barCategoryGap}
+        maxBarSize={polarChartProps.maxBarSize}
+        stackOffset={polarChartProps.stackOffset}
+        barGap={polarChartProps.barGap}
+        barSize={polarChartProps.barSize}
+        syncId={polarChartProps.syncId}
+        syncMethod={polarChartProps.syncMethod}
+        className={polarChartProps.className}
+      />
+      <ReportPolarOptions
+        cx={polarChartProps.cx}
+        cy={polarChartProps.cy}
+        startAngle={polarChartProps.startAngle}
+        endAngle={polarChartProps.endAngle}
+        innerRadius={polarChartProps.innerRadius}
+        outerRadius={polarChartProps.outerRadius}
+      />
+      <CategoricalChart {...otherCategoricalProps} ref={ref} />
+    </RechartsStoreProvider>
   );
 });

--- a/src/chart/RechartsWrapper.tsx
+++ b/src/chart/RechartsWrapper.tsx
@@ -11,7 +11,6 @@ import {
   useState,
 } from 'react';
 import { clsx } from 'clsx';
-import throttle from 'es-toolkit/compat/throttle';
 import { mouseLeaveChart } from '../state/tooltipSlice';
 import { useAppDispatch } from '../state/hooks';
 import { mouseClickAction, mouseMoveAction } from '../state/mouseEventsMiddleware';
@@ -100,8 +99,6 @@ const ResponsiveDiv = forwardRef<HTMLDivElement, WrapperDivProps>((props: Wrappe
     });
   }, []);
 
-  const debounce = 0;
-
   const innerRef = useCallback(
     (node: HTMLDivElement | null) => {
       if (typeof ref === 'function') {
@@ -110,16 +107,10 @@ const ResponsiveDiv = forwardRef<HTMLDivElement, WrapperDivProps>((props: Wrappe
       if (node != null) {
         const { width: containerWidth, height: containerHeight } = node.getBoundingClientRect();
         setContainerSize(containerWidth, containerHeight);
-        let callback = (entries: ResizeObserverEntry[]) => {
+        const callback = (entries: ResizeObserverEntry[]) => {
           const { width, height } = entries[0].contentRect;
           setContainerSize(width, height);
         };
-        if (debounce > 0) {
-          callback = throttle(callback, debounce, {
-            trailing: true,
-            leading: false,
-          });
-        }
         const observer = new ResizeObserver(callback);
         observer.observe(node);
         if (observerRef.current != null) {
@@ -138,7 +129,7 @@ const ResponsiveDiv = forwardRef<HTMLDivElement, WrapperDivProps>((props: Wrappe
         observer.disconnect();
       }
     };
-  }, [setContainerSize, debounce]);
+  }, [setContainerSize]);
 
   return (
     <>

--- a/src/chart/RechartsWrapper.tsx
+++ b/src/chart/RechartsWrapper.tsx
@@ -1,6 +1,17 @@
 import * as React from 'react';
-import { CSSProperties, forwardRef, ReactNode, Ref, useState, useCallback } from 'react';
+import {
+  CSSProperties,
+  forwardRef,
+  HTMLAttributes,
+  ReactNode,
+  Ref,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { clsx } from 'clsx';
+import throttle from 'es-toolkit/compat/throttle';
 import { mouseLeaveChart } from '../state/tooltipSlice';
 import { useAppDispatch } from '../state/hooks';
 import { mouseClickAction, mouseMoveAction } from '../state/mouseEventsMiddleware';
@@ -12,6 +23,9 @@ import { externalEventAction } from '../state/externalEventsMiddleware';
 import { touchEventAction } from '../state/touchEventsMiddleware';
 import { TooltipPortalContext } from '../context/tooltipPortalContext';
 import { LegendPortalContext } from '../context/legendPortalContext';
+import { ReportChartSize } from '../context/chartLayoutContext';
+import { useResponsiveContainerContext } from '../component/ResponsiveContainer';
+import { Percent } from '../util/types';
 
 type Nullable<T> = {
   [P in keyof T]: T[P] | undefined;
@@ -19,19 +33,143 @@ type Nullable<T> = {
 
 export type RechartsWrapperProps = Nullable<ExternalMouseEvents> & {
   children: ReactNode;
-  width: number;
-  height: number;
+  width: number | Percent;
+  height: number | Percent;
+  /**
+   * If true, then it will listen to container size changes and adapt the SVG chart accordingly.
+   * If false, then it renders the chart at the specified width and height and will stay that way
+   * even if the container size changes.
+   */
+  responsive: boolean;
   className?: string;
   style?: CSSProperties;
   ref?: Ref<HTMLDivElement>;
+  /**
+   * Treemap is special snowflake that handles its own mouse events so
+   * here is a flag to disable the dispatching of mouse events from RechartsWrapper.
+   * If false, then this disables mouse click and touch event dispatching.
+   * Mouse move events are still dispatched because they are needed for tooltip synchronization.
+   * @default true
+   */
+  dispatchTouchEvents?: boolean;
 };
 
+const EventSynchronizer = (): ReactNode => {
+  useSynchronisedEventsFromOtherCharts();
+  return null;
+};
+
+function getNumberOrZero(value: number | string | undefined): number {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = parseFloat(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
+}
+
+type WrapperDivProps = HTMLAttributes<HTMLDivElement> & {
+  width: number | string | undefined;
+  height: number | string | undefined;
+};
+
+const ResponsiveDiv = forwardRef<HTMLDivElement, WrapperDivProps>((props: WrapperDivProps, ref): ReactNode => {
+  const observerRef = useRef(null);
+
+  const [sizes, setSizes] = useState<{
+    containerWidth: number;
+    containerHeight: number;
+  }>({
+    containerWidth: getNumberOrZero(props.style?.width),
+    containerHeight: getNumberOrZero(props.style?.height),
+  });
+
+  const setContainerSize = useCallback((newWidth: number, newHeight: number) => {
+    setSizes(prevState => {
+      const roundedWidth = Math.round(newWidth);
+      const roundedHeight = Math.round(newHeight);
+      if (prevState.containerWidth === roundedWidth && prevState.containerHeight === roundedHeight) {
+        return prevState;
+      }
+
+      return { containerWidth: roundedWidth, containerHeight: roundedHeight };
+    });
+  }, []);
+
+  const debounce = 0;
+
+  const innerRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (typeof ref === 'function') {
+        ref(node);
+      }
+      if (node != null) {
+        const { width: containerWidth, height: containerHeight } = node.getBoundingClientRect();
+        setContainerSize(containerWidth, containerHeight);
+        let callback = (entries: ResizeObserverEntry[]) => {
+          const { width, height } = entries[0].contentRect;
+          setContainerSize(width, height);
+        };
+        if (debounce > 0) {
+          callback = throttle(callback, debounce, {
+            trailing: true,
+            leading: false,
+          });
+        }
+        const observer = new ResizeObserver(callback);
+        observer.observe(node);
+        if (observerRef.current != null) {
+          observerRef.current.disconnect();
+        }
+        observerRef.current = observer;
+      }
+    },
+    [ref, setContainerSize],
+  );
+
+  useEffect(() => {
+    return () => {
+      const observer = observerRef.current;
+      if (observer != null) {
+        observer.disconnect();
+      }
+    };
+  }, [setContainerSize, debounce]);
+
+  return (
+    <>
+      <ReportChartSize width={sizes.containerWidth} height={sizes.containerHeight} />
+      <div ref={innerRef} {...props} />
+    </>
+  );
+});
+
+const StaticDiv = forwardRef<HTMLDivElement, WrapperDivProps>((props: WrapperDivProps, ref): ReactNode => {
+  const { width: widthFromProps, height: heightFromProps, style } = props;
+  const width = getNumberOrZero(widthFromProps ?? style?.width);
+  const height = getNumberOrZero(heightFromProps ?? style?.height);
+  return (
+    <>
+      <ReportChartSize width={width} height={height} />
+      <div ref={ref} {...props} />
+    </>
+  );
+});
+
+function getWrapperDivComponent(responsive: boolean) {
+  return responsive === true ? ResponsiveDiv : StaticDiv;
+}
+
 export const RechartsWrapper = forwardRef<HTMLDivElement | null, RechartsWrapperProps>(
-  (
-    {
+  (props: RechartsWrapperProps, ref: Ref<HTMLDivElement | null>) => {
+    const {
       children,
       className,
-      height,
+      height: heightFromProps,
       onClick,
       onContextMenu,
       onDoubleClick,
@@ -44,17 +182,21 @@ export const RechartsWrapper = forwardRef<HTMLDivElement | null, RechartsWrapper
       onTouchMove,
       onTouchStart,
       style,
-      width,
-    }: RechartsWrapperProps,
-    ref: Ref<HTMLDivElement | null>,
-  ) => {
+      width: widthFromProps,
+      responsive,
+      dispatchTouchEvents = true,
+    } = props;
+    const containerRef = useRef<HTMLDivElement>(null);
     const dispatch = useAppDispatch();
     const [tooltipPortal, setTooltipPortal] = useState<HTMLElement | null>(null);
     const [legendPortal, setLegendPortal] = useState<HTMLElement | null>(null);
 
-    useSynchronisedEventsFromOtherCharts();
-
     const setScaleRef = useReportScale();
+
+    const responsiveContainerCalculations = useResponsiveContainerContext();
+    const width = responsiveContainerCalculations?.width > 0 ? responsiveContainerCalculations.width : widthFromProps;
+    const height =
+      responsiveContainerCalculations?.height > 0 ? responsiveContainerCalculations.height : heightFromProps;
 
     const innerRef = useCallback(
       (node: HTMLDivElement | null) => {
@@ -64,6 +206,9 @@ export const RechartsWrapper = forwardRef<HTMLDivElement | null, RechartsWrapper
         }
         setTooltipPortal(node);
         setLegendPortal(node);
+        if (node != null) {
+          containerRef.current = node;
+        }
       },
       [setScaleRef, ref, setTooltipPortal, setLegendPortal],
     );
@@ -148,7 +293,7 @@ export const RechartsWrapper = forwardRef<HTMLDivElement | null, RechartsWrapper
 
     /*
      * onTouchMove is special because it behaves different from mouse events.
-     * Mouse events have enter + leave combo that notify us when the mouse is over
+     * Mouse events have 'enter' + 'leave' combo that notify us when the mouse is over
      * a certain element. Touch events don't have that; touch only gives us
      * start (finger down), end (finger up) and move (finger moving).
      * So we need to figure out which element the user is touching
@@ -157,10 +302,12 @@ export const RechartsWrapper = forwardRef<HTMLDivElement | null, RechartsWrapper
      */
     const myOnTouchMove = useCallback(
       (e: React.TouchEvent<HTMLDivElement>) => {
-        dispatch(touchEventAction(e));
+        if (dispatchTouchEvents) {
+          dispatch(touchEventAction(e));
+        }
         dispatch(externalEventAction({ handler: onTouchMove, reactEvent: e }));
       },
-      [dispatch, onTouchMove],
+      [dispatch, dispatchTouchEvents, onTouchMove],
     );
 
     const myOnTouchEnd = useCallback(
@@ -170,14 +317,22 @@ export const RechartsWrapper = forwardRef<HTMLDivElement | null, RechartsWrapper
       [dispatch, onTouchEnd],
     );
 
+    const WrapperDiv = getWrapperDivComponent(responsive);
+
     return (
       <TooltipPortalContext.Provider value={tooltipPortal}>
         <LegendPortalContext.Provider value={legendPortal}>
-          {/* TODO fix this a11y violation - we should probably add AccessibilityManager in here ? */}
-          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
-          <div
+          <WrapperDiv
+            width={width}
+            height={height}
             className={clsx('recharts-wrapper', className)}
-            style={{ position: 'relative', cursor: 'default', width, height, ...style }}
+            style={{
+              position: 'relative',
+              cursor: 'default',
+              width,
+              height,
+              ...style,
+            }}
             onClick={myOnClick}
             onContextMenu={myOnContextMenu}
             onDoubleClick={myOnDoubleClick}
@@ -193,8 +348,9 @@ export const RechartsWrapper = forwardRef<HTMLDivElement | null, RechartsWrapper
             onTouchStart={myOnTouchStart}
             ref={innerRef}
           >
+            <EventSynchronizer />
             {children}
-          </div>
+          </WrapperDiv>
         </LegendPortalContext.Provider>
       </TooltipPortalContext.Provider>
     );

--- a/src/chart/SunburstChart.tsx
+++ b/src/chart/SunburstChart.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { CSSProperties, useState } from 'react';
 import { scaleLinear } from 'victory-vendor/d3-scale';
 import { clsx } from 'clsx';
 import get from 'es-toolkit/compat/get';
@@ -24,7 +24,6 @@ import { RechartsStoreProvider } from '../state/RechartsStoreProvider';
 import { ChartCoordinate, DataKey, Margin, Percent } from '../util/types';
 import { useAppDispatch } from '../state/hooks';
 import { RechartsRootState } from '../state/store';
-import { ResponsiveContainer } from '../component/ResponsiveContainer';
 
 export interface SunburstData {
   [key: string]: any;
@@ -50,7 +49,16 @@ export interface SunburstChartProps {
   data: SunburstData;
   width?: number | Percent;
   height?: number | Percent;
-  aspectRatio?: number;
+  /**
+   * If true, then it will listen to container size changes and adapt the SVG chart accordingly.
+   * If false, then it renders the chart at the specified width and height and will stay that way
+   * even if the container size changes.
+   *
+   * This is similar to ResponsiveContainer but without the need for an extra wrapper component.
+   * The `responsive` prop also uses standard CSS sizing rules, instead of custom resolution logic (like ResponsiveContainer does).
+   * @default false
+   */
+  responsive?: boolean;
   padding?: number;
   dataKey?: string;
   nameKey?: DataKey<any>;
@@ -79,6 +87,7 @@ export interface SunburstChartProps {
   onMouseLeave?: (node: SunburstData, e: React.MouseEvent) => void;
 
   onClick?: (node: SunburstData) => void;
+  style?: CSSProperties;
 }
 
 interface DrawArcOptions {
@@ -199,6 +208,8 @@ const SunburstChartImpl = ({
   onClick,
   onMouseEnter,
   onMouseLeave,
+  responsive = false,
+  style,
 }: SunburstChartProps) => {
   const dispatch = useAppDispatch();
 
@@ -314,8 +325,9 @@ const SunburstChartImpl = ({
       <RechartsWrapper
         className={className}
         width={width}
-        // Sunburst doesn't support `style` property, why?
         height={height}
+        responsive={responsive}
+        style={style}
         ref={(node: HTMLDivElement) => {
           if (tooltipPortal == null && node != null) {
             setTooltipPortal(node);
@@ -348,12 +360,10 @@ const SunburstChartImpl = ({
 
 export const SunburstChart = (props: SunburstChartProps) => {
   return (
-    <ResponsiveContainer width={props.width} height={props.height} aspect={props.aspectRatio}>
-      <RechartsStoreProvider preloadedState={preloadedState} reduxStoreName={props.className ?? 'SunburstChart'}>
-        <ReportChartSize width={props.width} height={props.height} />
-        <ReportChartMargin margin={defaultSunburstMargin} />
-        <SunburstChartImpl {...props} />
-      </RechartsStoreProvider>
-    </ResponsiveContainer>
+    <RechartsStoreProvider preloadedState={preloadedState} reduxStoreName={props.className ?? 'SunburstChart'}>
+      <ReportChartSize width={props.width} height={props.height} />
+      <ReportChartMargin margin={defaultSunburstMargin} />
+      <SunburstChartImpl {...props} />
+    </RechartsStoreProvider>
   );
 };

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PureComponent, ReactNode, useCallback } from 'react';
+import { PureComponent, ReactNode, useCallback, useState } from 'react';
 import omit from 'es-toolkit/compat/omit';
 import get from 'es-toolkit/compat/get';
 
@@ -21,7 +21,7 @@ import {
   Percent,
   RectanglePosition,
 } from '../util/types';
-import { ReportChartMargin, ReportChartSize, useChartHeight, useChartWidth } from '../context/chartLayoutContext';
+import { ReportChartMargin, useChartHeight, useChartWidth } from '../context/chartLayoutContext';
 import { TooltipPortalContext } from '../context/tooltipPortalContext';
 import { RechartsWrapper } from './RechartsWrapper';
 import {
@@ -39,7 +39,6 @@ import { AppDispatch } from '../state/store';
 import { isPositiveNumber } from '../util/isWellBehavedNumber';
 import { svgPropertiesNoEvents } from '../util/svgPropertiesNoEvents';
 import { CSSTransitionAnimate } from '../animation/CSSTransitionAnimate';
-import { ResponsiveContainer } from '../component/ResponsiveContainer';
 import { RequiresDefaultProps, resolveDefaultProps } from '../util/resolveDefaultProps';
 
 const NODE_VALUE_KEY = 'value';
@@ -343,11 +342,22 @@ export interface Props {
   style?: React.CSSProperties;
 
   /**
-   * This is aspect ratio of both the chart, and the individual treemap rectangles.
-   * If you define both width and height on the treemap, this prop will be ignored for the main chart,
-   * but will still be used for the rectangles.
+   * This is aspect ratio of the individual treemap rectangles.
+   * If you want to define aspect ratio of the chart itself, set it via the `style` prop:
+   * e.g. `<Treemap style={{ aspectRatio: 4 / 3 }}>`
    */
   aspectRatio?: number;
+
+  /**
+   * If true, then it will listen to container size changes and adapt the SVG chart accordingly.
+   * If false, then it renders the chart at the specified width and height and will stay that way
+   * even if the container size changes.
+   *
+   * This is similar to ResponsiveContainer but without the need for an extra wrapper component.
+   * The `responsive` prop also uses standard CSS sizing rules, instead of custom resolution logic (like ResponsiveContainer does).
+   * @default false
+   */
+  responsive?: boolean;
 
   content?: TreemapContentType;
 
@@ -411,7 +421,6 @@ interface State {
   prevHeight?: number;
   prevDataKey: DataKey<any>;
   prevAspectRatio: number;
-  tooltipPortal: HTMLElement | null;
 }
 
 const defaultTreeMapProps = {
@@ -424,8 +433,7 @@ const defaultTreeMapProps = {
   animationBegin: 0,
   animationDuration: 1500,
   animationEasing: 'linear',
-  // width: '100%',
-  // height: '100%',
+  responsive: false,
 } as const satisfies Partial<Props>;
 
 const defaultState: State = {
@@ -433,7 +441,6 @@ const defaultState: State = {
   formatRoot: null,
   currentRoot: null,
   nestIndex: [],
-  tooltipPortal: null,
   prevAspectRatio: defaultTreeMapProps.aspectRatio,
   prevDataKey: defaultTreeMapProps.dataKey,
 };
@@ -875,7 +882,7 @@ class TreemapWithState extends PureComponent<InternalTreemapProps, State> {
     );
   }
 
-  handleTouchMove = (_state: never, e: React.TouchEvent<SVGElement>) => {
+  handleTouchMove = (e: React.TouchEvent<SVGElement>) => {
     const touchEvent = e.touches[0];
     const target = document.elementFromPoint(touchEvent.clientX, touchEvent.clientY);
     if (!target || !target.getAttribute || this.state.formatRoot == null) {
@@ -906,50 +913,31 @@ class TreemapWithState extends PureComponent<InternalTreemapProps, State> {
   };
 
   render() {
-    const { width, height, className, style, children, type, ...others } = this.props;
+    const { width, height, className, style, children, type, responsive, ...others } = this.props;
     const attrs = svgPropertiesNoEvents(others);
 
     return (
-      <TooltipPortalContext.Provider value={this.state.tooltipPortal}>
+      <>
         <SetTooltipEntrySettings
           fn={getTooltipEntrySettings}
           args={{ props: this.props, currentRoot: this.state.currentRoot }}
         />
-        <RechartsWrapper
-          className={className}
-          style={style}
+        <Surface
+          {...attrs}
           width={width}
-          height={height}
-          ref={(node: HTMLDivElement) => {
-            if (this.state.tooltipPortal == null) {
-              this.setState({ tooltipPortal: node });
-            }
-          }}
-          onMouseEnter={undefined}
-          onMouseLeave={undefined}
-          onClick={undefined}
-          onMouseMove={undefined}
-          onMouseDown={undefined}
-          onMouseUp={undefined}
-          onContextMenu={undefined}
-          onDoubleClick={undefined}
-          onTouchStart={undefined}
+          height={type === 'nest' ? height - 30 : height}
           onTouchMove={this.handleTouchMove}
-          onTouchEnd={undefined}
         >
-          <Surface {...attrs} width={width} height={type === 'nest' ? height - 30 : height}>
-            {this.renderAllNodes()}
-            {children}
-          </Surface>
-          {type === 'nest' && this.renderNestIndex()}
-        </RechartsWrapper>
-      </TooltipPortalContext.Provider>
+          {this.renderAllNodes()}
+          {children}
+        </Surface>
+        {type === 'nest' && this.renderNestIndex()}
+      </>
     );
   }
 }
 
-function TreemapDispatchInject(outsideProps: Props) {
-  const props = resolveDefaultProps(outsideProps, defaultTreeMapProps);
+function TreemapDispatchInject(props: RequiresDefaultProps<Props, typeof defaultTreeMapProps>) {
   const dispatch = useAppDispatch();
   const width = useChartWidth();
   const height = useChartHeight();
@@ -959,16 +947,43 @@ function TreemapDispatchInject(outsideProps: Props) {
   return <TreemapWithState {...props} width={width} height={height} dispatch={dispatch} />;
 }
 
-export function Treemap(props: Props) {
-  const { width, height, aspectRatio } = props;
+export function Treemap(outsideProps: Props) {
+  const props = resolveDefaultProps(outsideProps, defaultTreeMapProps);
+  const { className, style, width, height, responsive = false } = props;
+
+  const [tooltipPortal, setTooltipPortal] = useState<HTMLElement | null>(null);
 
   return (
-    <ResponsiveContainer width={width} height={height} aspect={aspectRatio}>
-      <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={props.className ?? 'Treemap'}>
-        <ReportChartSize width={width} height={height} />
-        <ReportChartMargin margin={defaultTreemapMargin} />
-        <TreemapDispatchInject {...props} />
-      </RechartsStoreProvider>
-    </ResponsiveContainer>
+    <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={props.className ?? 'Treemap'}>
+      <ReportChartMargin margin={defaultTreemapMargin} />
+      <RechartsWrapper
+        dispatchTouchEvents={false}
+        className={className}
+        style={style}
+        width={width}
+        height={height}
+        responsive={responsive}
+        ref={(node: HTMLDivElement) => {
+          if (tooltipPortal == null && node != null) {
+            setTooltipPortal(node);
+          }
+        }}
+        onMouseEnter={undefined}
+        onMouseLeave={undefined}
+        onClick={undefined}
+        onMouseMove={undefined}
+        onMouseDown={undefined}
+        onMouseUp={undefined}
+        onContextMenu={undefined}
+        onDoubleClick={undefined}
+        onTouchStart={undefined}
+        onTouchMove={undefined}
+        onTouchEnd={undefined}
+      >
+        <TooltipPortalContext.Provider value={tooltipPortal}>
+          <TreemapDispatchInject {...props} />
+        </TooltipPortalContext.Provider>
+      </RechartsWrapper>
+    </RechartsStoreProvider>
   );
 }

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -348,17 +348,6 @@ export interface Props {
    */
   aspectRatio?: number;
 
-  /**
-   * If true, then it will listen to container size changes and adapt the SVG chart accordingly.
-   * If false, then it renders the chart at the specified width and height and will stay that way
-   * even if the container size changes.
-   *
-   * This is similar to ResponsiveContainer but without the need for an extra wrapper component.
-   * The `responsive` prop also uses standard CSS sizing rules, instead of custom resolution logic (like ResponsiveContainer does).
-   * @default false
-   */
-  responsive?: boolean;
-
   content?: TreemapContentType;
 
   fill?: string;
@@ -433,7 +422,6 @@ const defaultTreeMapProps = {
   animationBegin: 0,
   animationDuration: 1500,
   animationEasing: 'linear',
-  responsive: false,
 } as const satisfies Partial<Props>;
 
 const defaultState: State = {
@@ -913,7 +901,7 @@ class TreemapWithState extends PureComponent<InternalTreemapProps, State> {
   };
 
   render() {
-    const { width, height, className, style, children, type, responsive, ...others } = this.props;
+    const { width, height, className, style, children, type, ...others } = this.props;
     const attrs = svgPropertiesNoEvents(others);
 
     return (
@@ -949,7 +937,7 @@ function TreemapDispatchInject(props: RequiresDefaultProps<Props, typeof default
 
 export function Treemap(outsideProps: Props) {
   const props = resolveDefaultProps(outsideProps, defaultTreeMapProps);
-  const { className, style, width, height, responsive = false } = props;
+  const { className, style, width, height } = props;
 
   const [tooltipPortal, setTooltipPortal] = useState<HTMLElement | null>(null);
 
@@ -962,7 +950,12 @@ export function Treemap(outsideProps: Props) {
         style={style}
         width={width}
         height={height}
-        responsive={responsive}
+        /*
+         * Treemap has a bug where it doesn't include strokeWidth in its dimension calculation
+         * which makes the actual chart exactly {strokeWidth} larger than asked for.
+         * It's not a huge deal usually, but it makes the responsive option cycle infinitely.
+         */
+        responsive={false}
         ref={(node: HTMLDivElement) => {
           if (tooltipPortal == null && node != null) {
             setTooltipPortal(node);

--- a/src/state/ReportMainChartProps.tsx
+++ b/src/state/ReportMainChartProps.tsx
@@ -1,23 +1,19 @@
-import * as React from 'react';
 import { ReactNode, useEffect } from 'react';
-import { LayoutType, Margin, Percent } from '../util/types';
+import { LayoutType, Margin } from '../util/types';
 import { useIsPanorama } from '../context/PanoramaContext';
 import { setLayout, setMargin } from './layoutSlice';
 import { useAppDispatch } from './hooks';
-import { ReportChartSize } from '../context/chartLayoutContext';
 
 /**
  * "Main" props are props that are only accepted on the main chart,
  * as opposed to the small panorama chart inside a Brush.
  */
 type MainChartProps = {
-  width: number | Percent;
-  height: number | Percent;
   layout: LayoutType;
   margin: Partial<Margin>;
 };
 
-export function ReportMainChartProps({ layout, width, height, margin }: MainChartProps): ReactNode {
+export function ReportMainChartProps({ layout, margin }: MainChartProps): ReactNode {
   const dispatch = useAppDispatch();
 
   /*
@@ -38,6 +34,6 @@ export function ReportMainChartProps({ layout, width, height, margin }: MainChar
       dispatch(setLayout(layout));
       dispatch(setMargin(margin));
     }
-  }, [dispatch, isPanorama, layout, width, height, margin]);
-  return <ReportChartSize width={width} height={height} />;
+  }, [dispatch, isPanorama, layout, margin]);
+  return null;
 }

--- a/src/util/YAxisUtils.tsx
+++ b/src/util/YAxisUtils.tsx
@@ -2,11 +2,13 @@ type IGetBoundingClient = Pick<Element, 'getBoundingClientRect'>;
 
 /**
  * Calculates the width of the Y-axis based on the tick labels and the axis label.
- * @param {Object} params - The parameters object.
- * @param {React.RefObject<any>} params.cartesianAxisRef - The ref to the CartesianAxis component.
- * @param {React.RefObject<Element>} params.labelRef - The ref to the label element.
- * @param {number} [params.labelGapWithTick=5] - The gap between the label and the tick.
- * @returns {number} The calculated width of the Y-axis.
+ * @param params - The parameters object.
+ * @param [params.ticks] - An array-like object of tick elements, each with a `getBoundingClientRect` method.
+ * @param [params.label] - The axis label element, with a `getBoundingClientRect` method.
+ * @param [params.labelGapWithTick=5] - The gap between the label and the tick.
+ * @param [params.tickSize=0] - The length of the tick line.
+ * @param [params.tickMargin=0] - The margin between the tick line and the tick text.
+ * @returns The calculated width of the Y-axis.
  */
 export const getCalculatedYAxisWidth = ({
   ticks,
@@ -15,7 +17,7 @@ export const getCalculatedYAxisWidth = ({
   tickSize = 0,
   tickMargin = 0,
 }: {
-  ticks: ReadonlyArray<IGetBoundingClient> | undefined;
+  ticks: ArrayLike<IGetBoundingClient> | undefined;
   label: IGetBoundingClient | null | undefined;
   labelGapWithTick: number | undefined;
   tickSize: number | undefined;
@@ -24,7 +26,7 @@ export const getCalculatedYAxisWidth = ({
   // find the max width of the tick labels
   let maxTickWidth = 0;
   if (ticks) {
-    ticks.forEach((tickNode: Element) => {
+    Array.from(ticks).forEach((tickNode: Element) => {
       if (tickNode) {
         const bbox = tickNode.getBoundingClientRect();
 

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1014,7 +1014,16 @@ export interface CartesianChartProps extends Partial<ExternalMouseEvents> {
   throttleDelay?: number;
   title?: string;
   width?: number | Percent;
-  aspectRatio?: number;
+  /**
+   * If true, then it will listen to container size changes and adapt the SVG chart accordingly.
+   * If false, then it renders the chart at the specified width and height and will stay that way
+   * even if the container size changes.
+   *
+   * This is similar to ResponsiveContainer but without the need for an extra wrapper component.
+   * The `responsive` prop also uses standard CSS sizing rules, instead of custom resolution logic (like ResponsiveContainer does).
+   * @default false
+   */
+  responsive?: boolean;
 }
 
 export interface PolarChartProps extends Partial<ExternalMouseEvents> {
@@ -1048,7 +1057,16 @@ export interface PolarChartProps extends Partial<ExternalMouseEvents> {
   throttleDelay?: number;
   title?: string;
   width?: number | Percent;
-  aspectRatio?: number;
+  /**
+   * If true, then it will listen to container size changes and adapt the SVG chart accordingly.
+   * If false, then it renders the chart at the specified width and height and will stay that way
+   * even if the container size changes.
+   *
+   * This is similar to ResponsiveContainer but without the need for an extra wrapper component.
+   * The `responsive` prop also uses standard CSS sizing rules, instead of custom resolution logic (like ResponsiveContainer does).
+   * @default false
+   */
+  responsive?: boolean;
 }
 
 export type Percent = `${number}%`;

--- a/test-vr/tests/Bar.6192.spec-vr.tsx
+++ b/test-vr/tests/Bar.6192.spec-vr.tsx
@@ -275,6 +275,7 @@ test('ComposedChart with stacked Area and Bar', async ({ mount }) => {
       <ComposedChart
         width="100%"
         height="100%"
+        responsive
         data={data}
         stackOffset="sign"
         margin={{

--- a/test-vr/tests/Treemap.spec-vr.tsx
+++ b/test-vr/tests/Treemap.spec-vr.tsx
@@ -36,11 +36,8 @@ test('nested treemap', async ({ mount }) => {
 test('custom aspect ratio', async ({ mount }) => {
   const component = await mount(
     <Treemap
-      style={{
-        width: '500px',
-        aspectRatio: 1,
-      }}
-      responsive
+      width={500}
+      height={500}
       data={exampleTreemapData}
       isAnimationActive={false}
       nameKey="name"

--- a/test-vr/tests/Treemap.spec-vr.tsx
+++ b/test-vr/tests/Treemap.spec-vr.tsx
@@ -36,8 +36,11 @@ test('nested treemap', async ({ mount }) => {
 test('custom aspect ratio', async ({ mount }) => {
   const component = await mount(
     <Treemap
-      width={500}
-      height={250}
+      style={{
+        width: '500px',
+        aspectRatio: 1,
+      }}
+      responsive
       data={exampleTreemapData}
       isAnimationActive={false}
       nameKey="name"

--- a/test/chart/chartEvents.spec.tsx
+++ b/test/chart/chartEvents.spec.tsx
@@ -14,6 +14,7 @@ import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { Bar, BarChart, Tooltip, XAxis } from '../../src';
 import { PageData } from '../_data';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
+import { mockTouchingElement } from '../helper/mockTouchingElement';
 
 /**
  * These three charts accept the same named events - but they only trigger them when user interacts with the graphics.
@@ -107,7 +108,7 @@ describe('chart wrapper events', () => {
     });
   });
 
-  describe.each(onlyCompact(allCharts))('$testName', ({ ChartElement }) => {
+  describe.each(onlyCompact(allCharts))('$testName', ({ ChartElement, tooltipIndex }) => {
     it('should not call onClick when user clicks on the chart', () => {
       const { container } = render(<ChartElement onClick={spies.onClick} />);
       fireEvent.click(container.querySelector('.recharts-surface'), { clientX: 10, clientY: 10 });
@@ -131,6 +132,8 @@ describe('chart wrapper events', () => {
     });
 
     it('should not call onTouchStart, onTouchMove, or onTouchEnd', () => {
+      mockTouchingElement(tooltipIndex, 'uv');
+
       const { container } = render(
         <ChartElement
           onTouchStart={spies.onTouchStart}
@@ -138,8 +141,8 @@ describe('chart wrapper events', () => {
           onTouchEnd={spies.onTouchEnd}
         />,
       );
-      fireEvent.touchStart(container.querySelector('.recharts-surface'), { clientX: 10, clientY: 10 });
-      fireEvent.touchMove(container.querySelector('.recharts-surface'), { clientX: 20, clientY: 20 });
+      fireEvent.touchStart(container.querySelector('.recharts-surface'), { touches: [{ clientX: 20, clientY: 20 }] });
+      fireEvent.touchMove(container.querySelector('.recharts-surface'), { touches: [{ clientX: 20, clientY: 20 }] });
       fireEvent.touchEnd(container.querySelector('.recharts-surface'));
       expect(spies.onTouchStart).not.toHaveBeenCalled();
       expect(spies.onTouchMove).not.toHaveBeenCalled();

--- a/test/helper/parameterizedTestCases.tsx
+++ b/test/helper/parameterizedTestCases.tsx
@@ -19,6 +19,7 @@ import {
   Treemap,
 } from '../../src';
 import { PageData, exampleSankeyData, exampleSunburstData, exampleTreemapData } from '../_data';
+import { TooltipIndex } from '../../src/state/tooltipSlice';
 
 /**
  * This is for parameterized tests - for when you have a bunch of tests and you want to run the same tests
@@ -46,6 +47,7 @@ export type CartesianChartTestCase = {
     onTouchEnd?: (param: unknown) => void;
   }>;
   testName: string;
+  tooltipIndex: TooltipIndex;
 };
 
 export type PolarChartTestCase = {
@@ -53,10 +55,11 @@ export type PolarChartTestCase = {
   testName: string;
 };
 
-function makeCompact({ ChartElement, testName }: CartesianChartTestCase) {
+function makeCompact({ ChartElement, testName, tooltipIndex }: CartesianChartTestCase) {
   const compactTestCase: CartesianChartTestCase = {
     ChartElement: props => <ChartElement {...props} compact />,
     testName: `compact ${testName}`,
+    tooltipIndex,
   };
   return compactTestCase;
 }
@@ -94,21 +97,25 @@ export function onlyCompact(testCases: ReadonlyArray<CartesianChartTestCase>): R
 export const ComposedChartCase: CartesianChartTestCase = {
   ChartElement: props => <ComposedChart width={500} height={500} {...props} />,
   testName: 'ComposedChart',
+  tooltipIndex: '0',
 };
 
 export const AreaChartCase: CartesianChartTestCase = {
   ChartElement: props => <AreaChart width={500} height={500} {...props} />,
   testName: 'AreaChart',
+  tooltipIndex: '0',
 };
 
 export const BarChartCase: CartesianChartTestCase = {
   ChartElement: props => <BarChart width={500} height={500} {...props} />,
   testName: 'BarChart',
+  tooltipIndex: '0',
 };
 
 export const LineChartCase: CartesianChartTestCase = {
   ChartElement: props => <LineChart width={500} height={500} {...props} />,
   testName: 'LineChart',
+  tooltipIndex: '0',
 };
 
 export const ScatterChartCase: CartesianChartTestCase = {
@@ -118,6 +125,7 @@ export const ScatterChartCase: CartesianChartTestCase = {
     </ScatterChart>
   ),
   testName: 'ScatterChart',
+  tooltipIndex: '0',
 };
 
 export const PieChartCase: PolarChartTestCase = {
@@ -150,6 +158,7 @@ export const RadialBarChartCase: PolarChartTestCase = {
 export const FunnelChartCase: CartesianChartTestCase = {
   ChartElement: props => <FunnelChart width={500} height={500} {...props} />,
   testName: 'FunnelChart',
+  tooltipIndex: '0',
 };
 
 export const TreemapChartCase: CartesianChartTestCase = {
@@ -166,6 +175,7 @@ export const TreemapChartCase: CartesianChartTestCase = {
     />
   ),
   testName: 'Treemap',
+  tooltipIndex: 'children[0]children[0]',
 };
 
 export const SankeyChartCase: CartesianChartTestCase = {
@@ -174,6 +184,7 @@ export const SankeyChartCase: CartesianChartTestCase = {
     return <Sankey width={400} height={400} {...rest} data={exampleSankeyData} />;
   },
   testName: 'Sankey',
+  tooltipIndex: '0',
 };
 
 export const SunburstChartCase: CartesianChartTestCase = {
@@ -182,6 +193,7 @@ export const SunburstChartCase: CartesianChartTestCase = {
     return <SunburstChart width={500} height={500} {...rest} data={exampleSunburstData} />;
   },
   testName: 'Sunburst',
+  tooltipIndex: '0',
 };
 
 /**

--- a/test/state/selectors/cartesianAxisSlice.spec.ts
+++ b/test/state/selectors/cartesianAxisSlice.spec.ts
@@ -1,0 +1,59 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { describe, it, expect } from 'vitest';
+import { addYAxis, cartesianAxisReducer, updateYAxisWidth, YAxisSettings } from '../../../src/state/cartesianAxisSlice';
+
+describe('cartesianAxisSlice', () => {
+  describe('updateYAxisWidth', () => {
+    it('should stop updating width after oscillation is detected', () => {
+      const store = configureStore({
+        reducer: {
+          cartesianAxis: cartesianAxisReducer,
+        },
+      });
+
+      const yAxis: YAxisSettings = {
+        id: 'test-axis',
+        width: 'auto',
+        scale: 'auto',
+        type: 'number',
+        dataKey: undefined,
+        unit: undefined,
+        name: undefined,
+        allowDuplicatedCategory: true,
+        allowDataOverflow: false,
+        reversed: false,
+        includeHidden: false,
+        domain: undefined,
+        allowDecimals: true,
+        tickCount: 5,
+        ticks: undefined,
+        tick: true,
+        interval: 'preserveEnd',
+        mirror: false,
+        minTickGap: 5,
+        angle: 0,
+        hide: false,
+        tickFormatter: undefined,
+        padding: { top: 0, bottom: 0 },
+        orientation: 'left',
+      };
+
+      store.dispatch(addYAxis(yAxis));
+
+      expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe('auto');
+
+      store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 50 }));
+      expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(50);
+
+      store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 60 }));
+      expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(60);
+
+      store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 50 }));
+      expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(50);
+
+      // This is the 4th action. The oscillation should be detected and the update ignored.
+      store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 60 }));
+      expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(50);
+    });
+  });
+});

--- a/www/src/components/GuideView/GettingStarted.tsx
+++ b/www/src/components/GuideView/GettingStarted.tsx
@@ -62,7 +62,7 @@ const MyChart = () => (
 );`}
         </Highlight>
 
-        <LineChart width={600} height={300} data={data}>
+        <LineChart style={{ width: '100%', aspectRatio: 1.618, maxWidth: 600 }} responsive data={data}>
           <Line dataKey="uv" />
         </LineChart>
       </div>
@@ -75,7 +75,7 @@ const MyChart = () => (
 const data = [{name: 'Page A', uv: 400, pv: 2400, amt: 2400}, ...];
 
 const MyChart = () => (
-  <LineChart width={600} height={300} data={data}>
+  <LineChart style={{ width: '100%', aspectRatio: 1.618, maxWidth: 600 }} responsive data={data}>
     <CartesianGrid />
     <Line dataKey="uv" />
     <XAxis dataKey="name" />
@@ -85,7 +85,7 @@ const MyChart = () => (
 );`}
         </Highlight>
 
-        <LineChart width={600} height={300} data={data}>
+        <LineChart style={{ width: '100%', aspectRatio: 1.618, maxWidth: 600 }} responsive data={data}>
           <CartesianGrid />
           <Line dataKey="uv" />
           <XAxis dataKey="name" />
@@ -102,7 +102,7 @@ const MyChart = () => (
 const data = [{name: 'Page A', uv: 400, pv: 2400, amt: 2400}, ...];
 
 const MyChart = () => (
-  <LineChart width={600} height={300} data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+  <LineChart style={{ width: '100%', aspectRatio: 1.618, maxWidth: 600 }} responsive data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
     <CartesianGrid stroke="#aaa" strokeDasharray="5 5" />
     <Line type="monotone" dataKey="uv" stroke="purple" strokeWidth={2} name="My data series name" />
     <XAxis dataKey="name" />
@@ -113,8 +113,8 @@ const MyChart = () => (
         </Highlight>
 
         <LineChart
-          width={600}
-          height={300}
+          style={{ width: '100%', aspectRatio: 1.618, maxWidth: 600 }}
+          responsive
           data={data}
           margin={{
             top: 20,
@@ -139,7 +139,7 @@ const MyChart = () => (
 const data = [{name: 'Page A', uv: 400, pv: 2400, amt: 2400}, ...];
 
 const MyChart = () => (
-  <LineChart width={600} height={300} data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+  <LineChart style={{ width: '100%', aspectRatio: 1.618, maxWidth: 600 }} responsive data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
     <CartesianGrid stroke="#aaa" strokeDasharray="5 5" />
     <Line type="monotone" dataKey="uv" stroke="purple" strokeWidth={2} name="My data series name" />
     <XAxis dataKey="name" />
@@ -151,8 +151,8 @@ const MyChart = () => (
         </Highlight>
 
         <LineChart
-          width={600}
-          height={300}
+          style={{ width: '100%', aspectRatio: 1.618, maxWidth: 600 }}
+          responsive
           data={data}
           margin={{
             top: 20,
@@ -200,7 +200,7 @@ const renderCustomAxisTick = ({ x, y, payload }) => {
 };
 
 const renderLineChart = (
-  <LineChart width={600} height={300} data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+  <LineChart style={{ width: '100%', aspectRatio: 1.618, maxWidth: 600 }} responsive data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
     <CartesianGrid stroke="#aaa" strokeDasharray="5 5" />
     <Line type="monotone" dataKey="uv" stroke="purple" strokeWidth={2} name="My data series name" />
     <XAxis dataKey="name" tick={renderCustomAxisTick} />
@@ -213,8 +213,8 @@ const renderLineChart = (
         </Highlight>
 
         <LineChart
-          width={600}
-          height={300}
+          style={{ width: '100%', aspectRatio: 1.618, maxWidth: 600 }}
+          responsive
           data={data}
           margin={{
             top: 20,

--- a/www/src/docs/exampleComponents/PieChart/CustomActiveShapePieChart.tsx
+++ b/www/src/docs/exampleComponents/PieChart/CustomActiveShapePieChart.tsx
@@ -88,6 +88,7 @@ export default function Example() {
     <ResponsiveContainer width="100%" height="100%">
       <PieChart width={400} height={400}>
         <Pie
+          // @ts-expect-error the parameter type doesn't match
           activeShape={renderActiveShape}
           data={data}
           cx="50%"

--- a/www/src/styles/container.scss
+++ b/www/src/styles/container.scss
@@ -28,7 +28,6 @@ footer {
 
     h2,
     .sub-title {
-      height: 40px;
       line-height: 40px;
       margin: 20px 0;
       font-size: 24px;

--- a/www/src/views/IndexView.tsx
+++ b/www/src/views/IndexView.tsx
@@ -83,24 +83,18 @@ class IndexView extends PureComponent<RouteComponentProps> {
         </div>
 
         <div className="examples">
+          <LineChart
+            style={{ width: '100%', aspectRatio: 1.618, maxWidth: 600, margin: 'auto' }}
+            responsive
+            data={data}
+          >
+            <CartesianGrid stroke="#eee" strokeDasharray="5 5" />
+            <XAxis dataKey="name" />
+            <YAxis width="auto" />
+            <Line type="monotone" dataKey="uv" stroke="#8884d8" />
+            <Line type="monotone" dataKey="pv" stroke="#82ca9d" />
+          </LineChart>
           <div className="ex-code">
-            <LineChart
-              width={500}
-              height={300}
-              data={data}
-              margin={{
-                top: 5,
-                right: 5,
-                bottom: 5,
-                left: 0,
-              }}
-            >
-              <CartesianGrid stroke="#eee" strokeDasharray="5 5" />
-              <XAxis dataKey="name" />
-              <YAxis />
-              <Line type="monotone" dataKey="uv" stroke="#8884d8" />
-              <Line type="monotone" dataKey="pv" stroke="#82ca9d" />
-            </LineChart>
             <Highlight className="jsx">{exCode}</Highlight>
           </div>
         </div>

--- a/www/tsconfig.json
+++ b/www/tsconfig.json
@@ -20,7 +20,14 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "recharts": ["../types/index.d.ts"],
+      // TODO we should export all public types from the main entry point, and then remove all deep imports
+      "recharts/types/*": ["../types/*"],
+    }
   },
-  "include": ["src"]
+  "include": ["./src"],
+  "exclude": ["node_modules", "docs"]
 }


### PR DESCRIPTION
## Description

So I went and tried to use the new built-in ResponsiveContainer on the website and I discovered several problems:

1. I did not pass couple of props, like `maxWidth` and `minHeight` to the built-in variant
2. The custom ResponsiveContainer size calculation is different from DOM size calculation
3. I struggled hard to horizontally center the chart, because of the three nested divs.

I already had fix for 1. and I was halfway through fix for 2. and then I realized that it's all pointless and we don't need another div inside div because we already have RechartsWrapper which renders its own div so let's use that instead. So that's this PR.

The gist is:
- Just pass `style` to the wrapper, let browser do all the calculations
- By default, the chart is rendered with static dimensions, meaning that it won't update when the `div.recharts-wrapper` changes
- New prop `responsive` will read updates from the wrapper div, and re-render chart, same as ResponsiveContainer used to do
- No more custom calculation logic. Now we use the browser to do calculations for us.

For now this new calculation is entirely opt-it via the new `responsive` prop. I would see what feedback we get and then get rid of `ResponsiveContainer` in 4.0.

From my experience trying the charts on the website, it works just fine. Horizontal and vertical centering is super easy now, the regular `margin: 0 auto` or flexbox works as expected.

I have also discovered that YAxis width=auto can cycle render and crash so I added a detector for it.

Treemap is excluded from the responsiveness because it calculates its sizes wrong.

ResponsiveContainer itself is unchanged.

I will update docs and the website in separate PR, now I want to see if all the tests will work and get you a chance to play with the new `responsive` on main branch.

## Related Issue

I believe this should help with https://github.com/recharts/recharts/issues/6112 where instead of hacky workarounds, regular CSS will work.

## Motivation and Context

ResponsiveContainer is a dumpster fire.

## Screenshots (if appropriate):
<img width="3303" height="1826" alt="image" src="https://github.com/user-attachments/assets/a356a399-e212-4716-813b-7729130e772b" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes
