### PR TITLE
Fix Label + Text types

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -74,7 +74,7 @@ export interface CartesianAxisProps {
    * this is Recharts scale, based on d3-scale.
    */
   scale?: RechartsScale;
-  labelRef?: React.RefObject<Element> | null;
+  labelRef?: React.RefObject<SVGTextElement> | null;
 
   ref?: React.Ref<CartesianAxisRef>;
 }

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createContext, PropsWithoutRef, SVGProps, useContext } from 'react';
 import last from 'es-toolkit/compat/last';
 
-import { LabelContentType, isLabelContentAFunction, Label, LabelPosition } from './Label';
+import { LabelContentType, isLabelContentAFunction, Label, LabelPosition, LabelFormatter } from './Label';
 import { Layer } from '../container/Layer';
 import { getValueByDataKey } from '../util/ChartUtils';
 import { CartesianViewBoxRequired, DataKey, PolarViewBoxRequired } from '../util/types';
@@ -56,14 +56,14 @@ interface LabelListProps {
   position?: LabelPosition;
   offset?: LabelProps['offset'];
   angle?: number;
-  formatter?: (label: React.ReactNode) => React.ReactNode;
+  formatter?: LabelFormatter;
 }
 
 /**
  * LabelList props do not allow refs because the same props are reused in multiple elements so we don't have a good single place to ref to.
  */
 type SvgTextProps = PropsWithoutRef<SVGProps<SVGTextElement>>;
-export type Props = SvgTextProps & LabelListProps;
+export type Props = Omit<SvgTextProps, 'children'> & LabelListProps;
 
 /**
  * This is the type accepted for the `label` prop on various graphical items.

--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -47,6 +47,8 @@ export type TextAnchor = 'start' | 'middle' | 'end' | 'inherit';
 
 export type TextVerticalAnchor = 'start' | 'middle' | 'end';
 
+export type RenderableText = string | number | boolean | null | undefined;
+
 interface TextProps {
   /**
    * When true, scales the text to fit within the specified width.
@@ -125,7 +127,7 @@ interface TextProps {
    * Can be a string or number. Numbers will be converted to strings.
    * undefined or null values will result in no text being rendered.
    */
-  children?: string | number;
+  children?: RenderableText;
 
   /**
    * Maximum number of lines to display when text wrapping is enabled.

--- a/test/cartesian/YAxis/YAxis.label.spec.tsx
+++ b/test/cartesian/YAxis/YAxis.label.spec.tsx
@@ -147,12 +147,13 @@ describe('<YAxis /> Label', () => {
       ]);
     });
 
-    it('renders nonsense if <Label /> itself has element children - this looks like a bug, we should fix it!', () => {
+    it('renders nonsense if <Label /> itself has element children', () => {
       const { container } = render(
         <AreaChart width={500} height={500} data={PageData}>
           <Area dataKey="uv" />
           <YAxis>
             <Label value="Test Label" angle={-80} position="insideEnd">
+              {/* @ts-expect-error the type here says it doesn't accept span, and it is correct! the Label doesn't render it properly */}
               <span>Additional Content</span>
             </Label>
           </YAxis>
@@ -160,7 +161,6 @@ describe('<YAxis /> Label', () => {
       );
       expectYAxisLabel(container, [
         {
-          // ... this is not great. Room for improvement definitely.
           textContent: '[object Object]',
           transform: 'rotate(-80, 35, 250)',
           x: '35',

--- a/test/component/Label.spec.tsx
+++ b/test/component/Label.spec.tsx
@@ -194,7 +194,6 @@ describe('<Label />', () => {
         });
 
         it('should render label when given value prop', () => {
-          // @ts-expect-error Label type says it doesn't accept boolean as value, but in practice it does render it just fine
           renderLabelWithValue(false);
 
           const label = screen.getAllByText('false');
@@ -360,6 +359,7 @@ describe('<Label />', () => {
         const element = <>label from element</>;
 
         it('should render label when given children prop', () => {
+          // @ts-expect-error typescript is correct here, Label does not allow React element as value, and it renders gibberish
           const { container } = renderLabelWithChildren(element);
 
           const label = container.querySelector('.recharts-label');
@@ -392,7 +392,7 @@ describe('<Label />', () => {
         const array = ['label', 'from', 'array'];
 
         it('should render label when given children prop', () => {
-          // the type says that this is allowed but perhaps it shouldn't be?
+          // @ts-expect-error typescript is correct here, Label does not allow React element as value, and it renders gibberish
           const { container } = renderLabelWithChildren(array);
 
           const label = container.querySelector('.recharts-label');

--- a/test/component/Text.spec.tsx
+++ b/test/component/Text.spec.tsx
@@ -49,7 +49,6 @@ describe('<Text />', () => {
     const { container } = render(
       <Surface width={300} height={300}>
         <Text width={300} style={{ fontFamily: 'Courier' }}>
-          {/* @ts-expect-error typescript says that booleans are not allowed, but it does render it just fine */}
           {true}
         </Text>
       </Surface>,
@@ -76,7 +75,7 @@ describe('<Text />', () => {
     expect(text.textContent).toBe('NaN');
   });
 
-  test.each([null, undefined] as const)('Renders empty text when children is %s', (children: null | undefined) => {
+  test.each([null, undefined] as const)('Renders nothing when children is %s', (children: null | undefined) => {
     const { container } = render(
       <Surface width={300} height={300}>
         <Text width={300} style={{ fontFamily: 'Courier' }}>


### PR DESCRIPTION
## Description

Text component has always been able to only render `string | number` but the Label component (which calls Text internally) had children: ReactNode. How come? Well there was one small `as any` that completely disabled all type checking in several files so here is a fix.

I added tests that show what renders and what does not, and then updated the types to match. I also fixed the ref type which was wrong and hidden behind the same `as any`.

## Related Issue

https://github.com/recharts/recharts/issues/6427

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes
