### PR TITLE
test: add comprehensive tests for YAxis interval={0} behavior

### DIFF
--- a/test/cartesian/YAxis/YAxis.interval-zero.spec.tsx
+++ b/test/cartesian/YAxis/YAxis.interval-zero.spec.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Line, LineChart, XAxis, YAxis } from '../../../src';
+
+describe('YAxis interval={0} with custom ticks - comprehensive tests', () => {
+  const data = [
+    { name: 'A', value: -30 },
+    { name: 'B', value: -10 },
+    { name: 'C', value: 0 },
+    { name: 'D', value: 10 },
+    { name: 'E', value: 30 },
+  ];
+
+  const customTicks = [-35, -25, -15, -5, 0, 5, 15, 25, 35];
+
+  it('should display all 9 ticks with interval={0} - standard size', () => {
+    const { container } = render(
+      <LineChart width={500} height={300} data={data}>
+        <XAxis dataKey="name" />
+        <YAxis domain={[-35, 35]} interval={0} ticks={customTicks} />
+        <Line dataKey="value" />
+      </LineChart>,
+    );
+
+    const allTicks = container.querySelectorAll('.recharts-yAxis-tick-labels .recharts-cartesian-axis-tick-value');
+    expect(allTicks.length).toBe(9);
+
+    const tickTexts = Array.from(allTicks).map(tick => tick.textContent);
+    expect(tickTexts).toEqual(['-35', '-25', '-15', '-5', '0', '5', '15', '25', '35']);
+  });
+
+  it('should display all 9 ticks with interval={0} - small height', () => {
+    const { container } = render(
+      <LineChart width={500} height={200} data={data}>
+        <XAxis dataKey="name" />
+        <YAxis domain={[-35, 35]} interval={0} ticks={customTicks} />
+        <Line dataKey="value" />
+      </LineChart>,
+    );
+
+    const allTicks = container.querySelectorAll('.recharts-yAxis-tick-labels .recharts-cartesian-axis-tick-value');
+    expect(allTicks.length).toBe(9);
+
+    const tickTexts = Array.from(allTicks).map(tick => tick.textContent);
+    expect(tickTexts).toContain('0'); // Ensure 0 is present
+  });
+
+  it('should display all 9 ticks with interval={0} and large minTickGap', () => {
+    const { container } = render(
+      <LineChart width={500} height={300} data={data}>
+        <XAxis dataKey="name" />
+        <YAxis domain={[-35, 35]} interval={0} ticks={customTicks} minTickGap={20} />
+        <Line dataKey="value" />
+      </LineChart>,
+    );
+
+    const allTicks = container.querySelectorAll('.recharts-yAxis-tick-labels .recharts-cartesian-axis-tick-value');
+    // With interval={0}, ALL ticks should be shown regardless of minTickGap
+    expect(allTicks.length).toBe(9);
+
+    const tickTexts = Array.from(allTicks).map(tick => tick.textContent);
+    expect(tickTexts).toContain('0');
+  });
+
+  it('should respect interval={1} and skip every other tick', () => {
+    const { container } = render(
+      <LineChart width={500} height={300} data={data}>
+        <XAxis dataKey="name" />
+        <YAxis domain={[-35, 35]} interval={1} ticks={customTicks} />
+        <Line dataKey="value" />
+      </LineChart>,
+    );
+
+    const allTicks = container.querySelectorAll('.recharts-yAxis-tick-labels .recharts-cartesian-axis-tick-value');
+    // interval={1} means show every other tick: indices 0, 2, 4, 6, 8
+    expect(allTicks.length).toBe(5);
+
+    const tickTexts = Array.from(allTicks).map(tick => tick.textContent);
+    expect(tickTexts).toEqual(['-35', '-15', '0', '15', '35']);
+  });
+});


### PR DESCRIPTION
## Description

This PR adds comprehensive test cases to verify that `interval={0}` on YAxis correctly displays all custom ticks, addressing issue #6699.

## Changes

- Added new test file `test/cartesian/YAxis/YAxis.interval-zero.spec.tsx` with 4 test cases:
  1. Verify all 9 ticks are displayed with `interval={0}` in standard chart size
  2. Verify all 9 ticks are displayed with `interval={0}` in small chart height
  3. Verify all 9 ticks are displayed with `interval={0}` and large `minTickGap`
  4. Verify `interval={1}` correctly skips every other tick

## Testing

All tests pass successfully:
- ✅ 4 new tests added
- ✅ All 113 YAxis tests pass
- ✅ Full test suite passes (5787 tests passed, 18 skipped)

## Findings

After thorough investigation, the reported issue in #6699 **cannot be reproduced** in the current codebase (v3.5.1) or even in v3.2.0. The `interval={0}` functionality works correctly and displays all custom ticks as expected, including the "0" tick mentioned in the issue.

The implementation in `src/cartesian/getTicks.ts` correctly handles numeric interval values by returning early from `getNumberIntervalTicks()`, which bypasses the visibility filtering logic. When `interval=0`, it returns all ticks without any filtering.

These test cases serve to:
1. Document the expected behavior of `interval={0}`
2. Prevent regression in future changes
3. Provide clarity to users about how interval values work

Closes #6699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for YAxis interval behavior, validating tick rendering and labeling across various configurations including custom tick displays and interval settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->