### PR TITLE
refactor: enhance type definitions for LabelList and Area components

### DIFF
--- a/src/component/Text.tsx
+++ b/src/component/Text.tsx
@@ -74,6 +74,10 @@ export type TextVerticalAnchor = 'start' | 'middle' | 'end';
  */
 export type RenderableText = string | number | boolean | null | undefined;
 
+export function isRenderableText(val: unknown): val is RenderableText {
+  return isNullish(val) || typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean';
+}
+
 interface TextProps {
   /**
    * When true, scales the text to fit within the specified width.

--- a/src/shape/Curve.tsx
+++ b/src/shape/Curve.tsx
@@ -4,33 +4,33 @@
 import * as React from 'react';
 import { Ref } from 'react';
 import {
-  line as shapeLine,
   area as shapeArea,
-  CurveFactory,
+  Area as D3AreaCurve,
+  curveBasis,
   curveBasisClosed,
   curveBasisOpen,
-  curveBasis,
   curveBumpX,
   curveBumpY,
-  curveLinearClosed,
+  CurveFactory,
   curveLinear,
+  curveLinearClosed,
   curveMonotoneX,
   curveMonotoneY,
   curveNatural,
   curveStep,
   curveStepAfter,
   curveStepBefore,
-  Area as D3AreaCurve,
+  line as shapeLine,
   Line as D3LineCurve,
 } from 'victory-vendor/d3-shape';
 
 import { clsx } from 'clsx';
 import {
-  LayoutType,
-  PresentationAttributesWithProps,
   adaptEventHandlers,
-  NullableCoordinate,
   Coordinate,
+  LayoutType,
+  NullableCoordinate,
+  PresentationAttributesWithProps,
   RechartsMouseEventHandler,
 } from '../util/types';
 import { isNumber, upperFirst } from '../util/DataUtils';
@@ -83,6 +83,11 @@ type AreaPoint = Coordinate & { base: Coordinate };
 
 type NullableAreaPoint = NullableCoordinate & { base?: NullableCoordinate };
 
+/**
+ * @inline
+ */
+export type BaseLineType = number | ReadonlyArray<NullableCoordinate>;
+
 const defined = (p: NullableCoordinate): p is Coordinate => isWellBehavedNumber(p.x) && isWellBehavedNumber(p.y);
 const areaDefined = (d: NullableAreaPoint): d is AreaPoint => d.base != null && defined(d.base) && defined(d);
 const getX = (p: Coordinate) => p.x;
@@ -124,7 +129,7 @@ interface CurveProps {
    * - number: uses the corresponding axis value as a flat baseline;
    * - an array of coordinates: describes a custom baseline path.
    */
-  baseLine?: number | ReadonlyArray<NullableCoordinate>;
+  baseLine?: BaseLineType;
   /**
    * The coordinates of all the points in the curve, like an array of objects with x and y coordinates.
    */

--- a/src/state/selectors/areaSelectors.ts
+++ b/src/state/selectors/areaSelectors.ts
@@ -24,7 +24,7 @@ import { selectXAxisIdFromGraphicalItemId, selectYAxisIdFromGraphicalItemId } fr
 export interface AreaPointItem extends NullableCoordinate {
   x: number | null;
   y: number | null;
-  value?: [number, number];
+  value?: ReadonlyArray<unknown>;
   payload?: any;
 }
 

--- a/www/src/components/GuideView/ZIndex/PrahaMetro.tsx
+++ b/www/src/components/GuideView/ZIndex/PrahaMetro.tsx
@@ -213,7 +213,6 @@ function MetroLine(props: LineProps) {
         dy={-15}
         dx={5}
         valueAccessor={(entry: LabelListEntry) => {
-          // @ts-expect-error Recharts does not have types for the payload property
           const label: string | undefined = entry.payload?.name;
           if (label != null && customLabels.includes(label)) {
             return undefined;


### PR DESCRIPTION
## Description

- Removed `as` cast from baseLine
- changed `[number, number]` type to Array of `unknown` as that better describes what is going on - nothing here guarantees numbers, and indeed charts with two categorical axes are not going to have numeric data in them.
- Removed couple of ts-expect-errors

## Related Issue

https://github.com/recharts/recharts/issues/6645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved type consistency and validation for area rendering, baseline handling, and label components.
  * Enhanced runtime type safety for renderable content through strengthened type definitions across components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->