### PR TITLE
Remove propTransformer prop from Shape

### DIFF
--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -136,7 +136,7 @@ function RadialBarSectors({ sectors, allOtherRadialBarProps, showLabels }: Radia
 
   return (
     <RadialBarLabelListProvider showLabels={showLabels} sectors={sectors}>
-      {sectors.map((entry, i) => {
+      {sectors.map((entry: RadialBarDataItem, i: number) => {
         const isActive = activeShape && activeIndex === String(i);
         // @ts-expect-error the types need a bit of attention
         const onMouseEnter = onMouseEnterFromContext(entry, i);

--- a/src/util/ActiveShapeUtils.tsx
+++ b/src/util/ActiveShapeUtils.tsx
@@ -24,16 +24,18 @@ import { Curve } from '../shape/Curve';
  */
 type ShapeType = 'trapezoid' | 'rectangle' | 'sector' | 'symbols' | 'curve';
 
-export type ShapeProps<OptionType, ExtraProps, ShapePropsType> = {
+export type ShapeProps<OptionType, ExtraProps> = {
   shapeType: ShapeType;
   option: OptionType;
   isActive?: boolean;
   index?: string | number;
   activeClassName?: string;
-  propTransformer?: (option: OptionType, props: unknown) => ShapePropsType;
 } & ExtraProps;
 
-function defaultPropTransformer<OptionType, ExtraProps, ShapePropsType>(option: OptionType, props: ExtraProps) {
+function defaultPropTransformer<OptionType, ExtraProps, ShapePropsType>(
+  option: OptionType,
+  props: ExtraProps,
+): ShapePropsType {
   return {
     ...props,
     ...option,
@@ -81,10 +83,9 @@ export function getPropsFromShapeOption<T>(option: ReactElement<T> | T): T {
 export function Shape<OptionType, ExtraProps, ShapePropsType extends React.JSX.IntrinsicAttributes>({
   option,
   shapeType,
-  propTransformer = defaultPropTransformer,
   activeClassName = 'recharts-active-shape',
   ...props
-}: ShapeProps<OptionType, ExtraProps, ShapePropsType>) {
+}: ShapeProps<OptionType, ExtraProps>) {
   let shape: React.JSX.Element;
 
   if (isValidElement(option)) {
@@ -93,7 +94,7 @@ export function Shape<OptionType, ExtraProps, ShapePropsType extends React.JSX.I
   } else if (typeof option === 'function') {
     shape = option(props, props.index);
   } else if (isPlainObject(option) && typeof option !== 'boolean') {
-    const nextProps = propTransformer(option, props);
+    const nextProps: ShapePropsType = defaultPropTransformer(option, props);
     shape = <ShapeSelector<ShapePropsType> shapeType={shapeType} elementProps={nextProps} />;
   } else {
     const elementProps = props as unknown as ShapePropsType;

--- a/src/util/BarUtils.tsx
+++ b/src/util/BarUtils.tsx
@@ -1,40 +1,10 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
 import invariant from 'tiny-invariant';
 import { ActiveShape, DataKey } from './types';
 import { Props as RectangleProps } from '../shape/Rectangle';
 import { BarProps } from '../cartesian/Bar';
 import { Shape } from './ActiveShapeUtils';
 import { isNullish, isNumber } from './DataUtils';
-
-// Rectangle props is expecting x, y, height, width as numbers, name as a string, and radius as a custom type
-// When props are being spread in from a user defined component in Bar,
-// the prop types of an SVGElement have these typed as something else.
-// This function will return the passed in props
-// along with x, y, height as numbers, name as a string, and radius as number | [number, number, number, number]
-function typeguardBarRectangleProps(
-  { x: xProp, y: yProp, ...option }: SVGProps<SVGPathElement>,
-  props: BarRectangleProps,
-): RectangleProps {
-  const xValue = `${xProp}`;
-  const x = parseInt(xValue, 10);
-  const yValue = `${yProp}`;
-  const y = parseInt(yValue, 10);
-  const heightValue = `${props.height || option.height}`;
-  const height = parseInt(heightValue, 10);
-  const widthValue = `${props.width || option.width}`;
-  const width = parseInt(widthValue, 10);
-  return {
-    ...props,
-    ...option,
-    ...(x ? { x } : {}),
-    ...(y ? { y } : {}),
-    height,
-    width,
-    name: props.name as string,
-    radius: props.radius,
-  };
-}
 
 export type BarRectangleProps = {
   option: ActiveShape<BarProps, SVGPathElement> | undefined;
@@ -49,14 +19,7 @@ export type BarRectangleProps = {
 } & Omit<RectangleProps, 'onAnimationStart' | 'onAnimationEnd'>;
 
 export function BarRectangle(props: BarRectangleProps) {
-  return (
-    <Shape
-      shapeType="rectangle"
-      propTransformer={typeguardBarRectangleProps}
-      activeClassName="recharts-active-bar"
-      {...props}
-    />
-  );
+  return <Shape shapeType="rectangle" activeClassName="recharts-active-bar" {...props} />;
 }
 
 export type MinPointSize = number | ((value: number | undefined | null, index: number) => number);

--- a/src/util/FunnelUtils.tsx
+++ b/src/util/FunnelUtils.tsx
@@ -1,31 +1,9 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
 import { Props as FunnelProps, FunnelTrapezoidItem } from '../cartesian/Funnel';
-import { Props as TrapezoidProps } from '../shape/Trapezoid';
-import { Shape, getPropsFromShapeOption } from './ActiveShapeUtils';
-
-// Trapezoid props is expecting x, y, height as numbers.
-// When props are being spread in from a user defined component in Funnel,
-// the prop types of an SVGElement have these typed as string | number.
-// This function will return the passed in props along with x, y, height as numbers.
-export function typeGuardTrapezoidProps(option: SVGProps<SVGPathElement>, props: FunnelTrapezoidProps): TrapezoidProps {
-  const xValue = `${props.x || option.x}`;
-  const x = parseInt(xValue, 10);
-  const yValue = `${props.y || option.y}`;
-  const y = parseInt(yValue, 10);
-  const heightValue = `${props?.height || option?.height}`;
-  const height = parseInt(heightValue, 10);
-  return {
-    ...props,
-    ...getPropsFromShapeOption(option),
-    height,
-    x,
-    y,
-  };
-}
+import { Shape } from './ActiveShapeUtils';
 
 export type FunnelTrapezoidProps = { option: FunnelProps['activeShape']; isActive: boolean } & FunnelTrapezoidItem;
 
 export function FunnelTrapezoid(props: FunnelTrapezoidProps) {
-  return <Shape shapeType="trapezoid" propTransformer={typeGuardTrapezoidProps} {...props} />;
+  return <Shape shapeType="trapezoid" {...props} />;
 }

--- a/src/util/RadialBarUtils.tsx
+++ b/src/util/RadialBarUtils.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { SVGProps } from 'react';
 import { RadialBarProps } from '../polar/RadialBar';
 import { Props as SectorProps } from '../shape/Sector';
 import { Shape } from './ActiveShapeUtils';
@@ -12,23 +11,6 @@ export function parseCornerRadius(cornerRadius: string | number | undefined): nu
   return cornerRadius;
 }
 
-// Sector props is expecting cx, cy as numbers.
-// When props are being spread in from a user defined component in RadialBar,
-// the prop types of an SVGElement have these typed as string | number.
-// This function will return the passed in props along with cx, cy as numbers.
-export function typeGuardSectorProps(option: SVGProps<SVGPathElement>, props: SectorProps): SectorProps {
-  const cxValue = `${props.cx || option.cx}`;
-  const cx = Number(cxValue);
-  const cyValue = `${props.cy || option.cy}`;
-  const cy = Number(cyValue);
-  return {
-    ...props,
-    ...option,
-    cx,
-    cy,
-  };
-}
-
 export interface RadialBarSectorProps extends SectorProps {
   index?: number;
   option: RadialBarProps['activeShape'];
@@ -36,5 +18,5 @@ export interface RadialBarSectorProps extends SectorProps {
 }
 
 export function RadialBarSector(props: RadialBarSectorProps) {
-  return <Shape shapeType="sector" propTransformer={typeGuardSectorProps} {...props} />;
+  return <Shape shapeType="sector" {...props} />;
 }

--- a/test/util/FunnelUtils.spec.tsx
+++ b/test/util/FunnelUtils.spec.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { typeGuardTrapezoidProps, FunnelTrapezoid, FunnelTrapezoidProps } from '../../src/util/FunnelUtils';
+import { FunnelTrapezoid, FunnelTrapezoidProps } from '../../src/util/FunnelUtils';
 import { Coordinate, TrapezoidViewBox } from '../../src/util/types';
 
 describe('funnelUtils', () => {
   const mockTooltipPosition: Coordinate = { x: 10, y: 10 };
-  const mockOptions = {
-    x: 10,
-    y: 10,
-    height: 100,
-  };
+
   const viewBox: TrapezoidViewBox = {
     x: 0,
     y: 0,
@@ -34,27 +30,7 @@ describe('funnelUtils', () => {
     val: 1,
     tooltipPayload: [],
   };
-  it('typeGuardTrapezoidProps returns object from options + props', () => {
-    const mockRes: FunnelTrapezoidProps = {
-      x: mockProps.x,
-      y: mockProps.y,
-      isActive: mockProps.isActive,
-      height: mockOptions.height,
-      lowerWidth: 60,
-      tooltipPosition: mockTooltipPosition,
-      upperWidth: 80,
-      width: 100,
-      labelViewBox: viewBox,
-      parentViewBox: viewBox,
-      val: 1,
-      option: undefined,
-      name: '',
-      tooltipPayload: [],
-    };
-    const res = typeGuardTrapezoidProps(mockOptions, mockProps);
 
-    expect(res).toEqual(mockRes);
-  });
   it('<FunnelTrapezoid /> returns a trapezoid shape with no options', () => {
     const { container } = render(
       <svg width={100} height={100}>


### PR DESCRIPTION
## Description

This feature is not doing anything other than making the typing more complicated. I think it was necessary in 2.x, but now all the properties that this was checking for, are already defined upstream.

## Related Issue

https://github.com/recharts/recharts/issues/6645

## How Has This Been Tested?

Everything looks like it works the same, let's see what storybook says.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal component architecture by removing unnecessary abstraction layers and simplifying prop handling logic.
  * Strengthened TypeScript type safety with explicit type annotations.
  * Reduced code complexity while maintaining existing functionality.

* **Tests**
  * Updated tests to align with simplified internal implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->