### PR TITLE
Fix Line animation when interrupted with non-data related changes

### DIFF
--- a/storybook/stories/API/chart/LineChart.stories.tsx
+++ b/storybook/stories/API/chart/LineChart.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { Args } from '@storybook/react-vite';
 import { pageData } from '../../data';
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis } from '../../../../src';
@@ -12,10 +12,26 @@ export default {
 
 export const Simple = {
   render: (args: Args) => {
+    const [isHovered, setIsHovered] = useState(false);
+
+    const onMouseEnter = useCallback(() => {
+      setIsHovered(true);
+    }, [setIsHovered]);
+
+    const onMouseLeave = useCallback(() => {
+      setIsHovered(false);
+    }, [setIsHovered]);
+
     return (
       <ResponsiveContainer width="100%" height={400}>
         <LineChart {...args}>
-          <Line dataKey="uv" />
+          <Line
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+            dataKey="uv"
+            strokeWidth={isHovered ? 8 : 4}
+            animationDuration={5000}
+          />
           <RechartsHookInspector />
         </LineChart>
       </ResponsiveContainer>


### PR DESCRIPTION
## Description

We already had a nice handing for when an animation is interrupted by a change in the data. We did not have anything for when an animation is interrupted by a render that does not change the data which is what https://github.com/recharts/recharts/issues/6044 is about.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/6044

Some improvements are already in main since https://github.com/recharts/recharts/pull/6634

## Screenshots (if appropriate):

This is what it looked like before https://github.com/recharts/recharts/pull/6634, same as in the original report in https://github.com/recharts/recharts/issues/6044:

https://github.com/user-attachments/assets/d477a374-c216-4411-8b12-47d0b8ed95f7

This is what is currently in the main branch, notice how the length suddenly jumps:

https://github.com/user-attachments/assets/f4adab16-a884-4c76-b896-b6ee0723dd53

After this PR:

https://github.com/user-attachments/assets/469c4fb5-22c2-461f-9613-589fcff5b0ce

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed line animations continuing from their previous position when strokeWidth or other properties change during playback, eliminating unwanted animation restarts.

* **Tests**
  * Added test coverage for property changes occurring during line animation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->