### PR TITLE
fix: legend should not report its size when there is an external portal

### DIFF
--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -199,7 +199,8 @@ export function Legend(outsideProps: Props) {
         verticalAlign={props.verticalAlign}
         itemSorter={props.itemSorter}
       />
-      <LegendSizeDispatcher width={lastBoundingBox.width} height={lastBoundingBox.height} />
+      {/* if we have a portal from props nothing should need the size of the legend */}
+      {!portalFromProps && <LegendSizeDispatcher width={lastBoundingBox.width} height={lastBoundingBox.height} />}
       <LegendContent
         {...props}
         {...widthOrHeight}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/recharts/recharts/issues/6608


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed legend sizing behavior when using portal targets, preventing unnecessary sizing computations in portal scenarios while maintaining existing functionality for standard usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->