### PR TITLE
Fix Pie event handlers type

### DIFF
--- a/src/context/tooltipContext.tsx
+++ b/src/context/tooltipContext.tsx
@@ -12,7 +12,7 @@ import {
  * Some graphical items choose to provide more information to the tooltip
  * and some do not.
  */
-type TooltipTriggerInfo = {
+export type TooltipTriggerInfo = {
   tooltipPayload?: TooltipPayload;
   tooltipPosition?: Coordinate;
 };

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -29,6 +29,7 @@ import {
 } from '../util/types';
 import { Shape } from '../util/ActiveShapeUtils';
 import {
+  TooltipTriggerInfo,
   useMouseClickItemDispatch,
   useMouseEnterItemDispatch,
   useMouseLeaveItemDispatch,
@@ -153,18 +154,17 @@ export type PieLabel =
    */
   | ReactElement<SVGElement>;
 
-export type PieSectorData = GeometrySector & {
-  dataKey?: DataKey<any>;
-  midAngle?: number;
-  middleRadius?: number;
-  name?: string | number;
-  paddingAngle?: number;
-  payload?: any;
-  percent?: number;
-  tooltipPayload?: TooltipPayload;
-  tooltipPosition: Coordinate;
-  value: number;
-};
+export type PieSectorData = GeometrySector &
+  TooltipTriggerInfo & {
+    dataKey?: DataKey<any>;
+    midAngle?: number;
+    middleRadius?: number;
+    name?: string | number;
+    paddingAngle?: number;
+    payload?: any;
+    percent?: number;
+    value: number;
+  };
 
 /**
  * We spread the data object into the sector data item,
@@ -185,10 +185,45 @@ export type PieSectorDataItem = PiePresentationProps &
 export type PieSectorShapeProps = PieSectorDataItem & { isActive: boolean; index: number };
 export type PieShape = ReactNode | ((props: PieSectorShapeProps, index: number) => React.ReactElement);
 
+interface PieEvents {
+  /**
+   * The customized event handler of click on the sectors in this group.
+   */
+  onClick?: (data: PieSectorDataItem, index: number, e: React.MouseEvent) => void;
+  /**
+   * The customized event handler of mousedown on the sectors in this group.
+   */
+  onMouseDown?: (data: PieSectorDataItem, index: number, e: React.MouseEvent) => void;
+  /**
+   * The customized event handler of mouseup on the sectors in this group.
+   */
+  onMouseUp?: (data: PieSectorDataItem, index: number, e: React.MouseEvent) => void;
+  /**
+   * The customized event handler of mousemove on the sectors in this group.
+   */
+  onMouseMove?: (data: PieSectorDataItem, index: number, e: React.MouseEvent) => void;
+  /**
+   * The customized event handler of mouseover on the sectors in this group.
+   */
+  onMouseOver?: (data: PieSectorDataItem, index: number, e: React.MouseEvent) => void;
+  /**
+   * The customized event handler of mouseout on the sectors in this group.
+   */
+  onMouseOut?: (data: PieSectorDataItem, index: number, e: React.MouseEvent) => void;
+  /**
+   * The customized event handler of mouseenter on the sectors in this group.
+   */
+  onMouseEnter?: (data: PieSectorDataItem, index: number, e: React.MouseEvent) => void;
+  /**
+   * The customized event handler of mouseleave on the sectors in this group.
+   */
+  onMouseLeave?: (data: PieSectorDataItem, index: number, e: React.MouseEvent) => void;
+}
+
 /**
  * Internal props, combination of external props + defaultProps + private Recharts state
  */
-interface InternalPieProps<DataPointType = unknown> extends DataProvider<DataPointType>, PieDef, ZIndexable {
+interface InternalPieProps<DataPointType = unknown> extends DataProvider<DataPointType>, PieDef, ZIndexable, PieEvents {
   id: GraphicalItemId;
   className?: string;
   dataKey: DataKey<any>;
@@ -214,13 +249,10 @@ interface InternalPieProps<DataPointType = unknown> extends DataProvider<DataPoi
   animationDuration?: AnimationDuration;
   onAnimationStart?: () => void;
   onAnimationEnd?: () => void;
-  onMouseEnter?: (data: any, index: number, e: React.MouseEvent) => void;
-  onMouseLeave?: (data: any, index: number, e: React.MouseEvent) => void;
-  onClick?: (data: any, index: number, e: React.MouseEvent) => void;
   rootTabIndex?: number;
 }
 
-interface PieProps<DataPointType = unknown> extends DataProvider<DataPointType>, PieDef, ZIndexable {
+interface PieProps<DataPointType = unknown> extends DataProvider<DataPointType>, PieDef, ZIndexable, PieEvents {
   /**
    * This component is rendered when this graphical item is activated
    * (could be by mouse hover, touch, keyboard, programmatically).
@@ -335,38 +367,6 @@ interface PieProps<DataPointType = unknown> extends DataProvider<DataPointType>,
    * The customized event handler of animation start.
    */
   onAnimationStart?: () => void;
-  /**
-   * The customized event handler of click on the sectors in this group.
-   */
-  onClick?: (data: any, index: number, e: React.MouseEvent) => void;
-  /**
-   * The customized event handler of mousedown on the sectors in this group.
-   */
-  onMouseDown?: (data: any, index: number, e: React.MouseEvent) => void;
-  /**
-   * The customized event handler of mouseup on the sectors in this group.
-   */
-  onMouseUp?: (data: any, index: number, e: React.MouseEvent) => void;
-  /**
-   * The customized event handler of mousemove on the sectors in this group.
-   */
-  onMouseMove?: (data: any, index: number, e: React.MouseEvent) => void;
-  /**
-   * The customized event handler of mouseover on the sectors in this group.
-   */
-  onMouseOver?: (data: any, index: number, e: React.MouseEvent) => void;
-  /**
-   * The customized event handler of mouseout on the sectors in this group.
-   */
-  onMouseOut?: (data: any, index: number, e: React.MouseEvent) => void;
-  /**
-   * The customized event handler of mouseenter on the sectors in this group.
-   */
-  onMouseEnter?: (data: any, index: number, e: React.MouseEvent) => void;
-  /**
-   * The customized event handler of mouseleave on the sectors in this group.
-   */
-  onMouseLeave?: (data: any, index: number, e: React.MouseEvent) => void;
   /**
    * The tabindex of wrapper surrounding the cells.
    * @defaultValue 0


### PR DESCRIPTION
## Description

Switches from `any` to `PieSectorDataItem`

## Related Issue

https://github.com/recharts/recharts/issues/6645


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pie component now supports comprehensive event handling (click, mouse interactions) with improved type safety
  * Enhanced tooltip integration for Pie charts with refined data structure
  * `Coordinate` type is now publicly exported for external use

* **Tests**
  * Expanded test coverage for Pie component event handlers, tooltips, and accessibility scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->