### PR TITLE
Stop passing NaN as a DOM attribute

### DIFF
--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -8,6 +8,7 @@ import { getStringSize } from '../util/DOMUtils';
 import { reduceCSSCalc } from '../util/ReduceCSSCalc';
 import { svgPropertiesAndEvents } from '../util/svgPropertiesAndEvents';
 import { resolveDefaultProps } from '../util/resolveDefaultProps';
+import { isWellBehavedNumber } from '../util/isWellBehavedNumber';
 
 const BREAKING_SPACES = /[ \f\n\r\t\v\u2028\u2029]+/;
 
@@ -392,6 +393,10 @@ export const Text = forwardRef<SVGTextElement, Props>((outsideProps, ref) => {
   }
   const x = Number(propsX) + (isNumber(dx) ? dx : 0);
   const y = Number(propsY) + (isNumber(dy) ? dy : 0);
+
+  if (!isWellBehavedNumber(x) || !isWellBehavedNumber(y)) {
+    return null;
+  }
 
   let startDy: string;
   switch (verticalAnchor) {

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -1865,20 +1865,21 @@ export const combineAxisTicks = (
         offset,
       };
     });
-
-    return result.filter((row: TickItem) => !isNan(row.coordinate));
+    return result.filter((row: TickItem) => isWellBehavedNumber(row.coordinate));
   }
 
   // When axis is a categorical axis, but the type of axis is number or the scale of axis is not "auto"
   if (isCategorical && categoricalDomain) {
-    return categoricalDomain.map(
-      (entry: any, index: number): TickItem => ({
-        coordinate: scale(entry) + offset,
-        value: entry,
-        index,
-        offset,
-      }),
-    );
+    return categoricalDomain
+      .map(
+        (entry: any, index: number): TickItem => ({
+          coordinate: scale(entry) + offset,
+          value: entry,
+          index,
+          offset,
+        }),
+      )
+      .filter((row: TickItem) => isWellBehavedNumber(row.coordinate));
   }
 
   if (scale.ticks) {

--- a/test/component/Text.spec.tsx
+++ b/test/component/Text.spec.tsx
@@ -189,7 +189,7 @@ describe('<Text />', () => {
     }, 1000);
   });
 
-  test('Render text when x or y is a percentage', () => {
+  test('Renders nothing when x or y is a percentage', () => {
     render(
       <Surface width={300} height={200}>
         <Text role="img" x="50%" y="50%">
@@ -198,12 +198,8 @@ describe('<Text />', () => {
       </Surface>,
     );
 
-    const text = screen.getByRole('img');
-    expect(text).toBeInTheDocument();
-
-    setTimeout(() => {
-      expect(text.textContent).toContain('anything');
-    }, 1000);
+    const text = screen.queryByRole('img');
+    expect(text).not.toBeInTheDocument();
   });
 
   test("Don't Render text when x or y is NaN", () => {

--- a/test/helper/consoleWarningToError.ts
+++ b/test/helper/consoleWarningToError.ts
@@ -24,7 +24,6 @@ export const IGNORE_WARNINGS: Array<string | RegExp> = [
   /An update to (.+) inside a test was not wrapped in act/,
   'A props object containing a "key" prop is being spread into JSX',
   /React does not recognize the (.+) prop on a DOM element/,
-  /Received NaN for the (.+) attribute/,
   'verticalCoordinatesGenerator should return Array but instead it returned',
   'horizontalCoordinatesGenerator should return Array but instead it returned',
 ];

--- a/test/polar/PolarRadiusAxis.spec.tsx
+++ b/test/polar/PolarRadiusAxis.spec.tsx
@@ -976,7 +976,7 @@ describe('<PolarRadiusAxis />', () => {
 
         expectRadiusAxisLabel(container, {
           textContent: 'test',
-          x: '299',
+          x: '348',
           y: '250',
         });
       });
@@ -1084,7 +1084,7 @@ describe('<PolarRadiusAxis />', () => {
 
       expectRadiusAxisLabel(container, {
         textContent: 'test',
-        x: '299',
+        x: '348',
         y: '250',
       });
     });


### PR DESCRIPTION
## Description

Text and PolarRadiusAxis were missing NaN checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed text component rendering when coordinates contain invalid values, preventing display anomalies
  * Improved axis tick positioning by filtering out invalid numeric coordinates during calculations
  * Enhanced robustness of chart components to gracefully handle edge cases with malformed numeric inputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->