### PR TITLE
Add margin support to Sankey and remove the doc from sunburst

### DIFF
--- a/omnidoc/omnidoc.spec.ts
+++ b/omnidoc/omnidoc.spec.ts
@@ -189,10 +189,6 @@ describe('omnidoc - documentation consistency', () => {
           "prop": "activeShape",
         },
         {
-          "component": "SunburstChart",
-          "prop": "margin",
-        },
-        {
           "component": "Trapezoid",
           "prop": "isAnimationActive",
         },

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -533,14 +533,6 @@ type Props = SVGProps<SVGSVGElement> & SankeyProps;
 
 type SankeyElementType = 'node' | 'link';
 
-// Why is margin not a Sankey prop? No clue. Probably it should be
-const defaultSankeyMargin: Margin = {
-  top: 0,
-  right: 0,
-  bottom: 0,
-  left: 0,
-};
-
 function renderLinkItem(option: SankeyLinkOptions | undefined, props: LinkProps) {
   if (React.isValidElement(option)) {
     return React.cloneElement(option, props);
@@ -996,7 +988,7 @@ export function Sankey(outsideProps: Props) {
     <RechartsStoreProvider preloadedState={{ options }} reduxStoreName={className ?? 'Sankey'}>
       <SetTooltipEntrySettings fn={getTooltipEntrySettings} args={props} />
       <ReportChartSize width={width} height={height} />
-      <ReportChartMargin margin={defaultSankeyMargin} />
+      <ReportChartMargin margin={props.margin} />
       <RechartsWrapper
         className={className}
         style={style}

--- a/storybook/stories/API/chart/SunburstChart.stories.tsx
+++ b/storybook/stories/API/chart/SunburstChart.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Args } from '@storybook/react-vite';
 import { ResponsiveContainer, SunburstChart, Tooltip } from '../../../../src';
 import { SunburstData } from '../../../../src/chart/SunburstChart';
-import { CategoricalChartProps, ChartSizeProps, data, dataKey, margin } from '../props/ChartProps';
+import { CategoricalChartProps, ChartSizeProps, data, dataKey } from '../props/ChartProps';
 import { PolarChartProps } from '../props/PolarChartProps';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 
@@ -13,7 +13,6 @@ const { onClick, onMouseEnter, onMouseLeave, className } = CategoricalChartProps
 export default {
   argTypes: {
     data,
-    margin,
     ...ChartSizeProps,
     dataKey,
     innerRadius,

--- a/test/chart/Sankey.spec.tsx
+++ b/test/chart/Sankey.spec.tsx
@@ -61,7 +61,7 @@ describe('<Sankey />', () => {
         </Sankey>,
       );
       expect(clipPathSpy).toHaveBeenLastCalledWith(undefined);
-      expect(viewBoxSpy).toHaveBeenLastCalledWith({ x: 0, y: 0, width: 1000, height: 500 });
+      expect(viewBoxSpy).toHaveBeenLastCalledWith({ x: 5, y: 5, width: 990, height: 490 });
       expect(viewBoxSpy).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
## Description

SunburstChart had margin documented but not actually implemented. When I tried to add support for margin I have discovered that indeed the numbers are ignored and margin doesn't do anything so I removed the doc.

I also discovered that while Sankey margin is not documented and unsupported, when I actually read the prop, it works well - so I added it.

I have also discovered that Treemap does not implement margin and ignores margin - so I left it alone.

## Related Issue

https://github.com/recharts/recharts/issues/6069
## How Has This Been Tested?

There should be visual diff in the storybook because Sankeys had margin defined but it never did anything - now it does.

## Types of changes

Technically new feature, Sankey now has margin prop.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated chart layout test expectations to reflect margin adjustments.

* **Refactor**
  * Modified margin configuration in chart components; Sankey chart now uses prop-based margins. Removed margin from SunburstChart story configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->