### PR TITLE
Fix tooltip payload type from any

### DIFF
--- a/omnidoc/verifyExamples.spec.ts
+++ b/omnidoc/verifyExamples.spec.ts
@@ -155,6 +155,8 @@ describe('Documentation Examples Coverage', () => {
     'YAxisPadding',
     'CartesianTickItem',
     'TextAnchor',
+    'TooltipItemSorter',
+    'TooltipPayload',
   ];
 
   describe.each(allExports.filter(name => !exportsThatNeedExamples.includes(name)))('Export: %s', exportName => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,13 @@ export { DefaultLegendContent } from './component/DefaultLegendContent';
 export type { Props as DefaultLegendContentProps, LegendPayload } from './component/DefaultLegendContent';
 export { Tooltip } from './component/Tooltip';
 export type { TooltipProps, TooltipContentProps } from './component/Tooltip';
-export type { TooltipIndex } from './state/tooltipSlice';
+export type { TooltipIndex, TooltipPayload } from './state/tooltipSlice';
 export { DefaultTooltipContent } from './component/DefaultTooltipContent';
 export type {
   Props as DefaultTooltipContentProps,
   Payload as TooltipPayloadEntry,
+  TooltipItemSorter,
+  ValueType as TooltipValueType,
 } from './component/DefaultTooltipContent';
 export { ResponsiveContainer } from './component/ResponsiveContainer';
 export type { Props as ResponsiveContainerProps } from './component/ResponsiveContainer';

--- a/test/component/DefaultTooltipContent.spec.tsx
+++ b/test/component/DefaultTooltipContent.spec.tsx
@@ -3,37 +3,12 @@ import { render } from '@testing-library/react';
 import { DefaultTooltipContent, DefaultTooltipContentProps } from '../../src';
 
 describe('DefaultTooltipContent', () => {
-  const mockProps: DefaultTooltipContentProps<number, string> = {
+  const mockProps: DefaultTooltipContentProps = {
     accessibilityLayer: true,
-    allowEscapeViewBox: { x: false, y: false },
-    animationDuration: 400,
-    animationEasing: 'ease',
     contentStyle: {},
-    coordinate: { x: 200, y: 200 },
-    cursor: true,
-    cursorStyle: {},
-    filterNull: true,
-    isAnimationActive: true,
     itemStyle: {},
     labelStyle: {},
-    offset: 10,
-    reverseDirection: { x: false, y: false },
     separator: ' : ',
-    trigger: 'hover',
-    useTranslate3d: false,
-    viewBox: {
-      brushBottom: 5,
-      top: 5,
-      bottom: 5,
-      left: 5,
-      right: 5,
-      width: 390,
-      height: 390,
-      x: 5,
-      y: 5,
-    },
-    wrapperStyle: {},
-    active: true,
     label: 2,
     payload: [
       {
@@ -47,8 +22,7 @@ describe('DefaultTooltipContent', () => {
         graphicalItemId: 'recharts-area-0',
       },
     ],
-    // @ts-expect-error itemSorter type is challenging
-    itemSorter: (d: { name: string }) => d.name,
+    itemSorter: d => d.name,
     labelFormatter: () => `mock labelFormatter`,
   };
 

--- a/test/component/Tooltip/Tooltip.content.spec.tsx
+++ b/test/component/Tooltip/Tooltip.content.spec.tsx
@@ -14,7 +14,7 @@ const commonChartProps = {
 };
 
 describe('Tooltip.content', () => {
-  const spy: Mock<(props: TooltipContentProps<number, string>) => ReactNode> = vi.fn();
+  const spy: Mock<(props: TooltipContentProps) => ReactNode> = vi.fn();
 
   beforeEach(() => {
     mockGetBoundingClientRect({ width: 100, height: 100 });

--- a/test/component/Tooltip/itemSorter.spec.tsx
+++ b/test/component/Tooltip/itemSorter.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { Selector } from '@reduxjs/toolkit';
 import {
@@ -18,7 +18,7 @@ import {
   RadialBarChart,
   Scatter,
   Tooltip,
-  TooltipProps,
+  TooltipItemSorter,
   XAxis,
   YAxis,
 } from '../../../src';
@@ -45,7 +45,7 @@ describe('itemSorter in ComposedChart', () => {
 
   describe('without name prop', () => {
     function renderTestCase<T>(
-      itemSorter: TooltipProps<number, string>['itemSorter'],
+      itemSorter: TooltipItemSorter | undefined,
       selector?: Selector<RechartsRootState, T, never>,
     ) {
       return createSelectorTestCase(({ children }) => (
@@ -480,14 +480,14 @@ describe('itemSorter in ComposedChart', () => {
 
     describe('when itemSorter is a function', () => {
       it('should render sorted payload', () => {
-        const { container } = renderTestCase(item => item.value);
+        const { container } = renderTestCase(item => String(item.value));
         showTooltip(container, composedChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', [
           'area : 200',
           'line : 2400',
           'bar : 9800',
-          'name : Page D',
           'pv : 9800',
+          'name : Page D',
         ]);
       });
 
@@ -603,7 +603,7 @@ describe('itemSorter in ComposedChart', () => {
 
   describe('with name prop', () => {
     function renderTestCase<T>(
-      itemSorter: TooltipProps<number, string>['itemSorter'],
+      itemSorter: TooltipItemSorter | undefined,
       selector?: Selector<RechartsRootState, T, never>,
     ) {
       return createSelectorTestCase(({ children }) => (
@@ -785,14 +785,14 @@ describe('itemSorter in ComposedChart', () => {
 
     describe('when itemSorter is a function', () => {
       it('should render sorted payload', () => {
-        const { container } = renderTestCase(item => item.value);
+        const { container } = renderTestCase(item => String(item.value));
         showTooltip(container, composedChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', [
           'Area : 200',
           'Line : 2400',
           'Bar : 9800',
-          'XAxis : Page D',
           'YAxis : 9800',
+          'XAxis : Page D',
         ]);
       });
 
@@ -913,7 +913,7 @@ describe('itemSorter in PieChart', () => {
   });
 
   function renderTestCase<T>(
-    itemSorter: TooltipProps<number, string>['itemSorter'],
+    itemSorter: TooltipItemSorter | undefined,
     selector?: Selector<RechartsRootState, T, never>,
   ) {
     return createSelectorTestCase(({ children }) => (
@@ -967,7 +967,7 @@ describe('itemSorter in RadarChart', () => {
 
   describe('without name prop', () => {
     function renderTestCase<T>(
-      itemSorter: TooltipProps<number, string>['itemSorter'],
+      itemSorter: TooltipItemSorter | undefined,
       selector?: Selector<RechartsRootState, T, never>,
     ) {
       return createSelectorTestCase(({ children }) => (
@@ -1083,7 +1083,7 @@ describe('itemSorter in RadarChart', () => {
 
     describe('when itemSorter is a function', () => {
       it('should render sorted payload', () => {
-        const { container } = renderTestCase(item => item.value);
+        const { container } = renderTestCase(item => String(item.value));
         showTooltip(container, radarChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page F', ['uv : 189', 'amt : 2400', 'pv : 4800']);
       });
@@ -1160,7 +1160,7 @@ describe('itemSorter in RadarChart', () => {
 
   describe('with name prop', () => {
     function renderTestCase<T>(
-      itemSorter: TooltipProps<number, string>['itemSorter'],
+      itemSorter: TooltipItemSorter | undefined,
       selector?: Selector<RechartsRootState, T, never>,
     ) {
       return createSelectorTestCase(({ children }) => (
@@ -1283,7 +1283,7 @@ describe('itemSorter in RadialBarChart', () => {
 
   describe('without name prop', () => {
     function renderTestCase<T>(
-      itemSorter: TooltipProps<number, string>['itemSorter'],
+      itemSorter: TooltipItemSorter | undefined,
       selector?: Selector<RechartsRootState, T, never>,
     ) {
       return createSelectorTestCase(({ children }) => (
@@ -1462,7 +1462,7 @@ describe('itemSorter in RadialBarChart', () => {
 
     describe('when itemSorter is a function', () => {
       it('should render sorted payload', () => {
-        const { container } = renderTestCase(item => item.value);
+        const { container } = renderTestCase(item => String(item.value));
         showTooltip(container, radialBarChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', ['uv : 200', 'amt : 2400', 'pv : 9800']);
       });
@@ -1602,7 +1602,7 @@ describe('itemSorter in RadialBarChart', () => {
 
   describe('with name prop', () => {
     function renderTestCase<T>(
-      itemSorter: TooltipProps<number, string>['itemSorter'],
+      itemSorter: TooltipItemSorter | undefined,
       selector?: Selector<RechartsRootState, T, never>,
     ) {
       return createSelectorTestCase(({ children }) => (
@@ -1797,7 +1797,7 @@ describe('itemSorter in RadialBarChart', () => {
 
     describe('when itemSorter is a function', () => {
       it('should render sorted payload', () => {
-        const { container } = renderTestCase(item => item.value);
+        const { container } = renderTestCase(item => String(item.value));
         showTooltip(container, radialBarChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', [
           'RadialBar-uv : 200',
@@ -1949,7 +1949,7 @@ describe('itemSorter in stacked BarChart', () => {
 
   describe('without name prop', () => {
     function renderTestCase<T>(
-      itemSorter: TooltipProps<number, string>['itemSorter'],
+      itemSorter: TooltipItemSorter | undefined,
       selector?: Selector<RechartsRootState, T, never>,
     ) {
       return createSelectorTestCase(({ children }) => (
@@ -2065,7 +2065,7 @@ describe('itemSorter in stacked BarChart', () => {
 
     describe('when itemSorter is a function', () => {
       it('should render sorted payload', () => {
-        const { container } = renderTestCase(item => item.value);
+        const { container } = renderTestCase(item => String(item.value));
         showTooltip(container, barChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', ['uv : 200', 'amt : 2400', 'pv : 9800']);
       });
@@ -2142,7 +2142,7 @@ describe('itemSorter in stacked BarChart', () => {
 
   describe('with name prop', () => {
     function renderTestCase<T>(
-      itemSorter: TooltipProps<number, string>['itemSorter'],
+      itemSorter: TooltipItemSorter | undefined,
       selector?: Selector<RechartsRootState, T, never>,
     ) {
       return createSelectorTestCase(({ children }) => (
@@ -2258,7 +2258,7 @@ describe('itemSorter in stacked BarChart', () => {
 
     describe('when itemSorter is a function', () => {
       it('should render sorted payload', () => {
-        const { container } = renderTestCase(item => item.value);
+        const { container } = renderTestCase(item => String(item.value));
         showTooltip(container, barChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', ['Bar-uv : 200', 'Bar-amt : 2400', 'Bar-pv : 9800']);
       });
@@ -2341,7 +2341,7 @@ describe('itemSorter in stacked AreaChart', () => {
 
   describe('without name prop', () => {
     function renderTestCase<T>(
-      itemSorter: TooltipProps<number, string>['itemSorter'],
+      itemSorter: TooltipItemSorter | undefined,
       selector?: Selector<RechartsRootState, T, never>,
     ) {
       return createSelectorTestCase(({ children }) => (
@@ -2457,7 +2457,7 @@ describe('itemSorter in stacked AreaChart', () => {
 
     describe('when itemSorter is a function', () => {
       it('should render sorted payload', () => {
-        const { container } = renderTestCase(item => item.value);
+        const { container } = renderTestCase(item => String(item.value));
         showTooltip(container, barChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', ['uv : 200', 'amt : 2400', 'pv : 9800']);
       });
@@ -2534,7 +2534,7 @@ describe('itemSorter in stacked AreaChart', () => {
 
   describe('with name prop', () => {
     function renderTestCase<T>(
-      itemSorter: TooltipProps<number, string>['itemSorter'],
+      itemSorter: TooltipItemSorter | undefined,
       selector?: Selector<RechartsRootState, T, never>,
     ) {
       return createSelectorTestCase(({ children }) => (
@@ -2650,7 +2650,7 @@ describe('itemSorter in stacked AreaChart', () => {
 
     describe('when itemSorter is a function', () => {
       it('should render sorted payload', () => {
-        const { container } = renderTestCase(item => item.value);
+        const { container } = renderTestCase(item => String(item.value));
         showTooltip(container, barChartMouseHoverTooltipSelector);
         expectTooltipPayload(container, 'Page D', ['Area-uv : 200', 'Area-amt : 2400', 'Area-pv : 9800']);
       });

--- a/www/src/components/GuideView/DomainAndTicks/MassBarChartCustomTicks.tsx
+++ b/www/src/components/GuideView/DomainAndTicks/MassBarChartCustomTicks.tsx
@@ -1,4 +1,4 @@
-import { Bar, BarChart, Tooltip, XAxis, YAxis } from 'recharts';
+import { Bar, BarChart, Tooltip, TooltipValueType, XAxis, YAxis } from 'recharts';
 import { RechartsDevtools } from '@recharts/devtools';
 
 // #region Solar System Data
@@ -82,12 +82,12 @@ const solarSystem = [
 ];
 // #endregion
 
-function kgToYottagram(value: number | undefined): string {
+function kgToYottagram(value: TooltipValueType | undefined): string {
   if (value == null) {
     return '';
   }
   // the data is defined in kg
-  const yottagram = value / 1e24;
+  const yottagram = Number(value) / 1e24;
   return `${yottagram.toFixed(2)}`;
 }
 

--- a/www/src/docs/exampleComponents/AreaChart/PercentAreaChart.tsx
+++ b/www/src/docs/exampleComponents/AreaChart/PercentAreaChart.tsx
@@ -1,4 +1,4 @@
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, TooltipContentProps } from 'recharts';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, TooltipContentProps, TooltipValueType } from 'recharts';
 import { RechartsDevtools } from '@recharts/devtools';
 
 // #region Sample data
@@ -47,18 +47,36 @@ const data = [
   },
 ];
 
-// #endregion
 const toPercent = (decimal: number): string => `${(decimal * 100).toFixed(0)}%`;
 
-const getPercent = (value: number, total: number): string => {
-  const ratio = total > 0 ? value / total : 0;
+const toNumber = (value: TooltipValueType | undefined): number => {
+  if (typeof value === 'number') {
+    return value;
+  }
+  let v;
+  if (typeof value === 'string') {
+    v = value;
+  }
+  if (Array.isArray(value)) {
+    [, v] = value;
+  }
+  const parsed = parseFloat(v);
+  if (!Number.isNaN(parsed)) {
+    return parsed;
+  }
+  return 0;
+};
+
+const getPercent = (value: TooltipValueType | undefined, total: number): string => {
+  const ratio = total > 0 ? toNumber(value) / total : 0;
 
   return toPercent(ratio);
 };
 
-const renderTooltipContent = (o: TooltipContentProps<number | string, string>) => {
+// #endregion
+const renderTooltipContent = (o: TooltipContentProps) => {
   const { payload, label } = o;
-  const total = payload.reduce((result, entry) => result + entry.value, 0);
+  const total = payload.reduce((result, entry) => result + Number(entry.value), 0);
 
   return (
     <div

--- a/www/src/docs/exampleComponents/BarChart/CandlestickExample.tsx
+++ b/www/src/docs/exampleComponents/BarChart/CandlestickExample.tsx
@@ -40,7 +40,7 @@ const Candlestick = (props: BarShapeProps) => {
   return <Rectangle {...props} fill={color} />;
 };
 
-const TooltipContent = (props: TooltipContentProps<number, string>) => {
+const TooltipContent = (props: TooltipContentProps) => {
   const { active, payload } = props;
   if (active && payload && payload.length) {
     const entry: MarketCandle = payload[0].payload;

--- a/www/src/docs/exampleComponents/BarChart/PopulationPyramidExample.tsx
+++ b/www/src/docs/exampleComponents/BarChart/PopulationPyramidExample.tsx
@@ -1,4 +1,14 @@
-import { Bar, BarChart, Legend, LegendPayload, Tooltip, XAxis, YAxis, RenderableText } from 'recharts';
+import {
+  Bar,
+  BarChart,
+  Legend,
+  LegendPayload,
+  Tooltip,
+  XAxis,
+  YAxis,
+  RenderableText,
+  TooltipValueType,
+} from 'recharts';
 import { RechartsDevtools } from '@recharts/devtools';
 
 // #region Data and helper functions
@@ -46,7 +56,7 @@ const percentageData = rawData.map(entry => {
   };
 });
 
-function formatPercent(val: RenderableText): string {
+function formatPercent(val: RenderableText | TooltipValueType): string {
   return `${Math.abs(Number(val)).toFixed(1)}%`;
 }
 
@@ -104,7 +114,7 @@ export default function PopulationPyramidExample({ defaultIndex }: { defaultInde
         radius={[0, 5, 5, 0]}
         label={{ position: 'right', formatter: formatPercent }}
       />
-      <Tooltip<number, string> formatter={formatPercent} defaultIndex={defaultIndex} />
+      <Tooltip formatter={formatPercent} defaultIndex={defaultIndex} />
       <Legend itemSorter={itemSorter} verticalAlign="top" align="right" />
       <RechartsDevtools />
     </BarChart>

--- a/www/src/docs/exampleComponents/ComposedChart/BandedChart.tsx
+++ b/www/src/docs/exampleComponents/ComposedChart/BandedChart.tsx
@@ -47,7 +47,7 @@ const data = [
   },
 ];
 
-const renderTooltipWithoutRange = ({ payload, content, ...rest }: TooltipContentProps<string | number, string>) => {
+const renderTooltipWithoutRange = ({ payload, content, ...rest }: TooltipContentProps) => {
   const newPayload = payload.filter(x => x.dataKey !== 'a');
   return <DefaultTooltipContent payload={newPayload} {...rest} />;
 };

--- a/www/src/docs/exampleComponents/ScatterChart/BubbleChart.tsx
+++ b/www/src/docs/exampleComponents/ScatterChart/BubbleChart.tsx
@@ -76,7 +76,7 @@ const domain = parseDomain();
 const range = [16, 225] as const;
 const margin = { top: 10, right: 0, bottom: 0, left: 0 };
 
-const renderTooltip = (props: TooltipContentProps<string | number, string>) => {
+const renderTooltip = (props: TooltipContentProps) => {
   const { active, payload } = props;
 
   if (active && payload && payload.length) {

--- a/www/src/docs/exampleComponents/Tooltip/CustomContentOfTooltip.tsx
+++ b/www/src/docs/exampleComponents/Tooltip/CustomContentOfTooltip.tsx
@@ -79,7 +79,7 @@ const getIntroOfPage = (label: string | number | undefined) => {
   return '';
 };
 
-const CustomTooltip = ({ active, payload, label }: TooltipContentProps<string | number, string>) => {
+const CustomTooltip = ({ active, payload, label }: TooltipContentProps) => {
   const isVisible = active && payload && payload.length;
   return (
     <div className="custom-tooltip" style={{ visibility: isVisible ? 'visible' : 'hidden' }}>


### PR DESCRIPTION
## Description

Changed Tooltip.TooltipContentProps.payload from `any` to `TooltipPayload` and it cascaded from there.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/6564

## Motivation and Context

I tried to keep the strict Tooltip generics but they are mostly a lie - there is zero guarantee that the other graphical elements are actually going to provide those types so it was a false sense of security. So I mostly reverted to the basic `ValueType` and `NameType` which are unions of the allowed values.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tooltip items can now be sorted using custom sorter functions or predefined options (dataKey, value, name).
  * Enhanced tooltip formatting with improved control over item display.

* **Chores**
  * New type exports added for better type safety and consistency across tooltip components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->