### PR TITLE
Don't verify when pushing, add debug

### DIFF
--- a/.github/workflows/update-vr-snapshots.yml
+++ b/.github/workflows/update-vr-snapshots.yml
@@ -111,7 +111,7 @@ jobs:
 
       # When running on main branch, create a new branch, commit changes, and open a PR
       - name: Commit and create PR on main branch
-        if: steps.check_changes.outputs.has_changes == 'true' && github.ref == 'refs/heads/main'
+        if: steps.check_changes.outputs.has_changes == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
The snapshot update script ALMOST worked but it had two small problems:

1. when pushing it tried to run tests but failed because it didn't have all dependencies installed -> I made it skip tests because the only purpose is to update snapshots, it need not bother running tests
2. it tried to open a new PR even though it was supposed to push a commit to the same PR -> added condition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated snapshot handling workflow with improved PR update management.
  * Enhanced automated messaging on pull requests to communicate update status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->