### PR TITLE
Improve performance of charts with multiple data arrays

### DIFF
--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -2,7 +2,7 @@
  * @fileOverview X Axis
  */
 import * as React from 'react';
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useLayoutEffect } from 'react';
 import { clsx } from 'clsx';
 import { CartesianAxis } from './CartesianAxis';
 import { AxisInterval, AxisTick, BaseAxisProps, PresentationAttributesAdaptChildEvent } from '../util/types';
@@ -47,7 +47,7 @@ export type Props = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>,
 function SetXAxisSettings(settings: XAxisSettings): ReactNode {
   const dispatch = useAppDispatch();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     dispatch(addXAxis(settings));
     return () => {
       dispatch(removeXAxis(settings));

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FunctionComponent, isValidElement, useEffect, useLayoutEffect, useRef } from 'react';
+import { FunctionComponent, isValidElement, useLayoutEffect, useRef } from 'react';
 import { clsx } from 'clsx';
 import { AxisInterval, AxisTick, BaseAxisProps, PresentationAttributesAdaptChildEvent, Size } from '../util/types';
 import { CartesianAxis, CartesianAxisRef } from './CartesianAxis';
@@ -55,7 +55,7 @@ export type Props = Omit<PresentationAttributesAdaptChildEvent<any, SVGElement>,
 
 function SetYAxisSettings(settings: YAxisSettings): null {
   const dispatch = useAppDispatch();
-  useEffect(() => {
+  useLayoutEffect(() => {
     dispatch(addYAxis(settings));
     return () => {
       dispatch(removeYAxis(settings));

--- a/src/state/SetGraphicalItem.ts
+++ b/src/state/SetGraphicalItem.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import { useAppDispatch } from './hooks';
 import {
   addCartesianGraphicalItem,
@@ -14,7 +14,7 @@ export function SetCartesianGraphicalItem<T extends CartesianGraphicalItemSettin
   const dispatch = useAppDispatch();
   const prevPropsRef = useRef<T | null>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (prevPropsRef.current === null) {
       dispatch(addCartesianGraphicalItem(props));
     } else if (prevPropsRef.current !== props) {
@@ -23,7 +23,7 @@ export function SetCartesianGraphicalItem<T extends CartesianGraphicalItemSettin
     prevPropsRef.current = props;
   }, [dispatch, props]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     return () => {
       if (prevPropsRef.current) {
         dispatch(removeCartesianGraphicalItem(prevPropsRef.current));
@@ -50,7 +50,7 @@ export function SetCartesianGraphicalItem<T extends CartesianGraphicalItemSettin
 
 export function SetPolarGraphicalItem(props: PolarGraphicalItemSettings): null {
   const dispatch = useAppDispatch();
-  useEffect(() => {
+  useLayoutEffect(() => {
     dispatch(addPolarGraphicalItem(props));
     return () => {
       dispatch(removePolarGraphicalItem(props));

--- a/src/state/cartesianAxisSlice.ts
+++ b/src/state/cartesianAxisSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction, prepareAutoBatched } from '@reduxjs/toolkit';
 import { castDraft } from 'immer';
 import { ReactElement, SVGProps } from 'react';
 import { AxisDomain, AxisDomainType, AxisInterval, AxisTick, DataKey, ScaleType } from '../util/types';
@@ -107,23 +107,41 @@ const cartesianAxisSlice = createSlice({
   name: 'cartesianAxis',
   initialState,
   reducers: {
-    addXAxis(state, action: PayloadAction<XAxisSettings>) {
-      state.xAxis[action.payload.id] = castDraft(action.payload);
+    addXAxis: {
+      reducer(state, action: PayloadAction<XAxisSettings>) {
+        state.xAxis[action.payload.id] = castDraft(action.payload);
+      },
+      prepare: prepareAutoBatched<XAxisSettings>(),
     },
-    removeXAxis(state, action: PayloadAction<XAxisSettings>) {
-      delete state.xAxis[action.payload.id];
+    removeXAxis: {
+      reducer(state, action: PayloadAction<XAxisSettings>) {
+        delete state.xAxis[action.payload.id];
+      },
+      prepare: prepareAutoBatched<XAxisSettings>(),
     },
-    addYAxis(state, action: PayloadAction<YAxisSettings>) {
-      state.yAxis[action.payload.id] = castDraft(action.payload);
+    addYAxis: {
+      reducer(state, action: PayloadAction<YAxisSettings>) {
+        state.yAxis[action.payload.id] = castDraft(action.payload);
+      },
+      prepare: prepareAutoBatched<YAxisSettings>(),
     },
-    removeYAxis(state, action: PayloadAction<YAxisSettings>) {
-      delete state.yAxis[action.payload.id];
+    removeYAxis: {
+      reducer(state, action: PayloadAction<YAxisSettings>) {
+        delete state.yAxis[action.payload.id];
+      },
+      prepare: prepareAutoBatched<YAxisSettings>(),
     },
-    addZAxis(state, action: PayloadAction<ZAxisSettings>) {
-      state.zAxis[action.payload.id] = castDraft(action.payload);
+    addZAxis: {
+      reducer(state, action: PayloadAction<ZAxisSettings>) {
+        state.zAxis[action.payload.id] = castDraft(action.payload);
+      },
+      prepare: prepareAutoBatched<ZAxisSettings>(),
     },
-    removeZAxis(state, action: PayloadAction<ZAxisSettings>) {
-      delete state.zAxis[action.payload.id];
+    removeZAxis: {
+      reducer(state, action: PayloadAction<ZAxisSettings>) {
+        delete state.zAxis[action.payload.id];
+      },
+      prepare: prepareAutoBatched<ZAxisSettings>(),
     },
     updateYAxisWidth(state, action: PayloadAction<{ id: AxisId; width: number }>) {
       const { id, width } = action.payload;

--- a/src/state/graphicalItemsSlice.ts
+++ b/src/state/graphicalItemsSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, current, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, current, PayloadAction, prepareAutoBatched } from '@reduxjs/toolkit';
 import { castDraft } from 'immer';
 import { ChartData } from './chartDataSlice';
 import { AxisId } from './cartesianAxisSlice';
@@ -98,30 +98,45 @@ const graphicalItemsSlice = createSlice({
   name: 'graphicalItems',
   initialState,
   reducers: {
-    addCartesianGraphicalItem(state, action: PayloadAction<CartesianGraphicalItemSettings>) {
-      state.cartesianItems.push(castDraft(action.payload));
+    addCartesianGraphicalItem: {
+      reducer(state, action: PayloadAction<CartesianGraphicalItemSettings>) {
+        state.cartesianItems.push(castDraft(action.payload));
+      },
+      prepare: prepareAutoBatched<CartesianGraphicalItemSettings>(),
     },
-    replaceCartesianGraphicalItem(state, action: PayloadAction<ReplacePayload<CartesianGraphicalItemSettings>>) {
-      const { prev, next } = action.payload;
-      const index = current(state).cartesianItems.indexOf(castDraft(prev));
-      if (index > -1) {
-        state.cartesianItems[index] = castDraft(next);
-      }
+    replaceCartesianGraphicalItem: {
+      reducer(state, action: PayloadAction<ReplacePayload<CartesianGraphicalItemSettings>>) {
+        const { prev, next } = action.payload;
+        const index = current(state).cartesianItems.indexOf(castDraft(prev));
+        if (index > -1) {
+          state.cartesianItems[index] = castDraft(next);
+        }
+      },
+      prepare: prepareAutoBatched<ReplacePayload<CartesianGraphicalItemSettings>>(),
     },
-    removeCartesianGraphicalItem(state, action: PayloadAction<CartesianGraphicalItemSettings>) {
-      const index = current(state).cartesianItems.indexOf(castDraft(action.payload));
-      if (index > -1) {
-        state.cartesianItems.splice(index, 1);
-      }
+    removeCartesianGraphicalItem: {
+      reducer(state, action: PayloadAction<CartesianGraphicalItemSettings>) {
+        const index = current(state).cartesianItems.indexOf(castDraft(action.payload));
+        if (index > -1) {
+          state.cartesianItems.splice(index, 1);
+        }
+      },
+      prepare: prepareAutoBatched<CartesianGraphicalItemSettings>(),
     },
-    addPolarGraphicalItem(state, action: PayloadAction<PolarGraphicalItemSettings>) {
-      state.polarItems.push(castDraft(action.payload));
+    addPolarGraphicalItem: {
+      reducer(state, action: PayloadAction<PolarGraphicalItemSettings>) {
+        state.polarItems.push(castDraft(action.payload));
+      },
+      prepare: prepareAutoBatched<PolarGraphicalItemSettings>(),
     },
-    removePolarGraphicalItem(state, action: PayloadAction<PolarGraphicalItemSettings>) {
-      const index = current(state).polarItems.indexOf(castDraft(action.payload));
-      if (index > -1) {
-        state.polarItems.splice(index, 1);
-      }
+    removePolarGraphicalItem: {
+      reducer(state, action: PayloadAction<PolarGraphicalItemSettings>) {
+        const index = current(state).polarItems.indexOf(castDraft(action.payload));
+        if (index > -1) {
+          state.polarItems.splice(index, 1);
+        }
+      },
+      prepare: prepareAutoBatched<PolarGraphicalItemSettings>(),
     },
   },
 });

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -682,15 +682,6 @@ const combineRelevantErrorBarSettings = (
     });
 };
 
-export const selectErrorBarsSettingsExceptStacked: (
-  state: RechartsRootState,
-  axisType: XorYorZType,
-  axisId: AxisId,
-) => ReadonlyArray<ErrorBarsSettings> = createSelector(
-  [selectCartesianItemsSettingsExceptStacked, selectAllErrorBarSettings, pickAxisType],
-  combineRelevantErrorBarSettings,
-);
-
 export const selectAllAppliedNumericalValuesIncludingErrorValues: (
   state: RechartsRootState,
   axisType: XorYorZType,

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -1863,7 +1863,7 @@ describe('<LineChart /> with dataKey as a function', () => {
     fireEvent.click(screen.getByText('Use data2'));
 
     expectLines(container, [{ d: 'M5,5L150,101.667L295,198.333' }]);
-    expect(dataKey1Spy).toHaveBeenCalledTimes(data1.length * 11);
+    expect(dataKey1Spy).toHaveBeenCalledTimes(data1.length * 7);
 
     expect(dataKey2Spy).toHaveBeenCalledTimes(data2.length * 7);
     expect(dataKey2Spy).toHaveBeenNthCalledWith(1, data2[0]);

--- a/www/src/docs/exampleComponents/ScatterChart/ScatterChartPerformance.tsx
+++ b/www/src/docs/exampleComponents/ScatterChart/ScatterChartPerformance.tsx
@@ -1,0 +1,70 @@
+import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+
+function* random(seed: number): Generator<number> {
+  // LCG good enough for our purposes https://en.wikipedia.org/wiki/Linear_congruential_generator
+  const m = 2 ** 16 + 1;
+  const a = 75;
+  const c = 74;
+  let x = seed;
+  // let's make Math.random() seeds a bit more random
+  if (x > 0 && x < 1) {
+    x = Math.round(x * 1000);
+  }
+  while (x < 0) {
+    x += m;
+  }
+  while (true) {
+    x = (a * x + c) % m;
+    yield Math.round(x);
+  }
+}
+
+function between(rng: Generator<number, number, unknown>, min: number, max: number): number {
+  const val = rng.next().value;
+  return (val % (max - min)) + min;
+}
+
+const gen = random(42);
+
+const chartData = {
+  points: Array.from({ length: 100 }, (_1, i) => ({
+    name: `line-${i}`,
+    passed: between(gen, 0, 10) > 5,
+    points: Array.from({ length: 10 }, (_2, j) => ({
+      x: j * 0.1,
+      y: between(gen, 0, 100),
+    })),
+  })),
+};
+
+export default function ScatterChartPerformance() {
+  return (
+    <ScatterChart
+      style={{ width: '100%', maxWidth: '700px', maxHeight: '70vh', aspectRatio: 1.618 }}
+      responsive
+      margin={{
+        top: 20,
+        right: 0,
+        bottom: 0,
+        left: 0,
+      }}
+    >
+      <CartesianGrid />
+      <XAxis dataKey="x" type="number" unit="m" domain={[0, 1]} />
+      <YAxis dataKey="y" type="number" unit="m" domain={[0, 100]} />
+      <Tooltip />
+
+      {chartData.points.map(line => (
+        <Scatter
+          key={line.name}
+          data={line.points}
+          fill={line.passed ? '#22c55e' : '#ef4444'}
+          isAnimationActive={false}
+          line
+          name={line.name}
+          strokeWidth={4}
+        />
+      ))}
+    </ScatterChart>
+  );
+}

--- a/www/src/docs/exampleComponents/ScatterChart/index.ts
+++ b/www/src/docs/exampleComponents/ScatterChart/index.ts
@@ -13,6 +13,8 @@ import scatterChartWithLabelsSource from './ScatterChartWithLabels?raw';
 import multipleYAxesScatterChartSource from './MultipleYAxesScatterChart?raw';
 import scatterChartWithCellsSource from './ScatterChartWithCells?raw';
 import { ChartExample } from '../types.ts';
+import ScatterChartPerformance from './ScatterChartPerformance';
+import scatterChartPerformanceSource from './ScatterChartPerformance?raw';
 
 export const scatterChartExamples: Record<string, ChartExample> = {
   SimpleScatterChart: {
@@ -49,5 +51,10 @@ export const scatterChartExamples: Record<string, ChartExample> = {
     Component: ScatterChartWithCells,
     sourceCode: scatterChartWithCellsSource,
     name: 'Scatter Chart With Cells',
+  },
+  ScatterChartPerformance: {
+    Component: ScatterChartPerformance,
+    sourceCode: scatterChartPerformanceSource,
+    name: 'Scatter Chart with many points (performance test)',
   },
 };

--- a/www/test/__snapshots__/navigation.spec.ts.snap
+++ b/www/test/__snapshots__/navigation.spec.ts.snap
@@ -586,6 +586,11 @@ exports[`getAllNavigationItems > should return all navigation items 1`] = `
             "key": "ScatterChartWithCells",
             "url": "/en-US/examples/ScatterChartWithCells",
           },
+          {
+            "displayName": "Scatter Chart with many points (performance test)",
+            "key": "ScatterChartPerformance",
+            "url": "/en-US/examples/ScatterChartPerformance",
+          },
         ],
         "key": "ScatterChart",
       },


### PR DESCRIPTION
## Description

Uses synchronous and batched dispatch to reduce wasted selector cycles. Improves chart rendering of this one specific example from 2500ms to 600ms on my laptop.

My browser still can't handle much more than 100 series, I will try to find more improvement.

## Related Issue

https://github.com/recharts/recharts/issues/6394

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes
