### PR TITLE
[www] Put Sankey chart example back on the website

### DIFF
--- a/www/src/docs/apiExamples/index.tsx
+++ b/www/src/docs/apiExamples/index.tsx
@@ -42,5 +42,5 @@ export const allApiExamples: Record<string, ReadonlyArray<ChartExample>> = {
   LabelList: labelListApiExamples,
   Funnel: funnelApiExamples,
   FunnelChart: funnelChartApiExamples,
-  SankeyChart: sankeyApiExamples,
+  Sankey: sankeyApiExamples,
 };


### PR DESCRIPTION
## Description

I think when renaming the chart I missed this one spot and it made the Sankey example quietly disappear from recharts.github.io.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the API examples key for Sankey charts from `SankeyChart` to `Sankey` for improved naming consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->