### PR TITLE
Use explicit types instead of inference

### DIFF
--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -733,7 +733,12 @@ export const selectDomainFromUserPreference: (
   numericalDomainSpecifiedWithoutRequiringData,
 );
 
-export const selectDomainOfStackGroups = createSelector(
+export const selectDomainOfStackGroups: (
+  state: RechartsRootState,
+  axisType: XorYorZType,
+  axisId: AxisId,
+  isPanorama: boolean,
+) => NumberDomain | undefined = createSelector(
   [selectStackGroups, selectChartDataWithIndexes, pickAxisType, selectDomainFromUserPreference],
   combineDomainOfStackGroups,
   {
@@ -892,7 +897,11 @@ export const filterReferenceElements = <T extends ReferenceElementSettings>(
     });
 };
 
-export const selectReferenceDotsByAxis = createSelector(
+export const selectReferenceDotsByAxis: (
+  state: RechartsRootState,
+  axisType: XorYorZType,
+  axisId: AxisId,
+) => ReadonlyArray<ReferenceDotSettings> = createSelector(
   [selectReferenceDots, pickAxisType, pickAxisId],
   filterReferenceElements,
 );
@@ -1494,7 +1503,11 @@ export const selectAxisScale: (
   combineScaleFunction,
 );
 
-export const selectErrorBarsSettings = createSelector(
+export const selectErrorBarsSettings: (
+  state: RechartsRootState,
+  axisType: XorYorZType,
+  axisId: AxisId,
+) => ReadonlyArray<ErrorBarsSettings> = createSelector(
   [selectCartesianItemsSettings, selectAllErrorBarSettings, pickAxisType],
   combineRelevantErrorBarSettings,
 );
@@ -1777,7 +1790,12 @@ export const selectCategoricalDomain: (
   combineCategoricalDomain,
 );
 
-export const selectAxisPropsNeededForCartesianGridTicksGenerator = createSelector(
+export const selectAxisPropsNeededForCartesianGridTicksGenerator: (
+  state: RechartsRootState,
+  axisType: XorYType,
+  axisId: AxisId,
+  isPanorama: boolean,
+) => AxisPropsForCartesianGridTicksGeneration | undefined = createSelector(
   [
     selectChartLayout,
     selectCartesianAxisSettings,
@@ -2032,7 +2050,12 @@ const selectZAxisScale: (
 
 export type ZAxisWithScale = ZAxisSettings & { scale: RechartsScale };
 
-export const selectZAxisWithScale = createSelector(
+export const selectZAxisWithScale: (
+  state: RechartsRootState,
+  _axisType: 'zAxis',
+  axisId: AxisId,
+  isPanorama: false,
+) => ZAxisWithScale | undefined = createSelector(
   (state: RechartsRootState, _axisType: 'zAxis', axisId: AxisId) => selectZAxisSettings(state, axisId),
   selectZAxisScale,
   (axis: ZAxisSettings, scale: RechartsScale | undefined): ZAxisWithScale | undefined => {

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,4 +1,4 @@
-import { Action, autoBatchEnhancer, combineReducers, configureStore, Dispatch, Store } from '@reduxjs/toolkit';
+import { Action, autoBatchEnhancer, combineReducers, configureStore, Dispatch, Reducer, Store } from '@reduxjs/toolkit';
 import { optionsReducer } from './optionsSlice';
 import { tooltipReducer } from './tooltipSlice';
 import { chartDataReducer } from './chartDataSlice';
@@ -20,7 +20,24 @@ import { errorBarReducer } from './errorBarSlice';
 import { Global } from '../util/Global';
 import { zIndexReducer } from './zIndexSlice';
 
-const rootReducer = combineReducers({
+export type RechartsRootState = {
+  brush: ReturnType<typeof brushReducer>;
+  cartesianAxis: ReturnType<typeof cartesianAxisReducer>;
+  chartData: ReturnType<typeof chartDataReducer>;
+  errorBars: ReturnType<typeof errorBarReducer>;
+  graphicalItems: ReturnType<typeof graphicalItemsReducer>;
+  layout: ReturnType<typeof chartLayoutReducer>;
+  legend: ReturnType<typeof legendReducer>;
+  options: ReturnType<typeof optionsReducer>;
+  polarAxis: ReturnType<typeof polarAxisReducer>;
+  polarOptions: ReturnType<typeof polarOptionsReducer>;
+  referenceElements: ReturnType<typeof referenceElementsReducer>;
+  rootProps: ReturnType<typeof rootPropsReducer>;
+  tooltip: ReturnType<typeof tooltipReducer>;
+  zIndex: ReturnType<typeof zIndexReducer>;
+};
+
+const rootReducer: Reducer<RechartsRootState> = combineReducers({
   brush: brushReducer,
   cartesianAxis: cartesianAxisReducer,
   chartData: chartDataReducer,
@@ -92,5 +109,4 @@ export const createRechartsStore = (
   });
 };
 
-export type RechartsRootState = ReturnType<typeof rootReducer>;
 export type AppDispatch = Dispatch<Action>;


### PR DESCRIPTION
## Description

Typescript was reporting error in types, even though we never imported those types directly. Turns out that TS compiler would inline some inferred types in the output d.ts file which caused the trouble.

So in this PR I am replacing the inferred types with explicit types that do not need any imports.

Once this is merged I will enable the skiplibchecks in CI so that we are protected from regression.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/6664

## How Has This Been Tested?

https://github.com/recharts/recharts-integ/pull/83

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal type and selector signatures were standardized and the root store shape was made explicit to improve type safety and maintainability without changing runtime behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->