### PR TITLE
Omnidoc: Update Label default values

### DIFF
--- a/omnidoc/componentsAndDefaultPropsMap.ts
+++ b/omnidoc/componentsAndDefaultPropsMap.ts
@@ -1,6 +1,7 @@
 import { referenceLineDefaultProps } from '../src/cartesian/ReferenceLine';
 import { textDefaultProps } from '../src/component/Text';
 import { defaultAreaProps } from '../src/cartesian/Area';
+import { defaultLabelProps } from '../src/component/Label';
 
 type ComponentMeta = {
   defaultProps: Record<string, unknown> | undefined;
@@ -10,4 +11,5 @@ export const componentMetaMap: Record<string, ComponentMeta> = {
   Area: { defaultProps: defaultAreaProps },
   ReferenceLine: { defaultProps: referenceLineDefaultProps },
   Text: { defaultProps: textDefaultProps },
+  Label: { defaultProps: defaultLabelProps },
 };

--- a/omnidoc/omnidoc.spec.ts
+++ b/omnidoc/omnidoc.spec.ts
@@ -121,7 +121,7 @@ describe('omnidoc - documentation consistency', () => {
       }
       if (documentedDefaultValue.type === 'known' && actualDefaultValue.type === 'known') {
         if (!compareValues(documentedDefaultValue.value, actualDefaultValue.value)) {
-          return `Documented default value "${documentedDefaultValue.value}", but actually in project it is "${actualDefaultValue.value}"`;
+          return `Documented default value "${documentedDefaultValue.value}" [${typeof documentedDefaultValue.value}], but actually in project it is "${actualDefaultValue.value}" [${typeof actualDefaultValue.value}]`;
         }
         return null;
       }
@@ -137,7 +137,7 @@ describe('omnidoc - documentation consistency', () => {
     const apiComponentsWithKnownIssues = ['ReferenceLine', 'Text'];
 
     test.each(apiDocReader.getPublicComponentNames().filter(c => !apiComponentsWithKnownIssues.includes(c)))(
-      'if component %s has default props in the API, then that default value must be the same as in the project',
+      'if %s has default props in the API, then that default value must be the same as in the project',
       component => {
         const allProps = apiDocReader.getRechartsPropsOf(component);
         const missingDefaultProps: string[] = [];
@@ -155,7 +155,7 @@ describe('omnidoc - documentation consistency', () => {
       },
     );
 
-    const storybookComponentsWithKnownIssues = ['Label', 'ReferenceLine', 'Text', 'Treemap'];
+    const storybookComponentsWithKnownIssues = ['ReferenceLine', 'Text', 'Treemap'];
 
     test.each(storybookReader.getPublicComponentNames().filter(c => !storybookComponentsWithKnownIssues.includes(c)))(
       'if %s has default props in Storybook, it should also have them in the project',

--- a/omnidoc/readProject.ts
+++ b/omnidoc/readProject.ts
@@ -328,15 +328,17 @@ export class ProjectDocReader implements DocReader {
   getDefaultValueOf(component: string, prop: string): DefaultValue {
     return this.getPropMeta(component, prop).reduce(
       (acc: DefaultValue, meta: PropMeta): DefaultValue => {
-        if (acc.type === 'known' || acc.type === 'none') {
-          return acc;
-        }
         /*
          * Here we intentionally prioritize default value from object over JSDoc,
          * because JSDoc may be missing or outdated.
+         * Sometimes JSDoc in the react TS types is also present, and also a string
+         * - so we prefer the actual defaultProps value from the source code.
          */
         if (meta.defaultValueFromObject.type !== 'unreadable') {
           return meta.defaultValueFromObject;
+        }
+        if (acc.type === 'known' || acc.type === 'none') {
+          return acc;
         }
         if (meta.defaultValueFromJSDoc.type !== 'unreadable') {
           return meta.defaultValueFromJSDoc;

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -70,15 +70,32 @@ interface LabelProps extends ZIndexable {
   parentViewBox?: ViewBox;
   formatter?: LabelFormatter;
   value?: RenderableText;
+  /**
+   * @defaultValue 5
+   */
   offset?: number;
+  /**
+   * @defaultValue middle
+   */
   position?: LabelPosition;
   children?: RenderableText;
   className?: string;
   content?: LabelContentType;
+  /**
+   * @defaultValue false
+   */
   textBreakAll?: boolean;
+  /**
+   * @defaultValue 0
+   */
   angle?: number;
   index?: number;
   labelRef?: React.RefObject<SVGTextElement> | null;
+  /**
+   * @since 3.4
+   * @defaultValue 2000
+   */
+  zIndex?: number;
 }
 
 export type Props = Omit<SVGProps<SVGTextElement>, 'viewBox'> & LabelProps;
@@ -534,9 +551,12 @@ export const getAttrsOfCartesianLabel = (
   };
 };
 
-const defaultLabelProps = {
+export const defaultLabelProps = {
+  angle: 0,
   offset: 5,
   zIndex: DefaultZIndexes.label,
+  position: 'middle',
+  textBreakAll: false,
 } as const satisfies Partial<Props>;
 
 export function Label(outerProps: Props) {

--- a/storybook/stories/API/props/LabelListProps.ts
+++ b/storybook/stories/API/props/LabelListProps.ts
@@ -27,6 +27,9 @@ export const positionProp: StorybookArg = {
     'middle',
   ],
   table: {
+    defaultValue: {
+      summary: 'middle',
+    },
     type: {
       summary:
         'top, left, right, bottom, inside, outside, insideLeft, ' +

--- a/test/cartesian/Bar.spec.tsx
+++ b/test/cartesian/Bar.spec.tsx
@@ -2,7 +2,18 @@ import React from 'react';
 import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { act, fireEvent } from '@testing-library/react';
 import { renderWithStrictMode } from '../helper/renderWithStrictMode';
-import { Bar, BarChart, BarProps, Customized, Legend, LegendType, Tooltip, XAxis, YAxis } from '../../src';
+import {
+  Bar,
+  BarChart,
+  BarProps,
+  Customized,
+  DefaultZIndexes,
+  Legend,
+  LegendType,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from '../../src';
 import {
   allCartesianChartsExcept,
   AreaChartCase,
@@ -32,7 +43,6 @@ import { BarSettings } from '../../src/state/types/BarSettings';
 import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 import { userEventSetup } from '../helper/userEventSetup';
 import { assertZIndexLayerOrder } from '../helper/assertZIndexLayerOrder';
-import { DefaultZIndexes } from '../../src/zIndex/DefaultZIndexes';
 
 type TestCase = CartesianChartTestCase;
 
@@ -1009,6 +1019,7 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
         expect(spy).toHaveBeenCalledTimes(data.length * 2);
         expect(spy).toBeCalledWith(
           {
+            angle: 0,
             content: spy,
             height: expect.any(Number),
             index: expect.any(Number),
@@ -1019,7 +1030,8 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
               x: expect.any(Number),
               y: expect.any(Number),
             },
-            textBreakAll: undefined,
+            textBreakAll: false,
+            position: 'middle',
             value: expect.any(Number),
             viewBox: {
               height: expect.any(Number),

--- a/test/component/Label.spec.tsx
+++ b/test/component/Label.spec.tsx
@@ -1,11 +1,10 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { Label, LabelProps, Line, LineChart, PieChart, ReferenceLine, Surface } from '../../src';
+import { describe, expect, it, vi } from 'vitest';
+import { DefaultZIndexes, Label, LabelProps, Line, LineChart, PieChart, ReferenceLine, Surface } from '../../src';
 import { PolarViewBoxRequired } from '../../src/util/types';
 import { rechartsTestRender } from '../helper/createSelectorTestCase';
 import { assertNotNull } from '../helper/assertNotNull';
-import { DefaultZIndexes } from '../../src/zIndex/DefaultZIndexes';
 
 const data = [
   { name: 'Page A', uv: 400, pv: 2400, amt: 2400 },
@@ -300,9 +299,11 @@ describe('<Label />', () => {
           expect(fn).toHaveBeenCalledTimes(1);
           expect(fn).toHaveBeenLastCalledWith(
             {
+              angle: 0,
               content: fn,
               offset: 5,
               position: 'center',
+              textBreakAll: false,
               zIndex: DefaultZIndexes.label,
               viewBox: {
                 height: 200,
@@ -460,9 +461,11 @@ describe('<Label />', () => {
         expect(contentFn).toHaveBeenCalledTimes(1);
         expect(contentFn).toHaveBeenLastCalledWith(
           {
+            angle: 0,
             children: 'label from children',
             content: contentFn,
             offset: 5,
+            textBreakAll: false,
             position: 'center',
             zIndex: DefaultZIndexes.label,
             viewBox: {
@@ -494,9 +497,11 @@ describe('<Label />', () => {
         expect(contentFn).toHaveBeenCalledTimes(1);
         expect(contentFn).toHaveBeenLastCalledWith(
           {
+            angle: 0,
             value: 'label from value',
             content: contentFn,
             offset: 5,
+            textBreakAll: false,
             position: 'center',
             zIndex: DefaultZIndexes.label,
             viewBox: {
@@ -530,9 +535,11 @@ describe('<Label />', () => {
         expect(contentFn).toHaveBeenCalledTimes(1);
         expect(contentFn).toHaveBeenLastCalledWith(
           {
+            angle: 0,
             children: 'label from children',
             value: 'label from value',
             content: contentFn,
+            textBreakAll: false,
             offset: 5,
             position: 'center',
             zIndex: DefaultZIndexes.label,
@@ -603,8 +610,10 @@ describe('<Label />', () => {
               x: 5,
               y: 5,
             },
+            angle: 0,
             value: 'text',
             content: contentFn,
+            textBreakAll: false,
             position: 'center',
             offset: 5,
             zIndex: DefaultZIndexes.label,
@@ -632,8 +641,10 @@ describe('<Label />', () => {
               outerRadius: 36,
               startAngle: 0,
             },
+            angle: 0,
             value: 'text',
             content: contentFn,
+            textBreakAll: false,
             position: 'insideEnd',
             offset: 5,
             zIndex: DefaultZIndexes.label,
@@ -664,8 +675,10 @@ describe('<Label />', () => {
               x: 5,
               y: 5,
             },
+            angle: 0,
             value: 'text',
             content: contentFn,
+            textBreakAll: false,
             position: 'center',
             offset: 5,
             zIndex: DefaultZIndexes.label,

--- a/www/src/docs/api/Label.ts
+++ b/www/src/docs/api/Label.ts
@@ -14,7 +14,6 @@ export const LabelAPI = {
     {
       name: 'formatter',
       type: 'Function',
-      defaultVal: 'null',
       isOptional: true,
       desc: {
         'en-US': 'The formatter function of label value which has only one parameter - the value of label.',
@@ -24,7 +23,6 @@ export const LabelAPI = {
     {
       name: 'value',
       type: 'String | Number',
-      defaultVal: 'null',
       isOptional: true,
       desc: {
         'en-US': 'The value of label, which can be specified by this props or the children of <Label />',
@@ -35,7 +33,7 @@ export const LabelAPI = {
     {
       name: 'position',
       type: '"top" | "left" | "right" | "bottom" | "inside" | "outside" | "insideLeft" | "insideRight" | "insideTop" | "insideBottom" | "insideTopLeft" | "insideBottomLeft" | "insideTopRight" | "insideBottomRight" | "insideStart" | "insideEnd" | "end" | "center"',
-      defaultVal: 'null',
+      defaultVal: 'middle',
       isOptional: true,
       desc: {
         'en-US': 'The position of label relative to the view box.',
@@ -45,7 +43,7 @@ export const LabelAPI = {
     {
       name: 'offset',
       type: 'Number',
-      defaultVal: '5',
+      defaultVal: 5,
       isOptional: false,
       desc: {
         'en-US': 'The offset to the specified "position"',
@@ -55,7 +53,6 @@ export const LabelAPI = {
     {
       name: 'children',
       type: 'String | Number',
-      defaultVal: 'null',
       isOptional: true,
       desc: {
         'en-US': 'The value of label, which can be specified by this props or the props "value"',
@@ -71,7 +68,6 @@ export const LabelAPI = {
     {
       name: 'content',
       type: 'ReactElement | Function',
-      defaultVal: 'null',
       isOptional: true,
       desc: {
         'en-US':
@@ -80,12 +76,6 @@ export const LabelAPI = {
           '定制 Label 展示的内容。如果值为 React element，会克隆这个元素来渲染 Label 的内容。如果值为函数，会调用这个函数来生成 Label 的内容。',
       },
       format: ['<Label content={<CustomizedLabel external={external} />} />', '<Label content={renderLabel} />'],
-      // examples: [
-      //   {
-      //     name: 'Customize label content',
-      //     url: '/examples/CustomContentOfLabel',
-      //   }
-      // ],
     },
     {
       name: 'id',


### PR DESCRIPTION
## Related Issue

https://github.com/recharts/recharts/issues/6069


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Label component now supports four new configurable properties: angle, position, textBreakAll, and zIndex, each with documented default values for consistent behavior.

* **Documentation**
  * Updated Label component API documentation to reflect accurate default values for all properties, including corrected documentation for position and offset defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->