### PR TITLE
Add zIndex to bar background

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -246,6 +246,13 @@ type BarBackgroundProps = {
   allOtherBarProps: Props;
 };
 
+function getZIndex(background: ActiveShape<BarProps, SVGPathElement> | undefined): number {
+  if (background && typeof background === 'object' && 'zIndex' in background && typeof background.zIndex === 'number') {
+    return background.zIndex;
+  }
+  return DefaultZIndexes.barBackground;
+}
+
 function BarBackground(props: BarBackgroundProps) {
   const activeIndex = useAppSelector(selectActiveTooltipIndex);
 
@@ -271,7 +278,7 @@ function BarBackground(props: BarBackgroundProps) {
   const backgroundProps = svgPropertiesNoEventsFromUnknown(backgroundFromProps);
 
   return (
-    <>
+    <ZIndexLayer zIndex={getZIndex(backgroundFromProps)}>
       {data.map((entry: BarRectangleItem, i: number) => {
         const { value, background: backgroundFromDataEntry, tooltipPosition, ...rest } = entry;
 
@@ -305,7 +312,7 @@ function BarBackground(props: BarBackgroundProps) {
 
         return <BarRectangle key={`background-bar-${i}`} {...barRectangleProps} />;
       })}
-    </>
+    </ZIndexLayer>
   );
 }
 

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -335,6 +335,18 @@ function getTooltipEntrySettings(props: RadialBarProps): TooltipPayloadConfigura
   };
 }
 
+function getZIndexForRadialBarBackground(background: RadialBarBackground | undefined): number {
+  if (
+    background != null &&
+    typeof background === 'object' &&
+    'zIndex' in background &&
+    typeof background.zIndex === 'number'
+  ) {
+    return background.zIndex;
+  }
+  return DefaultZIndexes.barBackground;
+}
+
 class RadialBarWithState extends PureComponent<RadialBarProps> {
   renderBackground(sectors?: ReadonlyArray<RadialBarDataItem>) {
     if (sectors == null) {
@@ -342,34 +354,38 @@ class RadialBarWithState extends PureComponent<RadialBarProps> {
     }
     const { cornerRadius } = this.props;
     const backgroundProps = svgPropertiesNoEventsFromUnknown(this.props.background);
-    return sectors.map((entry, i) => {
-      const { value, background, ...rest } = entry;
+    return (
+      <ZIndexLayer zIndex={getZIndexForRadialBarBackground(this.props.background)}>
+        {sectors.map((entry, i) => {
+          const { value, background, ...rest } = entry;
 
-      if (!background) {
-        return null;
-      }
+          if (!background) {
+            return null;
+          }
 
-      const props: RadialBarSectorProps = {
-        cornerRadius: parseCornerRadius(cornerRadius),
-        ...rest,
-        // @ts-expect-error backgroundProps is contributing unknown props
-        fill: '#eee',
-        ...background,
-        ...backgroundProps,
-        ...adaptEventsOfChild(this.props, entry, i),
-        index: i,
-        className: clsx('recharts-radial-bar-background-sector', String(backgroundProps?.className)),
-        option: background,
-        isActive: false,
-      };
+          const props: RadialBarSectorProps = {
+            cornerRadius: parseCornerRadius(cornerRadius),
+            ...rest,
+            // @ts-expect-error backgroundProps is contributing unknown props
+            fill: '#eee',
+            ...background,
+            ...backgroundProps,
+            ...adaptEventsOfChild(this.props, entry, i),
+            index: i,
+            className: clsx('recharts-radial-bar-background-sector', String(backgroundProps?.className)),
+            option: background,
+            isActive: false,
+          };
 
-      return (
-        <RadialBarSector
-          key={`background-${rest.cx}-${rest.cy}-${rest.innerRadius}-${rest.outerRadius}-${rest.startAngle}-${rest.endAngle}-${i}`} // eslint-disable-line react/no-array-index-key
-          {...props}
-        />
-      );
-    });
+          return (
+            <RadialBarSector
+              key={`background-${rest.cx}-${rest.cy}-${rest.innerRadius}-${rest.outerRadius}-${rest.startAngle}-${rest.endAngle}-${i}`} // eslint-disable-line react/no-array-index-key
+              {...props}
+            />
+          );
+        })}
+      </ZIndexLayer>
+    );
   }
 
   render() {

--- a/src/zindex/DefaultZIndexes.tsx
+++ b/src/zindex/DefaultZIndexes.tsx
@@ -6,6 +6,11 @@ export const DefaultZIndexes = {
    * CartesianGrid and PolarGrid
    */
   grid: -100,
+  /**
+   * Background of Bar and RadialBar.
+   * This is not visible by default but can be enabled by setting background={true} on Bar or RadialBar.
+   */
+  barBackground: -50,
 
   /*
    * other chart elements or custom elements without specific zIndex

--- a/test/zindex/zIndexSelectors.spec.ts
+++ b/test/zindex/zIndexSelectors.spec.ts
@@ -56,7 +56,7 @@ describe('zIndexSelectors', () => {
 
       // empty store returns all default zIndexes
       expect(selectAllRegisteredZIndexes(store.getState())).toEqual([
-        -100, 100, 200, 300, 400, 500, 600, 700, 1000, 1100,
+        -100, -50, 100, 200, 300, 400, 500, 600, 700, 1000, 1100,
       ]);
 
       store.dispatch(registerZIndexPortal({ zIndex: 2 }));
@@ -65,18 +65,18 @@ describe('zIndexSelectors', () => {
 
       // newly added zIndexes are included and sorted
       expect(selectAllRegisteredZIndexes(store.getState())).toEqual([
-        -100, -3, 1, 2, 100, 200, 300, 400, 500, 600, 700, 1000, 1100,
+        -100, -50, -3, 1, 2, 100, 200, 300, 400, 500, 600, 700, 1000, 1100,
       ]);
 
       store.dispatch(unregisterZIndexPortal({ zIndex: 1 }));
       expect(selectAllRegisteredZIndexes(store.getState())).toEqual([
-        -100, -3, 2, 100, 200, 300, 400, 500, 600, 700, 1000, 1100,
+        -100, -50, -3, 2, 100, 200, 300, 400, 500, 600, 700, 1000, 1100,
       ]);
 
       store.dispatch(unregisterZIndexPortal({ zIndex: -3 }));
       store.dispatch(unregisterZIndexPortal({ zIndex: 2 }));
       expect(selectAllRegisteredZIndexes(store.getState())).toEqual([
-        -100, 100, 200, 300, 400, 500, 600, 700, 1000, 1100,
+        -100, -50, 100, 200, 300, 400, 500, 600, 700, 1000, 1100,
       ]);
     });
 
@@ -95,7 +95,7 @@ describe('zIndexSelectors', () => {
 
       const thirdSelection = selectAllRegisteredZIndexes(store.getState());
       expect(thirdSelection).not.toBe(firstSelection); // Different reference after state change
-      expect(thirdSelection).toEqual([-100, 5, 10, 15, 100, 200, 300, 400, 500, 600, 700, 1000, 1100]);
+      expect(thirdSelection).toEqual([-100, -50, 5, 10, 15, 100, 200, 300, 400, 500, 600, 700, 1000, 1100]);
 
       // now, the portal element ID has been registered, but the zIndex list should remain the same
       store.dispatch(registerZIndexPortalId({ zIndex: 5, elementId: 'portal-1', isPanorama: false }));
@@ -109,12 +109,12 @@ describe('zIndexSelectors', () => {
 
       store.dispatch(registerZIndexPortal({ zIndex: 50 }));
       const firstSelection = selectAllRegisteredZIndexes(store.getState());
-      expect(firstSelection).toEqual([-100, 50, 100, 200, 300, 400, 500, 600, 700, 1000, 1100]);
+      expect(firstSelection).toEqual([-100, -50, 50, 100, 200, 300, 400, 500, 600, 700, 1000, 1100]);
 
       // Register the same zIndex again
       store.dispatch(registerZIndexPortal({ zIndex: 50 }));
       const secondSelection = selectAllRegisteredZIndexes(store.getState());
-      expect(secondSelection).toEqual([-100, 50, 100, 200, 300, 400, 500, 600, 700, 1000, 1100]);
+      expect(secondSelection).toEqual([-100, -50, 50, 100, 200, 300, 400, 500, 600, 700, 1000, 1100]);
       expect(secondSelection).toBe(firstSelection); // Should be memoized, no change
     });
 
@@ -122,13 +122,13 @@ describe('zIndexSelectors', () => {
       const store = createRechartsStore();
 
       const initialSelection = selectAllRegisteredZIndexes(store.getState());
-      expect(initialSelection).toEqual([-100, 100, 200, 300, 400, 500, 600, 700, 1000, 1100]);
+      expect(initialSelection).toEqual([-100, -50, 100, 200, 300, 400, 500, 600, 700, 1000, 1100]);
 
       // Register a portalId for a default zIndex without registering the zIndex itself
       store.dispatch(registerZIndexPortalId({ zIndex: 100, elementId: 'portal-100', isPanorama: false }));
       const afterRegister = selectAllRegisteredZIndexes(store.getState());
       // The zIndex list should remain unchanged
-      expect(afterRegister).toEqual([-100, 100, 200, 300, 400, 500, 600, 700, 1000, 1100]);
+      expect(afterRegister).toEqual([-100, -50, 100, 200, 300, 400, 500, 600, 700, 1000, 1100]);
       // With resultEqualityCheck, the reference should be preserved when contents match
       expect(afterRegister).toBe(initialSelection);
 
@@ -136,7 +136,7 @@ describe('zIndexSelectors', () => {
       store.dispatch(unregisterZIndexPortalId({ zIndex: 100, isPanorama: false }));
       const afterUnregister = selectAllRegisteredZIndexes(store.getState());
       // The zIndex list should still remain unchanged
-      expect(afterUnregister).toEqual([-100, 100, 200, 300, 400, 500, 600, 700, 1000, 1100]);
+      expect(afterUnregister).toEqual([-100, -50, 100, 200, 300, 400, 500, 600, 700, 1000, 1100]);
       // Reference should still be preserved
       expect(afterUnregister).toBe(initialSelection);
     });

--- a/www/src/docs/exampleComponents/BarChart/StackedBarChart.tsx
+++ b/www/src/docs/exampleComponents/BarChart/StackedBarChart.tsx
@@ -65,8 +65,8 @@ const StackedBarChart = () => {
       <YAxis width="auto" />
       <Tooltip />
       <Legend />
-      <Bar dataKey="pv" stackId="a" fill="#8884d8" />
-      <Bar dataKey="uv" stackId="a" fill="#82ca9d" />
+      <Bar dataKey="pv" stackId="a" fill="#8884d8" background />
+      <Bar dataKey="uv" stackId="a" fill="#82ca9d" background />
     </BarChart>
   );
 };


### PR DESCRIPTION
## Description

This is a problem in stacked charts so why not fix it now that we have the technology.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/2826

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bar and RadialBar components now properly layer background elements with correct z-index ordering, ensuring backgrounds appear behind other chart elements.
  * Updated documentation examples to demonstrate background rendering in stacked bar charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->