### PR TITLE
Fix mouse event type

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -470,7 +470,7 @@ type BarBackgroundProps = {
   background?: ActiveShape<BarShapeProps, SVGPathElement>;
   data: ReadonlyArray<BarRectangleItem> | undefined;
   dataKey: DataKey<any> | undefined;
-  allOtherBarProps: Props;
+  allOtherBarProps: InternalProps;
 };
 
 function BarBackground(props: BarBackgroundProps) {
@@ -485,11 +485,8 @@ function BarBackground(props: BarBackgroundProps) {
     ...restOfAllOtherProps
   } = allOtherBarProps;
 
-  // @ts-expect-error bar mouse events are not compatible with recharts mouse events
   const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps, dataKey, allOtherBarProps.id);
-  // @ts-expect-error bar mouse events are not compatible with recharts mouse events
   const onMouseLeaveFromContext = useMouseLeaveItemDispatch(onMouseLeaveFromProps);
-  // @ts-expect-error bar mouse events are not compatible with recharts mouse events
   const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps, dataKey, allOtherBarProps.id);
   if (!backgroundFromProps || data == null) {
     return null;
@@ -506,11 +503,8 @@ function BarBackground(props: BarBackgroundProps) {
           return null;
         }
 
-        // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
         const onMouseEnter = onMouseEnterFromContext(entry, i);
-        // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
         const onMouseLeave = onMouseLeaveFromContext(entry, i);
-        // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
         const onClick = onClickFromContext(entry, i);
 
         const barRectangleProps: BarRectangleProps = {
@@ -710,11 +704,8 @@ function BarRectangles({
     ...restOfAllOtherProps
   } = props;
 
-  // @ts-expect-error bar mouse events are not compatible with recharts mouse events
   const onMouseEnterFromContext = useMouseEnterItemDispatch(onMouseEnterFromProps, dataKey, id);
-  // @ts-expect-error bar mouse events are not compatible with recharts mouse events
   const onMouseLeaveFromContext = useMouseLeaveItemDispatch(onMouseLeaveFromProps);
-  // @ts-expect-error bar mouse events are not compatible with recharts mouse events
   const onClickFromContext = useMouseClickItemDispatch(onItemClickFromProps, dataKey, id);
 
   if (!data) {
@@ -731,11 +722,8 @@ function BarRectangles({
             key={`rectangle-${entry?.x}-${entry?.y}-${entry?.value}-${i}`}
             className="recharts-bar-rectangle"
             {...adaptEventsOfChild(restOfAllOtherProps, entry, i)}
-            // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
             onMouseEnter={onMouseEnterFromContext(entry, i)}
-            // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
             onMouseLeave={onMouseLeaveFromContext(entry, i)}
-            // @ts-expect-error BarRectangleItem type definition says it's missing properties, but I can see them present in debugger!
             onClick={onClickFromContext(entry, i)}
           >
             {activeBar ? (

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -322,11 +322,8 @@ function FunnelTrapezoids(props: FunnelTrapezoidsProps) {
             key={`trapezoid-${entry?.x}-${entry?.y}-${entry?.name}-${entry?.value}`}
             className="recharts-funnel-trapezoid"
             {...adaptEventsOfChild(restOfAllOtherProps, entry, i)}
-            // @ts-expect-error the types need a bit of attention
             onMouseEnter={onMouseEnterFromContext(entry, i)}
-            // @ts-expect-error the types need a bit of attention
             onMouseLeave={onMouseLeaveFromContext(entry, i)}
-            // @ts-expect-error the types need a bit of attention
             onClick={onClickFromContext(entry, i)}
           >
             <FunnelTrapezoid {...trapezoidProps} />

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -568,11 +568,8 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
             <Layer
               className="recharts-scatter-symbol"
               {...adaptEventsOfChild(restOfAllOtherProps, entry, i)}
-              // @ts-expect-error the types need a bit of attention
               onMouseEnter={onMouseEnterFromContext(entry, i)}
-              // @ts-expect-error the types need a bit of attention
               onMouseLeave={onMouseLeaveFromContext(entry, i)}
-              // @ts-expect-error the types need a bit of attention
               onClick={onClickFromContext(entry, i)}
             >
               <ScatterSymbol option={option} isActive={isActive} {...symbolProps} />

--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -1,30 +1,35 @@
 import * as React from 'react';
 import { Coordinate, DataKey } from '../util/types';
 import { useAppDispatch } from '../state/hooks';
-import { mouseLeaveItem, setActiveClickItemIndex, setActiveMouseOverItemIndex } from '../state/tooltipSlice';
+import {
+  mouseLeaveItem,
+  setActiveClickItemIndex,
+  setActiveMouseOverItemIndex,
+  TooltipPayload,
+} from '../state/tooltipSlice';
 
-export type TooltipPayloadType = any[];
-
-type TooltipTriggerInfo<T extends TooltipPayloadType> = {
-  tooltipPayload: T;
-  tooltipPosition: Coordinate;
-  cx: number;
-  cy: number;
+/**
+ * Some graphical items choose to provide more information to the tooltip
+ * and some do not.
+ */
+type TooltipTriggerInfo = {
+  tooltipPayload?: TooltipPayload;
+  tooltipPosition?: Coordinate;
 };
 
-export type ActivateTooltipAction<T extends TooltipPayloadType> = (
-  tooltipInfo: TooltipTriggerInfo<T>,
+export type MouseEnterLeaveEvent<T, E extends SVGElement = SVGElement> = (
+  data: T,
   index: number,
-  event: React.MouseEvent<SVGElement>,
+  event: React.MouseEvent<E>,
 ) => void;
 
-export const useMouseEnterItemDispatch = <T extends TooltipPayloadType>(
-  onMouseEnterFromProps: ActivateTooltipAction<T> | undefined,
+export const useMouseEnterItemDispatch = <T extends TooltipTriggerInfo, E extends SVGElement = SVGElement>(
+  onMouseEnterFromProps: MouseEnterLeaveEvent<T, E> | undefined,
   dataKey: DataKey<any> | undefined,
   graphicalItemId: string,
 ) => {
   const dispatch = useAppDispatch();
-  return (data: TooltipTriggerInfo<T>, index: number) => (event: React.MouseEvent<SVGElement>) => {
+  return (data: T, index: number) => (event: React.MouseEvent<E>) => {
     onMouseEnterFromProps?.(data, index, event);
     dispatch(
       setActiveMouseOverItemIndex({
@@ -37,23 +42,23 @@ export const useMouseEnterItemDispatch = <T extends TooltipPayloadType>(
   };
 };
 
-export const useMouseLeaveItemDispatch = <T extends TooltipPayloadType>(
-  onMouseLeaveFromProps: undefined | ActivateTooltipAction<T>,
+export const useMouseLeaveItemDispatch = <T extends TooltipTriggerInfo, E extends SVGElement = SVGElement>(
+  onMouseLeaveFromProps: undefined | MouseEnterLeaveEvent<T, E>,
 ) => {
   const dispatch = useAppDispatch();
-  return (data: TooltipTriggerInfo<T>, index: number) => (event: React.MouseEvent<SVGElement>) => {
+  return (data: T, index: number) => (event: React.MouseEvent<E>) => {
     onMouseLeaveFromProps?.(data, index, event);
     dispatch(mouseLeaveItem());
   };
 };
 
-export const useMouseClickItemDispatch = <T extends TooltipPayloadType>(
-  onMouseClickFromProps: ActivateTooltipAction<T> | undefined,
+export const useMouseClickItemDispatch = <T extends TooltipTriggerInfo, E extends SVGElement = SVGElement>(
+  onMouseClickFromProps: MouseEnterLeaveEvent<T, E> | undefined,
   dataKey: DataKey<any> | undefined,
   graphicalItemId: string,
 ) => {
   const dispatch = useAppDispatch();
-  return (data: TooltipTriggerInfo<T>, index: number) => (event: React.MouseEvent<SVGElement>) => {
+  return (data: T, index: number) => (event: React.MouseEvent<E>) => {
     onMouseClickFromProps?.(data, index, event);
     dispatch(
       setActiveClickItemIndex({

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -674,11 +674,8 @@ function PieSectors(props: PieSectorsProps) {
             tabIndex={-1}
             className="recharts-pie-sector"
             {...adaptEventsOfChild(restOfAllOtherProps, entry, i)}
-            // @ts-expect-error the types need a bit of attention
             onMouseEnter={onMouseEnterFromContext(entry, i)}
-            // @ts-expect-error the types need a bit of attention
             onMouseLeave={onMouseLeaveFromContext(entry, i)}
-            // @ts-expect-error the types need a bit of attention
             onClick={onClickFromContext(entry, i)}
           >
             <Shape option={shape ?? sectorOptions} index={i} shapeType="sector" isActive={isActive} {...sectorProps} />

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -138,11 +138,8 @@ function RadialBarSectors({ sectors, allOtherRadialBarProps, showLabels }: Radia
     <RadialBarLabelListProvider showLabels={showLabels} sectors={sectors}>
       {sectors.map((entry: RadialBarDataItem, i: number) => {
         const isActive: boolean = Boolean(activeShape && activeIndex === String(i));
-        // @ts-expect-error the types need a bit of attention
         const onMouseEnter = onMouseEnterFromContext(entry, i);
-        // @ts-expect-error the types need a bit of attention
         const onMouseLeave = onMouseLeaveFromContext(entry, i);
-        // @ts-expect-error the types need a bit of attention
         const onClick = onClickFromContext(entry, i);
 
         const radialBarSectorProps: RadialBarSectorProps = {


### PR DESCRIPTION
## Description

Updates the type and removes ts-expect-error

## Related Issue

https://github.com/recharts/recharts/issues/6645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript type safety and consistency across chart components (Bar, Funnel, Scatter, Pie, RadialBar) by refining event handler typing.
  * Simplified tooltip event handling system with clearer generic type definitions.
  * Removed TypeScript error suppressions, enabling better compile-time type checking throughout the charting library.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->