### PR TITLE
[Storybook] Allow defining defaultValue as object with 'summary' property

### DIFF
--- a/storybook/stories/API/cartesian/ZAxis.stories.tsx
+++ b/storybook/stories/API/cartesian/ZAxis.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Args, ArgTypes } from '@storybook/react-vite';
+import { Args } from '@storybook/react-vite';
 import {
   ScatterChart,
   Scatter,
@@ -14,8 +14,9 @@ import { pageData } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { SCALE_TYPES } from '../../../../src/util/ReactUtils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
+import type { StorybookArgs } from '../../../StorybookArgs';
 
-const ZAxisArgTypes: ArgTypes = {
+const ZAxisArgTypes: StorybookArgs = {
   zAxisId: {
     description: 'The id of z-axis which is corresponding to the data.',
     table: {
@@ -77,7 +78,6 @@ export const API = {
   },
   args: {
     ...getStoryArgsFromArgsTypesObject(ZAxisArgTypes),
-    zAxisId: 0,
     unit: 'km',
     name: 'A name',
     dataKey: 'pv',

--- a/storybook/stories/API/props/utils.ts
+++ b/storybook/stories/API/props/utils.ts
@@ -1,14 +1,21 @@
-import type { ArgTypes } from '@storybook/react-vite';
 import type { StorybookArgs } from '../../../StorybookArgs';
 
 // A helper function to generate Args for a story based on ArgsTypes objects
-export const getStoryArgsFromArgsTypesObject = (argsTypes: StorybookArgs | ArgTypes): Record<string, unknown> => {
+export const getStoryArgsFromArgsTypesObject = (argsTypes: StorybookArgs): Record<string, unknown> => {
   const args: Record<string, unknown> = {};
   Object.keys(argsTypes).forEach((key: string) => {
     const argsType = argsTypes[key];
     if ('defaultValue' in argsType) {
       args[key] = argsType.defaultValue;
     } else if ('table' in argsType && argsType.table != null && 'defaultValue' in argsType.table) {
+      if (
+        typeof argsType.table.defaultValue === 'object' &&
+        argsType.table.defaultValue != null &&
+        'summary' in argsType.table.defaultValue
+      ) {
+        args[key] = argsType.table.defaultValue.summary;
+        return;
+      }
       args[key] = argsType.table.defaultValue;
     }
   });


### PR DESCRIPTION
## Description

Storybook recommends to declare default values as an object with `summary` prop (and marks all other definitions as deprecated) but our own `getStoryArgsFromArgsTypesObject` did not parse that variant. I suspect this is the cause for some of the recent storybook diff.

## Related Issue

https://www.chromatic.com/build?appId=63da8268a0da9970db6992aa&number=3277


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated argument type handling across story utilities for improved consistency.
  * Enhanced default value processing to support additional configuration patterns.
  * Simplified story configuration management by refining how arguments are defined and processed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->