### PR TITLE
fix: adjust user block layout to prevent horizontal overflow

### DIFF
--- a/www/src/views/IndexView/IndexView.css
+++ b/www/src/views/IndexView/IndexView.css
@@ -108,20 +108,16 @@
 
   .who.block {
     max-width: 100%;
+
     .users {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      width: 100%;
       max-width: 1600px;
-      margin: auto;
+      overflow-x: auto;
+      display: grid;
+      grid-template-columns: repeat(5, minmax(300px, 1fr));
       gap: 20px;
 
-      @media (min-width: 1600px) {
-        grid-template-columns: repeat(5, 1fr);
-      }
-
       .user {
-        text-align: center;
-
         > a {
           display: flex;
           flex-direction: column;


### PR DESCRIPTION
## Description

While working on the dark mode feature I noticed this overflow issue:

<img width="760" height="622" alt="image" src="https://github.com/user-attachments/assets/11ad4db1-193b-4821-b01c-c1916162ced1" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Unify layout from mobile to desktop with a two rows horizontal scroll thing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the users display layout to feature a fixed 5-column grid with horizontal scrolling capability, replacing the previous responsive auto-fit behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->