### PR TITLE
correct index offset in stacked bar charts with Brush component

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -713,6 +713,7 @@ export function computeBarRectangles({
   offset,
   cells,
   parentViewBox,
+  dataStartIndex,
 }: {
   layout: 'horizontal' | 'vertical';
   barSettings: BarSettings;
@@ -727,6 +728,7 @@ export function computeBarRectangles({
   displayedData: any[];
   cells: ReadonlyArray<ReactElement> | undefined;
   parentViewBox: CartesianViewBoxRequired;
+  dataStartIndex: number;
 }): ReadonlyArray<BarRectangleItem> | undefined {
   const numericAxis = layout === 'horizontal' ? yAxis : xAxis;
   // @ts-expect-error this assumes that the domain is always numeric, but doesn't check for it
@@ -738,8 +740,8 @@ export function computeBarRectangles({
       let value, x: number | null, y, width, height, background: Rectangle;
 
       if (stackedData) {
-        // we don't need to use dataStartIndex here, because stackedData is already sliced from the selector
-        value = truncateByDomain(stackedData[index], stackedDomain);
+        // Use dataStartIndex to access the correct element in the full stackedData array
+        value = truncateByDomain(stackedData[index + dataStartIndex], stackedDomain);
       } else {
         value = getValueByDataKey(entry, dataKey);
 

--- a/src/state/selectors/barSelectors.ts
+++ b/src/state/selectors/barSelectors.ts
@@ -545,6 +545,7 @@ export const selectBarRectangles: (
       displayedData,
       offset,
       cells,
+      dataStartIndex,
     });
   },
 );

--- a/src/state/selectors/combiners/combineDisplayedStackedData.ts
+++ b/src/state/selectors/combiners/combineDisplayedStackedData.ts
@@ -33,7 +33,7 @@ export function combineDisplayedStackedData(
     // If there is no data on the individual item then we use the root chart data
     const resolvedData = item.data ?? chartData;
     if (resolvedData == null || resolvedData.length === 0) {
-      // if that didn't work then we skip this item
+      // if that doesn't work then we skip this item
       return;
     }
     const stackIdentifier = getStackSeriesIdentifier(item);

--- a/storybook/stories/Examples/BarChart/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart/BarChart.stories.tsx
@@ -511,6 +511,38 @@ export const WithCustomizedEvent = {
   },
 };
 
+export const StackedWithBrush = {
+  render: (args: Args) => {
+    return (
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart {...args}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Legend verticalAlign="top" wrapperStyle={{ lineHeight: '40px' }} />
+          <Tooltip defaultIndex={1} />
+          <Bar dataKey="pv" stackId="a" fill="#8884d8" activeBar={{ fill: 'gold' }} />
+          <Bar dataKey="uv" stackId="a" fill="#82ca9d" activeBar={{ fill: 'silver' }} />
+          <Brush dataKey="name" height={30} stroke="#8884d8" />
+          <RechartsHookInspector />
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(BarChartProps),
+    width: 500,
+    height: 300,
+    data: pageData,
+    margin: {
+      top: 5,
+      right: 30,
+      left: 20,
+      bottom: 5,
+    },
+  },
+};
+
 export const StackedBySign = {
   render: (args: Args) => {
     return (


### PR DESCRIPTION
## Description

When using a Brush component with stacked bar charts, there was an index mismatch issue that caused incorrect data to be displayed. When the brush was moved to filter data (e.g., showing only the last 3 pages), the chart would either display wrong data or disappear completely.

The root cause was that `displayedData` was sliced to match the brush selection (e.g., indices 0, 1, 2 for the last 3 pages), but `stackedData` contained all 6 original data points. When rendering, the code accessed `stackedData[0]` thinking it was Page E data, but it actually contained Page A data.

Added `dataStartIndex` parameter to the bar rendering pipeline to properly

offset the index when accessing the full `stackedData` array. Now the code

uses `stackedData[index + dataStartIndex]` to access the correct element.

- `src/state/selectors/barSelectors.ts`: Pass `dataStartIndex` to `computeBarRectangles` function
- `src/cartesian/Bar.tsx`: Add `dataStartIndex` parameter and use it to offset stackedData access (line 744: `stackedData[index + dataStartIndex]`)
- `storybook/stories/Examples/BarChart/BarChart.stories.tsx`: Add `StackedWithBrush` story to demonstrate the fix
- `test/cartesian/Brush.stacked.spec.tsx`: Add comprehensive tests for brush behavior with stacked charts, including edge cases when narrowing to last 3 pages

All 6 tests in Brush.stacked.spec.tsx pass, including new tests that verify:
- Bars render correctly when brush is narrowed to last 3 pages
- Stack groups maintain correct data structure throughout filtering

## Related Issue
- https://github.com/recharts/recharts/issues/6331

## Motivation and Context
To fix a bug.

## How Has This Been Tested?

- Added comprehensive test suite in `test/cartesian/Brush.stacked.spec.tsx`:
  - Tests for Brush interaction with stacked Bar charts
  - Verifies correct bar rendering after moving the Brush traveller
  - Validates stack groups and stacked data structure with proper data range
  - Tests both initial view and narrowed down view (last 3 pages)
- Added Storybook story `StackedWithBrush` in `storybook/stories/Examples/BarChart/BarChart.stories.tsx` for manual testing and visual verification
- Verified the fix resolves the issue reported in #6006

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/2364c811-883b-4c70-8065-7dd17b7e8c96


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes