### PR TITLE
Only use the YAxis width oscillation detection if the difference is > 1 pixel

### DIFF
--- a/src/state/cartesianAxisSlice.ts
+++ b/src/state/cartesianAxisSlice.ts
@@ -149,8 +149,14 @@ const cartesianAxisSlice = createSlice({
       if (axis) {
         const history = axis.widthHistory || [];
         // An oscillation is detected when the new width is the same as the width before the last one.
-        // This is a simple A -> B -> A pattern. If the next width is B, we ignore it.
-        if (history.length === 3 && history[0] === history[2] && width === history[1] && width !== axis.width) {
+        // This is a simple A -> B -> A pattern. If the next width is B, and the difference is less than 1 pixel, we ignore it.
+        if (
+          history.length === 3 &&
+          history[0] === history[2] &&
+          width === history[1] &&
+          width !== axis.width &&
+          Math.abs(width - history[0]) <= 1
+        ) {
           return;
         }
         const newHistory = [...history, width].slice(-3);

--- a/storybook/stories/API/chart/AreaChart.stories.tsx
+++ b/storybook/stories/API/chart/AreaChart.stories.tsx
@@ -14,12 +14,10 @@ export default {
 
 export const Simple = {
   render: (args: Args) => {
-    const [myState, setMyState] = React.useState(0);
     return (
       <ResponsiveContainer width="100%" height={400}>
         <AreaChart
           {...args}
-          onMouseDown={() => setMyState(myState + 1)}
           margin={{
             top: 0,
             bottom: 0,

--- a/test/state/selectors/cartesianAxisSlice.spec.ts
+++ b/test/state/selectors/cartesianAxisSlice.spec.ts
@@ -4,39 +4,39 @@ import { addYAxis, cartesianAxisReducer, updateYAxisWidth, YAxisSettings } from 
 
 describe('cartesianAxisSlice', () => {
   describe('updateYAxisWidth', () => {
+    const yAxis: YAxisSettings = {
+      id: 'test-axis',
+      width: 'auto',
+      scale: 'auto',
+      type: 'number',
+      dataKey: undefined,
+      unit: undefined,
+      name: undefined,
+      allowDuplicatedCategory: true,
+      allowDataOverflow: false,
+      reversed: false,
+      includeHidden: false,
+      domain: undefined,
+      allowDecimals: true,
+      tickCount: 5,
+      ticks: undefined,
+      tick: true,
+      interval: 'preserveEnd',
+      mirror: false,
+      minTickGap: 5,
+      angle: 0,
+      hide: false,
+      tickFormatter: undefined,
+      padding: { top: 0, bottom: 0 },
+      orientation: 'left',
+    };
+
     it('should stop updating width after oscillation is detected', () => {
       const store = configureStore({
         reducer: {
           cartesianAxis: cartesianAxisReducer,
         },
       });
-
-      const yAxis: YAxisSettings = {
-        id: 'test-axis',
-        width: 'auto',
-        scale: 'auto',
-        type: 'number',
-        dataKey: undefined,
-        unit: undefined,
-        name: undefined,
-        allowDuplicatedCategory: true,
-        allowDataOverflow: false,
-        reversed: false,
-        includeHidden: false,
-        domain: undefined,
-        allowDecimals: true,
-        tickCount: 5,
-        ticks: undefined,
-        tick: true,
-        interval: 'preserveEnd',
-        mirror: false,
-        minTickGap: 5,
-        angle: 0,
-        hide: false,
-        tickFormatter: undefined,
-        padding: { top: 0, bottom: 0 },
-        orientation: 'left',
-      };
 
       store.dispatch(addYAxis(yAxis));
 
@@ -45,15 +45,41 @@ describe('cartesianAxisSlice', () => {
       store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 50 }));
       expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(50);
 
-      store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 60 }));
-      expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(60);
+      store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 51 }));
+      expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(51);
 
       store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 50 }));
       expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(50);
 
       // This is the 4th action. The oscillation should be detected and the update ignored.
-      store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 60 }));
+      store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 51 }));
       expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(50);
+    });
+
+    it('should keep updating if the oscillation is larger than 1 pixel because that is likely to be intentional', () => {
+      // https://github.com/recharts/recharts/issues/6424
+      const store = configureStore({
+        reducer: {
+          cartesianAxis: cartesianAxisReducer,
+        },
+      });
+
+      store.dispatch(addYAxis(yAxis));
+
+      expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe('auto');
+
+      store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 50 }));
+      expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(50);
+
+      store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 52 }));
+      expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(52);
+
+      store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 50 }));
+      expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(50);
+
+      // This is the 4th action. The oscillation is larger than 1 pixel, so the update should be accepted.
+      store.dispatch(updateYAxisWidth({ id: 'test-axis', width: 52 }));
+      expect(store.getState().cartesianAxis.yAxis['test-axis'].width).toBe(52);
     });
   });
 });


### PR DESCRIPTION
## Description

The oscillation detector is there for sub-pixel rendering difference but here it was interfering with actual data changes.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/6424
