### PR TITLE
fix: support default export when resolving d3 scale functions

### DIFF
--- a/src/state/selectors/combiners/combineConfiguredScale.ts
+++ b/src/state/selectors/combiners/combineConfiguredScale.ts
@@ -14,15 +14,28 @@ import { upperFirst } from '../../../util/DataUtils';
 function getD3ScaleFromType<Domain extends CategoricalDomainItem = CategoricalDomainItem>(
   realScaleType: D3ScaleType | RechartsScaleType,
 ): CustomScaleDefinition<Domain> | undefined {
+  const callScale = (scale: unknown) => {
+    if (typeof scale === 'function') {
+      return scale();
+    }
+    if (scale && typeof (scale as any).default === 'function') {
+      return (scale as any).default();
+    }
+    return undefined;
+  };
+
   if (realScaleType in d3Scales) {
     // @ts-expect-error we should do better type verification here
-    return d3Scales[realScaleType]();
+    return callScale(d3Scales[realScaleType]);
   }
+
   const name = `scale${upperFirst(realScaleType)}`;
+
   if (name in d3Scales) {
     // @ts-expect-error we should do better type verification here
-    return d3Scales[name]();
+    return callScale(d3Scales[name]);
   }
+
   return undefined;
 }
 


### PR DESCRIPTION
## Description

Fixes an issue where `getD3ScaleFromType` assumes that exports from `victory-vendor/d3-scale` are directly callable functions.

Some bundlers (notably **Bun**) wrap namespace exports so that scale functions appear as:

```js
{ default: fn }
```

instead of:

```js
fn
```

When this happens, calling the export directly results in:

TypeError: d3Scales[name] is not a function

This change safely resolves the scale function from either the export itself or its `.default` property before invoking it.

The behavior remains unchanged for environments where the export is already a function.

---

## Related Issue

No existing issue was found.  
This PR fixes a runtime error when Recharts is bundled with **Bun**.

Error example:

TypeError: d3Scales[name] is not a function  
at getD3ScaleFromType

---

## Motivation and Context

`getD3ScaleFromType` dynamically resolves D3 scale functions from the `victory-vendor/d3-scale` namespace.

The implementation assumes the namespace members are directly callable. However, certain bundlers wrap ESM namespace exports, resulting in module objects with a `default` property containing the actual function.

This patch adds a small compatibility layer so the scale function can be resolved correctly regardless of how the module is wrapped.

---

## How Has This Been Tested?

Tested locally by building and running a React application using Recharts with **Bun's dev server**.

Before the change:

TypeError: d3Scales[name] is not a function

After the change:

Charts render correctly and scale resolution works as expected.

Existing functionality remains unchanged when the export is already a function.

---

## Screenshots (if appropriate)

N/A

---

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal scale handling and code maintainability with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->