### PR TITLE
docs: point Pie activeShape to shape

### DIFF
--- a/www/src/docs/api/Pie.ts
+++ b/www/src/docs/api/Pie.ts
@@ -186,7 +186,7 @@ export const PieAPI = {
       isOptional: true,
       deprecated: true,
       desc: {
-        'en-US': 'The shape of active sector.',
+        'en-US': 'The shape of active sector. DEPRECATED: Use shape instead.',
         'zh-CN': '激活楔子的形状。',
       },
       examples: [
@@ -203,7 +203,7 @@ export const PieAPI = {
       isOptional: true,
       deprecated: true,
       desc: {
-        'en-US': 'The shape of inactive sector.',
+        'en-US': 'The shape of inactive sector. DEPRECATED: Use shape instead.',
         'zh-CN': '未激活楔子的形状。',
       },
     },


### PR DESCRIPTION

Follow up, point deprecated shape props to new shape prop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * The `activeShape` and `inactiveShape` properties in the Pie chart component are now marked as deprecated. Users should use the `shape` property instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->