### PR TITLE
fix stuck chart issue

### DIFF
--- a/www/src/components/CodeEditorWithPreview.tsx
+++ b/www/src/components/CodeEditorWithPreview.tsx
@@ -105,13 +105,6 @@ export function CodeEditorWithPreview({
     setCodeToRun(editedCode);
   };
 
-  // Reset editor state when navigating to a different example
-  useEffect(() => {
-    setIsEditMode(false);
-    setEditedCode(null);
-    setCodeToRun(null);
-  }, [sourceCode, stackBlitzTitle, analyticsLabel]);
-
   const codeToDisplay = editedCode ?? sourceCode;
 
   return (

--- a/www/src/views/ExamplesView.tsx
+++ b/www/src/views/ExamplesView.tsx
@@ -51,6 +51,7 @@ function ExamplesViewImpl({ params }: ExamplesViewImplProps) {
           <div className="example-wrapper">
             <div className="example-inner-wrapper">
               <CodeEditorWithPreview
+                key={page}
                 Component={exampleResult.ExampleComponent}
                 sourceCode={exampleResult.sourceCode}
                 stackBlitzTitle={`Recharts example: ${exampleResult.cateName} - ${exampleResult.exampleName}`}


### PR DESCRIPTION
## Description

Reset the example editor state whenever I navigate to a different example so the sidebar keeps working after I hit Run.

<!--- Describe your changes in detail -->

## Related Issue
fixes #6618 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Started the docs locally, reproduced the bug, then verified the sidebar loads new examples normally after clicking Run.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/89009f9a-9ae0-4642-b228-b6a37d2b7fbe

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed component state handling when navigating between examples to ensure proper reset and clean state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->