### PR TITLE
Fix some places where we spread internal attributes to SVG elements

### DIFF
--- a/test/cartesian/ReferenceDot.spec.tsx
+++ b/test/cartesian/ReferenceDot.spec.tsx
@@ -171,11 +171,7 @@ describe('<ReferenceDot />', () => {
   });
 
   test('Render custom label when label is set to be a react element', () => {
-    const Label = ({ text, ...props }: { text: string }) => (
-      <text className="customized-label" {...props}>
-        {text}
-      </text>
-    );
+    const Label = ({ text }: { text: string }) => <text className="customized-label">{text}</text>;
     render(
       <BarChart
         width={1100}

--- a/test/cartesian/XAxis.spec.tsx
+++ b/test/cartesian/XAxis.spec.tsx
@@ -4912,12 +4912,12 @@ describe('<XAxis />', () => {
     }
 
     it('should pass object padding to custom tick component', () => {
-      let receivedPadding: { left?: number; right?: number } | undefined;
       const expectedPadding = { left: 20, right: 30 };
+      expect.assertions(6);
 
       const CustomXAxisTick = (props: TickProps) => {
-        receivedPadding = props.padding as { left?: number; right?: number };
-        return <text {...props}>Custom Tick</text>;
+        expect(props.padding).toEqual(expectedPadding);
+        return <text>Custom Tick</text>;
       };
 
       render(
@@ -4926,17 +4926,15 @@ describe('<XAxis />', () => {
           <Line type="monotone" dataKey="uv" stroke="#ff7300" />
         </LineChart>,
       );
-
-      expect(receivedPadding).toEqual(expectedPadding);
     });
 
     it('should pass string padding to custom tick component', () => {
-      let receivedPadding: string | undefined;
       const expectedPadding = 'gap';
+      expect.assertions(6);
 
       const CustomXAxisTick = (props: TickProps) => {
-        receivedPadding = props.padding as string;
-        return <text {...props}>Custom Tick</text>;
+        expect(props.padding).toBe(expectedPadding);
+        return <text>Custom Tick</text>;
       };
 
       render(
@@ -4945,17 +4943,15 @@ describe('<XAxis />', () => {
           <Line type="monotone" dataKey="uv" stroke="#ff7300" />
         </LineChart>,
       );
-
-      expect(receivedPadding).toBe(expectedPadding);
     });
 
     it('should pass padding to function-based custom tick', () => {
-      let receivedPadding: { left?: number; right?: number } | undefined;
       const expectedPadding = { left: 15, right: 25 };
+      expect.assertions(6);
 
       const customTickFunction = (props: TickProps) => {
-        receivedPadding = props.padding as { left?: number; right?: number };
-        return <text {...props}>Function Tick</text>;
+        expect(props.padding).toEqual(expectedPadding);
+        return <text>Function Tick</text>;
       };
 
       render(
@@ -4964,16 +4960,14 @@ describe('<XAxis />', () => {
           <Line type="monotone" dataKey="uv" stroke="#ff7300" />
         </LineChart>,
       );
-
-      expect(receivedPadding).toEqual(expectedPadding);
     });
 
     it('should pass default padding when no padding is specified', () => {
-      let receivedPadding: { left?: number; right?: number } | string = 'not-called';
+      expect.assertions(6);
 
       const CustomXAxisTick = (props: TickProps) => {
-        receivedPadding = props.padding as { left?: number; right?: number };
-        return <text {...props}>Custom Tick</text>;
+        expect(props.padding).toEqual({ left: 0, right: 0 });
+        return <text>Custom Tick</text>;
       };
 
       render(
@@ -4982,8 +4976,6 @@ describe('<XAxis />', () => {
           <Line type="monotone" dataKey="uv" stroke="#ff7300" />
         </LineChart>,
       );
-
-      expect(receivedPadding).toEqual({ left: 0, right: 0 });
     });
   });
 

--- a/test/cartesian/YAxis/YAxis.spec.tsx
+++ b/test/cartesian/YAxis/YAxis.spec.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
-import { describe, test, it, expect, vi } from 'vitest';
+import { describe, expect, it, test, vi } from 'vitest';
 import {
-  AreaChart,
   Area,
-  BarChart,
+  AreaChart,
   Bar,
-  LineChart,
-  Line,
+  BarChart,
   CartesianGrid,
-  Tooltip,
-  YAxis,
-  ReferenceDot,
-  ReferenceArea,
-  ReferenceLine,
-  XAxis,
   ComposedChart,
+  Line,
+  LineChart,
+  ReferenceArea,
+  ReferenceDot,
+  ReferenceLine,
+  Tooltip,
+  XAxis,
+  YAxis,
   YAxisProps,
 } from '../../../src';
 import { AxisDomain, CategoricalDomain, NumberDomain, StackOffsetType } from '../../../src/util/types';
@@ -2244,12 +2244,12 @@ describe('<YAxis />', () => {
     }
 
     it('should pass object padding to custom tick component', () => {
-      let receivedPadding: { top?: number; bottom?: number } | undefined;
       const expectedPadding = { top: 20, bottom: 30 };
+      expect.assertions(5);
 
       const CustomYAxisTick = (props: TickProps) => {
-        receivedPadding = props.padding as { top?: number; bottom?: number };
-        return <text {...props}>Custom Tick</text>;
+        expect(props.padding).toEqual(expectedPadding);
+        return <text>Custom Tick</text>;
       };
 
       render(
@@ -2258,17 +2258,15 @@ describe('<YAxis />', () => {
           <Line type="monotone" dataKey="uv" stroke="#ff7300" />
         </LineChart>,
       );
-
-      expect(receivedPadding).toEqual(expectedPadding);
     });
 
     it('should pass string padding to custom tick component', () => {
-      let receivedPadding: string | undefined;
       const expectedPadding = 'gap';
+      expect.assertions(5);
 
       const CustomYAxisTick = (props: TickProps) => {
-        receivedPadding = props.padding as string;
-        return <text {...props}>Custom Tick</text>;
+        expect(props.padding).toBe(expectedPadding);
+        return <text>Custom Tick</text>;
       };
 
       render(
@@ -2277,17 +2275,15 @@ describe('<YAxis />', () => {
           <Line type="monotone" dataKey="uv" stroke="#ff7300" />
         </LineChart>,
       );
-
-      expect(receivedPadding).toBe(expectedPadding);
     });
 
     it('should pass padding to function-based custom tick', () => {
-      let receivedPadding: { top?: number; bottom?: number } | undefined;
       const expectedPadding = { top: 15, bottom: 25 };
+      expect.assertions(5);
 
       const customTickFunction = (props: TickProps) => {
-        receivedPadding = props.padding as { top?: number; bottom?: number };
-        return <text {...props}>Function Tick</text>;
+        expect(props.padding).toEqual(expectedPadding);
+        return <text>Function Tick</text>;
       };
 
       render(
@@ -2296,16 +2292,14 @@ describe('<YAxis />', () => {
           <Line type="monotone" dataKey="uv" stroke="#ff7300" />
         </LineChart>,
       );
-
-      expect(receivedPadding).toEqual(expectedPadding);
     });
 
     it('should pass default padding when no padding is specified', () => {
-      let receivedPadding: { top?: number; bottom?: number } | string = 'not-called';
+      expect.assertions(5);
 
       const CustomYAxisTick = (props: TickProps) => {
-        receivedPadding = props.padding as { top?: number; bottom?: number };
-        return <text {...props}>Custom Tick</text>;
+        expect(props.padding).toEqual({ top: 0, bottom: 0 });
+        return <text>Custom Tick</text>;
       };
 
       render(
@@ -2314,8 +2308,6 @@ describe('<YAxis />', () => {
           <Line type="monotone" dataKey="uv" stroke="#ff7300" />
         </LineChart>,
       );
-
-      expect(receivedPadding).toEqual({ top: 0, bottom: 0 });
     });
   });
 });

--- a/test/helper/consoleWarningToError.ts
+++ b/test/helper/consoleWarningToError.ts
@@ -21,6 +21,11 @@
 export const IGNORE_WARNINGS: Array<string | RegExp> = [
   // Add patterns here to suppress warnings
   /An update to (.+) inside a test was not wrapped in act/,
+  /*
+   * There are unfortunately many cases where we put arbitrary props on DOM elements
+   * because of the element cloning - we can't tell what we have cloned.
+   * This warning will stay with us as long as we support cloning.
+   */
   /React does not recognize the (.+) prop on a DOM element/,
   'verticalCoordinatesGenerator should return Array but instead it returned',
   'horizontalCoordinatesGenerator should return Array but instead it returned',


### PR DESCRIPTION
… but can't fix them all

## Description

I thought we have some problems where we spread internal variables to SVG elements but turns out it's exclusively element cloning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Refactored test assertions for improved precision and maintainability.
  * Simplified custom component test definitions.
  * Enhanced assertion tracking with explicit assertion counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->