### PR TITLE
Display: block instead of overflow

### DIFF
--- a/src/chart/RechartsWrapper.tsx
+++ b/src/chart/RechartsWrapper.tsx
@@ -375,14 +375,6 @@ export const RechartsWrapper = forwardRef<HTMLDivElement | null, RechartsWrapper
             style={{
               position: 'relative',
               cursor: 'default',
-              /*
-               * Some charts may render outside their boundaries,
-               * maybe because of a bug or because of rounding errors.
-               * If that happens, and the chart is responsive, it would keep growing forever
-               * to accommodate the chart that always renders a little bit too large.
-               * Let's have overflow hidden here so that the chart size stabilises.
-               */
-              overflow: 'hidden',
               width,
               height,
               ...style,

--- a/src/container/RootSurface.tsx
+++ b/src/container/RootSurface.tsx
@@ -15,7 +15,20 @@ type RootSurfaceProps = {
   otherAttributes: Record<string, unknown>;
 };
 
-const FULL_WIDTH_AND_HEIGHT = { width: '100%', height: '100%' };
+const FULL_WIDTH_AND_HEIGHT = {
+  width: '100%',
+  height: '100%',
+  /*
+   * display: block is necessary here because the default for an SVG is display: inline,
+   * which in some browsers (Chrome) adds a little bit of extra space above and below the SVG
+   * to make space for the descender of letters like "g" and "y". This throws off the height calculation
+   * and causes the container to grow indefinitely on each render with responsive=true.
+   * Display: block removes that extra space.
+   *
+   * Interestingly, Firefox does not have this problem, but it doesn't hurt to add the style anyway.
+   */
+  display: 'block',
+};
 
 const MainChartSurface = forwardRef<SVGSVGElement, RootSurfaceProps>((props: RootSurfaceProps, ref) => {
   const width = useChartWidth();

--- a/storybook/stories/Examples/Tooltip.stories.tsx
+++ b/storybook/stories/Examples/Tooltip.stories.tsx
@@ -389,15 +389,13 @@ export const SharedTooltipInRadialBarChart = {
 export const TallTooltipInNarrowChart = {
   render: (args: Args) => {
     return (
-      <ResponsiveContainer width="100%" height={50}>
-        <LineChart data={pageData}>
-          <Tooltip {...args} />
-          <Line dataKey="uv" fill="green" />
-          <Line dataKey="pv" fill="red" />
-          <Line dataKey="amt" fill="amt" />
-          <RechartsHookInspector />
-        </LineChart>
-      </ResponsiveContainer>
+      <LineChart width="100%" height={50} responsive data={pageData}>
+        <Tooltip {...args} />
+        <Line dataKey="uv" fill="green" />
+        <Line dataKey="pv" fill="red" />
+        <Line dataKey="amt" fill="amt" />
+        <RechartsHookInspector />
+      </LineChart>
     );
   },
   args: {

--- a/test/container/chartDimensions.spec.tsx
+++ b/test/container/chartDimensions.spec.tsx
@@ -95,7 +95,7 @@ describe('Chart dimensions', () => {
       expect(surface).toHaveAttribute('width', '100');
       expect(surface).toHaveAttribute('height', '200');
       expect(surface).toHaveAttribute('viewBox', '0 0 100 200');
-      expect(surface).toHaveAttribute('style', 'width: 100%; height: 100%;');
+      expect(surface).toHaveStyle({ width: '100%', height: '100%', display: 'block' });
       expect(surface).toHaveAttribute('tabindex', '0');
       expect(surface).toHaveAttribute('role', 'application');
     });
@@ -234,7 +234,7 @@ describe('Chart dimensions', () => {
         expect(surface1).toHaveAttribute('width', '100');
         expect(surface1).toHaveAttribute('height', '200');
         expect(surface1).toHaveAttribute('viewBox', '0 0 100 200');
-        expect(surface1).toHaveAttribute('style', 'width: 100%; height: 100%;');
+        expect(surface1).toHaveStyle({ width: '100%', height: '100%', display: 'block' });
         expect(surface1).toHaveAttribute('tabindex', '0');
         expect(surface1).toHaveAttribute('role', 'application');
 

--- a/www/src/docs/exampleComponents/AreaChart/TinyAreaChart.tsx
+++ b/www/src/docs/exampleComponents/AreaChart/TinyAreaChart.tsx
@@ -49,6 +49,7 @@ const TinyAreaChart = () => {
   return (
     <AreaChart
       style={{ width: '100%', maxWidth: '300px', maxHeight: '100px', aspectRatio: 1.618 }}
+      responsive
       data={data}
       margin={{
         top: 5,

--- a/www/src/views/ExampleView.scss
+++ b/www/src/views/ExampleView.scss
@@ -4,7 +4,6 @@
 .page.page-examples .example-wrapper {
   .example-inner-wrapper {
     display: flex;
-    justify-content: stretch;
     align-items: flex-start;
     flex-direction: row;
     width: 100%;


### PR DESCRIPTION
## Description

Okay this fixes the growth problem too, and doesn't cut off Tooltips.