### PR TITLE
Fix: Remove redundant alt text from logo images in user showcase

### DIFF
--- a/www/src/views/IndexView/index.tsx
+++ b/www/src/views/IndexView/index.tsx
@@ -89,7 +89,7 @@ class IndexViewImpl extends PureComponent<RouteComponentProps> {
             {users.map(entry => (
               <li className="user" key={`user-${entry.url}`}>
                 <a href={entry.url} target="_blank" title={entry.name} rel="noreferrer">
-                  <img src={entry.logoImgUrl} title={entry.name} alt={entry.name} />
+                  <img src={entry.logoImgUrl} alt="" />
                   <span className="user-name">{entry.name}</span>
                 </a>
               </li>


### PR DESCRIPTION
## Description

This PR addresses 9 accessibility violations (#6871) identified by IBM Equal Access Accessibility Checker in the "Who's using recharts?" section. The fix removes redundant alt text from logo images that are already accompanied by visible text labels within the same link, improving the experience for screen reader users by eliminating unnecessary repetition.

## Related Issue

#6871

The accessibility checker identified 9 instances of redundant image alternative text:
**Violations found:**
- "The text alternative for an image within a link should not repeat the link text or adjacent link text"
- Affected logos: ShadeUI, EvilCharts, 阿里指数, 阿里数据, Fyndiq, chayns, Demisto, Squadlytics, ahrefs
<img width="2560" height="920" alt="image" src="https://github.com/user-attachments/assets/33fba579-bb22-44d4-96d4-e11efb7034a6" />

## Motivation and Context

Changed the image alt attribute from alt={entry.name} to alt="" (empty string), making the images decorative:
```tsx
<a href={entry.url} target="_blank" title={entry.name} rel="noreferrer">
  <img src={entry.logoImgUrl} alt="" />
  <span className="user-name">{entry.name}</span>
</a>
```

**Why empty alt (`alt=""`) is correct:**

- The visible text span already provides the accessible name for the link
- The logo image is decorative within this context (it doesn't add unique information)
- Empty alt tells screen readers to skip the image, avoiding redundancy
- The link's `title` attribute still provides hover tooltip for mouse users

**Note:** We also removed the redundant `title={entry.name}` from the `<img>` tag as it served no purpose and could cause additional tooltip clutter.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

**Fix Before:**
<img width="1917" height="1032" alt="image" src="https://github.com/user-attachments/assets/48580189-7758-40e0-99f6-b306b62d8069" />

**Fix After:**
<img width="2157" height="921" alt="image" src="https://github.com/user-attachments/assets/3e12a159-bad4-49b6-b98a-977c9ee34ca3" />

**Testing**

✅ Verified with IBM Equal Access Accessibility Checker
✅ All 9 "redundant alt text" violations resolved
✅ Screen reader testing (NVDA/JAWS): Each link now announces once (e.g., "ShadeUI, link" instead of "ShadeUI, image, ShadeUI, link")
✅ Visual appearance unchanged (logos and text still display normally)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the user logo image element's accessibility attributes and display behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->