### PR TITLE
Deprecate CartesianAxis, stop passing scale

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -21,7 +21,6 @@ import {
   TickProp,
 } from '../util/types';
 import { getTicks } from './getTicks';
-import { RechartsScale } from '../util/ChartUtils';
 import { svgPropertiesNoEvents, svgPropertiesNoEventsFromUnknown } from '../util/svgPropertiesNoEvents';
 import { XAxisPadding, YAxisPadding } from '../state/cartesianAxisSlice';
 import { getCalculatedYAxisWidth } from '../util/YAxisUtils';
@@ -73,10 +72,10 @@ export interface CartesianAxisProps extends ZIndexable {
   /** Angle in which ticks will be rendered. */
   angle?: number;
   /**
-   * This is NOT SVG scale attribute;
-   * this is Recharts scale, based on d3-scale.
+   * CartesianAxis reads scale internally and this prop is ignored since 3.0
+   * @deprecated
    */
-  scale?: RechartsScale;
+  scale?: unknown;
   labelRef?: React.RefObject<SVGTextElement> | null;
 
   ref?: React.Ref<CartesianAxisRef>;
@@ -539,6 +538,14 @@ const CartesianAxisComponent = forwardRef<CartesianAxisRef, InternalProps>((prop
   );
 });
 
+/**
+ * @deprecated
+ *
+ * This component is not meant to be used directly in app code.
+ * Use XAxis or YAxis instead.
+ *
+ * Starting from Recharts v4.0 we will make this component internal only.
+ */
 export const CartesianAxis = React.forwardRef((outsideProps: Props, ref: React.Ref<CartesianAxisRef>) => {
   const props = resolveDefaultProps(outsideProps, defaultCartesianAxisProps);
   return <CartesianAxisComponent {...props} ref={ref} />;

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -17,7 +17,6 @@ import {
 } from '../state/cartesianAxisSlice';
 import {
   implicitXAxis,
-  selectAxisScale,
   selectTicksOfAxis,
   selectXAxisPosition,
   selectXAxisSettingsNoDefaults,
@@ -113,7 +112,6 @@ const XAxisImpl = (props: PropsWithDefaults) => {
   const viewBox = useAppSelector(selectAxisViewBox);
   const isPanorama = useIsPanorama();
   const axisType = 'xAxis';
-  const scale = useAppSelector(state => selectAxisScale(state, axisType, xAxisId, isPanorama));
   const cartesianTickItems = useAppSelector(state => selectTicksOfAxis(state, axisType, xAxisId, isPanorama));
   const axisSize = useAppSelector(state => selectXAxisSize(state, xAxisId));
   const position = useAppSelector(state => selectXAxisPosition(state, xAxisId));
@@ -129,14 +127,13 @@ const XAxisImpl = (props: PropsWithDefaults) => {
     return null;
   }
 
-  const { dangerouslySetInnerHTML, ticks, ...allOtherProps } = props;
-  const { id, ...restSynchronizedSettings } = synchronizedSettings;
+  const { dangerouslySetInnerHTML, ticks, scale: del, ...allOtherProps } = props;
+  const { id, scale: del2, ...restSynchronizedSettings } = synchronizedSettings;
 
   return (
     <CartesianAxis
       {...allOtherProps}
       {...restSynchronizedSettings}
-      scale={scale}
       x={position.x}
       y={position.y}
       width={axisSize.width}

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -16,7 +16,6 @@ import {
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import {
   implicitYAxis,
-  selectAxisScale,
   selectTicksOfAxis,
   selectYAxisPosition,
   selectYAxisSettingsNoDefaults,
@@ -116,7 +115,6 @@ const YAxisImpl: FunctionComponent<Props> = (props: PropsWithDefaults) => {
   const isPanorama = useIsPanorama();
   const dispatch = useAppDispatch();
   const axisType = 'yAxis';
-  const scale = useAppSelector(state => selectAxisScale(state, axisType, yAxisId, isPanorama));
   const axisSize: Size | undefined = useAppSelector(state => selectYAxisSize(state, yAxisId));
   const position = useAppSelector(state => selectYAxisPosition(state, yAxisId));
   const cartesianTickItems = useAppSelector(state => selectTicksOfAxis(state, axisType, yAxisId, isPanorama));
@@ -169,8 +167,8 @@ const YAxisImpl: FunctionComponent<Props> = (props: PropsWithDefaults) => {
     return null;
   }
 
-  const { dangerouslySetInnerHTML, ticks, ...allOtherProps } = props;
-  const { id, ...restSynchronizedSettings } = synchronizedSettings;
+  const { dangerouslySetInnerHTML, ticks, scale: del, ...allOtherProps } = props;
+  const { id, scale: del2, ...restSynchronizedSettings } = synchronizedSettings;
 
   return (
     <CartesianAxis
@@ -178,7 +176,6 @@ const YAxisImpl: FunctionComponent<Props> = (props: PropsWithDefaults) => {
       {...restSynchronizedSettings}
       ref={cartesianAxisRef}
       labelRef={labelRef}
-      scale={scale}
       x={position.x}
       y={position.y}
       tickTextProps={width === 'auto' ? { width: undefined } : { width }}


### PR DESCRIPTION
## Description

I discovered that CartesianAxis never actually reads the scale prop. Also marked the whole component as deprecated - people should be using XAxis and YAxis instead.

## Related Issue

https://github.com/recharts/recharts/issues/6645 - we don't want to expose the internal scale object in public API

https://github.com/recharts/recharts/discussions/6734

## Motivation and Context

I want to add more things to the internal scale representation but couldn't since it was used in CartesianAxis as public API. Turns out it's not used!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Deprecated CartesianAxis component. Users are encouraged to use XAxis or YAxis for axis configuration instead. The component will become internal-only starting in Recharts v4.0.
  * Deprecated CartesianAxis scale property, which has been ignored since v3.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->