### PR TITLE
Add activeIndex to TooltipContentProps

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -46,6 +46,7 @@ export type TooltipContentProps<TValue extends ValueType, TName extends NameType
   coordinate: Coordinate | undefined;
   active: boolean;
   accessibilityLayer: boolean;
+  activeIndex: TooltipIndex | undefined;
 };
 
 function renderContent<TValue extends ValueType, TName extends NameType>(
@@ -265,6 +266,7 @@ export function Tooltip<TValue extends ValueType, TName extends NameType>(outsid
         payload: finalPayload,
         label: finalLabel,
         active: finalIsActive,
+        activeIndex,
         coordinate,
         accessibilityLayer,
       })}

--- a/test/component/Tooltip/Tooltip.content.spec.tsx
+++ b/test/component/Tooltip/Tooltip.content.spec.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
+import { PageData } from '../../_data';
+import { Area, AreaChart, Tooltip } from '../../../src';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
+import { showTooltip } from './tooltipTestHelpers';
+import { areaChartMouseHoverTooltipSelector } from './tooltipMouseHoverSelectors';
+import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
+
+const commonChartProps = {
+  width: 400,
+  height: 400,
+};
+
+describe('Tooltip.content', () => {
+  const spy = vi.fn();
+
+  beforeEach(() => {
+    mockGetBoundingClientRect({ width: 100, height: 100 });
+    spy.mockClear();
+  });
+
+  const renderTestCase = createSelectorTestCase(({ children }) => (
+    <AreaChart {...commonChartProps} data={PageData}>
+      <Area dataKey="uv" unit="kg" />
+      <Area dataKey="pv" unit="$$$" name="My custom name" />
+      <Area dataKey="amt" />
+      <Tooltip content={spy} />
+      {children}
+    </AreaChart>
+  ));
+
+  it('should be called and receive payload before any user interactions', () => {
+    expect(spy).toHaveBeenCalledTimes(0);
+    renderTestCase();
+    expect(spy).toHaveBeenCalledTimes(2);
+    expectLastCalledWith(
+      spy,
+      {
+        accessibilityLayer: true,
+        active: false,
+        activeIndex: null,
+        allowEscapeViewBox: {
+          x: false,
+          y: false,
+        },
+        animationDuration: 400,
+        animationEasing: 'ease',
+        axisId: 0,
+        content: spy,
+        contentStyle: {},
+        coordinate: undefined,
+        cursor: true,
+        filterNull: true,
+        isAnimationActive: true,
+        itemSorter: 'name',
+        itemStyle: {},
+        label: undefined,
+        labelStyle: {},
+        offset: 10,
+        payload: [],
+        reverseDirection: {
+          x: false,
+          y: false,
+        },
+        separator: ' : ',
+        trigger: 'hover',
+        useTranslate3d: false,
+        wrapperStyle: {},
+      },
+      expect.any(Object),
+    );
+  });
+
+  it('should be called and receive payload on hover', () => {
+    const { container, debug } = renderTestCase();
+    showTooltip(container, areaChartMouseHoverTooltipSelector, debug);
+    expect(spy).toHaveBeenCalledTimes(3);
+    expectLastCalledWith(
+      spy,
+      {
+        accessibilityLayer: true,
+        active: true,
+        activeIndex: '2',
+        allowEscapeViewBox: {
+          x: false,
+          y: false,
+        },
+        animationDuration: 400,
+        animationEasing: 'ease',
+        axisId: 0,
+        content: spy,
+        contentStyle: {},
+        coordinate: {
+          x: 161,
+          y: 200,
+        },
+        cursor: true,
+        filterNull: true,
+        isAnimationActive: true,
+        itemSorter: 'name',
+        itemStyle: {},
+        label: 2,
+        labelStyle: {},
+        offset: 10,
+        payload: [
+          {
+            color: '#3182bd',
+            dataKey: 'uv',
+            fill: '#3182bd',
+            hide: false,
+            name: 'uv',
+            nameKey: undefined,
+            payload: {
+              amt: 2400,
+              name: 'Page C',
+              pv: 1398,
+              uv: 300,
+            },
+            stroke: '#3182bd',
+            strokeWidth: undefined,
+            type: undefined,
+            unit: 'kg',
+            value: 300,
+          },
+          {
+            color: '#3182bd',
+            dataKey: 'pv',
+            fill: '#3182bd',
+            hide: false,
+            name: 'My custom name',
+            nameKey: undefined,
+            payload: {
+              amt: 2400,
+              name: 'Page C',
+              pv: 1398,
+              uv: 300,
+            },
+            stroke: '#3182bd',
+            strokeWidth: undefined,
+            type: undefined,
+            unit: '$$$',
+            value: 1398,
+          },
+          {
+            color: '#3182bd',
+            dataKey: 'amt',
+            fill: '#3182bd',
+            hide: false,
+            name: 'amt',
+            nameKey: undefined,
+            payload: {
+              amt: 2400,
+              name: 'Page C',
+              pv: 1398,
+              uv: 300,
+            },
+            stroke: '#3182bd',
+            strokeWidth: undefined,
+            type: undefined,
+            unit: undefined,
+            value: 2400,
+          },
+        ],
+        reverseDirection: {
+          x: false,
+          y: false,
+        },
+        separator: ' : ',
+        trigger: 'hover',
+        useTranslate3d: false,
+        wrapperStyle: {},
+      },
+      expect.any(Object),
+    );
+  });
+});


### PR DESCRIPTION
## Description

This information is already available in the general area so it's easy to pass it to the consumer component.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/6385
Fixes https://github.com/recharts/recharts/issues/3835

## How Has This Been Tested?

Added a unit test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tooltip content now exposes the active index to custom content renderers, allowing access to which data point is currently active.

* **Tests**
  * Added comprehensive test suite validating tooltip content payload behavior with multi-series area charts across initial render and interactive hover states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->