### PR TITLE
Horizontal center the index page

### DIFF
--- a/www/src/views/IndexView/IndexView.css
+++ b/www/src/views/IndexView/IndexView.css
@@ -1,4 +1,8 @@
 .page-index {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
   .block {
     max-width: 1000px;
     padding: 50px 20px;
@@ -18,7 +22,6 @@
 
   .desc {
     max-width: 1000px;
-    margin: 0 auto;
     padding: 60px 20px 0;
 
     a {
@@ -103,7 +106,8 @@
     }
   }
 
-  .who {
+  .who.block {
+    max-width: 100%;
     .users {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));


### PR DESCRIPTION
<img width="2416" height="1043" alt="image" src="https://github.com/user-attachments/assets/f0bac1ce-6f17-43c2-9138-91ffd86c5afc" />

Fixes https://github.com/recharts/recharts/issues/6587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined page layout alignment and element spacing for improved visual consistency and responsive design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->