### PR TITLE
Remove documented but not available props

### DIFF
--- a/omnidoc/omnidoc.spec.ts
+++ b/omnidoc/omnidoc.spec.ts
@@ -81,10 +81,6 @@ describe('omnidoc - documentation consistency', () => {
     expect(missingProps).toMatchInlineSnapshot(`
       [
         {
-          "component": "RadarChart",
-          "prop": "clockWise",
-        },
-        {
           "component": "ScatterChart",
           "prop": "onMouseOver",
         },
@@ -113,116 +109,12 @@ describe('omnidoc - documentation consistency', () => {
           "prop": "targetControlX",
         },
         {
-          "component": "Area",
-          "prop": "points",
-        },
-        {
-          "component": "Bar",
-          "prop": "layout",
-        },
-        {
-          "component": "Bar",
-          "prop": "data",
-        },
-        {
-          "component": "Line",
-          "prop": "points",
-        },
-        {
-          "component": "Scatter",
-          "prop": "points",
-        },
-        {
-          "component": "Brush",
-          "prop": "data",
-        },
-        {
-          "component": "Funnel",
-          "prop": "trapezoids",
-        },
-        {
-          "component": "Tooltip",
-          "prop": "viewBox",
-        },
-        {
-          "component": "Tooltip",
-          "prop": "coordinate",
-        },
-        {
-          "component": "Tooltip",
-          "prop": "payload",
-        },
-        {
-          "component": "Tooltip",
-          "prop": "label",
-        },
-        {
-          "component": "LabelList",
-          "prop": "data",
-        },
-        {
-          "component": "Pie",
-          "prop": "valueKey",
-        },
-        {
           "component": "RadialBar",
           "prop": "maxAngle",
         },
         {
           "component": "RadialBar",
           "prop": "minAngle",
-        },
-        {
-          "component": "ReferenceLine",
-          "prop": "alwaysShow",
-        },
-        {
-          "component": "ReferenceLine",
-          "prop": "viewBox",
-        },
-        {
-          "component": "ReferenceLine",
-          "prop": "xAxis",
-        },
-        {
-          "component": "ReferenceLine",
-          "prop": "yAxis",
-        },
-        {
-          "component": "ReferenceLine",
-          "prop": "isFront",
-        },
-        {
-          "component": "ReferenceDot",
-          "prop": "alwaysShow",
-        },
-        {
-          "component": "ReferenceDot",
-          "prop": "xAxis",
-        },
-        {
-          "component": "ReferenceDot",
-          "prop": "yAxis",
-        },
-        {
-          "component": "ReferenceDot",
-          "prop": "isFront",
-        },
-        {
-          "component": "ReferenceArea",
-          "prop": "alwaysShow",
-        },
-        {
-          "component": "ReferenceArea",
-          "prop": "xAxis",
-        },
-        {
-          "component": "ReferenceArea",
-          "prop": "yAxis",
-        },
-        {
-          "component": "ReferenceArea",
-          "prop": "isFront",
         },
       ]
     `);
@@ -257,24 +149,12 @@ describe('omnidoc - documentation consistency', () => {
     expect(missingProps).toMatchInlineSnapshot(`
       [
         {
-          "component": "AreaChart",
-          "prop": "defaultShowTooltip",
-        },
-        {
-          "component": "BarChart",
-          "prop": "defaultShowTooltip",
-        },
-        {
           "component": "Cell",
           "prop": "onPointerEnterCapture",
         },
         {
           "component": "Cell",
           "prop": "onPointerLeaveCapture",
-        },
-        {
-          "component": "ComposedChart",
-          "prop": "defaultShowTooltip",
         },
         {
           "component": "Funnel",
@@ -302,127 +182,19 @@ describe('omnidoc - documentation consistency', () => {
         },
         {
           "component": "FunnelChart",
-          "prop": "defaultShowTooltip",
-        },
-        {
-          "component": "FunnelChart",
           "prop": "shape",
-        },
-        {
-          "component": "LineChart",
-          "prop": "defaultShowTooltip",
-        },
-        {
-          "component": "Pie",
-          "prop": "activeIndex",
-        },
-        {
-          "component": "PieChart",
-          "prop": "activeIndex",
         },
         {
           "component": "PieChart",
           "prop": "activeShape",
         },
         {
-          "component": "PieChart",
-          "prop": "defaultShowTooltip",
-        },
-        {
-          "component": "RadarChart",
-          "prop": "defaultShowTooltip",
-        },
-        {
-          "component": "RadialBar",
-          "prop": "activeIndex",
-        },
-        {
-          "component": "RadialBarChart",
-          "prop": "defaultShowTooltip",
-        },
-        {
-          "component": "ReferenceDot",
-          "prop": "clipPathId",
-        },
-        {
-          "component": "ReferenceDot",
-          "prop": "xAxis",
-        },
-        {
-          "component": "ReferenceDot",
-          "prop": "yAxis",
-        },
-        {
-          "component": "ReferenceLine",
-          "prop": "clipPathId",
-        },
-        {
-          "component": "ReferenceLine",
-          "prop": "viewBox",
-        },
-        {
-          "component": "ReferenceLine",
-          "prop": "xAxis",
-        },
-        {
-          "component": "ReferenceLine",
-          "prop": "yAxis",
-        },
-        {
-          "component": "ScatterChart",
-          "prop": "defaultShowTooltip",
-        },
-        {
-          "component": "Sector",
-          "prop": "animationBegin",
-        },
-        {
-          "component": "Sector",
-          "prop": "animationDuration",
-        },
-        {
-          "component": "Sector",
-          "prop": "animationEasing",
-        },
-        {
-          "component": "Sector",
-          "prop": "dangerouslySetInnerHTML",
-        },
-        {
-          "component": "Sector",
-          "prop": "isAnimationActive",
-        },
-        {
           "component": "SunburstChart",
           "prop": "margin",
         },
         {
-          "component": "Text",
-          "prop": "content",
-        },
-        {
-          "component": "Tooltip",
-          "prop": "coordinate",
-        },
-        {
-          "component": "Tooltip",
-          "prop": "label",
-        },
-        {
-          "component": "Tooltip",
-          "prop": "payload",
-        },
-        {
-          "component": "Tooltip",
-          "prop": "viewBox",
-        },
-        {
           "component": "Trapezoid",
           "prop": "isAnimationActive",
-        },
-        {
-          "component": "YAxis",
-          "prop": "xAxisId",
         },
       ]
     `);

--- a/omnidoc/readApiDoc.spec.ts
+++ b/omnidoc/readApiDoc.spec.ts
@@ -64,13 +64,8 @@ describe('readApiDoc', () => {
         "yAxisId",
         "x",
         "y",
-        "alwaysShow",
         "ifOverflow",
-        "viewBox",
-        "xAxis",
-        "yAxis",
         "label",
-        "isFront",
         "strokeWidth",
         "segment",
       ]

--- a/omnidoc/readStorybookDoc.spec.ts
+++ b/omnidoc/readStorybookDoc.spec.ts
@@ -63,7 +63,6 @@ describe('readStorybookDoc', () => {
   it('should return props for ReferenceLine', () => {
     expect(reader.getRechartsPropsOf('ReferenceLine')).toMatchInlineSnapshot(`
       [
-        "clipPathId",
         "dangerouslySetInnerHTML",
         "ifOverflow",
         "label",
@@ -73,12 +72,9 @@ describe('readStorybookDoc', () => {
         "stroke",
         "strokeDasharray",
         "strokeWidth",
-        "viewBox",
         "x",
-        "xAxis",
         "xAxisId",
         "y",
-        "yAxis",
         "yAxisId",
       ]
     `);

--- a/storybook/stories/API/cartesian/ReferenceDot.stories.tsx
+++ b/storybook/stories/API/cartesian/ReferenceDot.stories.tsx
@@ -6,11 +6,7 @@ import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { EventHandlers } from '../props/EventHandlers';
 import { r } from '../props/DotProps';
 import { GeneralStyle } from '../props/Styles';
-import {
-  ReferenceComponentGeneralArgs,
-  ReferenceComponentInternalArgs,
-  ReferenceComponentStyle,
-} from '../props/ReferenceComponentShared';
+import { ReferenceComponentGeneralArgs, ReferenceComponentStyle } from '../props/ReferenceComponentShared';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 
 const GeneralProps: Args = {
@@ -67,7 +63,6 @@ export default {
     ...StyleProps,
     ...GeneralProps,
     ...LabelProps,
-    ...ReferenceComponentInternalArgs,
     ...EventHandlers,
     // Dot
     r,

--- a/storybook/stories/API/cartesian/ReferenceLine.stories.tsx
+++ b/storybook/stories/API/cartesian/ReferenceLine.stories.tsx
@@ -4,14 +4,11 @@ import { ComposedChart, Line, ReferenceLine, CartesianGrid, XAxis, YAxis, Respon
 import { pageData } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { GeneralStyle } from '../props/Styles';
-import {
-  ReferenceComponentGeneralArgs,
-  ReferenceComponentInternalArgs,
-  ReferenceComponentStyle,
-} from '../props/ReferenceComponentShared';
+import { ReferenceComponentGeneralArgs, ReferenceComponentStyle } from '../props/ReferenceComponentShared';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
+import { StorybookArgs } from '../../../StorybookArgs';
 
-const GeneralProps: Args = {
+const GeneralProps: StorybookArgs = {
   ...ReferenceComponentGeneralArgs,
   x: {
     description: `If set a string or a number, a vertical line perpendicular to the x-axis specified by xAxisId
@@ -31,7 +28,7 @@ const GeneralProps: Args = {
   },
 };
 
-const LabelProps: Args = {
+const LabelProps: StorybookArgs = {
   label: {
     description: `If set a string or a number, default label will be drawn, and the option is content.
     If set a React element, the option is the custom react element of drawing label. If set a function,
@@ -48,7 +45,7 @@ const LabelProps: Args = {
   },
 };
 
-const StyleProps: Args = {
+const StyleProps: StorybookArgs = {
   ...ReferenceComponentStyle,
   stroke: {
     ...GeneralStyle.stroke,
@@ -73,21 +70,11 @@ const StyleProps: Args = {
   },
 };
 
-const InternalProps: Args = {
-  ...ReferenceComponentInternalArgs,
-  viewBox: {
-    description: 'The box of the viewing area, usually calculated internally.',
-    table: { type: { summary: '{x: number, y: number, width: number, height: number}' }, category: 'Internal' },
-  },
-};
-
 export default {
   argTypes: {
     ...GeneralProps,
     ...LabelProps,
     ...StyleProps,
-    ...ReferenceComponentInternalArgs,
-    ...InternalProps,
     // Deprecated
     dangerouslySetInnerHTML: { table: { category: 'Deprecated' }, hide: true, disable: true },
   },

--- a/storybook/stories/API/chart/PieChart.stories.tsx
+++ b/storybook/stories/API/chart/PieChart.stories.tsx
@@ -9,7 +9,6 @@ import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 export default {
   argTypes: {
     ...CategoricalChartProps,
-    activeIndex: ActiveShapeProps.activeIndex,
     activeShape: ActiveShapeProps.activeShape,
   },
   component: PieChart,

--- a/storybook/stories/API/polar/Pie.stories.tsx
+++ b/storybook/stories/API/polar/Pie.stories.tsx
@@ -113,7 +113,6 @@ const GeneralProps: Args = {
     description: 'The source data which each element is an object.',
     table: { type: { summary: 'Array' }, category: 'General' },
   },
-  activeIndex: ActiveShapeProps.activeIndex,
   activeShape: ActiveShapeProps.activeShape,
   inactiveShape: {
     description: 'The shape of inactive sector.',

--- a/storybook/stories/API/props/ChartProps.ts
+++ b/storybook/stories/API/props/ChartProps.ts
@@ -137,16 +137,6 @@ toggling between multiple dataKey.`,
       category: 'Internal',
     },
   },
-  defaultShowTooltip: {
-    description: 'If true set, the tooltip will be displayed when the chart is rendered.',
-    table: {
-      type: {
-        summary: 'boolean',
-      },
-      defaultValue: false,
-      category: 'General',
-    },
-  },
   id: {
     description: 'The unique id of chart.',
     table: {

--- a/storybook/stories/API/props/ReferenceComponentShared.ts
+++ b/storybook/stories/API/props/ReferenceComponentShared.ts
@@ -22,19 +22,3 @@ export const ReferenceComponentGeneralArgs: StorybookArgs = {
     table: { type: { summary: 'string | number' }, category: 'General' },
   },
 };
-
-export const ReferenceComponentInternalArgs: StorybookArgs = {
-  xAxis: {
-    description: 'The configuration of the corresponding x-axis, usually calculated internally.',
-    table: { type: { summary: 'Object' }, category: 'Internal' },
-  },
-  yAxis: {
-    description: 'The configuration of the corresponding y-axis, usually calculated internally.',
-    table: { type: { summary: 'Object' }, category: 'Internal' },
-  },
-  clipPathId: {
-    description: `Used as the id for the clip path which is used to clip the reference component if
-    'ifOverflow' is set to 'hidden'"`,
-    table: { type: { summary: 'number | string' }, category: 'Internal' },
-  },
-};

--- a/storybook/stories/API/props/Styles.ts
+++ b/storybook/stories/API/props/Styles.ts
@@ -237,16 +237,6 @@ export const RadialBarStyle: Args = {
       category: 'Style',
     },
   },
-  activeIndex: {
-    description: 'The index of the active bar, this option can be changed in mouse event handlers.',
-    table: {
-      type: {
-        summary: 'number | number[]',
-        detail: '<Bar dataKey="value" activeIndex={0} />\n<Bar dataKey="value" activeIndex={[0, 1]} />',
-      },
-      category: 'Style',
-    },
-  },
   maxBarSize: {
     description: 'The maximum width of the bar.',
     table: {

--- a/storybook/stories/API/props/TextProps.ts
+++ b/storybook/stories/API/props/TextProps.ts
@@ -1,9 +1,6 @@
 import { StorybookArgs } from '../../../StorybookArgs';
 
 export const TextProps: StorybookArgs = {
-  content: {
-    description: 'The content of text.',
-  },
   lineHeight: {
     description: 'The height of each line of text in pixels.',
     table: {

--- a/storybook/stories/API/props/TooltipProps.tsx
+++ b/storybook/stories/API/props/TooltipProps.tsx
@@ -73,19 +73,6 @@ export const TooltipProps: StorybookArgs = {
       category: 'Styles',
     },
   },
-  viewBox: {
-    description: `The box of viewing area.
-    Has the shape of { x: number, y: number, width: number, height: number }.
-    Usually calculated internally.`,
-    defaultValue: { x: 0, y: 0, height: 0, width: 0 },
-    table: {
-      type: {
-        summary: 'Object',
-        detail: '{ x: number, y: number, width: number, height: number },',
-      },
-      category: 'Internal',
-    },
-  },
   allowEscapeViewBox: {
     description: 'Allows the tooltip to extend beyond the viewBox of the chart itself.',
     defaultValue: { x: false, y: false },
@@ -104,36 +91,6 @@ export const TooltipProps: StorybookArgs = {
       type: {
         summary: 'Object',
         detail: '{ x: number, y: number }',
-      },
-    },
-  },
-  coordinate: {
-    description: 'The coordinate of tooltip position, usually calculated internally.',
-    table: {
-      category: 'Internal',
-      type: {
-        summary: 'Object',
-        detail: '{ x: number, y: number }',
-      },
-    },
-    defaultValue: '{ x: 0, y: 0 }',
-  },
-  payload: {
-    description: 'The source data of the content to be displayed in the tooltip, usually calculated internally.',
-    table: {
-      category: 'Internal',
-      type: {
-        summary: 'Array',
-        detail: "[{ name: '05-01', value: 12, unit: 'kg' }]",
-      },
-    },
-  },
-  label: {
-    description: 'The label value which is active now, usually calculated internally.',
-    table: {
-      category: 'Internal',
-      type: {
-        summary: 'string | number',
       },
     },
   },

--- a/storybook/stories/API/props/YAxisProps.ts
+++ b/storybook/stories/API/props/YAxisProps.ts
@@ -3,8 +3,8 @@ import { sharedAxisProps } from './SharedAxisProps';
 
 export const YAxisProps: StorybookArgs = {
   ...sharedAxisProps,
-  xAxisId: {
-    description: 'The unique id of x-axis.',
+  yAxisId: {
+    description: 'The unique id of y-axis.',
     table: {
       type: {
         summary: 'String | Number',

--- a/storybook/stories/API/shapes/Sector.stories.tsx
+++ b/storybook/stories/API/shapes/Sector.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Sector } from '../../../../src';
 import { GeneralStyle } from '../props/Styles';
-import { animationBegin, animationDuration, animationEasing, isAnimationActive } from '../props/AnimationProps';
 import { SectorProps } from '../props/SectorProps';
 import {
   onAbort,
@@ -168,14 +167,8 @@ export default {
   component: Sector,
   argTypes: {
     ...SectorProps,
-    animationBegin,
-    animationDuration,
-    animationEasing,
-    isAnimationActive,
     stroke: GeneralStyle.stroke,
     fill: GeneralStyle.fill,
-    // Deprecated
-    dangerouslySetInnerHTML: { table: { category: 'Deprecated', disable: true } },
     // Event Handlers available
     onCopy,
     onCopyCapture,

--- a/www/src/docs/api/Area.ts
+++ b/www/src/docs/api/Area.ts
@@ -153,23 +153,11 @@ export const AreaAPI = {
       defaultVal: 'undefined',
       isOptional: false,
       desc: {
-        'en-US': 'The value which can describle the line, usually calculated internally.',
+        'en-US': 'The value which can describe the line, usually calculated internally.',
         'zh-CN': `基准线，可以是一个数值，这种情况会根据 layout 解析成 x = \${baseLine} 或者 y = \${baseLine}。当使用 AreaChart
            或者 ComposedChart 作为父组件的时候，不需要自己计算，父组件会计算好。`,
       },
       format: ['<Area dataKey="value" baseLine={8} />', '<Area dataKey="value" baseLine={[{ x: 12, y: 15 }]} />'],
-    },
-    {
-      name: 'points',
-      type: 'Array',
-      defaultVal: 'undefined',
-      isOptional: false,
-      desc: {
-        'en-US': 'The coordinates of all the points in the area, usually calculated internally.',
-        'zh-CN':
-          '曲线上点的坐标。当使用 AreaChart 或者 ComposedChart 作为父组件的时候，不需要自己计算，父组件会计算好。',
-      },
-      format: ['[{ x: 12, y: 12, value: 240 }]'],
     },
     {
       name: 'stackId',

--- a/www/src/docs/api/Bar.ts
+++ b/www/src/docs/api/Bar.ts
@@ -2,16 +2,6 @@ export const BarAPI = {
   name: 'Bar',
   props: [
     {
-      name: 'layout',
-      type: "'horizontal' | 'vertical'",
-      defaultVal: 'undefined',
-      isOptional: true,
-      desc: {
-        'en-US': 'The layout of bar in the chart, usually inherited from parent.',
-        'zh-CN': '布局类型，通常继承父组件的布局类型。',
-      },
-    },
-    {
       name: 'dataKey',
       type: 'String | Number | Function',
       defaultVal: 'undefined',
@@ -67,17 +57,6 @@ export const BarAPI = {
         '<Bar dataKey="value" label={{ fill: \'red\', fontSize: 20 }} />',
         '<Bar dataKey="value" label={<CustomizedLabel />} />',
       ],
-    },
-    {
-      name: 'data',
-      type: 'Array',
-      defaultVal: 'undefined',
-      isOptional: false,
-      desc: {
-        'en-US':
-          'The position information of all the rectangles, usually calculated internally. Will only take effect if `data` is also present on `BarChart`.',
-        'zh-CN': '描述所有柱条的坐标、尺寸数据。',
-      },
     },
     {
       name: 'barSize',

--- a/www/src/docs/api/Brush.ts
+++ b/www/src/docs/api/Brush.ts
@@ -52,16 +52,6 @@ export const BrushAPI = {
       },
     },
     {
-      name: 'data',
-      type: 'Array',
-      defaultVal: 'null',
-      isOptional: false,
-      desc: {
-        'en-US': 'The original data of a LineChart, a BarChart or an AreaChart.',
-        'zh-CN': '类目图表的输入数据。',
-      },
-    },
-    {
       name: 'travellerWidth',
       type: 'Number',
       defaultVal: '5',

--- a/www/src/docs/api/Funnel.ts
+++ b/www/src/docs/api/Funnel.ts
@@ -63,17 +63,6 @@ export const FunnelAPI = {
       },
     },
     {
-      name: 'trapezoids',
-      type: 'Array',
-      defaultVal: 'null',
-      isOptional: false,
-      desc: {
-        'en-US': 'The coordinates of all the trapezoids in the funnel, usually calculated internally.',
-        'zh-CN': '梯形的坐标点。当使用 FunnelChart 作为父组件的时候，不需要自己计算，父组件会计算好。',
-      },
-      format: ['[{x: 12, y: 12, upperWidth: 240, lowerWidth: 22, height: 80,}]'],
-    },
-    {
       name: 'isAnimationActive',
       type: 'Boolean',
       defaultVal: 'true in CSR, and false in SSR',

--- a/www/src/docs/api/LabelList.ts
+++ b/www/src/docs/api/LabelList.ts
@@ -73,16 +73,6 @@ export const LabelListAPI = {
       },
     },
     {
-      name: 'data',
-      type: 'Number',
-      defaultVal: 'null',
-      isOptional: true,
-      desc: {
-        'en-US': 'The data input to the charts.',
-        'zh-CN': '图表的输入数据',
-      },
-    },
-    {
       name: 'clockWise',
       type: 'String',
       defaultVal: 'false',

--- a/www/src/docs/api/Line.ts
+++ b/www/src/docs/api/Line.ts
@@ -163,18 +163,6 @@ export const LineAPI: ApiDoc = {
       examples: [],
     },
     {
-      name: 'points',
-      type: 'Array',
-      defaultVal: 'null',
-      isOptional: false,
-      desc: {
-        'en-US': 'The coordinates of all the points in the line, usually calculated internally.',
-        'zh-CN':
-          '曲线上点的坐标。当使用 LineChart 或者 ComposedChart 作为父组件的时候，不需要自己计算，父组件会计算好。',
-      },
-      format: ['[{x: 12, y: 12, value: 240}]'],
-    },
-    {
       name: 'stroke',
       type: 'String',
       defaultVal: '#3182bd',

--- a/www/src/docs/api/Pie.ts
+++ b/www/src/docs/api/Pie.ts
@@ -114,17 +114,6 @@ export const PieAPI = {
       },
     },
     {
-      name: 'valueKey',
-      type: 'String',
-      defaultVal: "'value'",
-      isOptional: false,
-      deprecated: true,
-      desc: {
-        'en-US': "Use 'dataKey' alternatively, The key of each sector's value.",
-        'zh-CN': '"value" 属性对应的 key。',
-      },
-    },
-    {
       name: 'legendType',
       type: "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'rect'",

--- a/www/src/docs/api/RadarChart.ts
+++ b/www/src/docs/api/RadarChart.ts
@@ -115,17 +115,6 @@ export const RadarChartAPI = {
       format: ['{ top: 5, right: 5, bottom: 5, left: 5 }'],
     },
     {
-      name: 'clockWise',
-      type: 'Bool',
-      deprecated: true,
-      defaultVal: 'true',
-      isOptional: false,
-      desc: {
-        'en-US': 'The direction of clockwise.',
-        'zh-CN': '是否顺时针',
-      },
-    },
-    {
       name: 'onMouseEnter',
       type: 'Function',
       defaultVal: 'null',

--- a/www/src/docs/api/ReferenceArea.ts
+++ b/www/src/docs/api/ReferenceArea.ts
@@ -70,16 +70,6 @@ export const ReferenceAreaAPI = {
       },
     },
     {
-      name: 'alwaysShow',
-      type: 'Boolean',
-      defaultVal: 'false',
-      isOptional: false,
-      deprecated: true,
-      desc: {
-        'en-US': "Use 'ifOverflow' instead.",
-      },
-    },
-    {
       name: 'ifOverflow',
       type: "'discard' | 'hidden' | 'visible' | 'extendDomain'",
       defaultVal: "'discard'",
@@ -113,26 +103,6 @@ export const ReferenceAreaAPI = {
         'en-US':
           'The box of viewing area, which has the shape of {x: someVal, y: someVal, width: someVal, height: someVal}, usually calculated internally.',
         'zh-CN': '图表的可视区域。',
-      },
-    },
-    {
-      name: 'xAxis',
-      type: 'Object',
-      defaultVal: 'null',
-      isOptional: false,
-      desc: {
-        'en-US': 'The configuration of the corresponding x-axis, usually calculated internally.',
-        'zh-CN': 'x 轴配置。',
-      },
-    },
-    {
-      name: 'yAxis',
-      type: 'Object',
-      defaultVal: 'null',
-      isOptional: false,
-      desc: {
-        'en-US': 'The configuration of the corresponding y-axis, usually calculated internally.',
-        'zh-CN': 'y 轴配置。',
       },
     },
     {
@@ -172,16 +142,6 @@ export const ReferenceAreaAPI = {
           isExternal: true,
         },
       ],
-    },
-    {
-      name: 'isFront',
-      type: 'Boolean',
-      defaultVal: 'false',
-      isOptional: false,
-      desc: {
-        'en-US': 'If set true, the line will be rendered in front of bars in BarChart, etc.',
-        'zh-CN': '是否展示在图表的最上层。',
-      },
     },
   ],
   parentComponents: ['AreaChart', 'BarChart', 'LineChart', 'ComposedChart', 'ScatterChart'],

--- a/www/src/docs/api/ReferenceDot.ts
+++ b/www/src/docs/api/ReferenceDot.ts
@@ -46,16 +46,6 @@ export const ReferenceDotAPI = {
       },
     },
     {
-      name: 'alwaysShow',
-      type: 'Boolean',
-      defaultVal: 'false',
-      isOptional: false,
-      deprecated: true,
-      desc: {
-        'en-US': "Use 'ifOverflow' instead.",
-      },
-    },
-    {
       name: 'ifOverflow',
       type: "'discard' | 'hidden' | 'visible' | 'extendDomain'",
       defaultVal: "'discard'",
@@ -74,26 +64,6 @@ export const ReferenceDotAPI = {
       },
     },
     {
-      name: 'xAxis',
-      type: 'Object',
-      defaultVal: 'null',
-      isOptional: false,
-      desc: {
-        'en-US': 'The configuration of the corresponding x-axis, usually calculated internally.',
-        'zh-CN': 'x 轴配置。',
-      },
-    },
-    {
-      name: 'yAxis',
-      type: 'Object',
-      defaultVal: 'null',
-      isOptional: false,
-      desc: {
-        'en-US': 'The configuration of the corresponding y-axis, usually calculated internally.',
-        'zh-CN': 'y 轴配置。',
-      },
-    },
-    {
       name: 'label',
       type: 'String | Number | ReactElement | Function',
       defaultVal: 'null',
@@ -109,16 +79,6 @@ export const ReferenceDotAPI = {
         '<ReferenceDot x="a" y={400} label={<CustomizedLabel />}/>',
         '<ReferenceDot x="a" y={400} label={renderLabel} />',
       ],
-    },
-    {
-      name: 'isFront',
-      type: 'Boolean',
-      defaultVal: 'false',
-      isOptional: false,
-      desc: {
-        'en-US': 'If set true, the dot will be rendered in front of bars in BarChart, etc.',
-        'zh-CN': '是否展示在图表的最上层。',
-      },
     },
     {
       name: 'shape',

--- a/www/src/docs/api/ReferenceLine.ts
+++ b/www/src/docs/api/ReferenceLine.ts
@@ -46,16 +46,6 @@ export const ReferenceLineAPI = {
       },
     },
     {
-      name: 'alwaysShow',
-      type: 'Boolean',
-      defaultVal: 'false',
-      isOptional: false,
-      deprecated: true,
-      desc: {
-        'en-US': "Use 'ifOverflow' instead.",
-      },
-    },
-    {
       name: 'ifOverflow',
       type: "'discard' | 'hidden' | 'visible' | 'extendDomain'",
       defaultVal: "'discard'",
@@ -81,37 +71,6 @@ export const ReferenceLineAPI = {
       ],
     },
     {
-      name: 'viewBox',
-      type: 'Object',
-      defaultVal: 'null',
-      isOptional: false,
-      desc: {
-        'en-US':
-          'The box of viewing area, which has the shape of {x: someVal, y: someVal, width: someVal, height: someVal}, usually calculated internally.',
-        'zh-CN': '图表的可视区域',
-      },
-    },
-    {
-      name: 'xAxis',
-      type: 'Object',
-      defaultVal: 'null',
-      isOptional: false,
-      desc: {
-        'en-US': 'The configuration of the corresponding x-axis, usually calculated internally.',
-        'zh-CN': 'x 轴配置。',
-      },
-    },
-    {
-      name: 'yAxis',
-      type: 'Object',
-      defaultVal: 'null',
-      isOptional: false,
-      desc: {
-        'en-US': 'The configuration of the corresponding y-axis, usually calculated internally.',
-        'zh-CN': 'y 轴配置。',
-      },
-    },
-    {
       name: 'label',
       type: 'String | Number | ReactElement | Function',
       defaultVal: 'null',
@@ -132,16 +91,6 @@ export const ReferenceLineAPI = {
           url: '/examples/LineChartWithReferenceLines',
         },
       ],
-    },
-    {
-      name: 'isFront',
-      type: 'Boolean',
-      defaultVal: 'false',
-      isOptional: false,
-      desc: {
-        'en-US': 'If set true, the line will be rendered in front of bars in BarChart, etc.',
-        'zh-CN': '是否展示在图表的最上层。',
-      },
     },
     {
       name: 'strokeWidth',

--- a/www/src/docs/api/Scatter.ts
+++ b/www/src/docs/api/Scatter.ts
@@ -99,17 +99,6 @@ export const ScatterAPI = {
       },
     },
     {
-      name: 'points',
-      type: 'Array',
-      defaultVal: 'null',
-      isOptional: false,
-      desc: {
-        'en-US': 'The coordinates of all the scatters.',
-        'zh-CN': '所有散点的坐标。',
-      },
-      format: ['[{ cx: 12, cy: 12, r: 4, payload: {x: 12, y: 45, z: 9 }}]'],
-    },
-    {
       name: 'isAnimationActive',
       type: 'Boolean',
       defaultVal: 'true in CSR, and false in SSR',

--- a/www/src/docs/api/Tooltip.ts
+++ b/www/src/docs/api/Tooltip.ts
@@ -121,18 +121,6 @@ export const TooltipAPI = {
       ],
     },
     {
-      name: 'viewBox',
-      type: 'Object',
-      defaultVal: 'null',
-      isOptional: false,
-      desc: {
-        'en-US':
-          'The box of viewing area, which has the shape of {x: someVal, y: someVal, width: someVal, height: someVal}, usually calculated internally.',
-        'zh-CN': '图表的可视区域。通常通过 x、y、width、height 来描述。',
-      },
-      format: ['{ x: 0, y: 0, width: 400, height: 400 }'],
-    },
-    {
       name: 'allowEscapeViewBox',
       type: 'Object',
       defaultVal: '{ x: false, y: false }',
@@ -150,7 +138,7 @@ export const TooltipAPI = {
       isOptional: false,
       desc: {
         'en-US':
-          'If set true, the tooltip is displayed. If set false, the tooltip is hidden, usually calculated internally.',
+          'If set true, the tooltip is displayed even after onMouseLeave. If set false, the tooltip is always hidden.',
         'zh-CN':
           '是否处于激活状态。如果值为 true, tooltip 会显示出来。如果值为 false, tooltip 会被隐藏，这个值一般是图表内部控制的。',
       },
@@ -165,39 +153,6 @@ export const TooltipAPI = {
         'zh-CN': '如果设置了此字段，则工具提示位置将固定不变，并且将不再移动。',
       },
       format: ['{ x: 100, y: 140 }'],
-    },
-    {
-      name: 'coordinate',
-      type: 'Object',
-      defaultVal: '{ x: 0, y: 0 }',
-      isOptional: false,
-      desc: {
-        'en-US': 'The coordinate of tooltip position, usually calculated internally.',
-        'zh-CN': '用来描述位置的坐标，也是图表内部计算的值。',
-      },
-      format: ['{ x: 100, y: 140 }'],
-    },
-    {
-      name: 'payload',
-      type: 'Array',
-      defaultVal: '[]',
-      isOptional: false,
-      desc: {
-        'en-US':
-          'The source data of the content to be displayed in the tooltip, always calculated internally and cannot be user set.',
-        'zh-CN': 'Tooltip 展示内容的源数据，通常是图表内部计算的。',
-      },
-      format: ["[{ name: '05-01', value: 12, unit: 'kg' }]"],
-    },
-    {
-      name: 'label',
-      type: 'String | Number',
-      defaultVal: 'null',
-      isOptional: true,
-      desc: {
-        'en-US': 'The label value which is active now, usually calculated internally.',
-        'zh-CN': '当 Tooltip 显示出来的时候，表示类目文字标签。',
-      },
     },
     {
       name: 'content',


### PR DESCRIPTION
## Description

Some of these we removed in 3.0 and some I don't know.

## Related Issue

https://github.com/recharts/recharts/issues/6069

https://github.com/recharts/recharts/pull/6582



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed internal, deprecated, and unused props from component API docs and clarified several descriptions to simplify public-facing docs.
* **Chores**
  * Streamlined Storybook stories to expose only public props by removing internal/deprecated story args and prop entries.
* **Tests**
  * Updated snapshot expectations to align with the reduced public prop surface across docs and stories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->