### PR TITLE
refactor: extract common Dots component from Area, Line, and Radar

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -53,6 +53,7 @@
   "es6/component/Customized.js",
   "es6/component/DefaultLegendContent.js",
   "es6/component/DefaultTooltipContent.js",
+  "es6/component/Dots.js",
   "es6/component/Label.js",
   "es6/component/LabelList.js",
   "es6/component/Legend.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -53,6 +53,7 @@
   "lib/component/Customized.js",
   "lib/component/DefaultLegendContent.js",
   "lib/component/DefaultTooltipContent.js",
+  "lib/component/Dots.js",
   "lib/component/Label.js",
   "lib/component/LabelList.js",
   "lib/component/Legend.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -53,6 +53,7 @@
   "types/component/Customized.d.ts",
   "types/component/DefaultLegendContent.d.ts",
   "types/component/DefaultTooltipContent.d.ts",
+  "types/component/Dots.d.ts",
   "types/component/Label.d.ts",
   "types/component/LabelList.d.ts",
   "types/component/Legend.d.ts",

--- a/src/component/ActivePoints.tsx
+++ b/src/component/ActivePoints.tsx
@@ -36,31 +36,30 @@ const renderActivePoint = ({
   if (activeDot === false || point.x == null || point.y == null) {
     return null;
   }
-  const dotProps: ActiveDotProps = {
+  const dotPropsTyped: ActiveDotProps = {
     index: childIndex,
     dataKey,
-    // @ts-expect-error activeDot is contributing unknown props
     cx: point.x,
-    // @ts-expect-error activeDot is contributing unknown props
     cy: point.y,
-    // @ts-expect-error activeDot is contributing unknown props
     r: 4,
-    // @ts-expect-error activeDot is contributing unknown props
     fill: mainColor ?? 'none',
-    // @ts-expect-error activeDot is contributing unknown props
     strokeWidth: 2,
-    // @ts-expect-error activeDot is contributing unknown props
     stroke: '#fff',
     payload: point.payload,
     value: point.value,
-    ...svgPropertiesNoEventsFromUnknown(activeDot),
     ...adaptEventHandlers(activeDot),
+  };
+
+  // @ts-expect-error svgPropertiesNoEventsFromUnknown(activeDot) is contributing unknown props
+  const dotProps: ActiveDotProps = {
+    ...dotPropsTyped,
+    ...svgPropertiesNoEventsFromUnknown(activeDot),
   };
 
   let dot;
 
   if (isValidElement(activeDot)) {
-    // @ts-expect-error element cloning does not have types
+    // @ts-expect-error we're improperly typing events
     dot = cloneElement(activeDot, dotProps);
   } else if (typeof activeDot === 'function') {
     dot = activeDot(dotProps);

--- a/src/component/Dots.tsx
+++ b/src/component/Dots.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { cloneElement, isValidElement } from 'react';
+import { clsx } from 'clsx';
+import { Dot, type Props as DotProps } from '../shape/Dot';
+import { Layer } from '../container/Layer';
+import { DataKey, DotItemDotProps, DotType } from '../util/types';
+import { isClipDot } from '../util/ReactUtils';
+import { svgPropertiesAndEventsFromUnknown } from '../util/svgPropertiesAndEvents';
+
+export interface DotPoint {
+  readonly x: number | null;
+  readonly y: number | null;
+  readonly value?: any;
+  readonly payload?: any;
+}
+
+type DotItemProps = {
+  option: DotType;
+  dotProps: DotItemDotProps;
+  className: string;
+};
+
+function DotItem({ option, dotProps, className }: DotItemProps) {
+  if (isValidElement(option)) {
+    // @ts-expect-error we can't type check element cloning properly
+    return cloneElement(option, dotProps);
+  }
+
+  if (typeof option === 'function') {
+    return option(dotProps);
+  }
+
+  const finalClassName = clsx(className, typeof option !== 'boolean' ? option.className : '');
+  const { points, ...props } = dotProps ?? {};
+  return <Dot {...props} className={finalClassName} />;
+}
+
+function shouldRenderDots(points: ReadonlyArray<DotPoint> | undefined, dot: DotType): boolean {
+  if (points == null) {
+    return false;
+  }
+  if (dot) {
+    return true;
+  }
+  return points.length === 1;
+}
+
+export type DotsDotProps = Omit<DotProps, 'cx' | 'cy' | 'key' | 'index' | 'dataKey' | 'value' | 'payload'>;
+
+type DotsProps = {
+  /**
+   * Points to render dots for
+   */
+  points: ReadonlyArray<DotPoint>;
+  /**
+   * Dot configuration - boolean, ReactElement, function, or props object
+   */
+  dot: DotType;
+  /**
+   * Base class name for the dots layer (e.g., 'recharts-area-dots')
+   */
+  className: string;
+  /**
+   * Base class name for individual dot (e.g., 'recharts-area-dot')
+   */
+  dotClassName: string;
+  /**
+   * DataKey for the data
+   */
+  dataKey: DataKey<any> | undefined;
+  /**
+   * Base props to spread onto each dot (from parent component).
+   * Except some properties that the Dots component manages itself.
+   */
+  baseProps: DotsDotProps;
+  /**
+   * Whether clipping is needed (cartesian only)
+   */
+  needClip?: boolean;
+  /**
+   * Clip path ID (cartesian only)
+   */
+  clipPathId?: string;
+};
+
+export function Dots({ points, dot, className, dotClassName, dataKey, baseProps, needClip, clipPathId }: DotsProps) {
+  if (!shouldRenderDots(points, dot)) {
+    return null;
+  }
+
+  const clipDot = isClipDot(dot);
+  const customDotProps = svgPropertiesAndEventsFromUnknown(dot);
+
+  const dots = points.map((entry, i) => {
+    const dotProps: DotItemDotProps = {
+      r: 3,
+      ...baseProps,
+      ...customDotProps,
+      index: i,
+      cx: entry.x ?? undefined,
+      cy: entry.y ?? undefined,
+      dataKey,
+      value: entry.value,
+      payload: entry.payload,
+      points,
+    };
+
+    return <DotItem key={`dot-${i}`} option={dot} dotProps={dotProps} className={dotClassName} />;
+  });
+
+  const layerProps: { clipPath?: string } = {};
+  if (needClip && clipPathId != null) {
+    layerProps.clipPath = `url(#clipPath-${clipDot ? '' : 'dots-'}${clipPathId})`;
+  }
+
+  return (
+    <Layer className={className} {...layerProps}>
+      {dots}
+    </Layer>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export { Polygon } from './shape/Polygon';
 export type { Props as PolygonProps } from './shape/Polygon';
 export { Dot } from './shape/Dot';
 export type { Props as DotProps } from './shape/Dot';
+export type { DotItemDotProps } from './util/types';
 export { Cross } from './shape/Cross';
 export type { Props as CrossProps } from './shape/Cross';
 export { Symbols } from './shape/Symbols';

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { Children, ReactNode } from 'react';
 import { isFragment } from 'react-is';
 import { isNullish } from './DataUtils';
-import { ActiveDotType } from './types';
+import { ActiveDotType, DotType } from './types';
 
 export const SCALE_TYPES = [
   'auto',
@@ -104,7 +104,7 @@ export function findAllByType<
   return result;
 }
 
-export const isClipDot = (dot: ActiveDotType): boolean => {
+export const isClipDot = (dot: ActiveDotType | DotType): boolean => {
   if (dot && typeof dot === 'object' && 'clipDot' in dot) {
     return Boolean(dot.clipDot);
   }

--- a/src/util/getRadiusAndStrokeWidthFromDot.tsx
+++ b/src/util/getRadiusAndStrokeWidthFromDot.tsx
@@ -1,7 +1,7 @@
-import { ActiveDotType } from './types';
+import { ActiveDotType, DotType } from './types';
 import { svgPropertiesNoEventsFromUnknown } from './svgPropertiesNoEvents';
 
-export function getRadiusAndStrokeWidthFromDot(dot: ActiveDotType): {
+export function getRadiusAndStrokeWidthFromDot(dot: ActiveDotType | DotType): {
   r: number;
   strokeWidth: number;
 } {

--- a/src/util/svgPropertiesNoEvents.ts
+++ b/src/util/svgPropertiesNoEvents.ts
@@ -339,9 +339,7 @@ export function isDataAttribute(key: PropertyKey): key is DataAttributeKeyType {
  * @param obj - The object to filter
  * @returns A new object containing only valid SVG properties, excluding event handlers.
  */
-export function svgPropertiesNoEvents<T extends Record<PropertyKey, any>>(
-  obj: T | boolean,
-): SVGPropsNoEvents<T> | null {
+export function svgPropertiesNoEvents<T extends Record<PropertyKey, any>>(obj: T | boolean): SVGPropsNoEvents<T> {
   const filteredEntries = Object.entries(obj).filter(([key]) => isSvgElementPropKey(key) || isDataAttribute(key));
   return Object.fromEntries(filteredEntries) as SVGPropsNoEvents<T>;
 }

--- a/storybook/stories/Examples/cartesian/Area/AreaWithCustomDot.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Area/AreaWithCustomDot.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ComposedChart, Area, ResponsiveContainer } from '../../../../../src';
 import { coordinateWithValueData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
+import { DotItemDotProps } from '../../../../../src/util/types';
 
 export default {
   title: 'Examples/cartesian/Area/Customised Dot',
@@ -9,7 +10,7 @@ export default {
 
 const [surfaceWidth, surfaceHeight] = [600, 300];
 
-const renderDot = (props: { cx: number | undefined; cy: number | undefined }) => {
+const renderDot = (props: DotItemDotProps) => {
   const { cx, cy } = props;
 
   if (cx == null || cy == null) {

--- a/storybook/stories/Examples/cartesian/Line/LineWithCustomDot.stories.tsx
+++ b/storybook/stories/Examples/cartesian/Line/LineWithCustomDot.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ComposedChart, Line, ResponsiveContainer } from '../../../../../src';
 import { pageData } from '../../../data';
 import { RechartsHookInspector } from '../../../../storybook-addon-recharts';
+import { DotItemDotProps } from '../../../../../src/util/types';
 
 export default {
   title: 'Examples/cartesian/Line/Customised Dot',
@@ -9,7 +10,7 @@ export default {
 
 const [surfaceWidth, surfaceHeight] = [600, 300];
 
-const renderDot = (props: { cx: number | undefined; cy: number | undefined }) => {
+const renderDot = (props: DotItemDotProps) => {
   const { cx, cy } = props;
 
   if (cx == null || cy == null) {

--- a/test/cartesian/Area.spec.tsx
+++ b/test/cartesian/Area.spec.tsx
@@ -21,6 +21,7 @@ import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { AreaSettings } from '../../src/state/types/AreaSettings';
 import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 import { userEventSetup } from '../helper/userEventSetup';
+import { DotItemDotProps } from '../../src/util/types';
 
 type TestCase = CartesianChartTestCase;
 
@@ -97,7 +98,7 @@ describe.each(chartsThatSupportArea)('<Area /> as a child of $testName', ({ Char
   describe('dot', () => {
     test('Render customized dot when dot is set to be a function', () => {
       let areaDotProps;
-      const renderDot = (props: { cx: number | undefined; cy: number | undefined }) => {
+      const renderDot = (props: DotItemDotProps) => {
         const { cx, cy } = props;
         areaDotProps = props;
 

--- a/test/polar/Radar.spec.tsx
+++ b/test/polar/Radar.spec.tsx
@@ -12,8 +12,8 @@ import { userEventSetup } from '../helper/userEventSetup';
 import { assertNotNull } from '../helper/assertNotNull';
 import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 
-type point = { x: number; y: number };
-const CustomizedShape = ({ points }: { points: point[] }) => {
+type Point = { x?: number | string; y?: number | string };
+const CustomizedShape = ({ points }: { points: Point[] }) => {
   const d = (points || []).reduce(
     (result, entry, index) => result + (index ? `L${entry.x},${entry.y}` : `M${entry.x},${entry.y}`),
     '',
@@ -26,7 +26,7 @@ const CustomizedLabel = () => {
   return <text data-testid="customized-label">test</text>;
 };
 
-const CustomizedDot = ({ x, y }: point) => <circle cx={x} cy={y} r={10} data-testid="customized-dot" />;
+const CustomizedDot = ({ x, y }: Point) => <circle cx={x} cy={y} r={10} data-testid="customized-dot" />;
 
 describe('<Radar />', () => {
   it('should render a polygon in a simple Radar', () => {

--- a/www/src/docs/exampleComponents/LineChart/CustomizedDotLineChart.tsx
+++ b/www/src/docs/exampleComponents/LineChart/CustomizedDotLineChart.tsx
@@ -1,5 +1,5 @@
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
-import { ActiveDotProps } from 'recharts/types/util/types';
+import { DotItemDotProps } from 'recharts/types/util/types';
 
 // #region Sample data
 const data = [
@@ -48,7 +48,7 @@ const data = [
 ];
 
 // #endregion
-const CustomizedDot = (props: ActiveDotProps) => {
+const CustomizedDot = (props: DotItemDotProps) => {
   const { cx, cy, value } = props;
 
   if (cx == null || cy == null) {


### PR DESCRIPTION
## Description

I noticed that we have three identical Dots implementations so I moved them all to a new file. It will help with the zIndex changes and it's easy to split in its own PR.

I also fixed some of the types while here.

## Motivation and Context

DRY

## How Has This Been Tested?

All tests passing

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced new public types `DotItemDotProps` and `DotType` for consistent dot customization across all chart components.
  * New unified dot rendering system provides a standardized interface for customizing data point visualization.

* **Refactor**
  * Streamlined dot rendering logic across Area, Line, and Radar charts for improved consistency and maintainability.
  * Examples updated to reflect the new dot customization API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->