### PR TITLE
fix(storybook): use flat dataset for Simple and WithTooltip Treemap stories (#6364)

### DIFF
--- a/storybook/stories/API/chart/Treemap.stories.tsx
+++ b/storybook/stories/API/chart/Treemap.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Args } from '@storybook/react-vite';
-import { sizeData, treemapData } from '../../data';
+import { flatTreemapData, sizeData, treemapData } from '../../data';
 import { ResponsiveContainer, Tooltip, Treemap, TreemapNode } from '../../../../src';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
@@ -24,7 +24,7 @@ export const API = {
   },
   args: {
     ...getStoryArgsFromArgsTypesObject(TreemapArgs),
-    data: sizeData,
+    data: flatTreemapData,
     dataKey: 'size',
     nameKey: 'name',
     isAnimationActive: false,
@@ -44,7 +44,7 @@ export const WithTooltip = {
   },
   args: {
     ...getStoryArgsFromArgsTypesObject(TreemapArgs),
-    data: sizeData,
+    data: flatTreemapData,
     dataKey: 'size',
     nameKey: 'name',
     isAnimationActive: false,
@@ -103,6 +103,27 @@ export const WithCustomContent = {
     ...getStoryArgsFromArgsTypesObject(TreemapArgs),
     data: treemapData,
     dataKey: 'size',
+    isAnimationActive: false,
+  },
+};
+
+export const Nested = {
+  render: (args: Args) => {
+    return (
+      <ResponsiveContainer width="100%" height={400}>
+        <Treemap {...args}>
+          <Tooltip />
+          <RechartsHookInspector />
+        </Treemap>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(TreemapArgs),
+    data: sizeData,
+    dataKey: 'size',
+    nameKey: 'name',
+    type: 'nest',
     isAnimationActive: false,
   },
 };

--- a/storybook/stories/data/Size.ts
+++ b/storybook/stories/data/Size.ts
@@ -1,3 +1,30 @@
+const flatTreemapData = [
+  { name: 'Axis', size: 24593 },
+  { name: 'Data', size: 20544 },
+  { name: 'Legend', size: 20859 },
+  { name: 'NodeSprite', size: 19382 },
+  { name: 'DataList', size: 19788 },
+  { name: 'NodeLinkTreeLayout', size: 12870 },
+  { name: 'CirclePackingLayout', size: 12003 },
+  { name: 'RadialTreeLayout', size: 12348 },
+  { name: 'ScaleBinding', size: 11275 },
+  { name: 'DataSprite', size: 10349 },
+  { name: 'LegendRange', size: 10530 },
+  { name: 'Labeler', size: 9956 },
+  { name: 'TreeBuilder', size: 9930 },
+  { name: 'TreeMapLayout', size: 9191 },
+  { name: 'CircleLayout', size: 9317 },
+  { name: 'StackedAreaLayout', size: 9121 },
+  { name: 'TooltipControl', size: 8435 },
+  { name: 'ForceDirectedLayout', size: 8411 },
+  { name: 'SelectionControl', size: 7862 },
+  { name: 'Layout', size: 7881 },
+  { name: 'DataEvent', size: 7313 },
+  { name: 'Tree', size: 7147 },
+  { name: 'SelectionEvent', size: 6880 },
+  { name: 'CartesianAxes', size: 6703 },
+];
+
 const sizeData = [
   {
     name: 'analytics',
@@ -156,4 +183,4 @@ const treemapData = [
   },
 ];
 
-export { sizeData, treemapData };
+export { flatTreemapData, sizeData, treemapData };


### PR DESCRIPTION
## Summary

Fixes #6364

The **Simple** and **With tooltip** Treemap storybook examples had overlapping/broken labels.

## Root Cause

Both stories used `sizeData`, a **nested/hierarchical** dataset (with `children` arrays). Since the Treemap defaults to `type="flat"`, it renders rectangles at every depth level — parents and children occupy overlapping space. The default `ContentItem` renderer draws a label on every node where the name fits, regardless of depth, causing all labels to pile on top of each other.

The **Custom** story didn't have this problem because its custom `content` function only renders labels at `depth === 1`.

## Changes

1. **Added `flatTreemapData`** in `storybook/stories/data/Size.ts` — a flat dataset (no `children` nesting) that works correctly with `type="flat"`
2. **Updated `Simple` and `WithTooltip` stories** to use `flatTreemapData` instead of `sizeData`
3. **Added a new `Nested` story** that properly demonstrates hierarchical data with `type="nest"` mode

## Verification

- ✅ TypeScript compilation passes (zero errors)
- ✅ All 21 Treemap unit tests pass
- ✅ ESLint passes (0 errors)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Treemap component documentation with additional story examples
  * Added nested Treemap variant demonstration

* **Chores**
  * Extended example datasets for Treemap component testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->