### PR TITLE
chore: remove unused react-monaco-editor dependency

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -19,7 +19,6 @@
         "react-dom": "^18.3.1",
         "react-ga4": "^2.1.0",
         "react-helmet": "^6.1.0",
-        "react-monaco-editor": "^0.59.0",
         "react-router": "^7.9.4",
         "react-runner": "^1.0.5",
         "recharts": "^3.2.1",
@@ -4726,17 +4725,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/react-monaco-editor": {
-      "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/react-monaco-editor/-/react-monaco-editor-0.59.0.tgz",
-      "integrity": "sha512-SggqfZCdUauNk7GI0388bk5n25zYsQ1ai1i+VhxAgwbCH+MTGl7L1fBNTJ6V+oXeUApf+bpzikprHJEZm9J/zA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "monaco-editor": "^0.52.0",
-        "react": ">=16.8.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/www/package.json
+++ b/www/package.json
@@ -38,7 +38,6 @@
     "react-dom": "^18.3.1",
     "react-ga4": "^2.1.0",
     "react-helmet": "^6.1.0",
-    "react-monaco-editor": "^0.59.0",
     "react-router": "^7.9.4",
     "react-runner": "^1.0.5",
     "recharts": "^3.2.1",


### PR DESCRIPTION
We're already using the more modern variant @monaco-editor/react