### PR TITLE
Add tests for getAttrsOfCartesianLabel, allow Percent type for custom label position

### DIFF
--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
 import {
   cloneElement,
-  isValidElement,
-  ReactNode,
-  ReactElement,
-  createElement,
-  SVGProps,
   createContext,
+  createElement,
+  isValidElement,
+  ReactElement,
+  ReactNode,
+  SVGProps,
   useContext,
   useMemo,
 } from 'react';
 import { clsx } from 'clsx';
-import { Text } from './Text';
-import { isNumOrStr, isNumber, isPercent, getPercentValue, uniqueId, mathSign, isNullish } from '../util/DataUtils';
+import { Text, TextAnchor, TextVerticalAnchor } from './Text';
+import { getPercentValue, isNullish, isNumber, isNumOrStr, isPercent, mathSign, uniqueId } from '../util/DataUtils';
 import { polarToCartesian } from '../util/PolarUtils';
-import { ViewBox, DataKey, CartesianViewBoxRequired, PolarViewBoxRequired } from '../util/types';
+import { CartesianViewBoxRequired, DataKey, Percent, PolarViewBoxRequired, ViewBox } from '../util/types';
 import { useViewBox } from '../context/chartLayoutContext';
 import { useAppSelector } from '../state/hooks';
 import { selectPolarViewBox } from '../state/selectors/polarAxisSelectors';
@@ -46,8 +46,8 @@ type CartesianLabelPosition =
   | 'centerBottom'
   | 'middle'
   | {
-      x?: number;
-      y?: number;
+      x?: number | Percent;
+      y?: number | Percent;
     };
 
 type PolarLabelPosition = 'insideStart' | 'insideEnd' | 'end';
@@ -281,7 +281,25 @@ const getAttrsOfPolarLabel = (viewBox: PolarViewBoxRequired, offset: number, pos
 const isPolar = (viewBox: CartesianViewBoxRequired | PolarViewBoxRequired): viewBox is PolarViewBoxRequired =>
   'cx' in viewBox && isNumber(viewBox.cx);
 
-const getAttrsOfCartesianLabel = (props: PropsWithDefaults, viewBox: CartesianViewBoxRequired) => {
+export type CartesianLabelPositionInput = {
+  parentViewBox?: ViewBox;
+  offset: number;
+  position?: CartesianLabelPosition;
+};
+
+export type LabelPositionAttributes = {
+  x: number;
+  y: number;
+  textAnchor: TextAnchor;
+  verticalAnchor: TextVerticalAnchor;
+  width?: number;
+  height?: number;
+};
+
+export const getAttrsOfCartesianLabel = (
+  props: CartesianLabelPositionInput,
+  viewBox: CartesianViewBoxRequired,
+): LabelPositionAttributes => {
   const { parentViewBox: parentViewBoxFromProps, offset, position } = props;
   let parentViewBox: CartesianViewBoxRequired | undefined;
   if (parentViewBoxFromProps != null && !isPolar(parentViewBoxFromProps)) {
@@ -304,7 +322,7 @@ const getAttrsOfCartesianLabel = (props: PropsWithDefaults, viewBox: CartesianVi
   const horizontalStart = horizontalSign > 0 ? 'start' : 'end';
 
   if (position === 'top') {
-    const attrs = {
+    const attrs: LabelPositionAttributes = {
       x: x + width / 2,
       y: y - verticalSign * offset,
       textAnchor: 'middle',
@@ -323,7 +341,7 @@ const getAttrsOfCartesianLabel = (props: PropsWithDefaults, viewBox: CartesianVi
   }
 
   if (position === 'bottom') {
-    const attrs = {
+    const attrs: LabelPositionAttributes = {
       x: x + width / 2,
       y: y + height + verticalOffset,
       textAnchor: 'middle',
@@ -342,7 +360,7 @@ const getAttrsOfCartesianLabel = (props: PropsWithDefaults, viewBox: CartesianVi
   }
 
   if (position === 'left') {
-    const attrs = {
+    const attrs: LabelPositionAttributes = {
       x: x - horizontalOffset,
       y: y + height / 2,
       textAnchor: horizontalEnd,
@@ -361,7 +379,7 @@ const getAttrsOfCartesianLabel = (props: PropsWithDefaults, viewBox: CartesianVi
   }
 
   if (position === 'right') {
-    const attrs = {
+    const attrs: LabelPositionAttributes = {
       x: x + width + horizontalOffset,
       y: y + height / 2,
       textAnchor: horizontalStart,

--- a/test/component/Label.getAttrsOfCartesianLabel.spec.ts
+++ b/test/component/Label.getAttrsOfCartesianLabel.spec.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  CartesianLabelPositionInput,
+  getAttrsOfCartesianLabel,
+  LabelPositionAttributes,
+} from '../../src/component/Label';
+import { CartesianViewBoxRequired } from '../../src/util/types';
+
+describe('getAttrsOfCartesianLabel', () => {
+  describe('in a rectangle', () => {
+    const viewBox: CartesianViewBoxRequired = {
+      x: 100,
+      y: 50,
+      width: 200,
+      height: 100,
+    };
+    const offset = 5;
+
+    it('should return correct attributes for position "insideTop"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'insideTop',
+        offset: 0,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = {
+        x: 200,
+        y: 50,
+        textAnchor: 'middle',
+        verticalAnchor: 'start',
+      };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position "top"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'top',
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = { x: 200, y: 45, textAnchor: 'middle', verticalAnchor: 'end' };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position "bottom"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'bottom',
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = { x: 200, y: 155, textAnchor: 'middle', verticalAnchor: 'start' };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position "left"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'left',
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = { x: 95, y: 100, textAnchor: 'end', verticalAnchor: 'middle' };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position "right"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'right',
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = { x: 305, y: 100, textAnchor: 'start', verticalAnchor: 'middle' };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position "insideLeft"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'insideLeft',
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = {
+        x: 105,
+        y: 100,
+        textAnchor: 'start',
+        verticalAnchor: 'middle',
+      };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position "insideRight"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'insideRight',
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = {
+        x: 295,
+        y: 100,
+        textAnchor: 'end',
+        verticalAnchor: 'middle',
+      };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position "insideBottom"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'insideBottom',
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = {
+        x: 200,
+        y: 145,
+        textAnchor: 'middle',
+        verticalAnchor: 'end',
+      };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position "insideTopLeft"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'insideTopLeft',
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = {
+        x: 105,
+        y: 55,
+        textAnchor: 'start',
+        verticalAnchor: 'start',
+      };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position "insideTopRight"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'insideTopRight',
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = {
+        x: 295,
+        y: 55,
+        textAnchor: 'end',
+        verticalAnchor: 'start',
+      };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position "insideBottomLeft"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'insideBottomLeft',
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = {
+        x: 105,
+        y: 145,
+        textAnchor: 'start',
+        verticalAnchor: 'end',
+      };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position "insideBottomRight"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'insideBottomRight',
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = {
+        x: 295,
+        y: 145,
+        textAnchor: 'end',
+        verticalAnchor: 'end',
+      };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position as an object with number coordinates', () => {
+      const input: CartesianLabelPositionInput = {
+        position: { x: 10, y: 20 },
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = { x: 110, y: 70, textAnchor: 'end', verticalAnchor: 'end' };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position as an object with percentage coordinates', () => {
+      const input: CartesianLabelPositionInput = {
+        position: { x: '50%', y: '50%' },
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = { x: 200, y: 100, textAnchor: 'end', verticalAnchor: 'end' };
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return correct attributes for position "center"', () => {
+      const input: CartesianLabelPositionInput = {
+        position: 'center',
+        offset,
+      };
+      const actual = getAttrsOfCartesianLabel(input, viewBox);
+      const expected: LabelPositionAttributes = {
+        x: 200,
+        y: 100,
+        textAnchor: 'middle',
+        verticalAnchor: 'middle',
+      };
+      expect(actual).toEqual(expected);
+    });
+
+    describe('with negative height', () => {
+      const negativeHeightViewBox: CartesianViewBoxRequired = {
+        x: 100,
+        y: 150,
+        width: 175,
+        height: -100,
+      };
+
+      it('should return correct attributes for position "top"', () => {
+        const input: CartesianLabelPositionInput = {
+          position: 'top',
+          offset,
+        };
+        const actual = getAttrsOfCartesianLabel(input, negativeHeightViewBox);
+        const expected: LabelPositionAttributes = { x: 187.5, y: 155, textAnchor: 'middle', verticalAnchor: 'start' };
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('with negative width', () => {
+      const negativeWidthViewBox: CartesianViewBoxRequired = {
+        x: 300,
+        y: 50,
+        width: -175,
+        height: 100,
+      };
+
+      it('should return correct attributes for position "left"', () => {
+        const input: CartesianLabelPositionInput = {
+          position: 'left',
+          offset,
+        };
+        const actual = getAttrsOfCartesianLabel(input, negativeWidthViewBox);
+        const expected: LabelPositionAttributes = { x: 305, y: 100, textAnchor: 'start', verticalAnchor: 'middle' };
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('with parentViewBox', () => {
+      const parentViewBox: CartesianViewBoxRequired = { x: 0, y: 0, width: 500, height: 500 };
+
+      it('should return correct attributes for position "top"', () => {
+        const input: CartesianLabelPositionInput = {
+          position: 'top',
+          offset,
+          parentViewBox,
+        };
+        const actual = getAttrsOfCartesianLabel(input, viewBox);
+        const expected: LabelPositionAttributes = {
+          x: 200,
+          y: 45,
+          textAnchor: 'middle',
+          verticalAnchor: 'end',
+          height: 50,
+          width: 200,
+        };
+        expect(actual).toEqual(expected);
+      });
+
+      it('should return correct attributes for position "insideLeft"', () => {
+        const input: CartesianLabelPositionInput = {
+          position: 'insideLeft',
+          offset,
+          parentViewBox,
+        };
+        const actual = getAttrsOfCartesianLabel(input, viewBox);
+        const expected: LabelPositionAttributes = {
+          x: 105,
+          y: 100,
+          textAnchor: 'start',
+          verticalAnchor: 'middle',
+          width: 200,
+          height: 100,
+        };
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

I have discovered that the x,y of Label position allow percentage based dimensions so I updated the type to match.

## Related Issue

https://github.com/recharts/recharts/issues/6427

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes
