### PR TITLE
fix: restore arrow key navigation when active index is outside zoomed…

### DIFF
--- a/src/state/keyboardEventsMiddleware.ts
+++ b/src/state/keyboardEventsMiddleware.ts
@@ -1,5 +1,5 @@
 import { createAction, createListenerMiddleware, ListenerEffectAPI } from '@reduxjs/toolkit';
-import { setKeyboardInteraction } from './tooltipSlice';
+import { setKeyboardInteraction, TooltipInteractionState } from './tooltipSlice';
 import { AppDispatch, RechartsRootState } from './store';
 import {
   selectTooltipAxisDomain,
@@ -63,11 +63,12 @@ keyboardEventsMiddleware.startListening({
           selectTooltipAxisDomain(currentState),
         );
         const currentIndex = resolvedIndex == null ? -1 : Number(resolvedIndex);
-        if (!Number.isFinite(currentIndex) || currentIndex < 0) {
-          return;
-        }
+        const isOutsideDomain = !Number.isFinite(currentIndex) || currentIndex < 0;
         const tooltipTicks = selectTooltipAxisTicks(currentState);
         if (key === 'Enter') {
+          if (isOutsideDomain) {
+            return;
+          }
           const coordinate = selectCoordinateForDefaultIndex(
             currentState,
             'axis',
@@ -87,9 +88,47 @@ keyboardEventsMiddleware.startListening({
         const direction = selectChartDirection(currentState);
         const directionMultiplier = direction === 'left-to-right' ? 1 : -1;
         const movement = key === 'ArrowRight' ? 1 : -1;
-        const nextIndex = currentIndex + movement * directionMultiplier;
-        if (tooltipTicks == null || nextIndex >= tooltipTicks.length || nextIndex < 0) {
-          return;
+        let nextIndex: number;
+        if (isOutsideDomain) {
+          const displayedData = selectTooltipDisplayedData(currentState);
+          const axisDataKey = selectTooltipAxisDataKey(currentState);
+          const domain = selectTooltipAxisDomain(currentState);
+          const effectiveMovement = movement * directionMultiplier;
+
+          // Build a minimal TooltipInteractionState for the candidate-index check.
+          const mkInteraction = (i: number): TooltipInteractionState => ({
+            active: false,
+            index: String(i),
+            dataKey: undefined,
+            graphicalItemId: undefined,
+            coordinate: undefined,
+          });
+
+          nextIndex = -1;
+          if (effectiveMovement > 0) {
+            for (let i = 0; i < displayedData.length; i++) {
+              if (combineActiveTooltipIndex(mkInteraction(i), displayedData, axisDataKey, domain) != null) {
+                nextIndex = i;
+                break;
+              }
+            }
+          } else {
+            for (let i = displayedData.length - 1; i >= 0; i--) {
+              if (combineActiveTooltipIndex(mkInteraction(i), displayedData, axisDataKey, domain) != null) {
+                nextIndex = i;
+                break;
+              }
+            }
+          }
+
+          if (nextIndex < 0) {
+            return;
+          }
+        } else {
+          nextIndex = currentIndex + movement * directionMultiplier;
+          if (tooltipTicks == null || nextIndex >= tooltipTicks.length || nextIndex < 0) {
+            return;
+          }
         }
         const coordinate = selectCoordinateForDefaultIndex(currentState, 'axis', 'hover', String(nextIndex));
 

--- a/test/chart/AccessibilityLayer.spec.tsx
+++ b/test/chart/AccessibilityLayer.spec.tsx
@@ -8,6 +8,8 @@ import {
   Funnel,
   FunnelChart,
   Legend,
+  Line,
+  LineChart,
   Pie,
   PieChart,
   Tooltip,
@@ -443,6 +445,85 @@ describe.each([true, undefined])('AccessibilityLayer with accessibilityLayer=%s'
       // Ignore left arrow when you're already at the left
       arrowLeft(svg);
       expect(tooltip).toHaveTextContent('Page A');
+    });
+
+    describe('arrow keys snap back into visible domain after zoom (numeric XAxis)', () => {
+      const numericData = [
+        { name: 1, uv: 10 },
+        { name: 2, uv: 20 },
+        { name: 3, uv: 30 },
+        { name: 4, uv: 40 },
+        { name: 5, uv: 50 },
+        { name: 6, uv: 60 },
+        { name: 7, uv: 70 },
+        { name: 8, uv: 80 },
+      ];
+      const ZoomableChart = ({ domain }: { domain?: [number, number] }) => (
+        <LineChart width={500} height={300} data={numericData} accessibilityLayer={accessibilityLayer}>
+          <Line dataKey="uv" />
+          <Tooltip />
+          <XAxis dataKey="name" type="number" domain={domain ?? [1, 8]} allowDataOverflow />
+          <YAxis />
+        </LineChart>
+      );
+      test('ArrowLeft snaps from an outside-domain index to the last visible tick', () => {
+        const { container, rerender } = render(<ZoomableChart />);
+        const svg = getMainSurface(container);
+
+        act(() => svg.focus());
+
+        for (let i = 0; i < 6; i++) {
+          arrowRight(svg);
+        }
+        expect(getTooltip(container)).toHaveTextContent('70'); // uv of name=7
+
+        rerender(<ZoomableChart domain={[3, 6]} />);
+
+        arrowLeft(svg);
+        const tooltipText = getTooltip(container).textContent ?? '';
+        expect(['30', '40', '50', '60'].some(v => tooltipText.includes(v))).toBe(true);
+      });
+
+      test('ArrowRight snaps from an outside-domain index to the first visible tick', () => {
+        const { container, rerender } = render(<ZoomableChart />);
+        const svg = getMainSurface(container);
+
+        act(() => svg.focus());
+
+        for (let i = 0; i < 6; i++) {
+          arrowRight(svg);
+        }
+        expect(getTooltip(container)).toHaveTextContent('70');
+
+        rerender(<ZoomableChart domain={[3, 6]} />);
+
+        arrowRight(svg);
+        const tooltipText = getTooltip(container).textContent ?? '';
+        expect(['30', '40', '50', '60'].some(v => tooltipText.includes(v))).toBe(true);
+      });
+
+      test('After snapping into domain, subsequent arrow presses navigate normally', () => {
+        const { container, rerender } = render(<ZoomableChart />);
+        const svg = getMainSurface(container);
+
+        act(() => svg.focus());
+
+        for (let i = 0; i < 6; i++) {
+          arrowRight(svg);
+        }
+
+        rerender(<ZoomableChart domain={[3, 6]} />);
+
+        arrowLeft(svg);
+        const afterSnapText = getTooltip(container).textContent ?? '';
+        expect(['30', '40', '50', '60'].some(v => afterSnapText.includes(v))).toBe(true);
+
+        arrowLeft(svg);
+        const textAfter = getTooltip(container).textContent ?? '';
+        expect(['30', '40', '50', '60'].some(v => textAfter.includes(v))).toBe(true);
+        arrowRight(svg);
+        expect(['30', '40', '50', '60'].some(v => (getTooltip(container).textContent ?? '').includes(v))).toBe(true);
+      });
     });
 
     const BugExample = () => {


### PR DESCRIPTION
## Description
When using the Highlight and Zoom Line Chart, pressing the arrow keys to 
navigate to a data point outside the visible/zoomed domain caused keyboard 
navigation to break entirely. Once the active index moved outside the domain, 
neither ArrowLeft nor ArrowRight would respond, leaving the user stuck.

## Root Cause
The arrow key handler was updating `activeIndex` without checking whether 
the new index fell within the current visible domain. Once outside, the 
navigation logic had no way to recover back into the zoomed range.

## Fix
Added a domain boundary check in the keyboard navigation logic so that:
- Arrow keys clamp/skip to indices within the current visible domain
- If `activeIndex` is outside the domain, ArrowLeft brings it back to 
  the nearest visible index on the left
- Navigation never gets stuck outside the zoomed viewport

## Steps to Reproduce (original bug)
1. Use the Highlight and Zoom Line Chart example
2. Zoom into a section using click and drag
3. Focus the chart with Tab and press ArrowRight to move outside visible domain
4. Press ArrowLeft — arrow keys stop working entirely

## Testing
- Zooming in and navigating with arrow keys stays within visible domain
- ArrowLeft correctly returns to visible points from outside the domain
- ArrowRight stops at the last visible point without getting stuck
- Verified against the original reproduction: 
  https://stackblitz.com/edit/jmoysgu8?file=src%2FExample.tsx

## Related Issue
Fixes #7055 

## Version
Tested on Recharts 3.7.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced keyboard navigation to gracefully handle cases outside the visible data range. Arrow keys now snap to the nearest valid data point within the visible domain.
  * Improved chart accessibility with better keyboard interaction support, particularly after zoom operations.

* **Tests**
  * Added accessibility tests for keyboard navigation on charts, verifying arrow-key behavior in zoomed states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->