### PR TITLE
Add optional explicit generics to graphical items and charts

### DIFF
--- a/omnidoc/readProject.spec.ts
+++ b/omnidoc/readProject.spec.ts
@@ -51,15 +51,6 @@ describe('readProject', () => {
     expect(variables).not.toContain('AreaProps');
   });
 
-  it('should return properties', () => {
-    // this is not entirely helpful for what we need to do
-    expect(reader.getPropertiesOf('Funnel')).toMatchInlineSnapshot(`
-      [
-        "displayName",
-      ]
-    `);
-  });
-
   it('should return Recharts props of Bar', () => {
     expect(reader.getRechartsPropsOf('Bar')).toMatchInlineSnapshot(`
       [

--- a/omnidoc/readProject.ts
+++ b/omnidoc/readProject.ts
@@ -150,24 +150,6 @@ export class ProjectDocReader implements DocReader {
     return declarations[0];
   }
 
-  private getComponentType(component: string): Type {
-    const declaration = this.getComponentDeclaration(component);
-
-    return declaration.getType();
-  }
-
-  /**
-   * This returns properties of a symbol. So if you pass a React component, you get back React lifecycle methods,
-   * and displayName.
-   * @param component
-   */
-  getPropertiesOf(component: string): ReadonlyArray<string> | undefined {
-    const type = this.getComponentType(component);
-
-    const properties = type.getProperties();
-    return properties.map(p => p.getName());
-  }
-
   private getDeclarationOrigin(declaration: Node): PropOrigin {
     const sourceFile = declaration.getSourceFile();
     const filePath = sourceFile.getFilePath();

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { MutableRefObject, ReactNode, useCallback, useMemo, useRef, useState } from 'react';
+import { MutableRefObject, ReactElement, ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 import omit from 'es-toolkit/compat/omit';
 
 import { clsx } from 'clsx';
@@ -195,7 +195,8 @@ type FunnelSvgProps = Omit<PresentationAttributesAdaptChildEvent<FunnelTrapezoid
 
 type InternalProps = FunnelSvgProps & InternalFunnelProps;
 
-export type Props = FunnelSvgProps & FunnelProps;
+export type Props<DataPointType = any, DataValueType = any> = FunnelSvgProps &
+  FunnelProps<DataPointType, DataValueType>;
 
 type RealFunnelData = unknown;
 
@@ -687,7 +688,7 @@ export function computeFunnelTrapezoids({
  * @provides LabelListContext
  * @provides CellReader
  */
-export function Funnel(outsideProps: Props) {
+function FunnelFn(outsideProps: Props) {
   const { id: externalId, ...props } = resolveDefaultProps(outsideProps, defaultFunnelProps);
   return (
     <RegisterGraphicalItemId id={externalId} type="funnel">
@@ -696,4 +697,9 @@ export function Funnel(outsideProps: Props) {
   );
 }
 
+export const Funnel = FunnelFn as {
+  <DataPointType = any, DataValueType = any>(outsideProps: Props<DataPointType, DataValueType>): ReactElement;
+  (outsideProps: Props<any, any>): ReactElement;
+};
+// @ts-expect-error we need to set the displayName for debugging purposes
 Funnel.displayName = 'Funnel';

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import {
   Component,
-  ComponentType,
   MutableRefObject,
+  ReactElement,
   ReactNode,
   Ref,
   useCallback,
@@ -323,7 +323,7 @@ type LineSvgProps = Omit<CurveProps, 'points' | 'pathRef' | 'ref' | 'layout' | '
 
 type InternalProps = LineSvgProps & InternalLineProps;
 
-export type Props = LineSvgProps & LineProps;
+export type Props<DataPointType = any, ValueAxisType = any> = LineSvgProps & LineProps<DataPointType, ValueAxisType>;
 
 const computeLegendPayloadFromAreaData = (props: Props): ReadonlyArray<LegendPayload> => {
   const { dataKey, name, stroke, legendType, hide } = props;
@@ -997,5 +997,9 @@ function LineFn(outsideProps: Props) {
  * @provides ErrorBarContext
  * @consumes CartesianChartContext
  */
-export const Line: ComponentType<Props> = React.memo(LineFn, propsAreEqual);
+export const Line = React.memo(LineFn, propsAreEqual) as {
+  <DataPointType = any, ValueAxisType = any>(props: Props<DataPointType, ValueAxisType>): ReactElement;
+  (props: Props<any, any>): ReactElement;
+};
+// @ts-expect-error we need to set the displayName for debugging purposes
 Line.displayName = 'Line';

--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -22,7 +22,13 @@ import { DefaultZIndexes } from '../zIndex/DefaultZIndexes';
 import { RechartsScale } from '../util/scale/RechartsScale';
 import { CartesianScaleHelperImpl } from '../util/scale/CartesianScaleHelper';
 
-interface ReferenceAreaProps extends Overflowable, ZIndexable {
+type ReferenceCoordinateValue = number | string;
+
+interface ReferenceAreaProps<
+  XValueType extends ReferenceCoordinateValue = any,
+  YValueType extends ReferenceCoordinateValue = any,
+>
+  extends Overflowable, ZIndexable {
   /**
    * Starting X-coordinate of the area.
    * This value is using your chart's domain, so you will provide a data value instead of a pixel value.
@@ -34,7 +40,7 @@ interface ReferenceAreaProps extends Overflowable, ZIndexable {
    * @example <ReferenceArea x1={10} x2={50} />
    * @example <ReferenceArea x1="Page C" />
    */
-  x1?: number | string;
+  x1?: XValueType;
   /**
    * Ending X-coordinate of the area.
    * This value is using your chart's domain, so you will provide a data value instead of a pixel value.
@@ -46,7 +52,7 @@ interface ReferenceAreaProps extends Overflowable, ZIndexable {
    * @example <ReferenceArea x1={10} x2={50} />
    * @example <ReferenceArea x2="Page C" />
    */
-  x2?: number | string;
+  x2?: XValueType;
   /**
    * Starting Y-coordinate of the area.
    * This value is using your chart's domain, so you will provide a data value instead of a pixel value.
@@ -58,7 +64,7 @@ interface ReferenceAreaProps extends Overflowable, ZIndexable {
    * @example <ReferenceArea y1="low" y2="high" />
    * @example <ReferenceArea y1={200} />
    */
-  y1?: number | string;
+  y1?: YValueType;
   /**
    * Ending Y-coordinate of the area.
    * This value is using your chart's domain, so you will provide a data value instead of a pixel value.
@@ -70,7 +76,7 @@ interface ReferenceAreaProps extends Overflowable, ZIndexable {
    * @example <ReferenceArea y1="low" y2="high" />
    * @example <ReferenceArea y2={400} />
    */
-  y2?: number | string;
+  y2?: YValueType;
 
   className?: number | string;
   /**
@@ -121,7 +127,11 @@ interface ReferenceAreaProps extends Overflowable, ZIndexable {
  * Omit width, height, x, y from SVGPropsAndEvents because ReferenceArea receives x1, x2, y1, y2 instead.
  * The position is calculated internally instead.
  */
-export type Props = Omit<SVGPropsAndEvents<RectangleProps>, 'width' | 'height' | 'x' | 'y'> & ReferenceAreaProps;
+export type Props<
+  XValueType extends ReferenceCoordinateValue = any,
+  YValueType extends ReferenceCoordinateValue = any,
+> = Omit<SVGPropsAndEvents<RectangleProps>, 'width' | 'height' | 'x' | 'y'> &
+  ReferenceAreaProps<XValueType, YValueType>;
 
 const getRect = (
   hasX1: boolean,
@@ -256,7 +266,10 @@ type PropsWithDefaults = RequiresDefaultProps<Props, typeof referenceAreaDefault
  * @provides CartesianLabelContext
  * @consumes CartesianChartContext
  */
-export function ReferenceArea(outsideProps: Props) {
+export function ReferenceArea<
+  XValueType extends ReferenceCoordinateValue = any,
+  YValueType extends ReferenceCoordinateValue = any,
+>(outsideProps: Props<XValueType, YValueType>) {
   const props = resolveDefaultProps(outsideProps, referenceAreaDefaultProps);
   return (
     <>

--- a/src/cartesian/ReferenceDot.tsx
+++ b/src/cartesian/ReferenceDot.tsx
@@ -20,7 +20,13 @@ import { DefaultZIndexes } from '../zIndex/DefaultZIndexes';
 import { Coordinate } from '../util/types';
 import { CartesianScaleHelperImpl } from '../util/scale/CartesianScaleHelper';
 
-interface ReferenceDotProps extends Overflowable, ZIndexable {
+type ReferenceCoordinateValue = number | string;
+
+interface ReferenceDotProps<
+  XValueType extends ReferenceCoordinateValue = any,
+  YValueType extends ReferenceCoordinateValue = any,
+>
+  extends Overflowable, ZIndexable {
   /**
    * The radius of the dot in pixels.
    *
@@ -35,7 +41,7 @@ interface ReferenceDotProps extends Overflowable, ZIndexable {
    *
    * @example <ReferenceDot x="January" y="2026" />
    */
-  x?: number | string;
+  x?: XValueType;
   /**
    * The y-coordinate of the center of the dot.
    *
@@ -44,7 +50,7 @@ interface ReferenceDotProps extends Overflowable, ZIndexable {
    *
    * @example <ReferenceDot x="January" y="2026" />
    */
-  y?: number | string;
+  y?: YValueType;
 
   className?: number | string;
   /**
@@ -125,7 +131,10 @@ interface ReferenceDotProps extends Overflowable, ZIndexable {
   onMouseLeave?: (dotProps: DotProps, e: React.MouseEvent<SVGCircleElement>) => void;
 }
 
-export type Props = Omit<DotProps, 'cx' | 'cy' | 'clipDot' | 'dangerouslySetInnerHTML'> & ReferenceDotProps;
+export type Props<
+  XValueType extends ReferenceCoordinateValue = any,
+  YValueType extends ReferenceCoordinateValue = any,
+> = Omit<DotProps, 'cx' | 'cy' | 'clipDot' | 'dangerouslySetInnerHTML'> & ReferenceDotProps<XValueType, YValueType>;
 
 const useCoordinate = (
   x: number | string | undefined,
@@ -253,7 +262,10 @@ type PropsWithDefaults = RequiresDefaultProps<Props, typeof referenceDotDefaultP
  * @provides CartesianLabelContext
  * @consumes CartesianChartContext
  */
-export function ReferenceDot(outsideProps: Props) {
+export function ReferenceDot<
+  XValueType extends ReferenceCoordinateValue = any,
+  YValueType extends ReferenceCoordinateValue = any,
+>(outsideProps: Props<XValueType, YValueType>) {
   const props = resolveDefaultProps(outsideProps, referenceDotDefaultProps);
   const { x, y, r, ifOverflow, yAxisId, xAxisId } = props;
   return (

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -48,7 +48,13 @@ export type ReferenceLineSegment = readonly [
   },
 ];
 
-interface ReferenceLineProps extends Overflowable, ZIndexable {
+type ReferenceCoordinateValue = number | string;
+
+interface ReferenceLineProps<
+  XValueType extends ReferenceCoordinateValue = any,
+  YValueType extends ReferenceCoordinateValue = any,
+>
+  extends Overflowable, ZIndexable {
   /**
    * If defined, renders a horizontal line on this position.
    *
@@ -57,7 +63,7 @@ interface ReferenceLineProps extends Overflowable, ZIndexable {
    *
    * @example <ReferenceLine y="Page D" />
    */
-  y?: number | string;
+  y?: YValueType;
 
   /**
    * If defined, renders a vertical line on this position.
@@ -67,12 +73,21 @@ interface ReferenceLineProps extends Overflowable, ZIndexable {
    *
    * @example <ReferenceLine x="Monday" />
    */
-  x?: number | string;
+  x?: XValueType;
 
   /**
    * Tuple of coordinates. If defined, renders a diagonal line segment.
    */
-  segment?: ReferenceLineSegment;
+  segment?: readonly [
+    {
+      x?: XValueType;
+      y?: YValueType;
+    },
+    {
+      x?: XValueType;
+      y?: YValueType;
+    },
+  ];
 
   /**
    * The position of the reference line when the axis has bandwidth
@@ -134,7 +149,10 @@ interface ReferenceLineProps extends Overflowable, ZIndexable {
  *    - so there's a conflict, and the component will throw if it gets string
  * 2. Internally the component calls `svgPropertiesNoEvents` which filters the viewBox away anyway
  */
-export type Props = Omit<SVGProps<SVGLineElement>, 'viewBox'> & ReferenceLineProps;
+export type Props<
+  XValueType extends ReferenceCoordinateValue = any,
+  YValueType extends ReferenceCoordinateValue = any,
+> = Omit<SVGProps<SVGLineElement>, 'viewBox'> & ReferenceLineProps<XValueType, YValueType>;
 
 const renderLine = (option: ReferenceLineProps['shape'], props: SVGProps<SVGLineElement>) => {
   let line;
@@ -365,7 +383,10 @@ type PropsWithDefaults = RequiresDefaultProps<Props, typeof referenceLineDefault
  * @provides CartesianLabelContext
  * @consumes CartesianChartContext
  */
-export function ReferenceLine(outsideProps: Props) {
+export function ReferenceLine<
+  XValueType extends ReferenceCoordinateValue = any,
+  YValueType extends ReferenceCoordinateValue = any,
+>(outsideProps: Props<XValueType, YValueType>) {
   const props: PropsWithDefaults = resolveDefaultProps(outsideProps, referenceLineDefaultProps);
   return (
     <>

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -1,14 +1,5 @@
 import * as React from 'react';
-import {
-  ComponentType,
-  MutableRefObject,
-  ReactElement,
-  ReactNode,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { MutableRefObject, ReactElement, ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 
 import { clsx } from 'clsx';
 import { Layer } from '../container/Layer';
@@ -347,7 +338,8 @@ type BaseScatterSvgProps = Omit<
 
 type InternalProps = BaseScatterSvgProps & ScatterInternalProps;
 
-export type Props = BaseScatterSvgProps & ScatterProps;
+export type Props<DataPointType = any, ValueAxisType = any> = BaseScatterSvgProps &
+  ScatterProps<DataPointType, ValueAxisType>;
 
 const computeLegendPayloadFromScatterProps = (props: Props): ReadonlyArray<LegendPayload> => {
   const { dataKey, name, fill, legendType, hide } = props;
@@ -924,6 +916,10 @@ function ScatterFn(outsideProps: Props) {
  * @provides CellReader
  * @consumes CartesianChartContext
  */
-export const Scatter: ComponentType<Props> = React.memo(ScatterFn, propsAreEqual);
+export const Scatter = React.memo(ScatterFn, propsAreEqual) as {
+  <DataPointType = any, ValueAxisType = any>(props: Props<DataPointType, ValueAxisType>): ReactElement;
+  (props: Props<any, any>): ReactElement;
+};
+// @ts-expect-error we need to set the displayName for debugging purposes
 
 Scatter.displayName = 'Scatter';

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -2,7 +2,7 @@
  * @fileOverview X Axis
  */
 import * as React from 'react';
-import { ComponentType, ReactNode, useLayoutEffect, useMemo, useRef } from 'react';
+import { ReactElement, ReactNode, useLayoutEffect, useMemo, useRef } from 'react';
 import { clsx } from 'clsx';
 import { CartesianAxis, defaultCartesianAxisProps } from './CartesianAxis';
 import {
@@ -186,7 +186,11 @@ interface XAxisProps<DataPointType = any, DataValueType = any> extends Omit<
   letterSpacing?: number | string;
 }
 
-export type Props = Omit<PresentationAttributesAdaptChildEvent<TickItem, SVGTextElement>, 'scale' | 'ref'> & XAxisProps;
+export type Props<DataPointType = any, DataValueType = any> = Omit<
+  PresentationAttributesAdaptChildEvent<TickItem, SVGTextElement>,
+  'scale' | 'ref'
+> &
+  XAxisProps<DataPointType, DataValueType>;
 
 function SetXAxisSettings(props: Omit<XAxisSettings, 'type'> & { type: AxisDomainTypeInput }): ReactNode {
   const dispatch = useAppDispatch();
@@ -294,10 +298,13 @@ export const xAxisDefaultProps = {
   xAxisId: 0,
 } as const satisfies Partial<Props>;
 
-type PropsWithDefaults = RequiresDefaultProps<Props, typeof xAxisDefaultProps>;
+type PropsWithDefaults<DataPointType = any, DataValueType = any> = RequiresDefaultProps<
+  Props<DataPointType, DataValueType>,
+  typeof xAxisDefaultProps
+>;
 
-const XAxisSettingsDispatcher = (outsideProps: Props) => {
-  const props: PropsWithDefaults = resolveDefaultProps(outsideProps, xAxisDefaultProps);
+const XAxisSettingsDispatcher = <DataPointType, DataValueType>(outsideProps: Props<DataPointType, DataValueType>) => {
+  const props: PropsWithDefaults<DataPointType, DataValueType> = resolveDefaultProps(outsideProps, xAxisDefaultProps);
   return (
     <>
       <SetXAxisSettings
@@ -335,6 +342,12 @@ const XAxisSettingsDispatcher = (outsideProps: Props) => {
  * @consumes CartesianViewBoxContext
  * @provides CartesianLabelContext
  */
-export const XAxis: ComponentType<Props> = React.memo(XAxisSettingsDispatcher, axisPropsAreEqual);
+export const XAxis = React.memo(XAxisSettingsDispatcher, axisPropsAreEqual) as <
+  DataPointType = any,
+  DataValueType = any,
+>(
+  props: Props<DataPointType, DataValueType>,
+) => ReactElement;
+// @ts-expect-error we need to set the displayName for debugging purposes
 
 XAxis.displayName = 'XAxis';

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ComponentType, isValidElement, SVGProps, useLayoutEffect, useMemo, useRef } from 'react';
+import { ReactElement, isValidElement, SVGProps, useLayoutEffect, useMemo, useRef } from 'react';
 import { clsx } from 'clsx';
 import {
   AxisDomainTypeInput,
@@ -201,7 +201,11 @@ interface YAxisProps<DataPointType = any, DataValueType = any> extends Omit<
   letterSpacing?: number | string;
 }
 
-export type Props = Omit<PresentationAttributesAdaptChildEvent<TickItem, SVGTextElement>, 'scale' | 'ref'> & YAxisProps;
+export type Props<DataPointType = any, DataValueType = any> = Omit<
+  PresentationAttributesAdaptChildEvent<TickItem, SVGTextElement>,
+  'scale' | 'ref'
+> &
+  YAxisProps<DataPointType, DataValueType>;
 
 function SetYAxisSettings(props: Omit<YAxisSettings, 'type'> & { type: AxisDomainTypeInput }): null {
   const dispatch = useAppDispatch();
@@ -354,10 +358,13 @@ export const yAxisDefaultProps = {
   yAxisId: 0,
 } as const satisfies Partial<Props>;
 
-type PropsWithDefaults = RequiresDefaultProps<Props, typeof yAxisDefaultProps>;
+type PropsWithDefaults<DataPointType = any, DataValueType = any> = RequiresDefaultProps<
+  Props<DataPointType, DataValueType>,
+  typeof yAxisDefaultProps
+>;
 
-const YAxisSettingsDispatcher = (outsideProps: Props) => {
-  const props: PropsWithDefaults = resolveDefaultProps(outsideProps, yAxisDefaultProps);
+const YAxisSettingsDispatcher = <DataPointType, DataValueType>(outsideProps: Props<DataPointType, DataValueType>) => {
+  const props: PropsWithDefaults<DataPointType, DataValueType> = resolveDefaultProps(outsideProps, yAxisDefaultProps);
   return (
     <>
       <SetYAxisSettings
@@ -395,6 +402,12 @@ const YAxisSettingsDispatcher = (outsideProps: Props) => {
  * @consumes CartesianViewBoxContext
  * @provides CartesianLabelContext
  */
-export const YAxis: ComponentType<Props> = React.memo(YAxisSettingsDispatcher, axisPropsAreEqual);
+export const YAxis = React.memo(YAxisSettingsDispatcher, axisPropsAreEqual) as <
+  DataPointType = any,
+  DataValueType = any,
+>(
+  props: Props<DataPointType, DataValueType>,
+) => ReactElement;
+// @ts-expect-error we need to set the displayName for debugging purposes
 
 YAxis.displayName = 'YAxis';

--- a/src/cartesian/ZAxis.tsx
+++ b/src/cartesian/ZAxis.tsx
@@ -120,7 +120,7 @@ export const zAxisDefaultProps = {
  *
  * @consumes CartesianViewBoxContext
  */
-export function ZAxis(outsideProps: Props) {
+export function ZAxis<DataPointType = any, DataValueType = any>(outsideProps: Props<DataPointType, DataValueType>) {
   const props = resolveDefaultProps(outsideProps, zAxisDefaultProps);
   return (
     <SetZAxisSettings

--- a/src/chart/AreaChart.tsx
+++ b/src/chart/AreaChart.tsx
@@ -24,6 +24,6 @@ export const AreaChart = forwardRef<SVGSVGElement, CartesianChartProps<unknown>>
       />
     );
   },
-) as <DataPointType>(
+) as <DataPointType = any>(
   props: CartesianChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
 ) => React.ReactElement;

--- a/src/chart/BarChart.tsx
+++ b/src/chart/BarChart.tsx
@@ -24,6 +24,6 @@ export const BarChart = forwardRef<SVGSVGElement, CartesianChartProps<unknown>>(
       />
     );
   },
-) as <DataPointType>(
+) as <DataPointType = any>(
   props: CartesianChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
 ) => React.ReactElement;

--- a/src/chart/ComposedChart.tsx
+++ b/src/chart/ComposedChart.tsx
@@ -24,6 +24,6 @@ export const ComposedChart = forwardRef<SVGSVGElement, CartesianChartProps<unkno
       />
     );
   },
-) as <DataPointType>(
+) as <DataPointType = any>(
   props: CartesianChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
 ) => React.ReactElement;

--- a/src/chart/FunnelChart.tsx
+++ b/src/chart/FunnelChart.tsx
@@ -24,6 +24,6 @@ export const FunnelChart = forwardRef<SVGSVGElement, CartesianChartProps<unknown
       />
     );
   },
-) as <DataPointType>(
+) as <DataPointType = any>(
   props: CartesianChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
 ) => React.ReactElement;

--- a/src/chart/LineChart.tsx
+++ b/src/chart/LineChart.tsx
@@ -24,6 +24,6 @@ export const LineChart = forwardRef<SVGSVGElement, CartesianChartProps<unknown>>
       />
     );
   },
-) as <DataPointType>(
+) as <DataPointType = any>(
   props: CartesianChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
 ) => React.ReactElement;

--- a/src/chart/PieChart.tsx
+++ b/src/chart/PieChart.tsx
@@ -31,4 +31,6 @@ export const PieChart = forwardRef<SVGSVGElement, PolarChartProps<unknown>>((pro
       ref={ref}
     />
   );
-}) as <DataPointType>(props: PolarChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> }) => React.ReactElement;
+}) as <DataPointType = any>(
+  props: PolarChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
+) => React.ReactElement;

--- a/src/chart/RadarChart.tsx
+++ b/src/chart/RadarChart.tsx
@@ -54,4 +54,6 @@ export const RadarChart = forwardRef<SVGSVGElement, RadarChartProps<unknown>>(
       />
     );
   },
-) as <DataPointType>(props: PolarChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> }) => React.ReactElement;
+) as <DataPointType = any>(
+  props: PolarChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
+) => React.ReactElement;

--- a/src/chart/RadialBarChart.tsx
+++ b/src/chart/RadialBarChart.tsx
@@ -33,4 +33,6 @@ export const RadialBarChart = forwardRef<SVGSVGElement, PolarChartProps<unknown>
       />
     );
   },
-) as <DataPointType>(props: PolarChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> }) => React.ReactElement;
+) as <DataPointType = any>(
+  props: PolarChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
+) => React.ReactElement;

--- a/src/chart/ScatterChart.tsx
+++ b/src/chart/ScatterChart.tsx
@@ -24,6 +24,6 @@ export const ScatterChart = forwardRef<SVGSVGElement, CartesianChartProps<unknow
       />
     );
   },
-) as <DataPointType>(
+) as <DataPointType = any>(
   props: CartesianChartProps<DataPointType> & { ref?: React.Ref<SVGSVGElement> },
 ) => React.ReactElement;

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -387,7 +387,7 @@ type PieSvgAttributes = Omit<PresentationAttributesAdaptChildEvent<any, SVGEleme
 
 type InternalProps = PieSvgAttributes & InternalPieProps;
 
-export type Props = PieSvgAttributes & PieProps;
+export type Props<DataPointType = any, DataValueType = any> = PieSvgAttributes & PieProps<DataPointType, DataValueType>;
 
 type RealPieData = Record<string, unknown>;
 
@@ -1037,7 +1037,7 @@ type PropsWithResolvedDefaults = RequiresDefaultProps<Props, typeof defaultPiePr
  * @provides LabelListContext
  * @provides CellReader
  */
-export function Pie(outsideProps: Props) {
+function PieFn(outsideProps: Props) {
   const props: PropsWithResolvedDefaults = resolveDefaultProps(outsideProps, defaultPieProps);
   const { id: externalId, ...propsWithoutId } = props;
   const presentationProps: PiePresentationProps | null = svgPropertiesNoEvents(propsWithoutId);
@@ -1078,4 +1078,9 @@ export function Pie(outsideProps: Props) {
     </RegisterGraphicalItemId>
   );
 }
+export const Pie = PieFn as {
+  <DataPointType = any, DataValueType = any>(outsideProps: Props<DataPointType, DataValueType>): ReactElement;
+  (outsideProps: Props<any, any>): ReactElement;
+};
+// @ts-expect-error we need to set the displayName for debugging purposes
 Pie.displayName = 'Pie';

--- a/src/polar/PolarAngleAxis.tsx
+++ b/src/polar/PolarAngleAxis.tsx
@@ -247,9 +247,13 @@ type AxisSvgProps = Omit<
   'scale' | 'type' | 'dangerouslySetInnerHTML'
 >;
 
-export type Props = AxisSvgProps & PolarAngleAxisProps;
+export type Props<DataPointType = any, DataValueType = any> = AxisSvgProps &
+  PolarAngleAxisProps<DataPointType, DataValueType>;
 
-type PropsWithDefaults = RequiresDefaultProps<Props, typeof defaultPolarAngleAxisProps>;
+type PropsWithDefaults<DataPointType = any, DataValueType = any> = RequiresDefaultProps<
+  Props<DataPointType, DataValueType>,
+  typeof defaultPolarAngleAxisProps
+>;
 
 type InternalPolarAngleAxisProps = Omit<PropsWithDefaults, 'scale'> & {
   cx: number;
@@ -486,8 +490,13 @@ export const PolarAngleAxisWrapper: FunctionComponent<PropsWithDefaults> = (defa
  * @provides PolarLabelContext
  * @consumes PolarViewBoxContext
  */
-export function PolarAngleAxis(outsideProps: Props): React.ReactNode {
-  const props = resolveDefaultProps(outsideProps, defaultPolarAngleAxisProps);
+export function PolarAngleAxis<DataPointType = any, DataValueType = any>(
+  outsideProps: Props<DataPointType, DataValueType>,
+): React.ReactNode {
+  const props: PropsWithDefaults<DataPointType, DataValueType> = resolveDefaultProps(
+    outsideProps,
+    defaultPolarAngleAxisProps,
+  );
 
   return (
     <SetAngleAxisSettings

--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -203,9 +203,13 @@ export interface PolarRadiusAxisProps<DataPointType = any, DataValueType = any>
 
 type AxisSvgProps = Omit<PresentationAttributesAdaptChildEvent<any, SVGTextElement>, 'scale' | 'type'>;
 
-export type Props = AxisSvgProps & PolarRadiusAxisProps;
+export type Props<DataPointType = any, DataValueType = any> = AxisSvgProps &
+  PolarRadiusAxisProps<DataPointType, DataValueType>;
 
-type PropsWithDefaults = RequiresDefaultProps<Props, typeof defaultPolarRadiusAxisProps>;
+type PropsWithDefaults<DataPointType = any, DataValueType = any> = RequiresDefaultProps<
+  Props<DataPointType, DataValueType>,
+  typeof defaultPolarRadiusAxisProps
+>;
 
 type InsideProps = Omit<PropsWithDefaults, 'scale'> &
   PolarViewBoxRequired & {
@@ -401,8 +405,13 @@ export const PolarRadiusAxisWrapper: FunctionComponent<PropsWithDefaults> = (def
  * @provides PolarLabelContext
  * @consumes PolarViewBoxContext
  */
-export function PolarRadiusAxis(outsideProps: Props) {
-  const props: PropsWithDefaults = resolveDefaultProps(outsideProps, defaultPolarRadiusAxisProps);
+export function PolarRadiusAxis<DataPointType = any, DataValueType = any>(
+  outsideProps: Props<DataPointType, DataValueType>,
+) {
+  const props: PropsWithDefaults<DataPointType, DataValueType> = resolveDefaultProps(
+    outsideProps,
+    defaultPolarRadiusAxisProps,
+  );
   return (
     <>
       <SetRadiusAxisSettings

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -161,7 +161,11 @@ export type AngleAxisForRadar = {
   cy: number;
 };
 
-export type Props = Omit<SVGProps<SVGGraphicsElement>, 'onMouseEnter' | 'onMouseLeave' | 'points' | 'ref'> & RadarProps;
+export type Props<DataPointType = any, DataValueType = any> = Omit<
+  SVGProps<SVGGraphicsElement>,
+  'onMouseEnter' | 'onMouseLeave' | 'points' | 'ref'
+> &
+  RadarProps<DataPointType, DataValueType>;
 
 export type RadarComposedData = {
   points: RadarPoint[];
@@ -604,7 +608,7 @@ function RadarImpl(props: WithIdRequired<PropsWithDefaults>) {
  * @consumes PolarChartContext
  * @provides LabelListContext
  */
-export function Radar(outsideProps: Props) {
+export function Radar<DataPointType = any, DataValueType = any>(outsideProps: Props<DataPointType, DataValueType>) {
   const props: PropsWithDefaults = resolveDefaultProps(outsideProps, defaultRadarProps);
   return (
     <RegisterGraphicalItemId id={props.id} type="radar">

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -414,11 +414,11 @@ interface InternalRadialBarProps<DataPointType = any, DataValueType = any>
   zIndex?: number;
 }
 
-export type RadialBarProps = Omit<
+export type RadialBarProps<DataPointType = any, DataValueType = any> = Omit<
   PresentationAttributesAdaptChildEvent<RadialBarDataItem, SVGElement>,
-  'ref' | keyof InternalRadialBarProps
+  'ref' | keyof InternalRadialBarProps<DataPointType, DataValueType>
 > &
-  Omit<InternalRadialBarProps, 'sectors'>;
+  Omit<InternalRadialBarProps<DataPointType, DataValueType>, 'sectors'>;
 
 type InternalProps = WithIdRequired<PropsWithDefaults> & Pick<InternalRadialBarProps, 'sectors'>;
 
@@ -594,7 +594,10 @@ export const defaultRadialBarProps = {
   zIndex: DefaultZIndexes.bar,
 } as const satisfies Partial<RadialBarProps>;
 
-type PropsWithDefaults = RequiresDefaultProps<RadialBarProps, typeof defaultRadialBarProps>;
+type PropsWithDefaults<DataPointType = any, DataValueType = any> = RequiresDefaultProps<
+  RadialBarProps<DataPointType, DataValueType>,
+  typeof defaultRadialBarProps
+>;
 
 export function computeRadialBarDataItems({
   displayedData,
@@ -735,8 +738,13 @@ export function computeRadialBarDataItems({
  * @provides LabelListContext
  * @provides CellReader
  */
-export function RadialBar(outsideProps: RadialBarProps) {
-  const props: PropsWithDefaults = resolveDefaultProps(outsideProps, defaultRadialBarProps);
+export function RadialBar<DataPointType = any, DataValueType = any>(
+  outsideProps: RadialBarProps<DataPointType, DataValueType>,
+) {
+  const props: PropsWithDefaults<DataPointType, DataValueType> = resolveDefaultProps(
+    outsideProps,
+    defaultRadialBarProps,
+  );
   return (
     <RegisterGraphicalItemId id={props.id} type="radialBar">
       {id => (

--- a/test/cartesian/Funnel.typed.spec.tsx
+++ b/test/cartesian/Funnel.typed.spec.tsx
@@ -1,8 +1,154 @@
 import React from 'react';
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
 import { Funnel, FunnelChart, FunnelTrapezoidItem, getRelativeCoordinate } from '../../src';
 
-describe('Funnel types', () => {
+type ExampleDataPoint = {
+  value: number;
+  name: string;
+};
+
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+  { value: 60, name: 'c' },
+  { value: 40, name: 'd' },
+  { value: 20, name: 'e' },
+];
+
+describe('Funnel with strong typing', () => {
+  describe('with all implicit types', () => {
+    it('should render Funnel with correct data and correct dataKey', () => {
+      const { container } = rechartsTestRender(
+        <FunnelChart data={data} width={400} height={400}>
+          <Funnel dataKey="value" isAnimationActive={false} />
+        </FunnelChart>,
+      );
+      expect(container.getElementsByClassName('recharts-funnel-trapezoid')).toHaveLength(data.length);
+    });
+
+    it('should allow using incorrect type dataKey', () => {
+      rechartsTestRender(
+        <FunnelChart data={data} width={400} height={400}>
+          <Funnel dataKey="name" isAnimationActive={false} />
+        </FunnelChart>,
+      );
+    });
+
+    it('should allow using non-existent dataKey', () => {
+      rechartsTestRender(
+        <FunnelChart data={data} width={400} height={400}>
+          <Funnel dataKey="foo" isAnimationActive={false} />
+        </FunnelChart>,
+      );
+    });
+
+    it('should allow using dataKey function that returns wrong value', () => {
+      rechartsTestRender(
+        <FunnelChart data={data} width={400} height={400}>
+          <Funnel dataKey={entry => entry.name} isAnimationActive={false} />
+        </FunnelChart>,
+      );
+    });
+
+    it('should allow using dataKey function that accesses non-existent property', () => {
+      rechartsTestRender(
+        <FunnelChart data={data} width={400} height={400}>
+          <Funnel dataKey={entry => entry.foo} isAnimationActive={false} />
+        </FunnelChart>,
+      );
+    });
+
+    it('should allow when Funnel data is matching Funnel dataKey as string', () => {
+      const { container } = rechartsTestRender(
+        <FunnelChart width={400} height={400}>
+          <Funnel data={data} dataKey="value" isAnimationActive={false} />
+        </FunnelChart>,
+      );
+      expect(container.getElementsByClassName('recharts-funnel-trapezoid')).toHaveLength(data.length);
+    });
+
+    it('should allow when Funnel data is matching Funnel dataKey as function', () => {
+      const { container } = rechartsTestRender(
+        <FunnelChart width={400} height={400}>
+          <Funnel data={data} dataKey={entry => entry.value} isAnimationActive={false} />
+        </FunnelChart>,
+      );
+      expect(container.getElementsByClassName('recharts-funnel-trapezoid')).toHaveLength(data.length);
+    });
+
+    it('should allow when Funnel data is not matching Funnel dataKey', () => {
+      rechartsTestRender(
+        <FunnelChart width={400} height={400}>
+          <Funnel data={data} dataKey="foo" isAnimationActive={false} />
+          {/* @ts-expect-error TypeScript is correct here - the dataKey does not match and this should be an error */}
+          <Funnel data={data} dataKey={entry => entry.foo} isAnimationActive={false} />
+        </FunnelChart>,
+      );
+    });
+  });
+
+  describe('with explicit Funnel type parameters', () => {
+    it('should allow correct dataKey when I type the Funnel to my data type', () => {
+      const { container } = rechartsTestRender(
+        <FunnelChart data={data} width={400} height={400}>
+          <Funnel<ExampleDataPoint> dataKey="value" isAnimationActive={false} />
+        </FunnelChart>,
+      );
+      expect(container.getElementsByClassName('recharts-funnel-trapezoid')).toHaveLength(data.length);
+    });
+
+    it('should allow correct dataKey function when I inline type the dataKey function', () => {
+      rechartsTestRender(
+        <FunnelChart data={data} width={400} height={400}>
+          <Funnel<ExampleDataPoint> dataKey={(entry: ExampleDataPoint) => entry.value} isAnimationActive={false} />
+        </FunnelChart>,
+      );
+    });
+
+    it('should allow correct dataKey function when I type the dataKey function', () => {
+      const dataKey = (entry: ExampleDataPoint) => entry.value;
+      rechartsTestRender(
+        <FunnelChart data={data} width={400} height={400}>
+          <Funnel<ExampleDataPoint> dataKey={dataKey} isAnimationActive={false} />
+        </FunnelChart>,
+      );
+    });
+
+    it('should show error if I type the Funnel explicitly but use wrong dataKey', () => {
+      rechartsTestRender(
+        <FunnelChart data={data} width={400} height={400}>
+          {/* @ts-expect-error TypeScript is correct here - the dataKey does not match and this should be an error */}
+          <Funnel<ExampleDataPoint, number> dataKey="name" isAnimationActive={false} />
+        </FunnelChart>,
+      );
+    });
+
+    it('should show error when dataKey is inline typed to return wrong value', () => {
+      rechartsTestRender(
+        <FunnelChart data={data} width={400} height={400}>
+          <Funnel<ExampleDataPoint, number>
+            /* @ts-expect-error TypeScript is correct here - the dataKey return type does not match and this should be an error */
+            dataKey={(entry: ExampleDataPoint) => entry.name}
+            isAnimationActive={false}
+          />
+        </FunnelChart>,
+      );
+    });
+
+    it('should show error when dataKey is const typed to return wrong value', () => {
+      const dataKey = (entry: ExampleDataPoint) => entry.name;
+      rechartsTestRender(
+        <FunnelChart data={data} width={400} height={400}>
+          {/* @ts-expect-error TypeScript is correct here - the dataKey return type does not match and this should be an error */}
+          <Funnel<ExampleDataPoint, number> dataKey={dataKey} isAnimationActive={false} />
+        </FunnelChart>,
+      );
+    });
+  });
+});
+
+describe('Funnel event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <FunnelChart width={100} height={100}>

--- a/test/cartesian/Line.typed.spec.tsx
+++ b/test/cartesian/Line.typed.spec.tsx
@@ -1,8 +1,153 @@
 import React from 'react';
-import { describe, it } from 'vitest';
-import { Line, LineChart, getRelativeCoordinate, CurveProps } from '../../src';
+import { describe, expect, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { CurveProps, Line, LineChart, getRelativeCoordinate } from '../../src';
 
-describe('Line types', () => {
+type ExampleDataPoint = {
+  x: number;
+  y: number;
+  value: number;
+  name: string;
+};
+
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { x: 10, y: 50, value: 100, name: 'a' },
+  { x: 50, y: 50, value: 100, name: 'b' },
+  { x: 90, y: 50, value: 100, name: 'c' },
+  { x: 130, y: 50, value: 100, name: 'd' },
+  { x: 170, y: 50, value: 100, name: 'e' },
+];
+
+describe('Line with strong typing', () => {
+  describe('with all implicit types', () => {
+    it('should render Line with correct data and correct dataKey', () => {
+      const { container } = rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey="value" isAnimationActive={false} />
+        </LineChart>,
+      );
+      expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
+    });
+
+    it('should allow using incorrect type dataKey', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey="name" isAnimationActive={false} />
+        </LineChart>,
+      );
+    });
+
+    it('should allow using non-existent dataKey', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey="foo" isAnimationActive={false} />
+        </LineChart>,
+      );
+    });
+
+    it('should allow using dataKey function that returns wrong value', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey={entry => entry.name} isAnimationActive={false} />
+        </LineChart>,
+      );
+    });
+
+    it('should allow using dataKey function that accesses non-existent property', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey={entry => entry.foo} isAnimationActive={false} />
+        </LineChart>,
+      );
+    });
+
+    it('should allow when Line data is matching Line dataKey as string', () => {
+      const { container } = rechartsTestRender(
+        <LineChart width={400} height={400}>
+          <Line data={data} dataKey="value" isAnimationActive={false} />
+        </LineChart>,
+      );
+      expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
+    });
+
+    it('should allow when Line data is matching Line dataKey as function', () => {
+      const { container } = rechartsTestRender(
+        <LineChart width={400} height={400}>
+          <Line data={data} dataKey={entry => entry.value} isAnimationActive={false} />
+        </LineChart>,
+      );
+      expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
+    });
+
+    it('should allow when Line data is not matching Line dataKey', () => {
+      rechartsTestRender(
+        <LineChart width={400} height={400}>
+          <Line data={data} dataKey="foo" isAnimationActive={false} />
+          {/* @ts-expect-error TypeScript is correct here - the dataKey does not match and this should be an error */}
+          <Line data={data} dataKey={entry => entry.foo} isAnimationActive={false} />
+        </LineChart>,
+      );
+    });
+  });
+
+  describe('with explicit Line type parameters', () => {
+    it('should allow correct dataKey when I type the Line to my data type', () => {
+      const { container } = rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line<ExampleDataPoint> dataKey="value" isAnimationActive={false} />
+        </LineChart>,
+      );
+      expect(container.querySelectorAll('.recharts-line-curve')).toHaveLength(1);
+    });
+
+    it('should allow correct dataKey function when I inline type the dataKey function', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line<ExampleDataPoint> dataKey={(entry: ExampleDataPoint) => entry.value} isAnimationActive={false} />
+        </LineChart>,
+      );
+    });
+
+    it('should allow correct dataKey function when I type the dataKey function', () => {
+      const dataKey = (entry: ExampleDataPoint) => entry.value;
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line<ExampleDataPoint> dataKey={dataKey} isAnimationActive={false} />
+        </LineChart>,
+      );
+    });
+
+    it('should show error if I type the Line explicitly but use wrong dataKey', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          {/* @ts-expect-error TypeScript is correct here - the dataKey does not match and this should be an error */}
+          <Line<ExampleDataPoint, number> dataKey="name" isAnimationActive={false} />
+        </LineChart>,
+      );
+    });
+
+    it('should show error when dataKey is inline typed to return wrong value', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          {/* @ts-expect-error TypeScript is correct here - the dataKey return type does not match and this should be an error */}
+          <Line<ExampleDataPoint, number> dataKey={(entry: ExampleDataPoint) => entry.name} isAnimationActive={false} />
+        </LineChart>,
+      );
+    });
+
+    it('should show error when dataKey is const typed to return wrong value', () => {
+      const dataKey = (entry: ExampleDataPoint) => entry.name;
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          {/* @ts-expect-error TypeScript is correct here - the dataKey return type does not match and this should be an error */}
+          <Line<ExampleDataPoint, number> dataKey={dataKey} isAnimationActive={false} />
+        </LineChart>,
+      );
+    });
+  });
+});
+
+describe('Line event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <LineChart width={100} height={100}>

--- a/test/cartesian/ReferenceArea.typed.spec.tsx
+++ b/test/cartesian/ReferenceArea.typed.spec.tsx
@@ -1,45 +1,67 @@
 import React from 'react';
-import { describe, it } from 'vitest';
-import { ReferenceArea, LineChart, getRelativeCoordinate } from '../../src';
+import { describe, expect, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { Line, LineChart, ReferenceArea, getRelativeCoordinate } from '../../src';
 
-describe('ReferenceArea types', () => {
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('ReferenceArea with strong typing', () => {
+  describe('with all implicit types', () => {
+    it('should render ReferenceArea with implicit coordinate types', () => {
+      const { container } = rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey="value" />
+          <ReferenceArea x1={0} x2={1} y1={80} y2={120} />
+        </LineChart>,
+      );
+      expect(container).toBeDefined();
+    });
+  });
+
+  describe('with explicit ReferenceArea type parameters', () => {
+    it('should allow matching explicit coordinate types', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey="value" />
+          <ReferenceArea<number, number> x1={0} x2={1} y1={80} y2={120} />
+        </LineChart>,
+      );
+    });
+
+    it('should show errors when explicit coordinate types do not match', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey="value" />
+          {/* @ts-expect-error TypeScript is correct here - x values should be numbers */}
+          <ReferenceArea<number, number> x1="a" x2={1} y1={80} y2={120} />
+          {/* @ts-expect-error TypeScript is correct here - y values should be numbers */}
+          <ReferenceArea<number, number> x1={0} x2={1} y1="a" y2={120} />
+        </LineChart>,
+      );
+    });
+  });
+});
+
+describe('ReferenceArea event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <LineChart width={100} height={100}>
         <ReferenceArea
-          onClick={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseDown={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseUp={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseMove={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseLeave={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOver={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOut={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseEnter={e => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchStart={e => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchMove={e => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchEnd={e => {
-            getRelativeCoordinate(e);
-          }}
+          onClick={e => getRelativeCoordinate(e)}
+          onMouseDown={e => getRelativeCoordinate(e)}
+          onMouseUp={e => getRelativeCoordinate(e)}
+          onMouseMove={e => getRelativeCoordinate(e)}
+          onMouseLeave={e => getRelativeCoordinate(e)}
+          onMouseOver={e => getRelativeCoordinate(e)}
+          onMouseOut={e => getRelativeCoordinate(e)}
+          onMouseEnter={e => getRelativeCoordinate(e)}
+          onTouchStart={e => getRelativeCoordinate(e)}
+          onTouchMove={e => getRelativeCoordinate(e)}
+          onTouchEnd={e => getRelativeCoordinate(e)}
         />
       </LineChart>
     );

--- a/test/cartesian/ReferenceDot.typed.spec.tsx
+++ b/test/cartesian/ReferenceDot.typed.spec.tsx
@@ -1,47 +1,69 @@
 import React from 'react';
-import { describe, it } from 'vitest';
-import { ReferenceDot, LineChart, getRelativeCoordinate, DotProps } from '../../src';
+import { describe, expect, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { DotProps, Line, LineChart, ReferenceDot, getRelativeCoordinate } from '../../src';
 
-describe('ReferenceDot types', () => {
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('ReferenceDot with strong typing', () => {
+  describe('with all implicit types', () => {
+    it('should render ReferenceDot with implicit coordinate types', () => {
+      const { container } = rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey="value" />
+          <ReferenceDot x={0} y={100} />
+        </LineChart>,
+      );
+      expect(container.querySelectorAll('.recharts-reference-dot-dot')).toHaveLength(1);
+    });
+  });
+
+  describe('with explicit ReferenceDot type parameters', () => {
+    it('should allow matching explicit coordinate types', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey="value" />
+          <ReferenceDot<number, number> x={0} y={100} />
+        </LineChart>,
+      );
+    });
+
+    it('should show errors when explicit coordinate types do not match', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey="value" />
+          {/* @ts-expect-error TypeScript is correct here - x should be number */}
+          <ReferenceDot<number, number> x="a" y={100} />
+          {/* @ts-expect-error TypeScript is correct here - y should be number */}
+          <ReferenceDot<number, number> x={0} y="a" />
+        </LineChart>,
+      );
+    });
+  });
+});
+
+describe('ReferenceDot event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <LineChart width={100} height={100}>
         <ReferenceDot
           x={10}
           y={10}
-          onClick={(_dotProps: DotProps, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseDown={(_dotProps: DotProps, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseUp={(_dotProps: DotProps, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseMove={(_dotProps: DotProps, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseLeave={(_dotProps: DotProps, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOver={(_dotProps: DotProps, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOut={(_dotProps: DotProps, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseEnter={(_dotProps: DotProps, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchStart={(_dotProps: DotProps, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchMove={(_dotProps: DotProps, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchEnd={(_dotProps: DotProps, e) => {
-            getRelativeCoordinate(e);
-          }}
+          onClick={(_dotProps: DotProps, e) => getRelativeCoordinate(e)}
+          onMouseDown={(_dotProps: DotProps, e) => getRelativeCoordinate(e)}
+          onMouseUp={(_dotProps: DotProps, e) => getRelativeCoordinate(e)}
+          onMouseMove={(_dotProps: DotProps, e) => getRelativeCoordinate(e)}
+          onMouseLeave={(_dotProps: DotProps, e) => getRelativeCoordinate(e)}
+          onMouseOver={(_dotProps: DotProps, e) => getRelativeCoordinate(e)}
+          onMouseOut={(_dotProps: DotProps, e) => getRelativeCoordinate(e)}
+          onMouseEnter={(_dotProps: DotProps, e) => getRelativeCoordinate(e)}
+          onTouchStart={(_dotProps: DotProps, e) => getRelativeCoordinate(e)}
+          onTouchMove={(_dotProps: DotProps, e) => getRelativeCoordinate(e)}
+          onTouchEnd={(_dotProps: DotProps, e) => getRelativeCoordinate(e)}
         />
       </LineChart>
     );

--- a/test/cartesian/ReferenceLine/ReferenceLine.typed.spec.tsx
+++ b/test/cartesian/ReferenceLine/ReferenceLine.typed.spec.tsx
@@ -1,45 +1,67 @@
 import React from 'react';
-import { describe, it } from 'vitest';
-import { ReferenceLine, LineChart, getRelativeCoordinate } from '../../../src';
+import { describe, expect, it } from 'vitest';
+import { rechartsTestRender } from '../../helper/createSelectorTestCase';
+import { Line, LineChart, ReferenceLine, getRelativeCoordinate } from '../../../src';
 
-describe('ReferenceLine types', () => {
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('ReferenceLine with strong typing', () => {
+  describe('with all implicit types', () => {
+    it('should render ReferenceLine with implicit coordinate types', () => {
+      const { container } = rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey="value" />
+          <ReferenceLine x={0} y={100} />
+        </LineChart>,
+      );
+      expect(container.querySelectorAll('.recharts-reference-line-line')).toHaveLength(1);
+    });
+  });
+
+  describe('with explicit ReferenceLine type parameters', () => {
+    it('should allow matching explicit coordinate types', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey="value" />
+          <ReferenceLine<number, number> x={0} y={100} />
+        </LineChart>,
+      );
+    });
+
+    it('should show errors when explicit coordinate types do not match', () => {
+      rechartsTestRender(
+        <LineChart data={data} width={400} height={400}>
+          <Line dataKey="value" />
+          {/* @ts-expect-error TypeScript is correct here - x should be number */}
+          <ReferenceLine<number, number> x="a" y={100} />
+          {/* @ts-expect-error TypeScript is correct here - y should be number */}
+          <ReferenceLine<number, number> x={0} y="a" />
+        </LineChart>,
+      );
+    });
+  });
+});
+
+describe('ReferenceLine event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <LineChart width={100} height={100}>
         <ReferenceLine
-          onClick={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseDown={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseUp={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseMove={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseLeave={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOver={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOut={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseEnter={e => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchStart={e => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchMove={e => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchEnd={e => {
-            getRelativeCoordinate(e);
-          }}
+          onClick={e => getRelativeCoordinate(e)}
+          onMouseDown={e => getRelativeCoordinate(e)}
+          onMouseUp={e => getRelativeCoordinate(e)}
+          onMouseMove={e => getRelativeCoordinate(e)}
+          onMouseLeave={e => getRelativeCoordinate(e)}
+          onMouseOver={e => getRelativeCoordinate(e)}
+          onMouseOut={e => getRelativeCoordinate(e)}
+          onMouseEnter={e => getRelativeCoordinate(e)}
+          onTouchStart={e => getRelativeCoordinate(e)}
+          onTouchMove={e => getRelativeCoordinate(e)}
+          onTouchEnd={e => getRelativeCoordinate(e)}
         />
       </LineChart>
     );

--- a/test/cartesian/Scatter.typed.spec.tsx
+++ b/test/cartesian/Scatter.typed.spec.tsx
@@ -1,8 +1,156 @@
 import React from 'react';
-import { describe, it } from 'vitest';
-import { Scatter, ScatterChart, getRelativeCoordinate, ScatterPointItem } from '../../src';
+import { describe, expect, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { Scatter, ScatterChart, ScatterPointItem, getRelativeCoordinate } from '../../src';
 
-describe('Scatter types', () => {
+type ExampleDataPoint = {
+  x: number;
+  y: number;
+  value: number;
+  name: string;
+};
+
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { x: 10, y: 50, value: 100, name: 'a' },
+  { x: 50, y: 50, value: 100, name: 'b' },
+  { x: 90, y: 50, value: 100, name: 'c' },
+  { x: 130, y: 50, value: 100, name: 'd' },
+  { x: 170, y: 50, value: 100, name: 'e' },
+];
+
+describe('Scatter with strong typing', () => {
+  describe('with all implicit types', () => {
+    it('should render Scatter with correct data and correct dataKey', () => {
+      const { container } = rechartsTestRender(
+        <ScatterChart data={data} width={400} height={400}>
+          <Scatter dataKey="value" isAnimationActive={false} />
+        </ScatterChart>,
+      );
+      expect(container.querySelectorAll('.recharts-scatter-symbol')).toHaveLength(data.length);
+    });
+
+    it('should allow using incorrect type dataKey', () => {
+      rechartsTestRender(
+        <ScatterChart data={data} width={400} height={400}>
+          <Scatter dataKey="name" isAnimationActive={false} />
+        </ScatterChart>,
+      );
+    });
+
+    it('should allow using non-existent dataKey', () => {
+      rechartsTestRender(
+        <ScatterChart data={data} width={400} height={400}>
+          <Scatter dataKey="foo" isAnimationActive={false} />
+        </ScatterChart>,
+      );
+    });
+
+    it('should allow using dataKey function that returns wrong value', () => {
+      rechartsTestRender(
+        <ScatterChart data={data} width={400} height={400}>
+          <Scatter dataKey={entry => entry.name} isAnimationActive={false} />
+        </ScatterChart>,
+      );
+    });
+
+    it('should allow using dataKey function that accesses non-existent property', () => {
+      rechartsTestRender(
+        <ScatterChart data={data} width={400} height={400}>
+          <Scatter dataKey={entry => entry.foo} isAnimationActive={false} />
+        </ScatterChart>,
+      );
+    });
+
+    it('should allow when Scatter data is matching Scatter dataKey as string', () => {
+      const { container } = rechartsTestRender(
+        <ScatterChart width={400} height={400}>
+          <Scatter data={data} dataKey="value" isAnimationActive={false} />
+        </ScatterChart>,
+      );
+      expect(container.querySelectorAll('.recharts-scatter-symbol')).toHaveLength(data.length);
+    });
+
+    it('should allow when Scatter data is matching Scatter dataKey as function', () => {
+      const { container } = rechartsTestRender(
+        <ScatterChart width={400} height={400}>
+          <Scatter data={data} dataKey={entry => entry.value} isAnimationActive={false} />
+        </ScatterChart>,
+      );
+      expect(container.querySelectorAll('.recharts-scatter-symbol')).toHaveLength(data.length);
+    });
+
+    it('should allow when Scatter data is not matching Scatter dataKey', () => {
+      rechartsTestRender(
+        <ScatterChart width={400} height={400}>
+          <Scatter data={data} dataKey="foo" isAnimationActive={false} />
+          {/* @ts-expect-error TypeScript is correct here - the dataKey does not match and this should be an error */}
+          <Scatter data={data} dataKey={entry => entry.foo} isAnimationActive={false} />
+        </ScatterChart>,
+      );
+    });
+  });
+
+  describe('with explicit Scatter type parameters', () => {
+    it('should allow correct dataKey when I type the Scatter to my data type', () => {
+      const { container } = rechartsTestRender(
+        <ScatterChart data={data} width={400} height={400}>
+          <Scatter<ExampleDataPoint> dataKey="value" isAnimationActive={false} />
+        </ScatterChart>,
+      );
+      expect(container.querySelectorAll('.recharts-scatter-symbol')).toHaveLength(data.length);
+    });
+
+    it('should allow correct dataKey function when I inline type the dataKey function', () => {
+      rechartsTestRender(
+        <ScatterChart data={data} width={400} height={400}>
+          <Scatter<ExampleDataPoint> dataKey={(entry: ExampleDataPoint) => entry.value} isAnimationActive={false} />
+        </ScatterChart>,
+      );
+    });
+
+    it('should allow correct dataKey function when I type the dataKey function', () => {
+      const dataKey = (entry: ExampleDataPoint) => entry.value;
+      rechartsTestRender(
+        <ScatterChart data={data} width={400} height={400}>
+          <Scatter<ExampleDataPoint> dataKey={dataKey} isAnimationActive={false} />
+        </ScatterChart>,
+      );
+    });
+
+    it('should show error if I type the Scatter explicitly but use wrong dataKey', () => {
+      rechartsTestRender(
+        <ScatterChart data={data} width={400} height={400}>
+          {/* @ts-expect-error TypeScript is correct here - the dataKey does not match and this should be an error */}
+          <Scatter<ExampleDataPoint, number> dataKey="name" isAnimationActive={false} />
+        </ScatterChart>,
+      );
+    });
+
+    it('should show error when dataKey is inline typed to return wrong value', () => {
+      rechartsTestRender(
+        <ScatterChart data={data} width={400} height={400}>
+          <Scatter<ExampleDataPoint, number>
+            /* @ts-expect-error TypeScript is correct here - the dataKey return type does not match and this should be an error */
+            dataKey={(entry: ExampleDataPoint) => entry.name}
+            isAnimationActive={false}
+          />
+        </ScatterChart>,
+      );
+    });
+
+    it('should show error when dataKey is const typed to return wrong value', () => {
+      const dataKey = (entry: ExampleDataPoint) => entry.name;
+      rechartsTestRender(
+        <ScatterChart data={data} width={400} height={400}>
+          {/* @ts-expect-error TypeScript is correct here - the dataKey return type does not match and this should be an error */}
+          <Scatter<ExampleDataPoint, number> dataKey={dataKey} isAnimationActive={false} />
+        </ScatterChart>,
+      );
+    });
+  });
+});
+
+describe('Scatter event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <ScatterChart width={100} height={100}>

--- a/test/cartesian/XAxis/XAxis.typed.spec.tsx
+++ b/test/cartesian/XAxis/XAxis.typed.spec.tsx
@@ -1,45 +1,53 @@
 import React from 'react';
 import { describe, it } from 'vitest';
-import { getRelativeCoordinate, LineChart, TickItem, XAxis } from '../../../src';
+import { rechartsTestRender } from '../../helper/createSelectorTestCase';
+import { Line, LineChart, TickItem, XAxis, getRelativeCoordinate } from '../../../src';
 
-describe('XAxis types', () => {
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('XAxis with strong typing', () => {
+  it('should allow implicit dataKey typing', () => {
+    rechartsTestRender(
+      <LineChart data={data} width={400} height={400}>
+        <XAxis dataKey="name" />
+        <Line dataKey="value" />
+      </LineChart>,
+    );
+  });
+
+  it('should allow explicit dataKey typing and reject invalid values', () => {
+    rechartsTestRender(
+      <LineChart data={data} width={400} height={400}>
+        <XAxis<ExampleDataPoint, number> dataKey="value" />
+        <XAxis<ExampleDataPoint, number> dataKey={(entry: ExampleDataPoint) => entry.value} />
+        {/* @ts-expect-error TypeScript is correct here - name is not number-valued */}
+        <XAxis<ExampleDataPoint, number> dataKey="name" />
+        <Line dataKey="value" />
+      </LineChart>,
+    );
+  });
+});
+
+describe('XAxis event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <LineChart width={100} height={100}>
         <XAxis
-          onClick={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseDown={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseUp={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseMove={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseLeave={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOver={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOut={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseEnter={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchStart={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchMove={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchEnd={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
+          onClick={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseDown={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseUp={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseMove={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseLeave={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseOver={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseOut={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseEnter={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onTouchStart={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onTouchMove={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onTouchEnd={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
         />
       </LineChart>
     );

--- a/test/cartesian/YAxis/YAxis.typed.spec.tsx
+++ b/test/cartesian/YAxis/YAxis.typed.spec.tsx
@@ -1,45 +1,53 @@
 import React from 'react';
 import { describe, it } from 'vitest';
-import { getRelativeCoordinate, LineChart, TickItem, YAxis } from '../../../src';
+import { rechartsTestRender } from '../../helper/createSelectorTestCase';
+import { Line, LineChart, TickItem, YAxis, getRelativeCoordinate } from '../../../src';
 
-describe('YAxis types', () => {
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('YAxis with strong typing', () => {
+  it('should allow implicit dataKey typing', () => {
+    rechartsTestRender(
+      <LineChart data={data} width={400} height={400}>
+        <YAxis dataKey="value" />
+        <Line dataKey="value" />
+      </LineChart>,
+    );
+  });
+
+  it('should allow explicit dataKey typing and reject invalid values', () => {
+    rechartsTestRender(
+      <LineChart data={data} width={400} height={400}>
+        <YAxis<ExampleDataPoint, number> dataKey="value" />
+        <YAxis<ExampleDataPoint, number> dataKey={(entry: ExampleDataPoint) => entry.value} />
+        {/* @ts-expect-error TypeScript is correct here - name is not number-valued */}
+        <YAxis<ExampleDataPoint, number> dataKey="name" />
+        <Line dataKey="value" />
+      </LineChart>,
+    );
+  });
+});
+
+describe('YAxis event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <LineChart width={100} height={100}>
         <YAxis
-          onClick={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseDown={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseUp={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseMove={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseLeave={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOver={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOut={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseEnter={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchStart={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchMove={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchEnd={(_tick: TickItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
+          onClick={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseDown={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseUp={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseMove={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseLeave={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseOver={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseOut={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseEnter={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onTouchStart={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onTouchMove={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
+          onTouchEnd={(_tick: TickItem, _i: number, e) => getRelativeCoordinate(e)}
         />
       </LineChart>
     );

--- a/test/cartesian/ZAxis.typed.spec.tsx
+++ b/test/cartesian/ZAxis.typed.spec.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { describe, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { Scatter, ScatterChart, ZAxis } from '../../src';
+
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('ZAxis with strong typing', () => {
+  it('should allow implicit dataKey typing', () => {
+    rechartsTestRender(
+      <ScatterChart data={data} width={400} height={400}>
+        <ZAxis dataKey="foo" />
+        <Scatter dataKey="value" isAnimationActive={false} />
+      </ScatterChart>,
+    );
+  });
+
+  it('should allow explicit dataKey typing and reject invalid values', () => {
+    rechartsTestRender(
+      <ScatterChart data={data} width={400} height={400}>
+        <ZAxis<ExampleDataPoint, number> dataKey="value" />
+        {/* @ts-expect-error TypeScript is correct here - name is not number-valued */}
+        <ZAxis<ExampleDataPoint, number> dataKey="name" />
+        <Scatter dataKey="value" isAnimationActive={false} />
+      </ScatterChart>,
+    );
+  });
+});

--- a/test/chart/AreaChart.typed.spec.tsx
+++ b/test/chart/AreaChart.typed.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { AreaChart, Area } from '../../src';
+
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('AreaChart with strong typing', () => {
+  it('should allow implicit chart typing', () => {
+    rechartsTestRender(
+      <AreaChart data={data} width={400} height={400}>
+        <Area dataKey="value" isAnimationActive={false} />
+      </AreaChart>,
+    );
+  });
+
+  it('should allow explicit chart typing', () => {
+    rechartsTestRender(
+      <AreaChart<ExampleDataPoint> data={data} width={400} height={400}>
+        <Area dataKey="value" isAnimationActive={false} />
+      </AreaChart>,
+    );
+  });
+
+  it('should show error when chart data shape does not match explicit generic type', () => {
+    const invalidChart = (
+      // @ts-expect-error TypeScript is correct here - chart data does not match explicit generic type
+      <AreaChart<ExampleDataPoint> data={{ wrong: 1 }} width={400} height={400}>
+        <Area dataKey="value" isAnimationActive={false} />
+      </AreaChart>
+    );
+    expect(invalidChart).toBeDefined();
+  });
+});

--- a/test/chart/BarChart.typed.spec.tsx
+++ b/test/chart/BarChart.typed.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { BarChart, Bar } from '../../src';
+
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('BarChart with strong typing', () => {
+  it('should allow implicit chart typing', () => {
+    rechartsTestRender(
+      <BarChart data={data} width={400} height={400}>
+        <Bar dataKey="value" isAnimationActive={false} />
+      </BarChart>,
+    );
+  });
+
+  it('should allow explicit chart typing', () => {
+    rechartsTestRender(
+      <BarChart<ExampleDataPoint> data={data} width={400} height={400}>
+        <Bar dataKey="value" isAnimationActive={false} />
+      </BarChart>,
+    );
+  });
+
+  it('should show error when chart data shape does not match explicit generic type', () => {
+    const invalidChart = (
+      // @ts-expect-error TypeScript is correct here - chart data does not match explicit generic type
+      <BarChart<ExampleDataPoint> data={{ wrong: 1 }} width={400} height={400}>
+        <Bar dataKey="value" isAnimationActive={false} />
+      </BarChart>
+    );
+    expect(invalidChart).toBeDefined();
+  });
+});

--- a/test/chart/ComposedChart.typed.spec.tsx
+++ b/test/chart/ComposedChart.typed.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { ComposedChart, Line } from '../../src';
+
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('ComposedChart with strong typing', () => {
+  it('should allow implicit chart typing', () => {
+    rechartsTestRender(
+      <ComposedChart data={data} width={400} height={400}>
+        <Line dataKey="value" isAnimationActive={false} />
+      </ComposedChart>,
+    );
+  });
+
+  it('should allow explicit chart typing', () => {
+    rechartsTestRender(
+      <ComposedChart<ExampleDataPoint> data={data} width={400} height={400}>
+        <Line dataKey="value" isAnimationActive={false} />
+      </ComposedChart>,
+    );
+  });
+
+  it('should show error when chart data shape does not match explicit generic type', () => {
+    const invalidChart = (
+      // @ts-expect-error TypeScript is correct here - chart data does not match explicit generic type
+      <ComposedChart<ExampleDataPoint> data={{ wrong: 1 }} width={400} height={400}>
+        <Line dataKey="value" isAnimationActive={false} />
+      </ComposedChart>
+    );
+    expect(invalidChart).toBeDefined();
+  });
+});

--- a/test/chart/FunnelChart.typed.spec.tsx
+++ b/test/chart/FunnelChart.typed.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { FunnelChart, Funnel } from '../../src';
+
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('FunnelChart with strong typing', () => {
+  it('should allow implicit chart typing', () => {
+    rechartsTestRender(
+      <FunnelChart data={data} width={400} height={400}>
+        <Funnel dataKey="value" isAnimationActive={false} />
+      </FunnelChart>,
+    );
+  });
+
+  it('should allow explicit chart typing', () => {
+    rechartsTestRender(
+      <FunnelChart<ExampleDataPoint> data={data} width={400} height={400}>
+        <Funnel dataKey="value" isAnimationActive={false} />
+      </FunnelChart>,
+    );
+  });
+
+  it('should show error when chart data shape does not match explicit generic type', () => {
+    const invalidChart = (
+      // @ts-expect-error TypeScript is correct here - chart data does not match explicit generic type
+      <FunnelChart<ExampleDataPoint> data={{ wrong: 1 }} width={400} height={400}>
+        <Funnel dataKey="value" isAnimationActive={false} />
+      </FunnelChart>
+    );
+    expect(invalidChart).toBeDefined();
+  });
+});

--- a/test/chart/LineChart.typed.spec.tsx
+++ b/test/chart/LineChart.typed.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { LineChart, Line } from '../../src';
+
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('LineChart with strong typing', () => {
+  it('should allow implicit chart typing', () => {
+    rechartsTestRender(
+      <LineChart data={data} width={400} height={400}>
+        <Line dataKey="value" isAnimationActive={false} />
+      </LineChart>,
+    );
+  });
+
+  it('should allow explicit chart typing', () => {
+    rechartsTestRender(
+      <LineChart<ExampleDataPoint> data={data} width={400} height={400}>
+        <Line dataKey="value" isAnimationActive={false} />
+      </LineChart>,
+    );
+  });
+
+  it('should show error when chart data shape does not match explicit generic type', () => {
+    const invalidChart = (
+      // @ts-expect-error TypeScript is correct here - chart data does not match explicit generic type
+      <LineChart<ExampleDataPoint> data={{ wrong: 1 }} width={400} height={400}>
+        <Line dataKey="value" isAnimationActive={false} />
+      </LineChart>
+    );
+    expect(invalidChart).toBeDefined();
+  });
+});

--- a/test/chart/PieChart.typed.spec.tsx
+++ b/test/chart/PieChart.typed.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { PieChart, Pie } from '../../src';
+
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('PieChart with strong typing', () => {
+  it('should allow implicit chart typing', () => {
+    rechartsTestRender(
+      <PieChart data={data} width={400} height={400}>
+        <Pie data={data} dataKey="value" isAnimationActive={false} />
+      </PieChart>,
+    );
+  });
+
+  it('should allow explicit chart typing', () => {
+    rechartsTestRender(
+      <PieChart<ExampleDataPoint> data={data} width={400} height={400}>
+        <Pie data={data} dataKey="value" isAnimationActive={false} />
+      </PieChart>,
+    );
+  });
+
+  it('should show error when chart data shape does not match explicit generic type', () => {
+    const invalidChart = (
+      // @ts-expect-error TypeScript is correct here - chart data does not match explicit generic type
+      <PieChart<ExampleDataPoint> data={{ wrong: 1 }} width={400} height={400}>
+        <Pie data={data} dataKey="value" isAnimationActive={false} />
+      </PieChart>
+    );
+    expect(invalidChart).toBeDefined();
+  });
+});

--- a/test/chart/RadarChart.typed.spec.tsx
+++ b/test/chart/RadarChart.typed.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { RadarChart, Radar } from '../../src';
+
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('RadarChart with strong typing', () => {
+  it('should allow implicit chart typing', () => {
+    rechartsTestRender(
+      <RadarChart data={data} width={400} height={400}>
+        <Radar dataKey="value" isAnimationActive={false} />
+      </RadarChart>,
+    );
+  });
+
+  it('should allow explicit chart typing', () => {
+    rechartsTestRender(
+      <RadarChart<ExampleDataPoint> data={data} width={400} height={400}>
+        <Radar dataKey="value" isAnimationActive={false} />
+      </RadarChart>,
+    );
+  });
+
+  it('should show error when chart data shape does not match explicit generic type', () => {
+    const invalidChart = (
+      // @ts-expect-error TypeScript is correct here - chart data does not match explicit generic type
+      <RadarChart<ExampleDataPoint> data={{ wrong: 1 }} width={400} height={400}>
+        <Radar dataKey="value" isAnimationActive={false} />
+      </RadarChart>
+    );
+    expect(invalidChart).toBeDefined();
+  });
+});

--- a/test/chart/RadialBarChart.typed.spec.tsx
+++ b/test/chart/RadialBarChart.typed.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { RadialBarChart, RadialBar } from '../../src';
+
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('RadialBarChart with strong typing', () => {
+  it('should allow implicit chart typing', () => {
+    rechartsTestRender(
+      <RadialBarChart data={data} width={400} height={400}>
+        <RadialBar dataKey="value" isAnimationActive={false} />
+      </RadialBarChart>,
+    );
+  });
+
+  it('should allow explicit chart typing', () => {
+    rechartsTestRender(
+      <RadialBarChart<ExampleDataPoint> data={data} width={400} height={400}>
+        <RadialBar dataKey="value" isAnimationActive={false} />
+      </RadialBarChart>,
+    );
+  });
+
+  it('should show error when chart data shape does not match explicit generic type', () => {
+    const invalidChart = (
+      // @ts-expect-error TypeScript is correct here - chart data does not match explicit generic type
+      <RadialBarChart<ExampleDataPoint> data={{ wrong: 1 }} width={400} height={400}>
+        <RadialBar dataKey="value" isAnimationActive={false} />
+      </RadialBarChart>
+    );
+    expect(invalidChart).toBeDefined();
+  });
+});

--- a/test/chart/ScatterChart.typed.spec.tsx
+++ b/test/chart/ScatterChart.typed.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { ScatterChart, Scatter } from '../../src';
+
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('ScatterChart with strong typing', () => {
+  it('should allow implicit chart typing', () => {
+    rechartsTestRender(
+      <ScatterChart data={data} width={400} height={400}>
+        <Scatter dataKey="value" isAnimationActive={false} />
+      </ScatterChart>,
+    );
+  });
+
+  it('should allow explicit chart typing', () => {
+    rechartsTestRender(
+      <ScatterChart<ExampleDataPoint> data={data} width={400} height={400}>
+        <Scatter dataKey="value" isAnimationActive={false} />
+      </ScatterChart>,
+    );
+  });
+
+  it('should show error when chart data shape does not match explicit generic type', () => {
+    const invalidChart = (
+      // @ts-expect-error TypeScript is correct here - chart data does not match explicit generic type
+      <ScatterChart<ExampleDataPoint> data={{ wrong: 1 }} width={400} height={400}>
+        <Scatter dataKey="value" isAnimationActive={false} />
+      </ScatterChart>
+    );
+    expect(invalidChart).toBeDefined();
+  });
+});

--- a/test/polar/Pie/Pie.typed.spec.tsx
+++ b/test/polar/Pie/Pie.typed.spec.tsx
@@ -1,45 +1,89 @@
 import React from 'react';
-import { describe, it } from 'vitest';
-import { getRelativeCoordinate, Pie, PieChart, PieSectorDataItem } from '../../../src';
+import { describe, expect, it } from 'vitest';
+import { rechartsTestRender } from '../../helper/createSelectorTestCase';
+import { Pie, PieChart, PieSectorDataItem, getRelativeCoordinate } from '../../../src';
 
-describe('Pie types', () => {
+type ExampleDataPoint = {
+  value: number;
+  name: string;
+};
+
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+  { value: 60, name: 'c' },
+  { value: 40, name: 'd' },
+  { value: 20, name: 'e' },
+];
+
+describe('Pie with strong typing', () => {
+  describe('with all implicit types', () => {
+    it('should render Pie with correct data and correct dataKey', () => {
+      const { container } = rechartsTestRender(
+        <PieChart width={400} height={400}>
+          <Pie data={data} dataKey="value" isAnimationActive={false} />
+        </PieChart>,
+      );
+      expect(container.querySelectorAll('.recharts-sector')).toHaveLength(data.length);
+    });
+
+    it('should allow incorrect or non-existent dataKeys in implicit mode', () => {
+      rechartsTestRender(
+        <PieChart width={400} height={400}>
+          <Pie data={data} dataKey="name" isAnimationActive={false} />
+          <Pie data={data} dataKey="foo" isAnimationActive={false} />
+        </PieChart>,
+      );
+    });
+  });
+
+  describe('with explicit Pie type parameters', () => {
+    it('should allow correct dataKey when typed explicitly', () => {
+      rechartsTestRender(
+        <PieChart width={400} height={400}>
+          <Pie<ExampleDataPoint> data={data} dataKey="value" isAnimationActive={false} />
+          <Pie<ExampleDataPoint>
+            data={data}
+            dataKey={(entry: ExampleDataPoint) => entry.value}
+            isAnimationActive={false}
+          />
+        </PieChart>,
+      );
+    });
+
+    it('should show errors when dataKey does not match explicit typing', () => {
+      rechartsTestRender(
+        <PieChart width={400} height={400}>
+          {/* @ts-expect-error TypeScript is correct here - the dataKey does not match and this should be an error */}
+          <Pie<ExampleDataPoint, number> data={data} dataKey="name" isAnimationActive={false} />
+          <Pie<ExampleDataPoint, number>
+            data={data}
+            /* @ts-expect-error TypeScript is correct here - the dataKey return type does not match and this should be an error */
+            dataKey={(entry: ExampleDataPoint) => entry.name}
+            isAnimationActive={false}
+          />
+        </PieChart>,
+      );
+    });
+  });
+});
+
+describe('Pie event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <PieChart>
         <Pie
-          onClick={(_data: PieSectorDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseDown={(_data: PieSectorDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseUp={(_data: PieSectorDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseMove={(_data: PieSectorDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseLeave={(_data: PieSectorDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOver={(_data: PieSectorDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOut={(_data: PieSectorDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseEnter={(_data: PieSectorDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchStart={(_data: PieSectorDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchMove={(_data: PieSectorDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchEnd={(_data: PieSectorDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
+          onClick={(_data: PieSectorDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseDown={(_data: PieSectorDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseUp={(_data: PieSectorDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseMove={(_data: PieSectorDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseLeave={(_data: PieSectorDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseOver={(_data: PieSectorDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseOut={(_data: PieSectorDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseEnter={(_data: PieSectorDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onTouchStart={(_data: PieSectorDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onTouchMove={(_data: PieSectorDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onTouchEnd={(_data: PieSectorDataItem, _i: number, e) => getRelativeCoordinate(e)}
         />
       </PieChart>
     );

--- a/test/polar/PolarAngleAxis/PolarAngleAxis.typed.spec.tsx
+++ b/test/polar/PolarAngleAxis/PolarAngleAxis.typed.spec.tsx
@@ -1,45 +1,52 @@
 import React from 'react';
 import { describe, it } from 'vitest';
-import { PolarAngleAxis, RadialBarChart, getRelativeCoordinate, TickItem } from '../../../src';
+import { rechartsTestRender } from '../../helper/createSelectorTestCase';
+import { PolarAngleAxis, RadialBar, RadialBarChart, TickItem, getRelativeCoordinate } from '../../../src';
 
-describe('PolarAngleAxis types', () => {
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('PolarAngleAxis with strong typing', () => {
+  it('should allow implicit dataKey typing', () => {
+    rechartsTestRender(
+      <RadialBarChart data={data} width={400} height={400}>
+        <PolarAngleAxis dataKey="name" />
+        <RadialBar dataKey="value" />
+      </RadialBarChart>,
+    );
+  });
+
+  it('should allow explicit dataKey typing and reject invalid values', () => {
+    rechartsTestRender(
+      <RadialBarChart data={data} width={400} height={400}>
+        <PolarAngleAxis<ExampleDataPoint, string> dataKey="name" />
+        {/* @ts-expect-error TypeScript is correct here - value is not string-valued */}
+        <PolarAngleAxis<ExampleDataPoint, string> dataKey="value" />
+        <RadialBar dataKey="value" />
+      </RadialBarChart>,
+    );
+  });
+});
+
+describe('PolarAngleAxis event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <RadialBarChart width={100} height={100}>
         <PolarAngleAxis
-          onClick={(_axisProps: TickItem, _index: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseDown={(_axisProps: TickItem, _index: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseUp={(_axisProps: TickItem, _index: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseMove={(_axisProps: TickItem, _index: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseLeave={(_axisProps: TickItem, _index: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOver={(_axisProps: TickItem, _index: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOut={(_axisProps: TickItem, _index: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseEnter={(_axisProps: TickItem, _index: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchStart={(_axisProps: TickItem, _index: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchMove={(_axisProps: TickItem, _index: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchEnd={(_axisProps: TickItem, _index: number, e) => {
-            getRelativeCoordinate(e);
-          }}
+          onClick={(_axisProps: TickItem, _index: number, e) => getRelativeCoordinate(e)}
+          onMouseDown={(_axisProps: TickItem, _index: number, e) => getRelativeCoordinate(e)}
+          onMouseUp={(_axisProps: TickItem, _index: number, e) => getRelativeCoordinate(e)}
+          onMouseMove={(_axisProps: TickItem, _index: number, e) => getRelativeCoordinate(e)}
+          onMouseLeave={(_axisProps: TickItem, _index: number, e) => getRelativeCoordinate(e)}
+          onMouseOver={(_axisProps: TickItem, _index: number, e) => getRelativeCoordinate(e)}
+          onMouseOut={(_axisProps: TickItem, _index: number, e) => getRelativeCoordinate(e)}
+          onMouseEnter={(_axisProps: TickItem, _index: number, e) => getRelativeCoordinate(e)}
+          onTouchStart={(_axisProps: TickItem, _index: number, e) => getRelativeCoordinate(e)}
+          onTouchMove={(_axisProps: TickItem, _index: number, e) => getRelativeCoordinate(e)}
+          onTouchEnd={(_axisProps: TickItem, _index: number, e) => getRelativeCoordinate(e)}
         />
       </RadialBarChart>
     );

--- a/test/polar/PolarRadiusAxis.typed.spec.tsx
+++ b/test/polar/PolarRadiusAxis.typed.spec.tsx
@@ -1,45 +1,52 @@
 import React from 'react';
 import { describe, it } from 'vitest';
-import { PolarRadiusAxis, RadialBarChart, getRelativeCoordinate } from '../../src';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { PolarRadiusAxis, RadialBar, RadialBarChart, getRelativeCoordinate } from '../../src';
 
-describe('PolarRadiusAxis types', () => {
+type ExampleDataPoint = { value: number; name: string };
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+];
+
+describe('PolarRadiusAxis with strong typing', () => {
+  it('should allow implicit dataKey typing', () => {
+    rechartsTestRender(
+      <RadialBarChart data={data} width={400} height={400}>
+        <PolarRadiusAxis dataKey="value" />
+        <RadialBar dataKey="value" />
+      </RadialBarChart>,
+    );
+  });
+
+  it('should allow explicit dataKey typing and reject invalid values', () => {
+    rechartsTestRender(
+      <RadialBarChart data={data} width={400} height={400}>
+        <PolarRadiusAxis<ExampleDataPoint, number> dataKey="value" />
+        {/* @ts-expect-error TypeScript is correct here - name is not number-valued */}
+        <PolarRadiusAxis<ExampleDataPoint, number> dataKey="name" />
+        <RadialBar dataKey="value" />
+      </RadialBarChart>,
+    );
+  });
+});
+
+describe('PolarRadiusAxis event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <RadialBarChart width={100} height={100}>
         <PolarRadiusAxis
-          onClick={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseDown={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseUp={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseMove={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseLeave={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOver={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOut={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseEnter={e => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchStart={e => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchMove={e => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchEnd={e => {
-            getRelativeCoordinate(e);
-          }}
+          onClick={e => getRelativeCoordinate(e)}
+          onMouseDown={e => getRelativeCoordinate(e)}
+          onMouseUp={e => getRelativeCoordinate(e)}
+          onMouseMove={e => getRelativeCoordinate(e)}
+          onMouseLeave={e => getRelativeCoordinate(e)}
+          onMouseOver={e => getRelativeCoordinate(e)}
+          onMouseOut={e => getRelativeCoordinate(e)}
+          onMouseEnter={e => getRelativeCoordinate(e)}
+          onTouchStart={e => getRelativeCoordinate(e)}
+          onTouchMove={e => getRelativeCoordinate(e)}
+          onTouchEnd={e => getRelativeCoordinate(e)}
         />
       </RadialBarChart>
     );

--- a/test/polar/Radar.typed.spec.tsx
+++ b/test/polar/Radar.typed.spec.tsx
@@ -1,46 +1,85 @@
 import React from 'react';
-import { describe, it } from 'vitest';
-import { Radar, RadarChart, getRelativeCoordinate, InternalRadarProps } from '../../src';
+import { describe, expect, it } from 'vitest';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { InternalRadarProps, Radar, RadarChart, getRelativeCoordinate } from '../../src';
 
-describe('Radar types', () => {
+type ExampleDataPoint = {
+  value: number;
+  name: string;
+};
+
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+  { value: 60, name: 'c' },
+  { value: 40, name: 'd' },
+  { value: 20, name: 'e' },
+];
+
+describe('Radar with strong typing', () => {
+  describe('with all implicit types', () => {
+    it('should render Radar with correct data and correct dataKey', () => {
+      const { container } = rechartsTestRender(
+        <RadarChart data={data} width={400} height={400}>
+          <Radar dataKey="value" isAnimationActive={false} />
+        </RadarChart>,
+      );
+      expect(container.querySelectorAll('.recharts-radar-polygon')).toHaveLength(1);
+    });
+
+    it('should allow incorrect or non-existent dataKeys in implicit mode', () => {
+      rechartsTestRender(
+        <RadarChart data={data} width={400} height={400}>
+          <Radar dataKey="name" isAnimationActive={false} />
+          <Radar dataKey="foo" isAnimationActive={false} />
+        </RadarChart>,
+      );
+    });
+  });
+
+  describe('with explicit Radar type parameters', () => {
+    it('should allow correct dataKey when typed explicitly', () => {
+      rechartsTestRender(
+        <RadarChart data={data} width={400} height={400}>
+          <Radar<ExampleDataPoint> dataKey="value" isAnimationActive={false} />
+          <Radar<ExampleDataPoint> dataKey={(entry: ExampleDataPoint) => entry.value} isAnimationActive={false} />
+        </RadarChart>,
+      );
+    });
+
+    it('should show errors when dataKey does not match explicit typing', () => {
+      rechartsTestRender(
+        <RadarChart data={data} width={400} height={400}>
+          {/* @ts-expect-error TypeScript is correct here - the dataKey does not match and this should be an error */}
+          <Radar<ExampleDataPoint, number> dataKey="name" isAnimationActive={false} />
+          <Radar<ExampleDataPoint, number>
+            /* @ts-expect-error TypeScript is correct here - the dataKey return type does not match and this should be an error */
+            dataKey={(entry: ExampleDataPoint) => entry.name}
+            isAnimationActive={false}
+          />
+        </RadarChart>,
+      );
+    });
+  });
+});
+
+describe('Radar event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <RadarChart width={100} height={100}>
         <Radar
           dataKey="foo"
-          onClick={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseDown={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseUp={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseMove={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseLeave={(_data: InternalRadarProps, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOver={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOut={e => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseEnter={(_data: InternalRadarProps, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchStart={e => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchMove={e => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchEnd={e => {
-            getRelativeCoordinate(e);
-          }}
+          onClick={e => getRelativeCoordinate(e)}
+          onMouseDown={e => getRelativeCoordinate(e)}
+          onMouseUp={e => getRelativeCoordinate(e)}
+          onMouseMove={e => getRelativeCoordinate(e)}
+          onMouseLeave={(_data: InternalRadarProps, e) => getRelativeCoordinate(e)}
+          onMouseOver={e => getRelativeCoordinate(e)}
+          onMouseOut={e => getRelativeCoordinate(e)}
+          onMouseEnter={(_data: InternalRadarProps, e) => getRelativeCoordinate(e)}
+          onTouchStart={e => getRelativeCoordinate(e)}
+          onTouchMove={e => getRelativeCoordinate(e)}
+          onTouchEnd={e => getRelativeCoordinate(e)}
         />
       </RadarChart>
     );

--- a/test/polar/RadialBar/RadialBar.typed.spec.tsx
+++ b/test/polar/RadialBar/RadialBar.typed.spec.tsx
@@ -1,46 +1,85 @@
 import React from 'react';
-import { describe, it } from 'vitest';
-import { getRelativeCoordinate, RadialBar, RadialBarChart, RadialBarDataItem } from '../../../src';
+import { describe, expect, it } from 'vitest';
+import { rechartsTestRender } from '../../helper/createSelectorTestCase';
+import { RadialBar, RadialBarChart, RadialBarDataItem, getRelativeCoordinate } from '../../../src';
 
-describe('RadialBar types', () => {
+type ExampleDataPoint = {
+  value: number;
+  name: string;
+};
+
+const data: ReadonlyArray<ExampleDataPoint> = [
+  { value: 100, name: 'a' },
+  { value: 80, name: 'b' },
+  { value: 60, name: 'c' },
+  { value: 40, name: 'd' },
+  { value: 20, name: 'e' },
+];
+
+describe('RadialBar with strong typing', () => {
+  describe('with all implicit types', () => {
+    it('should render RadialBar with correct data and correct dataKey', () => {
+      const { container } = rechartsTestRender(
+        <RadialBarChart data={data} width={400} height={400}>
+          <RadialBar dataKey="value" isAnimationActive={false} />
+        </RadialBarChart>,
+      );
+      expect(container.querySelectorAll('.recharts-radial-bar-sector').length).toBeGreaterThan(0);
+    });
+
+    it('should allow incorrect or non-existent dataKeys in implicit mode', () => {
+      rechartsTestRender(
+        <RadialBarChart data={data} width={400} height={400}>
+          <RadialBar dataKey="name" isAnimationActive={false} />
+          <RadialBar dataKey="foo" isAnimationActive={false} />
+        </RadialBarChart>,
+      );
+    });
+  });
+
+  describe('with explicit RadialBar type parameters', () => {
+    it('should allow correct dataKey when typed explicitly', () => {
+      rechartsTestRender(
+        <RadialBarChart data={data} width={400} height={400}>
+          <RadialBar<ExampleDataPoint> dataKey="value" isAnimationActive={false} />
+          <RadialBar<ExampleDataPoint> dataKey={(entry: ExampleDataPoint) => entry.value} isAnimationActive={false} />
+        </RadialBarChart>,
+      );
+    });
+
+    it('should show errors when dataKey does not match explicit typing', () => {
+      rechartsTestRender(
+        <RadialBarChart data={data} width={400} height={400}>
+          {/* @ts-expect-error TypeScript is correct here - the dataKey does not match and this should be an error */}
+          <RadialBar<ExampleDataPoint, number> dataKey="name" isAnimationActive={false} />
+          <RadialBar<ExampleDataPoint, number>
+            /* @ts-expect-error TypeScript is correct here - the dataKey return type does not match and this should be an error */
+            dataKey={(entry: ExampleDataPoint) => entry.name}
+            isAnimationActive={false}
+          />
+        </RadialBarChart>,
+      );
+    });
+  });
+});
+
+describe('RadialBar event handlers', () => {
   it('should allow calling getRelativeCoordinate with the type provided by Recharts event handler', () => {
     return (
       <RadialBarChart>
         <RadialBar
           dataKey="foo"
-          onClick={(_data: RadialBarDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseDown={(_data: RadialBarDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseUp={(_data: RadialBarDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseMove={(_data: RadialBarDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseLeave={(_data: RadialBarDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOver={(_data: RadialBarDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseOut={(_data: RadialBarDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onMouseEnter={(_data: RadialBarDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchStart={(_data: RadialBarDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchMove={(_data: RadialBarDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
-          onTouchEnd={(_data: RadialBarDataItem, _i: number, e) => {
-            getRelativeCoordinate(e);
-          }}
+          onClick={(_data: RadialBarDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseDown={(_data: RadialBarDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseUp={(_data: RadialBarDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseMove={(_data: RadialBarDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseLeave={(_data: RadialBarDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseOver={(_data: RadialBarDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseOut={(_data: RadialBarDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onMouseEnter={(_data: RadialBarDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onTouchStart={(_data: RadialBarDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onTouchMove={(_data: RadialBarDataItem, _i: number, e) => getRelativeCoordinate(e)}
+          onTouchEnd={(_data: RadialBarDataItem, _i: number, e) => getRelativeCoordinate(e)}
         />
       </RadialBarChart>
     );


### PR DESCRIPTION
## Description

We had Area and Bar before, now the rest.

## Related Issue

https://github.com/recharts/recharts/issues/6645

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced TypeScript support across chart components with generic type parameters for improved type safety and type inference, allowing more precise typing of data shapes.
  * Removed deprecated internal documentation methods.

* **Tests**
  * Added comprehensive type-safety test coverage for all chart components and axes to validate generic type behavior and catch type mismatches at compile time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->