### PR TITLE
Add label style prop in Legend

### DIFF
--- a/omnidoc/componentsAndDefaultPropsMap.ts
+++ b/omnidoc/componentsAndDefaultPropsMap.ts
@@ -36,6 +36,7 @@ import { defaultResponsiveContainerProps } from '../src/component/responsiveCont
 import { defaultCurveProps } from '../src/shape/Curve';
 import { defaultSunburstChartProps } from '../src/chart/SunburstChart';
 import { defaultDefaultTooltipContentProps } from '../src/component/DefaultTooltipContent';
+import { defaultLegendContentDefaultProps } from '../src/component/DefaultLegendContent';
 
 type ComponentMeta = {
   defaultProps: Record<string, unknown> | undefined;
@@ -52,6 +53,7 @@ export const componentMetaMap: Record<string, ComponentMeta> = {
   ComposedChart: { defaultProps: defaultCartesianChartProps },
   Curve: { defaultProps: defaultCurveProps },
   DefaultTooltipContent: { defaultProps: defaultDefaultTooltipContentProps },
+  DefaultLegendContent: { defaultProps: defaultLegendContentDefaultProps },
   ErrorBar: { defaultProps: errorBarDefaultProps },
   Funnel: { defaultProps: defaultFunnelProps },
   FunnelChart: { defaultProps: defaultCartesianChartProps },

--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactNode, MouseEvent, ReactElement } from 'react';
+import { ReactNode, MouseEvent, ReactElement, CSSProperties } from 'react';
 
 import { clsx } from 'clsx';
 import { Surface } from '../container/Surface';
@@ -110,17 +110,23 @@ interface DefaultLegendContentProps {
    * A custom payload can be passed here if desired, or it can be passed from the Legend "content" callback.
    */
   payload?: ReadonlyArray<LegendPayload>;
+  /**
+   * The style of each text label which is a span element.
+   * @defaultValue {}
+   */
+  labelStyle?: CSSProperties;
 }
 
 export type Props = DefaultLegendContentProps &
   Omit<PresentationAttributesAdaptChildEvent<any, ReactElement>, keyof DefaultLegendContentProps>;
 
-const defaultLegendContentDefaultProps = {
+export const defaultLegendContentDefaultProps = {
   align: 'center',
   iconSize: 14,
   inactiveColor: '#ccc',
   layout: 'horizontal',
   verticalAlign: 'middle',
+  labelStyle: {},
 } as const satisfies Partial<Props>;
 
 type InternalProps = RequiresDefaultProps<Props, typeof defaultLegendContentDefaultProps> & {
@@ -201,7 +207,7 @@ function Icon({
 }
 
 function Items(props: InternalProps) {
-  const { payload, iconSize, layout, formatter, inactiveColor, iconType } = props;
+  const { payload, iconSize, layout, formatter, inactiveColor, iconType, labelStyle } = props;
   const viewBox = { x: 0, y: 0, width: SIZE, height: SIZE };
   const itemStyle = {
     display: layout === 'horizontal' ? 'inline-block' : 'block',
@@ -220,7 +226,9 @@ function Items(props: InternalProps) {
       return null;
     }
 
-    const color = entry.inactive ? inactiveColor : entry.color;
+    const finalLabelStyle = typeof labelStyle === 'object' ? { ...labelStyle } : {};
+    finalLabelStyle.color = entry.inactive ? inactiveColor : finalLabelStyle.color || entry.color;
+
     const finalValue = finalFormatter ? finalFormatter(entry.value, entry, i) : entry.value;
 
     return (
@@ -234,7 +242,7 @@ function Items(props: InternalProps) {
         >
           <Icon data={entry} iconType={iconType} inactiveColor={inactiveColor} />
         </Surface>
-        <span className="recharts-legend-item-text" style={{ color }}>
+        <span className="recharts-legend-item-text" style={finalLabelStyle}>
           {finalValue}
         </span>
       </li>

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -867,9 +867,38 @@ describe('<Legend />', () => {
       );
 
       expectLegendLabels(container, [
-        { fill: 'none', textContent: 'pv' },
-        { fill: 'none', textContent: 'uv' },
+        { fill: 'none', textContent: 'pv', textColor: 'rgb(136, 132, 216)' },
+        { fill: 'none', textContent: 'uv', textColor: 'rgb(130, 202, 157)' },
       ]);
+    });
+
+    it('should render legend labels with same text color', () => {
+      const { container } = rechartsTestRender(
+        <LineChart width={600} height={300} data={categoricalData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+          <Legend iconType="plainline" labelStyle={{ color: '#666' }} />
+          <Line type="monotone" dataKey="pv" stroke="#8884d8" activeDot={{ r: 8 }} strokeDasharray="5 5" />
+          <Line type="monotone" dataKey="uv" stroke="#82ca9d" />
+        </LineChart>,
+      );
+
+      expectLegendLabels(container, [
+        { fill: 'none', textContent: 'pv', textColor: 'rgb(102, 102, 102)' },
+        { fill: 'none', textContent: 'uv', textColor: 'rgb(102, 102, 102)' },
+      ]);
+    });
+
+    test('label style should not change color of hidden Line', () => {
+      const { container } = rechartsTestRender(
+        <LineChart width={500} height={500} data={numericalData}>
+          <Legend inactiveColor="yellow" labelStyle={{ color: '#666' }} />
+          <Line dataKey="percent" stroke="red" hide />
+        </LineChart>,
+      );
+      const findResult = expectedLegendTypeSymbolsWithColor('yellow').find(tc => tc.legendType === 'line');
+      assertNotNull(findResult);
+      const { selector, expectedAttributes } = findResult;
+      assertExpectedAttributes(container, selector, expectedAttributes);
+      expectLegendLabels(container, [{ fill: 'none', textContent: 'percent', textColor: 'yellow' }]);
     });
 
     describe('legendType symbols', () => {

--- a/test/helper/expectLegendLabels.tsx
+++ b/test/helper/expectLegendLabels.tsx
@@ -8,7 +8,12 @@ export function assertHasLegend(container: Element): ReadonlyArray<Element> {
 
 export function expectLegendLabels(
   container: Element,
-  expectedLabels: null | ReadonlyArray<{ textContent: string; fill: string | null | undefined; stroke?: string }>,
+  expectedLabels: null | ReadonlyArray<{
+    textContent: string;
+    textColor?: string;
+    fill: string | null | undefined;
+    stroke?: string;
+  }>,
 ) {
   assertNotNull(container);
 
@@ -18,9 +23,13 @@ export function expectLegendLabels(
   }
 
   const expectsStroke = expectedLabels.some(label => label.stroke != null);
+  const expectsColor = expectedLabels.some(label => label.textColor !== undefined);
 
   const actualLabels = assertHasLegend(container).map(legend => ({
     textContent: legend.textContent,
+    textColor: expectsColor
+      ? (legend.querySelector('.recharts-legend-item-text') as HTMLElement)?.style.color
+      : undefined,
     fill: legend.querySelector('.recharts-legend-icon')?.getAttribute('fill'),
     stroke: expectsStroke ? legend.querySelector('.recharts-legend-icon')?.getAttribute('stroke') : undefined,
   }));


### PR DESCRIPTION
## Description
Customize text style of each legend item like it's made in DefaultTooltipContent.

## Motivation and Context
Use of single color for all text labels instead of item colors in Legend. Fit style accordingly to font size and line height in the document.

## How Has This Been Tested?
Unit tests added, existing ones passed

## Screenshots (if appropriate):
<img width="728" height="432" alt="linechart" src="https://github.com/user-attachments/assets/e45e7a83-adba-451f-802a-65fd1a5ad6c3" />
<img width="484" height="392" alt="piechart" src="https://github.com/user-attachments/assets/8c398e14-6b0f-4a14-b0c1-ef18cfbc45c5" />
<img width="286" height="361" alt="AgePieChart" src="https://github.com/user-attachments/assets/53e2345b-1f92-41e9-89d4-c72197b6e35e" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-item legend label styling: add a labelStyle option so legend entries can have custom text styling (including color); inactive/hidden items reflect the configured inactive color.
  * Legend default props are now public and included in component defaults.

* **Documentation**
  * Default legend props are surfaced in documentation metadata.

* **Tests**
  * Updated tests to verify legend label styling and correct color handling for active vs. inactive items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->