### PR TITLE
ChartData and DataProvider types have generics

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -34,6 +34,7 @@ import {
   AnimationTiming,
   CartesianLayout,
   DataKey,
+  DataProvider,
   DotType,
   LegendType,
   NullableCoordinate,
@@ -133,7 +134,7 @@ interface InternalAreaProps extends ZIndexable {
 /**
  * External props, intended for end users to fill in
  */
-interface AreaProps extends ZIndexable {
+interface AreaProps<DataPointType = any> extends DataProvider<DataPointType>, ZIndexable {
   /**
    * The active dot is rendered on the closest data point when user interacts with the chart. Options:
    *
@@ -182,7 +183,6 @@ interface AreaProps extends ZIndexable {
    * @see {@link https://recharts.github.io/en-US/examples/AreaChartConnectNulls/ AreaChart with connectNull true and false}
    */
   connectNulls?: boolean;
-  data?: ChartData;
   /**
    * Decides how to extract the value of this Area from the data:
    * - `string`: the name of the field in the data object;

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -73,7 +73,7 @@ type InternalFunnelProps = RequiresDefaultProps<FunnelProps, typeof defaultFunne
 /**
  * External props, intended for end users to fill in
  */
-interface FunnelProps extends DataProvider {
+interface FunnelProps<DataPointType = unknown> extends DataProvider<DataPointType> {
   /**
    * This component is rendered when this graphical item is activated
    * (could be by mouse hover, touch, keyboard, programmatically).

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -32,6 +32,7 @@ import {
   AnimationTiming,
   CartesianLayout,
   DataKey,
+  DataProvider,
   DotType,
   LegendType,
   TickItem,
@@ -123,7 +124,7 @@ interface InternalLineProps extends ZIndexable {
 /**
  * External props, intended for end users to fill in
  */
-interface LineProps extends ZIndexable {
+interface LineProps<DataPointType = unknown> extends DataProvider<DataPointType>, ZIndexable {
   /**
    * The active dot is rendered on the closest data point when user interacts with the chart. Options:
    *
@@ -168,7 +169,6 @@ interface LineProps extends ZIndexable {
    * @see {@link https://recharts.github.io/en-US/examples/LineChartConnectNulls/ LineChart with connectNull true and false}
    */
   connectNulls?: boolean;
-  data?: ChartData;
   /**
    * Decides how to extract the value of this Line from the data:
    * - `string`: the name of the field in the data object;

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -168,7 +168,7 @@ interface ScatterInternalProps extends ZIndexable {
 /**
  * External props, intended for end users to fill in
  */
-interface ScatterProps extends DataProvider, ZIndexable {
+interface ScatterProps<DataPointType = unknown> extends DataProvider<DataPointType>, ZIndexable {
   /**
    * Unique identifier of this component.
    * Used as an HTML attribute `id`, and also to identify this element internally.

--- a/src/chart/AreaChart.tsx
+++ b/src/chart/AreaChart.tsx
@@ -11,15 +11,19 @@ const allowedTooltipTypes: ReadonlyArray<TooltipEventType> = ['axis'];
  * @provides CartesianViewBoxContext
  * @provides CartesianChartContext
  */
-export const AreaChart = forwardRef<SVGSVGElement, CartesianChartProps>((props: CartesianChartProps, ref) => {
-  return (
-    <CartesianChart
-      chartName="AreaChart"
-      defaultTooltipEventType="axis"
-      validateTooltipEventTypes={allowedTooltipTypes}
-      tooltipPayloadSearcher={arrayTooltipSearcher}
-      categoricalChartProps={props}
-      ref={ref}
-    />
-  );
-});
+export const AreaChart = forwardRef<SVGSVGElement, CartesianChartProps<unknown>>(
+  (props: CartesianChartProps<unknown>, ref) => {
+    return (
+      <CartesianChart
+        chartName="AreaChart"
+        defaultTooltipEventType="axis"
+        validateTooltipEventTypes={allowedTooltipTypes}
+        tooltipPayloadSearcher={arrayTooltipSearcher}
+        categoricalChartProps={props}
+        ref={ref}
+      />
+    );
+  },
+) as <DataPointType>(
+  props: CartesianChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
+) => React.ReactElement;

--- a/src/chart/BarChart.tsx
+++ b/src/chart/BarChart.tsx
@@ -11,15 +11,19 @@ const allowedTooltipTypes: ReadonlyArray<TooltipEventType> = ['axis', 'item'];
  * @provides CartesianViewBoxContext
  * @provides CartesianChartContext
  */
-export const BarChart = forwardRef<SVGSVGElement, CartesianChartProps>((props: CartesianChartProps, ref) => {
-  return (
-    <CartesianChart
-      chartName="BarChart"
-      defaultTooltipEventType="axis"
-      validateTooltipEventTypes={allowedTooltipTypes}
-      tooltipPayloadSearcher={arrayTooltipSearcher}
-      categoricalChartProps={props}
-      ref={ref}
-    />
-  );
-});
+export const BarChart = forwardRef<SVGSVGElement, CartesianChartProps<unknown>>(
+  (props: CartesianChartProps<unknown>, ref) => {
+    return (
+      <CartesianChart
+        chartName="BarChart"
+        defaultTooltipEventType="axis"
+        validateTooltipEventTypes={allowedTooltipTypes}
+        tooltipPayloadSearcher={arrayTooltipSearcher}
+        categoricalChartProps={props}
+        ref={ref}
+      />
+    );
+  },
+) as <DataPointType>(
+  props: CartesianChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
+) => React.ReactElement;

--- a/src/chart/ComposedChart.tsx
+++ b/src/chart/ComposedChart.tsx
@@ -11,15 +11,19 @@ const allowedTooltipTypes: ReadonlyArray<TooltipEventType> = ['axis'];
  * @provides CartesianViewBoxContext
  * @provides CartesianChartContext
  */
-export const ComposedChart = forwardRef<SVGSVGElement, CartesianChartProps>((props: CartesianChartProps, ref) => {
-  return (
-    <CartesianChart
-      chartName="ComposedChart"
-      defaultTooltipEventType="axis"
-      validateTooltipEventTypes={allowedTooltipTypes}
-      tooltipPayloadSearcher={arrayTooltipSearcher}
-      categoricalChartProps={props}
-      ref={ref}
-    />
-  );
-});
+export const ComposedChart = forwardRef<SVGSVGElement, CartesianChartProps<unknown>>(
+  (props: CartesianChartProps<unknown>, ref) => {
+    return (
+      <CartesianChart
+        chartName="ComposedChart"
+        defaultTooltipEventType="axis"
+        validateTooltipEventTypes={allowedTooltipTypes}
+        tooltipPayloadSearcher={arrayTooltipSearcher}
+        categoricalChartProps={props}
+        ref={ref}
+      />
+    );
+  },
+) as <DataPointType>(
+  props: CartesianChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
+) => React.ReactElement;

--- a/src/chart/FunnelChart.tsx
+++ b/src/chart/FunnelChart.tsx
@@ -11,15 +11,19 @@ const allowedTooltipTypes: ReadonlyArray<TooltipEventType> = ['item'];
  * @provides CartesianViewBoxContext
  * @provides CartesianChartContext
  */
-export const FunnelChart = forwardRef<SVGSVGElement, CartesianChartProps>((props: CartesianChartProps, ref) => {
-  return (
-    <CartesianChart
-      chartName="FunnelChart"
-      defaultTooltipEventType="item"
-      validateTooltipEventTypes={allowedTooltipTypes}
-      tooltipPayloadSearcher={arrayTooltipSearcher}
-      categoricalChartProps={props}
-      ref={ref}
-    />
-  );
-});
+export const FunnelChart = forwardRef<SVGSVGElement, CartesianChartProps<unknown>>(
+  (props: CartesianChartProps<unknown>, ref) => {
+    return (
+      <CartesianChart
+        chartName="FunnelChart"
+        defaultTooltipEventType="item"
+        validateTooltipEventTypes={allowedTooltipTypes}
+        tooltipPayloadSearcher={arrayTooltipSearcher}
+        categoricalChartProps={props}
+        ref={ref}
+      />
+    );
+  },
+) as <DataPointType>(
+  props: CartesianChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
+) => React.ReactElement;

--- a/src/chart/LineChart.tsx
+++ b/src/chart/LineChart.tsx
@@ -11,15 +11,19 @@ const allowedTooltipTypes: ReadonlyArray<TooltipEventType> = ['axis'];
  * @provides CartesianViewBoxContext
  * @provides CartesianChartContext
  */
-export const LineChart = forwardRef<SVGSVGElement, CartesianChartProps>((props: CartesianChartProps, ref) => {
-  return (
-    <CartesianChart
-      chartName="LineChart"
-      defaultTooltipEventType="axis"
-      validateTooltipEventTypes={allowedTooltipTypes}
-      tooltipPayloadSearcher={arrayTooltipSearcher}
-      categoricalChartProps={props}
-      ref={ref}
-    />
-  );
-});
+export const LineChart = forwardRef<SVGSVGElement, CartesianChartProps<unknown>>(
+  (props: CartesianChartProps<unknown>, ref) => {
+    return (
+      <CartesianChart
+        chartName="LineChart"
+        defaultTooltipEventType="axis"
+        validateTooltipEventTypes={allowedTooltipTypes}
+        tooltipPayloadSearcher={arrayTooltipSearcher}
+        categoricalChartProps={props}
+        ref={ref}
+      />
+    );
+  },
+) as <DataPointType>(
+  props: CartesianChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
+) => React.ReactElement;

--- a/src/chart/PieChart.tsx
+++ b/src/chart/PieChart.tsx
@@ -12,14 +12,14 @@ export const defaultPieChartProps = {
   layout: 'centric',
   startAngle: 0,
   endAngle: 360,
-} as const satisfies Partial<PolarChartProps>;
+} as const satisfies Partial<PolarChartProps<never>>;
 
 /**
  * @consumes ResponsiveContainerContext
  * @provides PolarViewBoxContext
  * @provides PolarChartContext
  */
-export const PieChart = forwardRef<SVGSVGElement, PolarChartProps>((props: PolarChartProps, ref) => {
+export const PieChart = forwardRef<SVGSVGElement, PolarChartProps<unknown>>((props: PolarChartProps<unknown>, ref) => {
   const propsWithDefaults = resolveDefaultProps(props, defaultPieChartProps);
   return (
     <PolarChart
@@ -31,4 +31,4 @@ export const PieChart = forwardRef<SVGSVGElement, PolarChartProps>((props: Polar
       ref={ref}
     />
   );
-});
+}) as <DataPointType>(props: PolarChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> }) => React.ReactElement;

--- a/src/chart/PolarChart.tsx
+++ b/src/chart/PolarChart.tsx
@@ -30,7 +30,7 @@ export const defaultPolarChartProps = {
   cy: '50%',
   innerRadius: 0,
   outerRadius: '80%',
-} as const satisfies Partial<PolarChartProps>;
+} as const satisfies Partial<PolarChartProps<never>>;
 
 /**
  * These props are required for the PolarChart to function correctly.

--- a/src/chart/RadarChart.tsx
+++ b/src/chart/RadarChart.tsx
@@ -12,9 +12,9 @@ export const defaultRadarChartProps = {
   layout: 'centric',
   startAngle: 90,
   endAngle: -270,
-} as const satisfies Partial<PolarChartProps>;
+} as const satisfies Partial<PolarChartProps<never>>;
 
-type RadarChartProps = Omit<PolarChartProps, 'layout' | 'startAngle' | 'endAngle'> & {
+type RadarChartProps<DataPointType> = Omit<PolarChartProps<DataPointType>, 'layout' | 'startAngle' | 'endAngle'> & {
   /**
    * The layout of chart defines the orientation of axes, graphical items, and tooltip.
    *
@@ -40,16 +40,18 @@ type RadarChartProps = Omit<PolarChartProps, 'layout' | 'startAngle' | 'endAngle
  * @provides PolarViewBoxContext
  * @provides PolarChartContext
  */
-export const RadarChart = forwardRef<SVGSVGElement, RadarChartProps>((props: RadarChartProps, ref) => {
-  const propsWithDefaults = resolveDefaultProps(props, defaultRadarChartProps);
-  return (
-    <PolarChart
-      chartName="RadarChart"
-      defaultTooltipEventType="axis"
-      validateTooltipEventTypes={allowedTooltipTypes}
-      tooltipPayloadSearcher={arrayTooltipSearcher}
-      categoricalChartProps={propsWithDefaults}
-      ref={ref}
-    />
-  );
-});
+export const RadarChart = forwardRef<SVGSVGElement, RadarChartProps<unknown>>(
+  (props: RadarChartProps<unknown>, ref) => {
+    const propsWithDefaults = resolveDefaultProps(props, defaultRadarChartProps);
+    return (
+      <PolarChart
+        chartName="RadarChart"
+        defaultTooltipEventType="axis"
+        validateTooltipEventTypes={allowedTooltipTypes}
+        tooltipPayloadSearcher={arrayTooltipSearcher}
+        categoricalChartProps={propsWithDefaults}
+        ref={ref}
+      />
+    );
+  },
+) as <DataPointType>(props: PolarChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> }) => React.ReactElement;

--- a/src/chart/RadialBarChart.tsx
+++ b/src/chart/RadialBarChart.tsx
@@ -12,23 +12,25 @@ export const defaultRadialBarChartProps = {
   layout: 'radial',
   startAngle: 0,
   endAngle: 360,
-} as const satisfies Partial<PolarChartProps>;
+} as const satisfies Partial<PolarChartProps<never>>;
 
 /**
  * @consumes ResponsiveContainerContext
  * @provides PolarViewBoxContext
  * @provides PolarChartContext
  */
-export const RadialBarChart = forwardRef<SVGSVGElement, PolarChartProps>((props: PolarChartProps, ref) => {
-  const propsWithDefaults = resolveDefaultProps(props, defaultRadialBarChartProps);
-  return (
-    <PolarChart
-      chartName="RadialBarChart"
-      defaultTooltipEventType="axis"
-      validateTooltipEventTypes={allowedTooltipTypes}
-      tooltipPayloadSearcher={arrayTooltipSearcher}
-      categoricalChartProps={propsWithDefaults}
-      ref={ref}
-    />
-  );
-});
+export const RadialBarChart = forwardRef<SVGSVGElement, PolarChartProps<unknown>>(
+  (props: PolarChartProps<unknown>, ref) => {
+    const propsWithDefaults = resolveDefaultProps(props, defaultRadialBarChartProps);
+    return (
+      <PolarChart
+        chartName="RadialBarChart"
+        defaultTooltipEventType="axis"
+        validateTooltipEventTypes={allowedTooltipTypes}
+        tooltipPayloadSearcher={arrayTooltipSearcher}
+        categoricalChartProps={propsWithDefaults}
+        ref={ref}
+      />
+    );
+  },
+) as <DataPointType>(props: PolarChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> }) => React.ReactElement;

--- a/src/chart/ScatterChart.tsx
+++ b/src/chart/ScatterChart.tsx
@@ -11,15 +11,19 @@ const allowedTooltipTypes: ReadonlyArray<TooltipEventType> = ['item'];
  * @provides CartesianViewBoxContext
  * @provides CartesianChartContext
  */
-export const ScatterChart = forwardRef<SVGSVGElement, CartesianChartProps>((props: CartesianChartProps, ref) => {
-  return (
-    <CartesianChart
-      chartName="ScatterChart"
-      defaultTooltipEventType="item"
-      validateTooltipEventTypes={allowedTooltipTypes}
-      tooltipPayloadSearcher={arrayTooltipSearcher}
-      categoricalChartProps={props}
-      ref={ref}
-    />
-  );
-});
+export const ScatterChart = forwardRef<SVGSVGElement, CartesianChartProps<unknown>>(
+  (props: CartesianChartProps<unknown>, ref) => {
+    return (
+      <CartesianChart
+        chartName="ScatterChart"
+        defaultTooltipEventType="item"
+        validateTooltipEventTypes={allowedTooltipTypes}
+        tooltipPayloadSearcher={arrayTooltipSearcher}
+        categoricalChartProps={props}
+        ref={ref}
+      />
+    );
+  },
+) as <DataPointType>(
+  props: CartesianChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
+) => React.ReactElement;

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -77,7 +77,7 @@ interface LabelListProps extends ZIndexable {
    * Scatter requires this prop to be set.
    * Other graphical components will show the same value as the dataKey of the component by default.
    */
-  dataKey?: DataKey<Record<string, unknown>>;
+  dataKey?: DataKey<any>;
   /**
    * If set a React element, the option is the customized React element of rendering each label.
    * If set to a function, the function is called once for each item

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -187,7 +187,7 @@ export type PieShape = ReactNode | ((props: PieSectorShapeProps, index: number) 
 /**
  * Internal props, combination of external props + defaultProps + private Recharts state
  */
-interface InternalPieProps extends DataProvider, PieDef, ZIndexable {
+interface InternalPieProps<DataPointType = unknown> extends DataProvider<DataPointType>, PieDef, ZIndexable {
   id: GraphicalItemId;
   className?: string;
   dataKey: DataKey<any>;
@@ -219,7 +219,7 @@ interface InternalPieProps extends DataProvider, PieDef, ZIndexable {
   rootTabIndex?: number;
 }
 
-interface PieProps extends DataProvider, PieDef, ZIndexable {
+interface PieProps<DataPointType = unknown> extends DataProvider<DataPointType>, PieDef, ZIndexable {
   /**
    * This component is rendered when this graphical item is activated
    * (could be by mouse hover, touch, keyboard, programmatically).

--- a/src/state/chartDataSlice.ts
+++ b/src/state/chartDataSlice.ts
@@ -12,7 +12,7 @@ import { BrushStartEndIndex } from '../context/brushUpdateContext';
  *
  * @inline
  */
-export type ChartData = ReadonlyArray<unknown>;
+export type ChartData<DataPointType = unknown> = ReadonlyArray<DataPointType>;
 
 /**
  * So this is the same unknown type as ChartData but this is after the dataKey has been applied.

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1306,7 +1306,7 @@ export interface ChartPointer {
   chartY: number;
 }
 
-export interface DataProvider {
+export interface DataProvider<DataPointType> {
   /**
    * The source data. Each element should be an object.
    * The properties of each object represent the values of different data dimensions.
@@ -1316,13 +1316,13 @@ export interface DataProvider {
    * @example data={[{ name: 'a', value: 12 }]}
    * @example data={[{ label: 'foo', measurements: [5, 12] }]}
    */
-  data?: ChartData;
+  data?: ChartData<DataPointType>;
 }
 
 /**
  * Props shared with all charts.
  */
-interface BaseChartProps extends DataProvider, ExternalMouseEvents {
+interface BaseChartProps<DataPointType> extends DataProvider<DataPointType>, ExternalMouseEvents {
   /**
    * The width of chart container.
    * Can be a number or a percent string like "100%".
@@ -1387,7 +1387,7 @@ interface BaseChartProps extends DataProvider, ExternalMouseEvents {
   responsive?: boolean;
 }
 
-export interface CartesianChartProps extends BaseChartProps {
+export interface CartesianChartProps<DataPointType = unknown> extends BaseChartProps<DataPointType> {
   /**
    * The gap between two bar categories, which can be a percent value or a fixed value.
    *
@@ -1454,7 +1454,7 @@ export interface CartesianChartProps extends BaseChartProps {
   title?: string;
 }
 
-export interface PolarChartProps extends BaseChartProps {
+export interface PolarChartProps<DataPointType = unknown> extends BaseChartProps<DataPointType> {
   /**
    * The gap between two bar categories, which can be a percent value or a fixed value.
    *

--- a/storybook/stories/API/chart/PieChart.stories.tsx
+++ b/storybook/stories/API/chart/PieChart.stories.tsx
@@ -4,6 +4,7 @@ import { pageDataWithFillColor } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 import { PieChartArgs } from '../arg-types/PieChartArgs';
+import { assertNotNull } from '../../../../test/helper/assertNotNull';
 
 export default {
   argTypes: PieChartArgs,
@@ -70,21 +71,29 @@ export const Donut = {
 
 export const ChangingDataKey = {
   render: (args: Record<string, any>) => {
-    const data1 = [
+    type MockDataType = {
+      x?: { value: number };
+      y?: { value: number };
+      name: string;
+      fill: string;
+    };
+    const data1: ReadonlyArray<MockDataType> = [
       { x: { value: 1 }, name: 'x1', fill: 'blue' },
       { x: { value: 2 }, name: 'x2', fill: 'red' },
       { x: { value: 3 }, name: 'x3', fill: 'green' },
     ];
-    const data2 = [
+    const data2: ReadonlyArray<MockDataType> = [
       { y: { value: 3 }, name: 'y1', fill: 'blue' },
       { y: { value: 2 }, name: 'y2', fill: 'red' },
       { y: { value: 1 }, name: 'y3', fill: 'green' },
     ];
 
-    const dataKey1 = (d: any) => {
+    const dataKey1 = (d: MockDataType) => {
+      assertNotNull(d.x);
       return d.x.value;
     };
-    const dataKey2 = (d: any) => {
+    const dataKey2 = (d: MockDataType) => {
+      assertNotNull(d.y);
       return d.y.value;
     };
 

--- a/storybook/stories/Examples/BarChart/BarChart.stories.tsx
+++ b/storybook/stories/Examples/BarChart/BarChart.stories.tsx
@@ -21,6 +21,7 @@ import {
 import { getStoryArgsFromArgsTypesObject } from '../../API/props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 import { BarChartArgs } from '../../API/arg-types/BarChartArgs';
+import { assertNotNull } from '../../../../test/helper/assertNotNull';
 
 export default {
   argTypes: BarChartArgs,
@@ -987,21 +988,28 @@ export const CustomCursorBarChart = {
 
 export const ChangingDataKey = {
   render: (args: Args) => {
-    const data1 = [
+    type MockDataType = {
+      x?: { value: number };
+      y?: { value: number };
+      name: string;
+    };
+    const data1: ReadonlyArray<MockDataType> = [
       { x: { value: 1 }, name: 'x1' },
       { x: { value: 2 }, name: 'x2' },
       { x: { value: 3 }, name: 'x3' },
     ];
-    const data2 = [
+    const data2: ReadonlyArray<MockDataType> = [
       { y: { value: 3 }, name: 'y1' },
       { y: { value: 2 }, name: 'y2' },
       { y: { value: 1 }, name: 'y3' },
     ];
 
-    const dataKey1 = (d: any) => {
+    const dataKey1 = (d: MockDataType) => {
+      assertNotNull(d.x);
       return d.x.value;
     };
-    const dataKey2 = (d: any) => {
+    const dataKey2 = (d: MockDataType) => {
+      assertNotNull(d.y);
       return d.y.value;
     };
 

--- a/storybook/stories/Examples/LineChart/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart/LineChart.stories.tsx
@@ -20,6 +20,7 @@ import {
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 import { getStoryArgsFromArgsTypesObject } from '../../API/props/utils';
 import { LineChartArgs } from '../../API/arg-types/LineChartArgs';
+import { assertNotNull } from '../../../../test/helper/assertNotNull';
 
 export default {
   component: LineChart,
@@ -1038,20 +1039,27 @@ export const ReversedXAxis = {
 
 export const ChangingDataKey = {
   render: (args: Args) => {
-    const data1 = [
+    type MockDataType = {
+      x?: { value: number };
+      y?: { value: number };
+      name: string;
+    };
+    const data1: ReadonlyArray<MockDataType> = [
       { x: { value: 1 }, name: 'x1' },
       { x: { value: 2 }, name: 'x2' },
       { x: { value: 3 }, name: 'x3' },
     ];
-    const data2 = [
+    const data2: ReadonlyArray<MockDataType> = [
       { y: { value: 3 }, name: 'y1' },
       { y: { value: 2 }, name: 'y2' },
     ];
 
-    const dataKey1 = (d: any) => {
+    const dataKey1 = (d: MockDataType) => {
+      assertNotNull(d.x);
       return d.x.value;
     };
-    const dataKey2 = (d: any) => {
+    const dataKey2 = (d: MockDataType) => {
+      assertNotNull(d.y);
       return d.y.value;
     };
 

--- a/storybook/stories/Examples/ScatterChart.stories.tsx
+++ b/storybook/stories/Examples/ScatterChart.stories.tsx
@@ -17,6 +17,7 @@ import { StorybookArgs } from '../../StorybookArgs';
 import { RechartsHookInspector } from '../../storybook-addon-recharts';
 import { babiesAndVideosCorrelation } from '../data/spurriousCorrelations';
 import { ScatterChartArgs } from '../API/arg-types/ScatterChartArgs';
+import { assertNotNull } from '../../../test/helper/assertNotNull';
 
 export default {
   component: ScatterChart,
@@ -152,21 +153,24 @@ export const WithDuplicatedCategory: StoryObj<StorybookArgs> = {
 
 export const ChangingDataKey = {
   render: (args: Args) => {
-    const data1 = [
+    type MockDataType = { x?: { value: number }; y?: { value: number }; name: string };
+    const data1: ReadonlyArray<MockDataType> = [
       { x: { value: 1 }, name: 'x1' },
       { x: { value: 2 }, name: 'x2' },
       { x: { value: 3 }, name: 'x3' },
     ];
-    const data2 = [
+    const data2: ReadonlyArray<MockDataType> = [
       { y: { value: 3 }, name: 'y1' },
       { y: { value: 2 }, name: 'y2' },
       { y: { value: 1 }, name: 'y3' },
     ];
 
-    const dataKey1 = (d: any) => {
+    const dataKey1 = (d: MockDataType) => {
+      assertNotNull(d.x);
       return d.x.value;
     };
-    const dataKey2 = (d: any) => {
+    const dataKey2 = (d: MockDataType) => {
+      assertNotNull(d.y);
       return d.y.value;
     };
 

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -1802,20 +1802,27 @@ describe('<LineChart /> - Rendering two line charts with syncId', () => {
 });
 
 describe('<LineChart /> with dataKey as a function', () => {
-  const data1 = [
+  type MockDataPointType = {
+    x?: { value: number };
+    y?: { value: number };
+    name: string;
+  };
+  const data1: ReadonlyArray<MockDataPointType> = [
     { x: { value: 1 }, name: 'x1' },
     { x: { value: 2 }, name: 'x2' },
     { x: { value: 3 }, name: 'x3' },
   ];
-  const data2 = [
+  const data2: ReadonlyArray<MockDataPointType> = [
     { y: { value: 3 }, name: 'y1' },
     { y: { value: 2 }, name: 'y2' },
     { y: { value: 1 }, name: 'y3' },
   ];
-  const dataKey1 = (d: any) => {
+  const dataKey1 = (d: MockDataPointType) => {
+    assertNotNull(d.x);
     return d.x.value;
   };
-  const dataKey2 = (d: any) => {
+  const dataKey2 = (d: MockDataPointType) => {
+    assertNotNull(d.y);
     return d.y.value;
   };
 


### PR DESCRIPTION
## Description

Breaking down https://github.com/recharts/recharts/pull/6867 into smaller PRs that we can merge easier. The types tend to spread everywhere so I aim trying to isolate smaller chunks - this one is adding a generic to `ChartData` and `DataProvider` types. These generics are exposed to charts but 

## Related Issue

https://github.com/recharts/recharts/issues/6645

## Types of changes

New feature I think?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

I will add docs once it's done and ready for release

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety across chart components by introducing generic data-point typing and a standardized data-provider pattern for more reliable data handling.
* **Stories & Tests**
  * Strengthened example stories and tests with explicit data types and runtime null-safety checks to reduce runtime errors and improve developer confidence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->