### PR TITLE
fix: link storybook locally

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -40,6 +40,14 @@ jobs:
         working-directory: www
         run: VITE_RECHARTS_LATEST_VERSION=`curl -X GET "https://registry.npmjs.org/recharts/latest" | jq --raw-output '.version'` npm run build
 
+      - name: Build storybook
+        run: npm run build-storybook
+
+      - name: Move storybook to docs folder
+        run: |
+          mkdir www/docs/storybook-static
+          cp -r storybook/public/* www/docs/storybook-static/
+
       - name: Publish artifact
         id: publish-gh-pages
         uses: actions/upload-pages-artifact@v3

--- a/www/src/views/Storybook.tsx
+++ b/www/src/views/Storybook.tsx
@@ -1,11 +1,5 @@
 import './iframe.css';
 
 export function Storybook() {
-  return (
-    <iframe
-      title="Recharts storybook"
-      className="fullscreen"
-      src="https://main--63da8268a0da9970db6992aa.chromatic.com/"
-    />
-  );
+  return <iframe title="Recharts storybook" className="fullscreen" src="/storybook-static/index.html" />;
 }


### PR DESCRIPTION
## Description

Follow up from #6843, the idea is to not rely on chromatic to show the storybook stories. With this work I discovered that www docs are in SSR vite, in which I'm not an expert of but, I've built both storybook and www and simulated the steps present on the CI workflow locally (using `npm run preview -w www` command to startup the vite preview), and it seems to work properly.

## Related Issue

#6843 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Storybook is not working in production

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

> I've built both storybook and www and simulated the steps present on the CI workflow locally (using `npm run preview -w www` command to startup the vite preview), and it seems to work properly.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<img width="2558" height="660" alt="image" src="https://github.com/user-attachments/assets/29d23ed9-af03-4693-8c5f-2fa7e6321840" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Modify the deploy-website.yml workflow to build storybook and move it inside the docs build folder
- [x] Make the iframe point to the storybook build folder instead of chromatic URL

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storybook documentation is now self-hosted and included in deployments, loading from a local static build instead of an external service for improved performance and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->