### PR TITLE
Typescript strict

### DIFF
--- a/src/state/touchEventsMiddleware.ts
+++ b/src/state/touchEventsMiddleware.ts
@@ -11,7 +11,7 @@ import { selectTooltipCoordinate } from './selectors/touchSelectors';
 
 export const touchEventAction = createAction<React.TouchEvent<HTMLDivElement>>('touchMove');
 
-export const touchEventMiddleware = createListenerMiddleware();
+export const touchEventMiddleware = createListenerMiddleware<RechartsRootState>();
 
 touchEventMiddleware.startListening({
   actionCreator: touchEventAction,

--- a/src/state/zIndexSlice.ts
+++ b/src/state/zIndexSlice.ts
@@ -32,7 +32,7 @@ const seed: ZIndexState['zIndexMap'] = {};
 
 const initialState: ZIndexState = {
   zIndexMap: Object.values(DefaultZIndexes).reduce(
-    (acc: ZIndexState, current): ZIndexState => ({
+    (acc: ZIndexState['zIndexMap'], current: number): ZIndexState['zIndexMap'] => ({
       ...acc,
       [current]: {
         elementId: undefined,

--- a/src/util/LRUCache.ts
+++ b/src/util/LRUCache.ts
@@ -24,7 +24,9 @@ export class LRUCache<K, V> {
       this.cache.delete(key);
     } else if (this.cache.size >= this.maxSize) {
       const firstKey = this.cache.keys().next().value;
-      this.cache.delete(firstKey);
+      if (firstKey != null) {
+        this.cache.delete(firstKey);
+      }
     }
     this.cache.set(key, value);
   }

--- a/src/util/YAxisUtils.tsx
+++ b/src/util/YAxisUtils.tsx
@@ -26,7 +26,7 @@ export const getCalculatedYAxisWidth = ({
   // find the max width of the tick labels
   let maxTickWidth = 0;
   if (ticks) {
-    Array.from(ticks).forEach((tickNode: Element) => {
+    Array.from(ticks).forEach((tickNode: IGetBoundingClient) => {
       if (tickNode) {
         const bbox = tickNode.getBoundingClientRect();
 

--- a/src/util/scale/getNiceTickValues.ts
+++ b/src/util/scale/getNiceTickValues.ts
@@ -4,7 +4,7 @@
  * @date 2015-09-17
  */
 import Decimal from 'decimal.js-light';
-import { compose, range, memoize, map, reverse } from './util/utils';
+import { compose, range, map, reverse } from './util/utils';
 import { getDigitCount, rangeStep } from './util/arithmetic';
 import { NumberDomain } from '../types';
 
@@ -172,7 +172,7 @@ export const calculateStep = (
  * @param allowDecimals Allow the ticks to be decimals or not
  * @return array of ticks
  */
-function getNiceTickValuesFn([min, max]: NumberDomain, tickCount = 6, allowDecimals = true): number[] {
+export const getNiceTickValues = ([min, max]: NumberDomain, tickCount = 6, allowDecimals = true): number[] => {
   // More than two ticks should be return
   const count = Math.max(tickCount, 2);
   const [cormin, cormax] = getValidInterval([min, max]);
@@ -196,7 +196,7 @@ function getNiceTickValuesFn([min, max]: NumberDomain, tickCount = 6, allowDecim
   const values = rangeStep(tickMin, tickMax.add(new Decimal(0.1).mul(step)), step);
 
   return min > max ? reverse(values) : values;
-}
+};
 
 /**
  * Calculate the ticks of an interval.
@@ -207,7 +207,7 @@ function getNiceTickValuesFn([min, max]: NumberDomain, tickCount = 6, allowDecim
  * @param allowDecimals Allow the ticks to be decimals or not
  * @return array of ticks
  */
-function getTickValuesFixedDomainFn([min, max]: NumberDomain, tickCount: number, allowDecimals = true) {
+export const getTickValuesFixedDomain = ([min, max]: NumberDomain, tickCount: number, allowDecimals = true) => {
   // More than two ticks should be return
   const [cormin, cormax] = getValidInterval([min, max]);
 
@@ -234,7 +234,4 @@ function getTickValuesFixedDomainFn([min, max]: NumberDomain, tickCount: number,
   }
 
   return min > max ? reverse(values) : values;
-}
-
-export const getNiceTickValues = memoize(getNiceTickValuesFn);
-export const getTickValuesFixedDomain = memoize(getTickValuesFixedDomainFn);
+};

--- a/src/util/scale/util/arithmetic.ts
+++ b/src/util/scale/util/arithmetic.ts
@@ -4,7 +4,6 @@
  * @date 2015-09-17
  */
 import Decimal from 'decimal.js-light';
-import { curry } from './utils';
 
 /**
  * Get the digit count of a number.
@@ -52,52 +51,4 @@ function rangeStep(start: Decimal, end: Decimal, step: Decimal): Array<number> {
   return result;
 }
 
-/**
- * Linear interpolation of numbers.
- *
- * @param  {Number} a  Endpoint of the domain
- * @param  {Number} b  Endpoint of the domain
- * @param  {Number} t  A value in [0, 1]
- * @return {Number}    A value in the domain
- */
-const interpolateNumber = curry((a: number, b: number, t: number) => {
-  const newA = +a;
-  const newB = +b;
-
-  return newA + t * (newB - newA);
-});
-
-/**
- * Inverse operation of linear interpolation.
- *
- * @param  {Number} a Endpoint of the domain
- * @param  {Number} b Endpoint of the domain
- * @param  {Number} x Can be considered as an output value after interpolation
- * @return {Number}   When x is in the range a ~ b, the return value is in [0, 1]
- */
-const uninterpolateNumber = curry((a: number, b: number, x: number) => {
-  let diff = b - +a;
-
-  diff = diff || Infinity;
-
-  return (x - a) / diff;
-});
-
-/**
- * Inverse operation of linear interpolation with truncation.
- *
- * @param  {Number} a Endpoint of the domain
- * @param  {Number} b Endpoint of the domain
- * @param  {Number} x Can be considered as an output value after interpolation
- * @return {Number}   When x is in the interval a ~ b, the return value is in [0, 1].
- *                    When x is not in the interval a ~ b, it will be truncated to the interval a ~ b.
- */
-const uninterpolateTruncation = curry((a: number, b: number, x: number) => {
-  let diff = b - +a;
-
-  diff = diff || Infinity;
-
-  return Math.max(0, Math.min(1, (x - a) / diff));
-});
-
-export { rangeStep, getDigitCount, interpolateNumber, uninterpolateNumber, uninterpolateTruncation };
+export { rangeStep, getDigitCount };

--- a/src/util/scale/util/utils.ts
+++ b/src/util/scale/util/utils.ts
@@ -81,19 +81,3 @@ export const reverse = <T extends any[] | string>(arr: T): T => {
   // can be string
   return arr.split('').reverse().join('') as T;
 };
-
-export const memoize = <F extends (...args: unknown[]) => any>(fn: F): F => {
-  let lastArgs: unknown[] | null = null;
-  let lastResult: unknown[] | null = null;
-
-  return ((...args: Parameters<F>) => {
-    if (lastArgs && args.every((val, i) => val === lastArgs?.[i])) {
-      return lastResult;
-    }
-
-    lastArgs = args;
-    lastResult = fn(...args);
-
-    return lastResult;
-  }) as F;
-};

--- a/src/util/useElementOffset.ts
+++ b/src/util/useElementOffset.ts
@@ -50,7 +50,7 @@ export type SetElementOffset = (node: HTMLElement | null) => void;
 export function useElementOffset(extraDependencies: ReadonlyArray<unknown> = []): [ElementOffset, SetElementOffset] {
   const [lastBoundingBox, setLastBoundingBox] = useState<ElementOffset>({ height: 0, left: 0, top: 0, width: 0 });
   const updateBoundingBox = useCallback(
-    (node: HTMLDivElement | null) => {
+    (node: HTMLElement | null) => {
       if (node != null) {
         const rect = node.getBoundingClientRect();
         const box: ElementOffset = {

--- a/test/util/scale/arithmetic.spec.ts
+++ b/test/util/scale/arithmetic.spec.ts
@@ -1,12 +1,6 @@
 import { describe, expect } from 'vitest';
 import Decimal from 'decimal.js-light';
-import {
-  getDigitCount,
-  rangeStep,
-  interpolateNumber,
-  uninterpolateNumber,
-  uninterpolateTruncation,
-} from '../../../src/util/scale/util/arithmetic';
+import { getDigitCount, rangeStep } from '../../../src/util/scale/util/arithmetic';
 
 describe('arithmetic', () => {
   describe('getDigitCount', () => {
@@ -59,25 +53,6 @@ describe('arithmetic', () => {
       expect(result).toEqual([
         0, 0.00000035, 0.0000007, 0.00000105, 0.0000014, 0.00000175, 0.0000021, 0.00000245, 0.0000028, 0.00000315,
       ]);
-    });
-  });
-
-  describe('interpolate', () => {
-    it('should interpolate between two numbers', () => {
-      const interpolate = interpolateNumber(0, 10, 0.5);
-      expect(interpolate).toBe(5);
-    });
-
-    it('should uninterpolate between two numbers', () => {
-      const uninterpolate = uninterpolateNumber(0, 10, 7);
-      expect(uninterpolate).toBe(0.7);
-    });
-
-    it('should uninterpolate with truncation', () => {
-      const uninterpolateTruncZero = uninterpolateTruncation(0, 10, -5);
-      const uninterpolateTruncOne = uninterpolateTruncation(0, 10, 15);
-      expect(uninterpolateTruncZero).toBe(0);
-      expect(uninterpolateTruncOne).toBe(1);
     });
   });
 });

--- a/test/util/scale/utils.spec.ts
+++ b/test/util/scale/utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from 'vitest';
-import { compose, curry, map, memoize, range, reverse } from '../../../src/util/scale/util/utils';
+import { compose, curry, map, range, reverse } from '../../../src/util/scale/util/utils';
 
 describe('functional utilities', () => {
   describe('curry', () => {
@@ -52,23 +52,6 @@ describe('functional utilities', () => {
 
     it('should reverse strings', () => {
       expect(reverse('hello')).toBe('olleh');
-    });
-  });
-
-  describe('memoize', () => {
-    let callCount = 0;
-    const add = (a: number, b: number) => {
-      callCount++;
-      return a + b;
-    };
-    const memoizedAdd = memoize(add);
-
-    // if memoize works correctly, the call count should be 1 after the first call
-    it('should memoize a function', () => {
-      expect(memoizedAdd(1, 2)).toBe(3);
-      expect(callCount).toBe(1);
-      expect(memoizedAdd(1, 2)).toBe(3);
-      expect(callCount).toBe(1);
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,12 +6,21 @@
     "declarationDir": "./types" /* Output directory for generated declaration files. */,
     "jsx": "react",
     "module": "commonjs",
-    "noImplicitAny": true,
     "outDir": "./build/",
     "preserveConstEnums": true,
     "removeComments": false,
     "skipLibCheck": true,
     "strictNullChecks": true,
+    "strictBindCallApply": true,
+    "strictBuiltinIteratorReturn": true,
+    // TODO: Enable this option and fix errors https://github.com/recharts/recharts/issues/6645
+    "strictFunctionTypes": false,
+    "strictPropertyInitialization": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "useUnknownInCatchVariables": true,
+    // TODO: Enable this option and fix errors https://github.com/recharts/recharts/issues/6645
+    "noUncheckedIndexedAccess": false,
     "sourceMap": true,
     "target": "es6",
     "types": ["vitest/globals"]


### PR DESCRIPTION
## Description

There's more strict settings to turn on so let's kick it off.

One change to call out is the getNiceTickValues. It was wrapped in a custom memoize implementation that throws away types. `strictFunctionTypes` settings flags that as a problem (and it should). I tried to replace it with memoize from es-toolkit but turns out that es-toolkit only supports memoizing functions with a single argument. We have 3 arguments. Because we only ever use this function inside an already memoized selector, I figured we might just as well throw away the extra memo layer instead of reimplementing memoize we don't need.

Other changes are removing unused code, and fixing types. There are around 400 errors total to go through.

## Related Issue

https://github.com/recharts/recharts/issues/6645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential null reference errors in cache eviction when cache capacity is reached.

* **Chores**
  * Enhanced TypeScript compiler strictness options for improved type safety.
  * Removed unused memoization and interpolation utilities.
  * Refined internal type annotations across multiple modules for better code stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->