### PR TITLE
feat: accept data-* attributes (including data-testid) on components

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -24,8 +24,16 @@ import {
 } from './responsiveContainerUtils';
 import { Percent, Size } from '../util/types';
 import { isPositiveNumber } from '../util/isWellBehavedNumber';
+import { svgPropertiesAndEvents } from '../util/svgPropertiesAndEvents';
 
 export interface Props {
+  /**
+   * HTML data-* attributes (e.g. data-testid) forwarded to the container div.
+   *
+   * Note: These attributes are only applied when the container renders a wrapper element (i.e. when dimensions are not fixed).
+   * If width and height are fixed numbers, or if nested inside another ResponsiveContainer, the wrapper is optimized away and these attributes will not be rendered.
+   */
+  [key: `data-${string}`]: string | number | boolean | undefined;
   /**
    * width / height. If specified, the height will be calculated by width / aspect.
    */
@@ -135,6 +143,7 @@ const SizeDetectorContainer = forwardRef<HTMLDivElement | null, Props>(
       className,
       onResize,
       style = {},
+      ...rest
     }: Props,
     ref,
   ) => {
@@ -230,6 +239,7 @@ const SizeDetectorContainer = forwardRef<HTMLDivElement | null, Props>(
         className={clsx('recharts-responsive-container', className)}
         style={{ ...style, width, height, minWidth, minHeight, maxHeight }}
         ref={containerRef}
+        {...svgPropertiesAndEvents(rest)}
       >
         <div style={getInnerDivStyle({ width, height })}>
           <ResponsiveContainerContextProvider width={calculatedWidth} height={calculatedHeight}>

--- a/test/chart/BarChart.spec.tsx
+++ b/test/chart/BarChart.spec.tsx
@@ -3860,4 +3860,37 @@ describe('<BarChart />', () => {
       expect(spy).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('data-* attributes', () => {
+    it('should pass data-testid to the SVG element', () => {
+      const { container } = render(
+        <BarChart width={100} height={50} data={data} data-testid="my-bar-chart">
+          <Bar dataKey="uv" />
+        </BarChart>,
+      );
+
+      const svg = container.querySelector('svg.recharts-surface');
+      expect(svg).toHaveAttribute('data-testid', 'my-bar-chart');
+    });
+
+    it('should pass multiple data-* attributes to the SVG element', () => {
+      const { container } = render(
+        <BarChart
+          width={100}
+          height={50}
+          data={data}
+          data-testid="chart-1"
+          data-custom="custom-value"
+          data-analytics-id="bar-chart-analytics"
+        >
+          <Bar dataKey="uv" />
+        </BarChart>,
+      );
+
+      const svg = container.querySelector('svg.recharts-surface');
+      expect(svg).toHaveAttribute('data-testid', 'chart-1');
+      expect(svg).toHaveAttribute('data-custom', 'custom-value');
+      expect(svg).toHaveAttribute('data-analytics-id', 'bar-chart-analytics');
+    });
+  });
 });

--- a/test/component/ResponsiveContainer.spec.tsx
+++ b/test/component/ResponsiveContainer.spec.tsx
@@ -502,4 +502,40 @@ describe('<ResponsiveContainer />', () => {
     );
     expect(container.querySelector('.recharts-responsive-container')).toHaveClass('my-custom-class');
   });
+
+  it('should pass data-testid attribute to the container div', () => {
+    render(
+      <ResponsiveContainer data-testid="my-responsive-container">
+        <DimensionSpy />
+      </ResponsiveContainer>,
+    );
+
+    expect(screen.getByTestId('my-responsive-container')).toBeInTheDocument();
+    expect(screen.getByTestId('my-responsive-container')).toHaveClass('recharts-responsive-container');
+  });
+
+  it('should pass multiple data-* attributes to the container div', () => {
+    const { container } = render(
+      <ResponsiveContainer data-testid="my-container" data-custom="custom-value" data-analytics-id="chart-1">
+        <DimensionSpy />
+      </ResponsiveContainer>,
+    );
+
+    const responsiveContainer = container.querySelector('.recharts-responsive-container');
+    expect(responsiveContainer).toHaveAttribute('data-testid', 'my-container');
+    expect(responsiveContainer).toHaveAttribute('data-custom', 'custom-value');
+    expect(responsiveContainer).toHaveAttribute('data-analytics-id', 'chart-1');
+  });
+
+  it('should NOT forward data-* attributes when width and height are both fixed numbers (optimization)', () => {
+    const { container } = render(
+      <ResponsiveContainer width={100} height={100} data-testid="fixed-container">
+        <DimensionSpy />
+      </ResponsiveContainer>,
+    );
+    // Fixed dimensions skip the wrapper div, so data-* attributes are not rendered
+    expect(container.querySelector('[data-testid="fixed-container"]')).not.toBeInTheDocument();
+    // But the children are still rendered correctly
+    expect(screen.getByTestId('inside')).toHaveStyle({ width: '100px', height: '100px' });
+  });
 });


### PR DESCRIPTION
Closes #3253

## Summary
This PR enables passing `data-*` attributes (such as `data-testid`) to Recharts components, making it easier to write tests with React Testing Library.

## What's Changed

### Core Changes
- **Added `getDataProps` utility function** in `src/util/svgPropertiesNoEvents.ts` to extract `data-*` attributes from props objects
- **Updated `ResponsiveContainer`** to forward `data-*` attributes to its container div

### Already Supported
- Chart components (BarChart, LineChart, etc.) already support `data-*` attributes via `svgPropertiesAndEvents`, which includes `data-*` in its filter

## Usage Example

```tsx
// ResponsiveContainer with data-testid
<ResponsiveContainer data-testid="my-container">
  <LineChart data={data} data-testid="my-chart">
    <Line dataKey="value" />
  </LineChart>
</ResponsiveContainer>

// Testing with React Testing Library
const container = screen.getByTestId('my-container');
expect(container).toBeInTheDocument();
```

## Tests Added
- Tests for `getDataProps` utility function
- Tests for `ResponsiveContainer` `data-*` forwarding
- Tests verifying `BarChart` passes `data-*` to SVG element

## Related Discussion
Based on feedback from the issue and [PR #3783](https://github.com/recharts/recharts/pull/3783#pullrequestreview-1672699248), this implementation:
1. Uses a shared utility function (`getDataProps`) as suggested
2. Spreads `data-*` props onto base elements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Components now forward HTML data-* attributes (e.g., `data-testid`, `data-custom`, `data-analytics-id`) to their rendered DOM/SVG elements.

* **Tests**
  * Added and updated tests to verify data-* attributes are correctly forwarded from chart and container components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->