### PR TITLE
Close tooltip on blur

### DIFF
--- a/src/chart/RechartsWrapper.tsx
+++ b/src/chart/RechartsWrapper.tsx
@@ -16,7 +16,7 @@ import { mouseLeaveChart } from '../state/tooltipSlice';
 import { useAppDispatch } from '../state/hooks';
 import { mouseClickAction, mouseMoveAction } from '../state/mouseEventsMiddleware';
 import { useSynchronisedEventsFromOtherCharts } from '../synchronisation/useChartSynchronisation';
-import { focusAction, keyDownAction } from '../state/keyboardEventsMiddleware';
+import { focusAction, keyDownAction, blurAction } from '../state/keyboardEventsMiddleware';
 import { useReportScale } from '../util/useReportScale';
 import { ExternalMouseEvents } from './types';
 import { externalEventAction } from '../state/externalEventsMiddleware';
@@ -304,6 +304,10 @@ export const RechartsWrapper = forwardRef<HTMLDivElement | null, RechartsWrapper
       dispatch(focusAction());
     }, [dispatch]);
 
+    const onBlur = useCallback(() => {
+      dispatch(blurAction());
+    }, [dispatch]);
+
     const onKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLDivElement>) => {
         dispatch(keyDownAction(e.key));
@@ -392,6 +396,7 @@ export const RechartsWrapper = forwardRef<HTMLDivElement | null, RechartsWrapper
             onContextMenu={myOnContextMenu}
             onDoubleClick={myOnDoubleClick}
             onFocus={onFocus}
+            onBlur={onBlur}
             onKeyDown={onKeyDown}
             onMouseDown={myOnMouseDown}
             onMouseEnter={myOnMouseEnter}

--- a/src/state/keyboardEventsMiddleware.ts
+++ b/src/state/keyboardEventsMiddleware.ts
@@ -12,6 +12,7 @@ import { combineActiveTooltipIndex } from './selectors/combiners/combineActiveTo
 
 export const keyDownAction = createAction<KeyboardEvent['key']>('keyDown');
 export const focusAction = createAction('focus');
+export const blurAction = createAction('blur');
 
 export const keyboardEventsMiddleware = createListenerMiddleware<RechartsRootState>();
 
@@ -150,6 +151,27 @@ keyboardEventsMiddleware.startListening({
           active: true,
           activeIndex: nextIndex,
           activeCoordinate: coordinate,
+        }),
+      );
+    }
+  },
+});
+
+keyboardEventsMiddleware.startListening({
+  actionCreator: blurAction,
+  effect: (_action, listenerApi: ListenerEffectAPI<RechartsRootState, AppDispatch>) => {
+    const state: RechartsRootState = listenerApi.getState();
+    const accessibilityLayerIsActive = state.rootProps.accessibilityLayer !== false;
+    if (!accessibilityLayerIsActive) {
+      return;
+    }
+    const { keyboardInteraction } = state.tooltip;
+    if (keyboardInteraction.active) {
+      listenerApi.dispatch(
+        setKeyboardInteraction({
+          active: false,
+          activeIndex: keyboardInteraction.index,
+          activeCoordinate: keyboardInteraction.coordinate,
         }),
       );
     }


### PR DESCRIPTION
## Description

When focus leaves the chart (Tab to next element or blur event), the `blurAction` is dispatched, which sets the keyboard interaction to inactive, causing the tooltip to disappear.

Pressing Escape still closes tooltips as before.

## Related Issue

Closes https://github.com/recharts/recharts/issues/6937

## Motivation and Context

Solves the problem described in the related issue ^

## How Has This Been Tested?

- All related tests pass, including the new tests that specifically verify this behavior.
- Checked manually in storybook.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tooltips now automatically close when a chart loses focus, improving keyboard navigation and accessibility across multiple charts
  * Improved focus/blur handling so only the active chart shows its tooltip

* **Tests**
  * Added tests covering tooltip behavior for focus/blur interactions and multi-chart keyboard navigation scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->