### PR TITLE
Export getTickValuesFixedDomain from public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,8 +162,8 @@ export type { IfOverflow } from './util/IfOverflow';
 export { ZIndexLayer } from './zIndex/ZIndexLayer';
 export { DefaultZIndexes } from './zIndex/DefaultZIndexes';
 
-/** export getNiceTickValues so this can be used as a replacement for what is in recharts-scale */
-export { getNiceTickValues } from './util/scale/getNiceTickValues';
+/** export getNiceTickValues and getTickValuesFixedDomain so these can be used as replacements for what is in recharts-scale */
+export { getNiceTickValues, getTickValuesFixedDomain } from './util/scale/getNiceTickValues';
 
 export {
   useActiveTooltipLabel,


### PR DESCRIPTION
## Summary

`getNiceTickValues` is already publicly exported, but its sibling `getTickValuesFixedDomain` is not. This PR adds the export so consumers can predict the exact tick values recharts will render on a YAxis with an explicit numeric domain.

## Motivation

When a chart has a `YAxis` with an explicit `domain` prop (e.g. `[min, max]`), recharts uses `getTickValuesFixedDomain` (not `getNiceTickValues`) to compute tick values. Consumers who need to pre-calculate axis label widths — for example, to dynamically set `YAxis width` and avoid label clipping — currently cannot replicate this logic without copying internal code or patching the package.

Since `getNiceTickValues` is already exported for the "nice ticks" case, it's natural to also export `getTickValuesFixedDomain` for the "fixed domain" case.

## Changes

- Added `getTickValuesFixedDomain` to the named export from `./util/scale/getNiceTickValues` in `src/index.ts`.

## Test plan

- No new tests needed — the function itself is already tested. This only adds a re-export from the public entry point.
- Verified the export works correctly by importing `getTickValuesFixedDomain` from `recharts` in a consuming application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the public API with a new export for advanced tick value calculation functionality. This enhancement provides developers with enhanced control and flexibility when implementing custom scale and axis configurations, enabling more granular options for axis tick placement and formatting in data visualization components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->