### PR TITLE
docs: add missing description for radialLines prop in PolarGrid (#2578)

### DIFF
--- a/src/polar/PolarGrid.tsx
+++ b/src/polar/PolarGrid.tsx
@@ -59,6 +59,8 @@ interface PolarGridProps extends ZIndexable {
    */
   gridType?: 'polygon' | 'circle';
   /**
+   * Whether to display the radial lines that connect the center to the outer edge at each angle.
+   * When set to false, only the concentric grid lines (circles or polygons) are rendered.
    * @defaultValue true
    */
   radialLines?: boolean;


### PR DESCRIPTION
## Summary

Fixes #2578

The `radialLines` prop on `PolarGrid` was missing a human-readable description in its JSDoc comment. While the prop was visible in the Storybook controls panel, it had no explanation of what it does — unlike every other prop on `PolarGrid` which has a description.

## Changes

Added a JSDoc description to the `radialLines` prop in `src/polar/PolarGrid.tsx`:

```typescript
/**
 * Whether to display the radial lines that connect the center to the outer edge at each angle.
 * When set to false, only the concentric grid lines (circles or polygons) are rendered.
 * @defaultValue true
 */
radialLines?: boolean;
```

Since the Storybook arg-types are auto-generated from JSDoc comments, this description will now appear in the Storybook controls.

## Verification

- ✅ TypeScript compilation passes (zero errors)
- ✅ All 39 PolarGrid unit tests pass
- ✅ ESLint + Prettier pass (lint-staged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Polar grids now support toggling radial lines visibility. This new option allows control over whether radial lines extend from center to edge, with radial lines enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->