### PR TITLE
fix: correct regex operator precedence in CSS_LENGTH_UNIT_REGEX

### DIFF
--- a/src/util/ReduceCSSCalc.ts
+++ b/src/util/ReduceCSSCalc.ts
@@ -2,7 +2,7 @@ import { isNan } from './DataUtils';
 
 const MULTIPLY_OR_DIVIDE_REGEX = /(-?\d+(?:\.\d+)?[a-zA-Z%]*)([*/])(-?\d+(?:\.\d+)?[a-zA-Z%]*)/;
 const ADD_OR_SUBTRACT_REGEX = /(-?\d+(?:\.\d+)?[a-zA-Z%]*)([+-])(-?\d+(?:\.\d+)?[a-zA-Z%]*)/;
-const CSS_LENGTH_UNIT_REGEX = /^px|cm|vh|vw|em|rem|%|mm|in|pt|pc|ex|ch|vmin|vmax|Q$/;
+const CSS_LENGTH_UNIT_REGEX = /^(px|cm|vh|vw|em|rem|%|mm|in|pt|pc|ex|ch|vmin|vmax|Q)$/;
 const NUM_SPLIT_REGEX = /(-?\d+(?:\.\d+)?)([a-zA-Z%]+)?/;
 
 type SupportedUnits = 'cm' | 'mm' | 'pt' | 'pc' | 'in' | 'Q' | 'px';


### PR DESCRIPTION
## Summary

`CSS_LENGTH_UNIT_REGEX` in `src/util/ReduceCSSCalc.ts` has a regex operator precedence bug.

The current pattern:
```
/^px|cm|vh|vw|em|rem|%|mm|in|pt|pc|ex|ch|vmin|vmax|Q$/
```

Due to `|` (alternation) having lower precedence than `^` and `$`, this only anchors `px` at the start and `Q` at the end — the middle alternatives are unanchored.

### Fix

Wrap the alternation in a non-capturing group so the anchors apply to the entire expression:
```
/^(px|cm|vh|vw|em|rem|%|mm|in|pt|pc|ex|ch|vmin|vmax|Q)$/
```

### Impact

In practice this doesn't cause runtime issues because the regex is only tested against short, pre-parsed CSS unit strings. However, the current pattern triggers misleading-regex-precedence warnings in static analysis tools (ESLint, SonarQube), which propagate to downstream consumers of recharts.

Ref: https://github.com/elementary-data/elementary/issues/2036

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved CSS unit matching in calculations by fixing unit validation logic. CSS length units are now accurately recognized within complex CSS expressions, preventing misinterpretation that could occur from partial matches. This ensures more reliable and correct CSS value processing across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->