### PR TITLE
fix(Area): connectNulls works correctly across null values in stacked AreaChart

### DIFF
--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -995,7 +995,7 @@ export const getBaseValue = (
 };
 
 export function computeArea({
-  areaSettings: { connectNulls, baseValue: itemBaseValue, dataKey },
+  areaSettings: { baseValue: itemBaseValue, dataKey },
   stackedData,
   layout,
   chartBaseValue,
@@ -1042,7 +1042,7 @@ export function computeArea({
 
     const value1 = valueAsArray?.[1] ?? null;
 
-    const isBreakPoint = value1 == null || (hasStack && !connectNulls && getValueByDataKey(entry, dataKey) == null);
+    const isBreakPoint = value1 == null || (hasStack && getValueByDataKey(entry, dataKey) == null);
 
     if (isHorizontalLayout) {
       return {


### PR DESCRIPTION
Fixes #6985. As discussed in the issue, this allows Area charts with both `stackId` and `connectNulls={true}` to correctly connect across missing data points without erroneously treating the points as 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of null data points in stacked area charts when connectNulls is enabled, producing more consistent path connections across gaps.

* **Tests**
  * Updated tests to more precisely verify generated path commands and exact coordinates for null-point rendering in stacked area scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->