### PR TITLE
[Omnidoc] Add a test that verifies each component and each prop has a website example

### DIFF
--- a/omnidoc/readExamples.spec.ts
+++ b/omnidoc/readExamples.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { ExampleReader } from './readExamples';
+
+describe('ExampleReader', () => {
+  const reader = new ExampleReader();
+
+  it('should find examples for AreaChart', () => {
+    const examples = reader.getExamples('AreaChart');
+    expect(examples).toEqual(
+      expect.arrayContaining([
+        '/examples/SimpleAreaChart',
+        '/examples/StackedAreaChart',
+        '/examples/AreaChartConnectNulls',
+      ]),
+    );
+    expect(examples.length).toBeGreaterThan(5);
+  });
+
+  it('should find examples for a prop', () => {
+    const examples = reader.getExamples('AreaChart', 'data');
+    expect(examples).toEqual(expect.arrayContaining(['/examples/SimpleAreaChart']));
+    expect(examples.length).toBeGreaterThan(0);
+  });
+
+  it('should find examples for YAxis', () => {
+    const examples = reader.getExamples('YAxis');
+    expect(examples.length).toBeGreaterThan(0);
+  });
+
+  it('should find examples for YAxis width prop', () => {
+    const examples = reader.getExamples('YAxis', 'width');
+    expect(examples).toEqual(expect.arrayContaining(['/examples/SimpleAreaChart']));
+    expect(examples.length).toBeGreaterThan(0);
+  });
+
+  it('should find examples for LineChart from API examples', () => {
+    // LineChart examples are in apiExamples (as per file checks earlier)
+    // wait, debug output showed LineChartExamples in exampleComponents too.
+    // Let's check something that is ONLY in apiExamples or has specific api example path
+
+    const examples = reader.getExamples('LineChart');
+    // Based on previous file explorations, there are both.
+    // My debug output didn't explicitly show LineChart examples but it did show processing the map.
+    expect(examples.length).toBeGreaterThan(0);
+  });
+});

--- a/omnidoc/readExamples.ts
+++ b/omnidoc/readExamples.ts
@@ -1,0 +1,317 @@
+import { Project, SyntaxKind, Node, SourceFile, JsxOpeningElement, JsxSelfClosingElement } from 'ts-morph';
+
+export class ExampleReader {
+  private project: Project;
+
+  private fileToUrls: Map<string, string[]> = new Map();
+
+  private initialized = false;
+
+  constructor() {
+    this.project = new Project({
+      tsConfigFilePath: 'tsconfig.json',
+    });
+  }
+
+  public getExamples(componentName: string, propName?: string): string[] {
+    if (!this.initialized) {
+      this.initialize();
+    }
+
+    const examples = new Set<string>();
+
+    this.fileToUrls.forEach((urls, filePath) => {
+      const sourceFile = this.project.getSourceFile(filePath);
+      if (!sourceFile) return;
+
+      // Check for component usage
+      const isExplicitApiExample = urls.some(url => url === `/api/${componentName}`);
+
+      if (isExplicitApiExample || this.isComponentUsed(sourceFile, componentName)) {
+        // If propName is specified, check for prop usage
+        if (propName) {
+          // For explicit API examples, we can't easily verify prop usage if the component isn't imported.
+          // We default to requiring explicit usage for props.
+          if (this.isPropUsed(sourceFile, componentName, propName)) {
+            urls.forEach(url => examples.add(url));
+          }
+        } else {
+          urls.forEach(url => examples.add(url));
+        }
+      }
+    });
+
+    return Array.from(examples);
+  }
+
+  private initialize() {
+    // Add all relevant files
+    this.project.addSourceFilesAtPaths([
+      'www/src/docs/exampleComponents/**/*.{ts,tsx}',
+      'www/src/docs/apiExamples/**/*.{ts,tsx}',
+    ]);
+
+    this.buildUrlMap();
+    this.initialized = true;
+  }
+
+  private buildUrlMap() {
+    // 1. Parse www/src/docs/exampleComponents/index.ts
+    const exampleComponentsIndex = this.project.getSourceFile('www/src/docs/exampleComponents/index.ts');
+    if (exampleComponentsIndex) {
+      this.processExampleComponentsIndex(exampleComponentsIndex);
+    }
+
+    // 2. Parse www/src/docs/apiExamples/index.tsx
+    const apiExamplesIndex = this.project.getSourceFile('www/src/docs/apiExamples/index.tsx');
+    if (apiExamplesIndex) {
+      this.processApiExamplesIndex(apiExamplesIndex);
+    }
+  }
+
+  private processExampleComponentsIndex(sourceFile: SourceFile) {
+    const allExamplesExport = sourceFile.getVariableDeclaration('allExamples');
+    if (!allExamplesExport) return;
+
+    const initializer = allExamplesExport.getInitializerIfKind(SyntaxKind.ObjectLiteralExpression);
+    if (!initializer) return;
+
+    initializer.getProperties().forEach(prop => {
+      if (Node.isPropertyAssignment(prop)) {
+        // e.g. AreaChart: { examples: areaChartExamples ... }
+        // We want to process `areaChartExamples`
+        const objectLiteral = prop.getInitializerIfKind(SyntaxKind.ObjectLiteralExpression);
+        if (objectLiteral) {
+          const examplesProp = objectLiteral.getProperty('examples');
+          if (examplesProp && Node.isPropertyAssignment(examplesProp)) {
+            const examplesIdentifier = examplesProp.getInitializerIfKind(SyntaxKind.Identifier);
+            if (examplesIdentifier) {
+              const examplesName = examplesIdentifier.getText();
+              const definitions = examplesIdentifier.getDefinitions();
+              if (definitions.length > 0) {
+                const def = definitions[0];
+                const declaration = def?.getDeclarationNode();
+                if (declaration) {
+                  const declSourceFile = declaration.getSourceFile();
+                  if (declSourceFile !== sourceFile && Node.isVariableDeclaration(declaration)) {
+                    // It is defined in another file, process it there
+                    this.processExampleMap(declSourceFile, declaration.getName());
+                  } else if (Node.isImportSpecifier(declaration)) {
+                    // Sometimes it points to the import specifier
+                    const importDecl = declaration.getImportDeclaration();
+                    const moduleSpecifier = importDecl.getModuleSpecifierSourceFile();
+                    if (moduleSpecifier) {
+                      this.processExampleMap(moduleSpecifier, examplesName);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+
+  private processExampleMap(sourceFile: SourceFile, exportName: string) {
+    const variableDecl = sourceFile.getVariableDeclaration(exportName);
+    if (!variableDecl) return;
+
+    const initializer = variableDecl.getInitializerIfKind(SyntaxKind.ObjectLiteralExpression);
+    if (!initializer) return;
+
+    initializer.getProperties().forEach(prop => {
+      if (Node.isPropertyAssignment(prop)) {
+        const exampleName = prop.getName(); // e.g. SimpleAreaChart
+        const exampleObj = prop.getInitializerIfKind(SyntaxKind.ObjectLiteralExpression);
+        if (exampleObj) {
+          const componentProp = exampleObj.getProperty('Component');
+          if (componentProp && Node.isPropertyAssignment(componentProp)) {
+            const componentIdentifier = componentProp.getInitializerIfKind(SyntaxKind.Identifier);
+            if (componentIdentifier) {
+              // Find where this component is defined/imported
+              const definitions = componentIdentifier.getDefinitions();
+              if (definitions.length > 0) {
+                const def = definitions[0];
+                const declaration = def?.getDeclarationNode();
+                let componentSourceFile: SourceFile | undefined;
+
+                if (declaration && Node.isImportSpecifier(declaration)) {
+                  componentSourceFile = declaration.getImportDeclaration().getModuleSpecifierSourceFile();
+                } else if (
+                  declaration &&
+                  (Node.isFunctionDeclaration(declaration) || Node.isVariableDeclaration(declaration))
+                ) {
+                  componentSourceFile = declaration.getSourceFile();
+                }
+
+                if (componentSourceFile) {
+                  const filePath = componentSourceFile.getFilePath();
+                  const url = `/examples/${exampleName}`;
+                  if (!this.fileToUrls.has(filePath)) {
+                    this.fileToUrls.set(filePath, []);
+                  }
+                  this.fileToUrls.get(filePath)!.push(url);
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+
+  private processApiExamplesIndex(sourceFile: SourceFile) {
+    const allApiExamplesExport = sourceFile.getVariableDeclaration('allApiExamples');
+    if (!allApiExamplesExport) return;
+
+    const initializer = allApiExamplesExport.getInitializerIfKind(SyntaxKind.ObjectLiteralExpression);
+    if (!initializer) return;
+
+    initializer.getProperties().forEach(prop => {
+      if (Node.isPropertyAssignment(prop)) {
+        const componentName = prop.getName(); // e.g. AreaChart
+        const url = `/api/${componentName}`;
+
+        const examplesIdentifier = prop.getInitializerIfKind(SyntaxKind.Identifier);
+        if (examplesIdentifier) {
+          const definitions = examplesIdentifier.getDefinitions();
+          if (definitions.length > 0) {
+            const def = definitions[0];
+            const declaration = def?.getDeclarationNode();
+            if (declaration) {
+              const declSourceFile = declaration.getSourceFile();
+              if (declSourceFile !== sourceFile && Node.isVariableDeclaration(declaration)) {
+                this.processApiExampleArray(declSourceFile, declaration.getName(), url);
+              } else if (Node.isImportSpecifier(declaration)) {
+                const importDecl = declaration.getImportDeclaration();
+                const moduleSpecifier = importDecl.getModuleSpecifierSourceFile();
+                if (moduleSpecifier) {
+                  this.processApiExampleArray(moduleSpecifier, declaration.getName(), url);
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+
+  private processApiExampleArray(sourceFile: SourceFile, exportName: string, url: string) {
+    const variableDecl = sourceFile.getVariableDeclaration(exportName);
+    if (!variableDecl) return;
+
+    const initializer = variableDecl.getInitializerIfKind(SyntaxKind.ArrayLiteralExpression);
+    if (!initializer) return;
+
+    initializer.getElements().forEach(element => {
+      if (Node.isObjectLiteralExpression(element)) {
+        const componentProp = element.getProperty('Component');
+        if (componentProp && Node.isPropertyAssignment(componentProp)) {
+          const componentIdentifier = componentProp.getInitializerIfKind(SyntaxKind.Identifier);
+          if (componentIdentifier) {
+            const definitions = componentIdentifier.getDefinitions();
+            if (definitions.length > 0) {
+              const def = definitions[0];
+              const declaration = def?.getDeclarationNode();
+              let componentSourceFile: SourceFile | undefined;
+
+              if (declaration && Node.isImportSpecifier(declaration)) {
+                componentSourceFile = declaration.getImportDeclaration().getModuleSpecifierSourceFile();
+              } else if (
+                declaration &&
+                (Node.isFunctionDeclaration(declaration) || Node.isVariableDeclaration(declaration))
+              ) {
+                componentSourceFile = declaration.getSourceFile();
+              }
+
+              if (componentSourceFile) {
+                const filePath = componentSourceFile.getFilePath();
+                if (!this.fileToUrls.has(filePath)) {
+                  this.fileToUrls.set(filePath, []);
+                }
+                this.fileToUrls.get(filePath)!.push(url);
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+
+  private isComponentUsed(sourceFile: SourceFile, componentName: string): boolean {
+    // Check imports
+    const imports = sourceFile.getImportDeclarations();
+    for (const importDecl of imports) {
+      const namedImports = importDecl.getNamedImports();
+      for (const namedImport of namedImports) {
+        if (namedImport.getName() === componentName) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private isPropUsed(sourceFile: SourceFile, componentName: string, propName: string): boolean {
+    // Find all JSX elements matching componentName
+    // We need to resolve local name if aliased
+    let localName = componentName;
+    const imports = sourceFile.getImportDeclarations();
+    for (const importDecl of imports) {
+      const namedImports = importDecl.getNamedImports();
+      for (const namedImport of namedImports) {
+        if (namedImport.getName() === componentName) {
+          const alias = namedImport.getAliasNode();
+          if (alias) {
+            localName = alias.getText();
+          }
+          break;
+        }
+      }
+    }
+
+    const jsxElements = sourceFile.getDescendantsOfKind(SyntaxKind.JsxOpeningElement);
+    const jsxSelfClosingElements = sourceFile.getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement);
+
+    const checkAttributes = (node: JsxOpeningElement | JsxSelfClosingElement) => {
+      if (node.getTagNameNode().getText() === localName) {
+        // Special handling for children
+        if (propName === 'children') {
+          // Check if it's an attribute (rare but possible)
+          if (node.getAttribute('children')) return true;
+
+          // If it's an opening element, check if the parent JsxElement has children
+          if (Node.isJsxOpeningElement(node)) {
+            const jsxElement = node.getParentIfKind(SyntaxKind.JsxElement);
+            if (jsxElement) {
+              const children = jsxElement.getJsxChildren();
+              // Filter out empty text nodes (whitespace)
+              const hasRealChildren = children.some(child => {
+                if (Node.isJsxText(child)) {
+                  return child.getText().trim().length > 0;
+                }
+                return true;
+              });
+              if (hasRealChildren) return true;
+            }
+          }
+          return false;
+        }
+
+        const attr = node.getAttribute(propName);
+        return !!attr;
+      }
+      return false;
+    };
+
+    for (const el of jsxElements) {
+      if (checkAttributes(el)) return true;
+    }
+    for (const el of jsxSelfClosingElements) {
+      if (checkAttributes(el)) return true;
+    }
+
+    return false;
+  }
+}

--- a/omnidoc/verifyExamples.spec.ts
+++ b/omnidoc/verifyExamples.spec.ts
@@ -1,0 +1,170 @@
+import { describe, test, expect } from 'vitest';
+import { ProjectDocReader } from './readProject';
+import { ExampleReader } from './readExamples';
+
+describe('Documentation Examples Coverage', () => {
+  const projectReader = new ProjectDocReader();
+  const exampleReader = new ExampleReader();
+
+  // Get all exports
+  const allExports = projectReader.getPublicSymbolNames();
+  const components = new Set(projectReader.getPublicComponentNames());
+
+  /*
+   * List of exports that currently do not have example usages.
+   * We should aim to remove items from this list over time by adding examples to the docs.
+   */
+  const exportsThatNeedExamples: ReadonlyArray<string> = [
+    'ActiveDotProps',
+    'ActiveLabel',
+    'Area',
+    'AreaChart',
+    'AreaProps',
+    'AxisDomainItem',
+    'AxisId',
+    'AxisInterval',
+    'AxisRange',
+    'Bar',
+    'BarChart',
+    'BarStack',
+    'BarStackProps',
+    'Brush',
+    'BrushProps',
+    'CartesianAxis',
+    'CartesianAxisProps',
+    'CartesianGrid',
+    'CartesianGridProps',
+    'CartesianViewBox',
+    'CellProps',
+    'ChartOffset',
+    'ComposedChart',
+    'Coordinate',
+    'Cross',
+    'CrossProps',
+    'Curve',
+    'CurveProps',
+    'CustomScaleDefinition',
+    'Customized',
+    'CustomizedProps',
+    'DefaultLegendContent',
+    'DefaultTooltipContent',
+    'DefaultTooltipContentProps',
+    'Dot',
+    'DotItemDotProps',
+    'DotProps',
+    'ErrorBar',
+    'ErrorBarProps',
+    'Funnel',
+    'FunnelChart',
+    'FunnelProps',
+    'Global',
+    'IfOverflow',
+    'Label',
+    'LabelList',
+    'LabelListProps',
+    'LabelListPropsWithPosition',
+    'Layer',
+    'LayerProps',
+    'Legend',
+    'LegendProps',
+    'LegendType',
+    'Line',
+    'LineChart',
+    'Margin',
+    'NumberDomain',
+    'Padding',
+    'Pie',
+    'PieChart',
+    'PieLabel',
+    'PieSectorShapeProps',
+    'PieShape',
+    'PlotArea',
+    'PolarAngleAxis',
+    'PolarAngleAxisProps',
+    'PolarCoordinate',
+    'PolarGrid',
+    'PolarGridProps',
+    'PolarRadiusAxis',
+    'PolarRadiusAxisProps',
+    'Polygon',
+    'PolygonProps',
+    'Radar',
+    'RadarChart',
+    'RadarProps',
+    'RadialBar',
+    'RadialBarChart',
+    'RadialBarProps',
+    'Rectangle',
+    'RectangleProps',
+    'ReferenceArea',
+    'ReferenceAreaProps',
+    'ReferenceDot',
+    'ReferenceDotProps',
+    'ReferenceLine',
+    'ReferenceLineProps',
+    'ReferenceLineSegment',
+    'ResponsiveContainer',
+    'ResponsiveContainerProps',
+    'Sankey',
+    'SankeyData',
+    'SankeyLinkProps',
+    'SankeyNode',
+    'SankeyNodeOptions',
+    'SankeyProps',
+    'Scatter',
+    'ScatterChart',
+    'ScatterProps',
+    'Sector',
+    'SectorProps',
+    'SunburstChart',
+    'SunburstChartProps',
+    'Surface',
+    'SurfaceProps',
+    'Symbols',
+    'SymbolsProps',
+    'Text',
+    'TextProps',
+    'Tooltip',
+    'TooltipPayloadEntry',
+    'TooltipProps',
+    'Trapezoid',
+    'TrapezoidProps',
+    'Treemap',
+    'TreemapContentType',
+    'TreemapProps',
+    'XAxis',
+    'XAxisProps',
+    'YAxis',
+    'YAxisProps',
+    'ZAxis',
+    'ZAxisProps',
+    'getNiceTickValues',
+  ];
+
+  describe.each(allExports.filter(name => !exportsThatNeedExamples.includes(name)))('Export: %s', exportName => {
+    test('has at least one example usage', () => {
+      const examples = exampleReader.getExamples(exportName);
+      expect(examples.length, `No examples found for ${exportName}`).toBeGreaterThan(0);
+    });
+
+    if (components.has(exportName)) {
+      const props = projectReader.getRechartsPropsOf(exportName);
+
+      if (props.length > 0) {
+        describe('Props', () => {
+          test.each(props)('prop: %s has example usage', propName => {
+            // Skip event handlers as they are often not demonstrated in static examples
+            if (propName.startsWith('on')) {
+              return;
+            }
+            const propExamples = exampleReader.getExamples(exportName, propName);
+            expect(
+              propExamples.length,
+              `No examples found for prop ${propName} of component ${exportName}`,
+            ).toBeGreaterThan(0);
+          });
+        });
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Description

I want to use this test to verify that we have all of those props and types used at least once so that I know if we are introducing a breaking change or not. The website is the closest we have to production.

## Related Issue

https://github.com/recharts/recharts/issues/6645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for documentation examples validation, ensuring all exports have corresponding examples.
  * Added test coverage for example retrieval functionality across multiple component scenarios.

* **Chores**
  * Added internal infrastructure for scanning and mapping documentation examples to components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->