### PR TITLE
Fix stacked Bar animation

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -103,6 +103,10 @@ export interface BarRectangleItem extends RectangleProps {
   y: number;
   width: number;
   height: number;
+  /**
+   * Chart range coordinate of the baseValue of the first bar in a stack.
+   */
+  stackedBarStart: number;
 }
 
 export interface BarProps extends ZIndexable {
@@ -562,18 +566,20 @@ function RectanglesWithAnimation({
                   }
 
                   if (layout === 'horizontal') {
-                    const h = interpolate(0, entry.height, t);
+                    const height = interpolate(0, entry.height, t);
+                    const y = interpolate(entry.stackedBarStart, entry.y, t);
 
                     return {
                       ...entry,
-                      y: entry.y + entry.height - h,
-                      height: h,
+                      y,
+                      height,
                     };
                   }
 
                   const w = interpolate(0, entry.width, t);
+                  const x = interpolate(entry.stackedBarStart, entry.x, t);
 
-                  return { ...entry, width: w };
+                  return { ...entry, width: w, x };
                 });
 
           if (t > 0) {
@@ -762,6 +768,7 @@ export function computeBarRectangles({
   // @ts-expect-error this assumes that the domain is always numeric, but doesn't check for it
   const stackedDomain: ReadonlyArray<number> = stackedData ? numericAxis.scale.domain() : null;
   const baseValue = getBaseValueOfBar({ numericAxis });
+  const stackedBarStart: number = numericAxis.scale(baseValue);
 
   return displayedData
     .map((entry, index): BarRectangleItem | null => {
@@ -829,6 +836,7 @@ export function computeBarRectangles({
 
       const barRectangleItem: BarRectangleItem = {
         ...entry,
+        stackedBarStart,
         x,
         y,
         width,

--- a/test/cartesian/Bar.spec.tsx
+++ b/test/cartesian/Bar.spec.tsx
@@ -853,6 +853,7 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
           x: expect.any(Number),
           y: 50,
         },
+        stackedBarStart: expect.any(Number),
         width: 196,
         x: expect.any(Number),
         y: 5,
@@ -1784,6 +1785,7 @@ describe('mouse interactions in stacked bar: https://github.com/recharts/rechart
             x: 50,
             y: 50,
           },
+          stackedBarStart: 195,
           tooltipPosition: {
             x: 61.8,
             y: 163.33333333333334,
@@ -1837,6 +1839,7 @@ describe('mouse interactions in stacked bar: https://github.com/recharts/rechart
             x: 50,
             y: 50,
           },
+          stackedBarStart: 195,
           tooltipPosition: {
             x: 61.8,
             y: 163.33333333333334,
@@ -1877,6 +1880,7 @@ describe('mouse interactions in stacked bar: https://github.com/recharts/rechart
             x: 50,
             y: 50,
           },
+          stackedBarStart: 195,
           tooltipPosition: {
             x: 61.8,
             y: 163.33333333333334,
@@ -1929,6 +1933,7 @@ describe('mouse interactions in stacked bar: https://github.com/recharts/rechart
             x: 10,
             y: 50,
           },
+          stackedBarStart: 195,
           tooltipPosition: {
             x: 23.8,
             y: 179.16666666666669,

--- a/test/cartesian/Bar.truncateByDomain.spec.tsx
+++ b/test/cartesian/Bar.truncateByDomain.spec.tsx
@@ -105,6 +105,7 @@ describe('Bar stacked with truncateByDomain', () => {
             losses: 0,
             wins: 0,
           },
+          stackedBarStart: 275,
           tooltipPosition: {
             x: 230,
             y: 275,
@@ -140,6 +141,7 @@ describe('Bar stacked with truncateByDomain', () => {
             losses: -5,
             wins: 3,
           },
+          stackedBarStart: 275,
           tooltipPosition: {
             x: 610,
             y: 248,

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -793,6 +793,7 @@ describe('<BarChart />', () => {
             },
             // @ts-expect-error extra properties not expected in the type
             pv: 2400,
+            stackedBarStart: 45,
             tooltipPosition: {
               x: 68.75,
               y: 38.599999999999994,
@@ -825,6 +826,7 @@ describe('<BarChart />', () => {
             },
             // @ts-expect-error extra properties not expected in the type
             pv: 4567,
+            stackedBarStart: 45,
             tooltipPosition: {
               x: 76.25,
               y: 34.666,
@@ -857,6 +859,7 @@ describe('<BarChart />', () => {
             },
             // @ts-expect-error extra properties not expected in the type
             pv: 1398,
+            stackedBarStart: 45,
             tooltipPosition: {
               x: 83.75,
               y: 41.004,
@@ -889,6 +892,7 @@ describe('<BarChart />', () => {
             },
             // @ts-expect-error extra properties not expected in the type
             pv: 9800,
+            stackedBarStart: 45,
             tooltipPosition: {
               x: 91.25,
               y: 24.6,
@@ -2464,6 +2468,7 @@ describe('<BarChart />', () => {
           topWhisker: 200,
         },
         size: 150,
+        stackedBarStart: 165,
         tooltipPosition: {
           x: 120,
           y: 55,
@@ -2503,6 +2508,7 @@ describe('<BarChart />', () => {
           topWhisker: 100,
         },
         size: 250,
+        stackedBarStart: 165,
         tooltipPosition: {
           x: 230,
           y: 15,
@@ -2542,6 +2548,7 @@ describe('<BarChart />', () => {
           topWhisker: 200,
         },
         size: 350,
+        stackedBarStart: 165,
         tooltipPosition: {
           x: 340,
           y: 25,


### PR DESCRIPTION
## Description

Fix initial animation of stacked Bars.

At first I have considered rendering them at full height which would also solve this problem but that turned out to be much larger change than just animating the x/y position too.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/523

## Screenshots (if appropriate):

### Before

https://github.com/user-attachments/assets/30de9a15-44c7-42a3-b1a9-759fbe22a01b

https://github.com/user-attachments/assets/365f58b5-84a5-43dd-9621-634d1c9d4ff1

### After

https://github.com/user-attachments/assets/16f795f7-bce5-4db7-8800-2c3eac4e866b

https://github.com/user-attachments/assets/91a2684b-96a2-4389-bdb9-7155b1ebaadc

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `stackedBarStart` property to bar chart data structures, exposing the base coordinate for stacked bars.
  * Enhanced animation interpolation for stacked bars in both horizontal and vertical layouts, now properly positioning bar elements during transitions.

* **Tests**
  * Updated test expectations to verify the new `stackedBarStart` property is correctly included in bar chart payloads and event handlers across various stacking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->