### PR TITLE
test(xaxis): prevent Date data test from failing on non-English locales

### DIFF
--- a/test/helper/expectAxisTicks.ts
+++ b/test/helper/expectAxisTicks.ts
@@ -9,11 +9,16 @@ export type ExpectedTick = {
   y: string;
 };
 
+function normalizeDateString(str: string | null) {
+  if (!str) return str;
+  return str.replace(/\(.*?\)/, '(Coordinated Universal Time)');
+}
+
 export function expectXAxisTicks(container: Element, expectedTicks: ReadonlyArray<ExpectedTick>) {
   const allTicks = container.querySelectorAll('.recharts-xAxis-tick-labels .recharts-cartesian-axis-tick-value');
   assertNotNull(allTicks);
   const ticksContexts = Array.from(allTicks).map(tick => ({
-    textContent: tick.textContent,
+    textContent: normalizeDateString(tick.textContent),
     x: tick.getAttribute('x'),
     y: tick.getAttribute('y'),
   }));
@@ -24,7 +29,7 @@ export function expectYAxisTicks(container: Element, ticks: ReadonlyArray<Expect
   const allTicks = container.querySelectorAll('.recharts-yAxis-tick-labels .recharts-cartesian-axis-tick-value');
   assertNotNull(allTicks);
   const ticksContexts = Array.from(allTicks).map(tick => ({
-    textContent: tick.textContent,
+    textContent: normalizeDateString(tick.textContent),
     x: tick.getAttribute('x'),
     y: tick.getAttribute('y'),
   }));


### PR DESCRIPTION
Date.toString() returns different timezone labels depending on OS locale.
Because of this, the Date XAxis test failed on some machines.
I added a normalization in expectXAxisTicks so the comparison always uses the same UTC label.
This keeps the test reliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for axis tick validation with enhanced date-time formatting normalization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->