### PR TITLE
fix: in adaptEventHandlers check inputProps[key] before calling

### DIFF
--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1137,7 +1137,7 @@ export const adaptEventHandlers = (
   const out: RecordString<(e: Event) => void> = {};
 
   Object.keys(inputProps).forEach(key => {
-    if (isEventKey(key)) {
+    if (isEventKey(key) && typeof inputProps[key] === 'function') {
       out[key] = newHandler || ((e: Event) => inputProps[key](inputProps, e));
     }
   });

--- a/storybook/stories/Examples/LineChart/LineChart.stories.tsx
+++ b/storybook/stories/Examples/LineChart/LineChart.stories.tsx
@@ -1128,6 +1128,51 @@ export const ChangingDataKey = {
   },
 };
 
+export const UndefinedEventHandlers: StoryObj = {
+  render: (args: Args) => {
+    return (
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart {...args}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Legend />
+          <Line
+            type="monotone"
+            dataKey="pv"
+            stroke="#8884d8"
+            activeDot={{ r: 8 }}
+            onMouseEnter={undefined}
+            onMouseLeave={undefined}
+          />
+          <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+          <Tooltip />
+          <RechartsHookInspector />
+        </LineChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    width: 500,
+    height: 300,
+    data: pageData,
+    margin: {
+      top: 5,
+      right: 30,
+      left: 20,
+      bottom: 5,
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Reproduces a bug where passing `onMouseEnter: undefined` or `onMouseLeave: undefined` to a Line would crash because `adaptEventHandlers` tried to call undefined as a function. Hover over the chart to verify it works without errors.',
+      },
+    },
+  },
+};
+
 const activeDotExcludedDomainData = [
   { timestamp: 0.9, pv: 120 },
   { timestamp: 1.3, pv: 160 },

--- a/test/util/ReactUtils.spec.tsx
+++ b/test/util/ReactUtils.spec.tsx
@@ -44,6 +44,15 @@ describe('ReactUtils', () => {
       expect(adaptEventHandlers(vi.fn())).toEqual(null);
       expect(adaptEventHandlers(1 as any)).toEqual(null);
     });
+
+    test('adaptEventHandlers skips event props that are not functions', () => {
+      const result = adaptEventHandlers({
+        onMouseEnter: undefined,
+        onMouseLeave: undefined,
+        onClick: vi.fn(),
+      });
+      expect(Object.keys(result ?? {})).toEqual(['onClick']);
+    });
   });
 
   describe('adaptEventsOfChild', () => {


### PR DESCRIPTION
## Description

The fix adds a typeof inputProps[key] === 'function' guard to adaptEventHandlers (line 1140 in src/util/types.ts), matching the existing pattern in adaptEventsOfChild. Previously, when a       
  consumer passed onMouseEnter: undefined (or any non-function event prop), adaptEventHandlers would include it in the output object and later attempt to call undefined(...), throwing a TypeError. Now it 
  simply skips non-function event props.

On line 1141, adaptEventHandlers does:                                                                                                                                                  
   
  out[key] = newHandler || ((e: Event) => inputProps[key](inputProps, e));                                                                                                                                  
                                                                                                                                                                                                          
  When no newHandler is provided and inputProps[key] is undefined (e.g. onMouseEnter: undefined), the fallback lambda calls undefined(inputProps, e) which throws. Meanwhile, adaptEventsOfChild correctly  
  guards with typeof item === 'function' on line 1170.  

## Related Issue

related issue: https://github.com/recharts/recharts/issues/6968

## Motivation and Context

It solves the issue

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/a5e36b30-3f81-46c0-a9df-cbd65c01c744


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed event handler validation to properly filter out non-function properties. The system now only processes callable event handlers, preventing potential issues when event handlers are set to undefined or other non-function values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->