### PR TITLE
fix: enable tooltip synchronization for PieChart

### DIFF
--- a/src/state/selectors/combiners/combineTooltipPayloadConfigurations.ts
+++ b/src/state/selectors/combiners/combineTooltipPayloadConfigurations.ts
@@ -27,6 +27,15 @@ export const combineTooltipPayloadConfigurations = (
   } else {
     filterByGraphicalItemId = tooltipState.itemInteraction.click.graphicalItemId;
   }
+  if (tooltipState.syncInteraction.active && filterByGraphicalItemId == null) {
+    /*
+     * When a tooltip is synchronised from another chart, the local itemInteraction
+     * has no graphicalItemId because the user hasn't hovered over this chart.
+     * In that case we show all tooltip items so the receiving chart can display
+     * its own data at the synced index — matching the behaviour of axis-type tooltips.
+     */
+    return tooltipState.tooltipItemPayloads;
+  }
   if (filterByGraphicalItemId == null && defaultIndex != null) {
     /*
      * So when we use `defaultIndex` - we don't have a dataKey to filter by because user did not hover over anything yet.

--- a/src/synchronisation/useChartSynchronisation.tsx
+++ b/src/synchronisation/useChartSynchronisation.tsx
@@ -8,7 +8,7 @@ import { setSyncInteraction, TooltipIndex, TooltipSyncState } from '../state/too
 import { selectTooltipDataKey } from '../state/selectors/selectors';
 import { Coordinate, TickItem, TooltipEventType } from '../util/types';
 import { TooltipTrigger } from '../chart/types';
-import { selectTooltipAxisTicks } from '../state/selectors/tooltipSelectors';
+import { selectActiveTooltipGraphicalItemId, selectTooltipAxisTicks } from '../state/selectors/tooltipSelectors';
 import { selectSynchronisedTooltipState } from './syncSelectors';
 import { useChartLayout, useViewBox } from '../context/chartLayoutContext';
 import { BrushStartEndIndex } from '../context/brushUpdateContext';
@@ -203,6 +203,7 @@ export function useTooltipChartSynchronisation(
   isTooltipActive: boolean,
 ) {
   const activeDataKey = useAppSelector(state => selectTooltipDataKey(state, tooltipEventType, trigger));
+  const activeGraphicalItemId = useAppSelector(selectActiveTooltipGraphicalItemId);
   const eventEmitterSymbol = useAppSelector(selectEventEmitter);
   const syncId = useAppSelector(selectSyncId);
   const syncMethod = useAppSelector(selectSyncMethod);
@@ -240,13 +241,14 @@ export function useTooltipChartSynchronisation(
       index: activeIndex,
       label: typeof activeLabel === 'number' ? String(activeLabel) : activeLabel,
       sourceViewBox: viewBox,
-      graphicalItemId: undefined,
+      graphicalItemId: activeGraphicalItemId,
     });
     eventCenter.emit(TOOLTIP_SYNC_EVENT, syncId, syncAction, eventEmitterSymbol);
   }, [
     isReceivingSynchronisation,
     activeCoordinate,
     activeDataKey,
+    activeGraphicalItemId,
     activeIndex,
     activeLabel,
     eventEmitterSymbol,

--- a/test/component/Tooltip/Tooltip.sync.spec.tsx
+++ b/test/component/Tooltip/Tooltip.sync.spec.tsx
@@ -13,6 +13,8 @@ import {
   Legend,
   Line,
   LineChart,
+  Pie,
+  PieChart,
   PolarAngleAxis,
   PolarGrid,
   PolarRadiusAxis,
@@ -40,6 +42,7 @@ import {
   composedChartMouseHoverTooltipSelector,
   lineChartMouseHoverTooltipSelector,
   MouseHoverTooltipTriggerSelector,
+  pieChartMouseHoverTooltipSelector,
   radarChartMouseHoverTooltipSelector,
   radialBarChartMouseHoverTooltipSelector,
 } from './tooltipMouseHoverSelectors';
@@ -219,17 +222,17 @@ const RadialBarChartTestCase: TooltipSyncTestCase = {
   tooltipContent: { chartOne: { name: 'Mike', value: '200' }, chartTwo: { name: 'Mike', value: '9800' } },
 };
 
-// TODO: fix synchronization in Pie, Scatter, Funnel. These currently accept syncId as a prop but do not work.
-// const PieChartTestCase: TooltipVisibilityTestCase = {
-//   name: 'PieChart',
-//   Wrapper: ({ children, syncId }) => (
-//     <PieChart height={400} width={400} syncId={syncId}>
-//       <Pie data={PageData} isAnimationActive={false} dataKey="uv" nameKey="name" cx={200} cy={200} />
-//       {children}
-//     </PieChart>
-//   ),
-//   mouseHoverSelector: pieChartMouseHoverTooltipSelector,
-// };
+const PieChartTestCase: TooltipSyncTestCase = {
+  name: 'PieChart',
+  Wrapper: ({ children, syncId, dataKey }) => (
+    <PieChart height={400} width={400} syncId={syncId}>
+      <Pie data={PageData} isAnimationActive={false} dataKey={dataKey} nameKey="name" cx={200} cy={200} />
+      {children}
+    </PieChart>
+  ),
+  mouseHoverSelector: pieChartMouseHoverTooltipSelector,
+  tooltipContent: { chartOne: { name: 'Page A', value: '400' }, chartTwo: { name: 'Page A', value: '2400' } },
+};
 
 // const ScatterChartTestCase: TooltipVisibilityTestCase = {
 //   name: 'ScatterChart',
@@ -309,12 +312,12 @@ const cartesianTestCases: ReadonlyArray<TooltipSyncTestCase> = [
 ];
 
 const radialTestCases: ReadonlyArray<TooltipSyncTestCase> = [
-  // PieChartTestCase,
+  PieChartTestCase,
   RadarChartTestCase,
   RadialBarChartTestCase,
 ];
 
-// Tooltip sync does not work for PieChart, ScatterChart, FunnelChart, SunburstChart, SankeyChart, Treemap
+// Tooltip sync does not work for ScatterChart, FunnelChart, SunburstChart, SankeyChart, Treemap
 describe('Tooltip synchronization', () => {
   beforeEach(() => {
     mockGetBoundingClientRect({ width: 100, height: 100 });


### PR DESCRIPTION
## Description

Fix tooltip synchronization for PieChart (and other `item`-type charts like ScatterChart/FunnelChart).

When two PieCharts share a `syncId`, hovering on the first chart should display a tooltip on the second — but currently no tooltip appears on the receiving chart. This was a known issue explicitly marked as `TODO` in the test suite.

### Root Cause

Two bugs in the tooltip sync pipeline:

1. **[combineTooltipPayloadConfigurations](cci:1://file:///Users/vidhitt.s/Desktop/recharts/src/state/selectors/combiners/combineTooltipPayloadConfigurations.ts:5:0-51:2)** filters payloads by `graphicalItemId` from `itemInteraction.hover`, but on the receiving chart the interaction arrives via `syncInteraction` — so `filterByGraphicalItemId` is `undefined` and the filter returns an empty array → no tooltip.

2. **[useTooltipChartSynchronisation](cci:1://file:///Users/vidhitt.s/Desktop/recharts/src/synchronisation/useChartSynchronisation.tsx:182:0-259:1)** always sets `graphicalItemId: undefined` in sync events, never forwarding the source chart's active item ID.

### Changes

- Add sync-aware fallback in [combineTooltipPayloadConfigurations](cci:1://file:///Users/vidhitt.s/Desktop/recharts/src/state/selectors/combiners/combineTooltipPayloadConfigurations.ts:5:0-51:2) so receiving charts show tooltip items when `syncInteraction` is active
- Pass `activeGraphicalItemId` through sync events instead of `undefined`
- Uncomment and enable PieChart sync test case

## Related Issue

Tooltip synchronization for Pie, Scatter, and Funnel charts was marked as a `TODO` in [Tooltip.sync.spec.tsx](cci:7://file:///Users/vidhitt.s/Desktop/recharts/test/component/Tooltip/Tooltip.sync.spec.tsx:0:0-0:0).

Fixes #6863

## Motivation and Context

PieChart tooltip sync was broken in Recharts v3. Users with synced PieCharts saw no tooltip on the receiving chart when hovering the first.

## How Has This Been Tested?

- Uncommented and enabled the existing `PieChartTestCase` in [Tooltip.sync.spec.tsx](cci:7://file:///Users/vidhitt.s/Desktop/recharts/test/component/Tooltip/Tooltip.sync.spec.tsx:0:0-0:0)
- All **102 tooltip sync tests pass** (4 pre-existing skips), zero regressions
- Full test suite: **13,878 tests pass** (16 skipped, 2 todo)
- Type checking passes across all projects (lib, test, storybook, website)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltip synchronization now shows all items at the synced index when no specific item filter is applied.
  * Tooltip synchronization correctly uses the currently active graphical item when emitting sync events.

* **New Features**
  * Added PieChart support for tooltip synchronization and updated tests to cover radial charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->