### PR TITLE
fix(DefaultLegendContent): use entry.value for aria-label when formatter returns React element

### DIFF
--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -238,7 +238,7 @@ function Items(props: InternalProps) {
           height={iconSize}
           viewBox={viewBox}
           style={svgStyle}
-          aria-label={`${finalValue} legend icon`}
+          aria-label={`${entry.value} legend icon`}
         >
           <Icon data={entry} iconType={iconType} inactiveColor={inactiveColor} />
         </Surface>

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -596,6 +596,19 @@ describe('<Legend />', () => {
       expect(surface.getAttribute('aria-label')).toBe('My Line Data legend icon');
     });
 
+    test('aria-label uses the raw entry value even when formatter returns a React element', () => {
+      const { container } = rechartsTestRender(
+        <LineChart width={500} height={500} data={numericalData}>
+          <Legend formatter={value => <strong>{value}</strong>} />
+          <Line dataKey="value" name="UV" />
+        </LineChart>,
+      );
+
+      const legendItem = container.getElementsByClassName('legend-item-0')[0];
+      const surface = legendItem.getElementsByClassName('recharts-surface')[0];
+      expect(surface.getAttribute('aria-label')).toBe('UV legend icon');
+    });
+
     it('should render one line legend item for each Line, with default class and style attributes', () => {
       const { container, getByText } = rechartsTestRender(
         <LineChart width={500} height={500} data={numericalData}>


### PR DESCRIPTION
## Problem

When a `Legend` formatter returns a React element (JSX), the `aria-label` on each legend icon `<svg>` ends up as `"[object Object] legend icon"` because the formatter's return value is coerced to a string via a template literal.

**Repro:**
```tsx
<LineChart width={500} height={300} data={data}>
  <Legend formatter={value => <strong>{value}</strong>} />
  <Line dataKey="value" name="UV" />
</LineChart>
```
Produces: `aria-label="[object Object] legend icon"`  
Expected: `aria-label="UV legend icon"`

Fixes #7105.

## Root Cause

In `DefaultLegendContent.tsx`, the icon surface element uses `finalValue` (the formatter's return value) for the `aria-label`:

```tsx
const finalValue = formatter ? formatter(value, entry, i) : value;
// ...
<Surface aria-label={`${finalValue} legend icon`} ...>
```

`finalValue` may be a React element, which stringifies to `[object Object]`.

## Fix

Use `entry.value` (the raw string data key/name) for the `aria-label` instead of `finalValue`. The formatter output is the visual label and may be arbitrary JSX; the accessible name should always reflect the underlying series name.

```diff
-  aria-label={`${finalValue} legend icon`}
+  aria-label={`${entry.value} legend icon`}
```

## Test

A new test case in `test/component/Legend.spec.tsx` verifies that `aria-label` uses the raw entry value even when the formatter returns JSX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed legend accessibility by updating aria-labels to consistently display raw data values instead of potentially formatted display text. This ensures screen reader users receive accurate and predictable information when interacting with chart legends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->