### PR TITLE
On website, use recharts from the source code instead of npm registry

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -42,7 +42,7 @@
     "react-router": "^7.9.5",
     "react-router-dom": "^7.9.5",
     "react-runner": "^1.0.5",
-    "recharts": "^3.5.1",
+    "recharts": "latest",
     "simple-line-icons": "^2.5.5"
   },
   "license": "MIT"

--- a/www/tsconfig.json
+++ b/www/tsconfig.json
@@ -23,9 +23,16 @@
     "types": ["vite/client"],
     "baseUrl": ".",
     "paths": {
+      /*
+       * Recharts package path mapping points to the types folder in the main Recharts package.
+       * This means that to see any changes, you need to run `npm run build-types` from the main Recharts package.
+       * We _could_ point this to the `src` folder instead, but that would make typescript also validate
+       * the source code using this config above, which leads to extra errors because this config is stricter
+       * than the one in the main package.
+       */
       "recharts": ["../types/index.d.ts"],
       // TODO we should export all public types from the main entry point, and then remove all deep imports
-      "recharts/types/*": ["../types/*"],
+      "recharts/types/*": ["../types/*"]
     }
   },
   "include": ["./src"],

--- a/www/vite.config.ts
+++ b/www/vite.config.ts
@@ -5,7 +5,7 @@ import sitemap from 'vite-plugin-sitemap';
 import { getSiteRoutes } from './src/navigation.data';
 import { supportedLocales } from './src/locale';
 
-export default defineConfig(({ mode }) => ({
+export default defineConfig(() => ({
   base: process.env.BASE_URL || '/',
   plugins: [
     react(),
@@ -41,16 +41,16 @@ export default defineConfig(({ mode }) => ({
     outDir: resolve(__dirname, 'docs'),
   },
   resolve: {
-    alias:
-      mode === 'development'
-        ? {
-            /*
-             * This is needed to make sure that when we run the website locally,
-             * we are using the local version of recharts from ../src with latest changes.
-             * This also gives us hot module reload for free!
-             */
-            recharts: resolve(__dirname, '../src'),
-          }
-        : undefined,
+    alias: {
+      /*
+       * We are using the local version of recharts from ../src with latest changes
+       * instead of the published version from npm's node_modules.
+       * This means we can use recharts directly as we develop the website,
+       * and use unreleased features / fixes directly to verify them.
+       *
+       * This also gives us hot module reload for free!
+       */
+      recharts: resolve(__dirname, '../src'),
+    },
   },
 }));


### PR DESCRIPTION
## Description

We already had this for local dev, now the same config applies for prod as well.

## Related Issue

The zIndex fiasco.

## Motivation and Context

This allows us to write examples and guides for not-yet-released features. Same as we were doing with Storybook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated recharts dependency to the latest version
  * Streamlined development build configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->