### PR TITLE
fix: React warning about textBreakAll prop on DOM element

### DIFF
--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -429,12 +429,12 @@ export function Label(outerProps: Props) {
   };
 
   if (isValidElement(content)) {
-    const { labelRef: _, ...propsWithoutLabelRef } = propsWithViewBox;
+    const { labelRef: _, textBreakAll: __, zIndex: ___, ...propsWithoutLabelRef } = propsWithViewBox;
     return cloneElement(content, propsWithoutLabelRef);
   }
 
   if (typeof content === 'function') {
-    const { content: _, ...propsForContent } = propsWithViewBox;
+    const { content: _, textBreakAll: __, zIndex: ___, ...propsForContent } = propsWithViewBox;
     // @ts-expect-error we're not checking if the content component returns something that Text is able to render
     label = createElement(content, propsForContent);
 

--- a/test/cartesian/Bar/Bar.spec.tsx
+++ b/test/cartesian/Bar/Bar.spec.tsx
@@ -1020,7 +1020,6 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
               x: expect.any(Number),
               y: expect.any(Number),
             },
-            textBreakAll: false,
             position: 'middle',
             value: expect.any(Number),
             viewBox: {
@@ -1034,7 +1033,6 @@ describe.each(chartsThatSupportBar)('<Bar /> as a child of $testName', ({ ChartE
             width: expect.any(Number),
             x: expect.any(Number),
             y: expect.any(Number),
-            zIndex: 0,
           },
           {}, // second argument is a ref object
         );

--- a/test/component/Label.spec.tsx
+++ b/test/component/Label.spec.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { DefaultZIndexes, Label, LabelProps, Line, LineChart, PieChart, ReferenceLine, Surface } from '../../src';
+import { Label, LabelProps, Line, LineChart, PieChart, ReferenceLine, Surface } from '../../src';
 import { PolarViewBoxRequired } from '../../src/util/types';
 import { rechartsTestRender } from '../helper/createSelectorTestCase';
 import { assertNotNull } from '../helper/assertNotNull';
@@ -302,8 +302,6 @@ describe('<Label />', () => {
               angle: 0,
               offset: 5,
               position: 'center',
-              textBreakAll: false,
-              zIndex: DefaultZIndexes.label,
               viewBox: {
                 height: 200,
                 width: 200,
@@ -463,9 +461,7 @@ describe('<Label />', () => {
             angle: 0,
             children: 'label from children',
             offset: 5,
-            textBreakAll: false,
             position: 'center',
-            zIndex: DefaultZIndexes.label,
             viewBox: {
               height: 200,
               width: 200,
@@ -498,9 +494,7 @@ describe('<Label />', () => {
             angle: 0,
             value: 'label from value',
             offset: 5,
-            textBreakAll: false,
             position: 'center',
-            zIndex: DefaultZIndexes.label,
             viewBox: {
               height: 200,
               width: 200,
@@ -535,10 +529,8 @@ describe('<Label />', () => {
             angle: 0,
             children: 'label from children',
             value: 'label from value',
-            textBreakAll: false,
             offset: 5,
             position: 'center',
-            zIndex: DefaultZIndexes.label,
             viewBox: {
               height: 200,
               width: 200,
@@ -608,10 +600,8 @@ describe('<Label />', () => {
             },
             angle: 0,
             value: 'text',
-            textBreakAll: false,
             position: 'center',
             offset: 5,
-            zIndex: DefaultZIndexes.label,
           },
           {},
         );
@@ -638,10 +628,8 @@ describe('<Label />', () => {
             },
             angle: 0,
             value: 'text',
-            textBreakAll: false,
             position: 'insideEnd',
             offset: 5,
-            zIndex: DefaultZIndexes.label,
           },
           {},
         );
@@ -671,10 +659,8 @@ describe('<Label />', () => {
             },
             angle: 0,
             value: 'text',
-            textBreakAll: false,
             position: 'center',
             offset: 5,
-            zIndex: DefaultZIndexes.label,
           },
           {},
         );


### PR DESCRIPTION
Fixes #3177. Filters `textBreakAll` and `zIndex` props from being passed to custom content (including DOM elements) in the `Label` component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated Label component's behavior when rendering custom content to adjust which props are provided to content functions and elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->