### PR TITLE
Perf: filter zero-dimension rectangles early

### DIFF
--- a/src/cartesian/BarStack.tsx
+++ b/src/cartesian/BarStack.tsx
@@ -66,13 +66,6 @@ export const useStackId = (childStackId: StackId | undefined): NormalizedStackId
   return getNormalizedStackId(childStackId);
 };
 
-/**
- * Returns whether the current component is rendered inside a BarStack.
- * @returns `true` when BarStack context is available, otherwise `false`.
- * @consumes BarStackContext
- */
-export const useIsInBarStack = (): boolean => useContext(BarStackContext) != null;
-
 export const defaultBarStackProps = {
   radius: 0,
 } as const satisfies Partial<BarStackProps>;

--- a/src/state/selectors/barStackSelectors.ts
+++ b/src/state/selectors/barStackSelectors.ts
@@ -76,8 +76,9 @@ const combineStackRects: (
   const stackRects: Array<BarStackItem | undefined> = [];
   allBarIds.forEach(barId => {
     const rectangles = selectBarRectangles(state, barId, isPanorama, undefined);
-    rectangles?.forEach((rect, index) => {
-      stackRects[index] = expandRectangle(stackRects[index], rect);
+    rectangles?.forEach(rect => {
+      const rectIndex = rect.originalDataIndex;
+      stackRects[rectIndex] = expandRectangle(stackRects[rectIndex], rect);
     });
   });
   return stackRects;

--- a/src/state/types/BarSettings.ts
+++ b/src/state/types/BarSettings.ts
@@ -7,5 +7,4 @@ export type BarSettings = BaseCartesianGraphicalItemSettings &
     type: 'bar';
     maxBarSize: number | undefined;
     minPointSize: MinPointSize;
-    isInBarStack?: boolean;
   };


### PR DESCRIPTION
Filter out zero-dimension rectangles early in computeBarRectangles to avoid creating unnecessary React component trees for sparse stacked bar charts.

Problem:
For stacked bars with sparse data, recharts builds the full component tree for each empty rectangle before Rectangle returns null, causing lag with many categories.

Solution:
Add width === 0 || height === 0 to the existing null check in computeBarRectangles. Safe because Rectangle already returns null for these—we're just checking earlier.

Changes:
Updated computeBarRectangles to filter zero-dimension rectangles early
Updated test to expect only non-zero rectangles

Fixes #354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed bar chart rendering with sparse or filtered data to ensure tooltips and active states align correctly.
  * Zero-dimension bars (bars with no visible width or height) are now automatically filtered to improve rendering performance and reduce DOM overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->