### PR TITLE
feat: add syncValueFallback prop for closest-match fallback in syncMethod="value"

### DIFF
--- a/src/chart/CartesianChart.tsx
+++ b/src/chart/CartesianChart.tsx
@@ -24,6 +24,7 @@ export const defaultCartesianChartProps = {
   reverseStackOrder: false,
   stackOffset: 'none',
   syncMethod: 'index',
+  syncValueFallback: 'none',
   ...initialEventSettingsState,
 } as const satisfies Partial<CartesianChartProps>;
 
@@ -80,6 +81,7 @@ export const CartesianChart = forwardRef<SVGSVGElement, CartesianChartOptions>(f
         barSize={rootChartProps.barSize}
         syncId={rootChartProps.syncId}
         syncMethod={rootChartProps.syncMethod}
+        syncValueFallback={rootChartProps.syncValueFallback}
         className={rootChartProps.className}
         reverseStackOrder={rootChartProps.reverseStackOrder}
       />

--- a/src/chart/PolarChart.tsx
+++ b/src/chart/PolarChart.tsx
@@ -26,6 +26,7 @@ export const defaultPolarChartProps = {
   margin: defaultMargin,
   reverseStackOrder: false,
   syncMethod: 'index',
+  syncValueFallback: 'none',
   layout: 'radial',
   responsive: false,
   cx: '50%',
@@ -101,6 +102,7 @@ export const PolarChart = forwardRef<SVGSVGElement, PolarChartOptions>(function 
         barSize={polarChartProps.barSize}
         syncId={polarChartProps.syncId}
         syncMethod={polarChartProps.syncMethod}
+        syncValueFallback={polarChartProps.syncValueFallback}
         className={polarChartProps.className}
         reverseStackOrder={polarChartProps.reverseStackOrder}
       />

--- a/src/state/rootPropsSlice.ts
+++ b/src/state/rootPropsSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { StackOffsetType } from '../util/types';
-import { SyncMethod } from '../synchronisation/types';
+import { SyncMethod, SyncValueFallback } from '../synchronisation/types';
 import { BaseValue } from '../cartesian/Area';
 
 /**
@@ -24,6 +24,7 @@ export type UpdatableChartOptions = {
    */
   syncId: number | string | undefined;
   syncMethod: SyncMethod;
+  syncValueFallback: SyncValueFallback;
   baseValue: BaseValue | undefined;
   /**
    * If false, stacked items will be rendered left to right. If true, stacked items will be rendered right to left.
@@ -42,6 +43,7 @@ export const initialState: UpdatableChartOptions = {
   stackOffset: 'none',
   syncId: undefined,
   syncMethod: 'index',
+  syncValueFallback: 'none',
   baseValue: undefined,
   reverseStackOrder: false,
 };
@@ -59,6 +61,7 @@ const rootPropsSlice = createSlice({
       state.stackOffset = action.payload.stackOffset;
       state.syncId = action.payload.syncId;
       state.syncMethod = action.payload.syncMethod;
+      state.syncValueFallback = action.payload.syncValueFallback;
       state.className = action.payload.className;
       state.baseValue = action.payload.baseValue;
       state.reverseStackOrder = action.payload.reverseStackOrder;

--- a/src/state/selectors/rootPropsSelectors.ts
+++ b/src/state/selectors/rootPropsSelectors.ts
@@ -1,6 +1,6 @@
 import { RechartsRootState } from '../store';
 import { StackOffsetType } from '../../util/types';
-import { SyncMethod } from '../../synchronisation/types';
+import { SyncMethod, SyncValueFallback } from '../../synchronisation/types';
 import { BaseValue } from '../../cartesian/Area';
 
 export const selectRootMaxBarSize = (state: RechartsRootState): number | undefined => state.rootProps.maxBarSize;
@@ -13,6 +13,8 @@ export const selectChartName = (state: RechartsRootState) => state.options.chart
 
 export const selectSyncId = (state: RechartsRootState) => state.rootProps.syncId;
 export const selectSyncMethod = (state: RechartsRootState): SyncMethod => state.rootProps.syncMethod;
+export const selectSyncValueFallback = (state: RechartsRootState): SyncValueFallback =>
+  state.rootProps.syncValueFallback;
 export const selectEventEmitter = (state: RechartsRootState) => state.options.eventEmitter;
 export const selectChartBaseValue: (state: RechartsRootState) => BaseValue | undefined = (state: RechartsRootState) =>
   state.rootProps.baseValue;

--- a/src/synchronisation/types.ts
+++ b/src/synchronisation/types.ts
@@ -38,3 +38,12 @@ export type MouseHandlerDataParam = {
  * argument 2: active tooltip state from the other chart
  */
 export type SyncMethod = 'index' | 'value' | ((ticks: ReadonlyArray<TickItem>, data: MouseHandlerDataParam) => number);
+
+/**
+ * Controls what happens when syncMethod="value" cannot find an exact label match
+ * in the receiving chart's ticks.
+ *
+ * - 'none': the tooltip is hidden (default, preserves existing behavior)
+ * - 'closest': falls back to the nearest tick by string comparison
+ */
+export type SyncValueFallback = 'none' | 'closest';

--- a/src/synchronisation/useChartSynchronisation.tsx
+++ b/src/synchronisation/useChartSynchronisation.tsx
@@ -1,7 +1,12 @@
 import { useEffect } from 'react';
 import { PayloadAction } from '@reduxjs/toolkit';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
-import { selectEventEmitter, selectSyncId, selectSyncMethod } from '../state/selectors/rootPropsSelectors';
+import {
+  selectEventEmitter,
+  selectSyncId,
+  selectSyncMethod,
+  selectSyncValueFallback,
+} from '../state/selectors/rootPropsSelectors';
 import { BRUSH_SYNC_EVENT, eventCenter, TOOLTIP_SYNC_EVENT } from '../util/Events';
 import { createEventEmitter } from '../state/optionsSlice';
 import { setSyncInteraction, TooltipIndex, TooltipSyncState } from '../state/tooltipSlice';
@@ -15,6 +20,52 @@ import { BrushStartEndIndex } from '../context/brushUpdateContext';
 import { setDataStartEndIndexes } from '../state/chartDataSlice';
 import { ActiveLabel, MouseHandlerDataParam } from './types';
 import { noop } from '../util/DataUtils';
+
+/**
+ * When syncMethod="value" cannot find an exact label match in the receiving chart's ticks,
+ * this function finds the closest tick using binary search on string-compared values.
+ *
+ * This handles cases where synced charts have slightly different data arrays
+ * (e.g., one chart starts a day earlier than another). Instead of hiding the tooltip
+ * entirely, the receiving chart shows the nearest available data point.
+ */
+function findClosestTick(ticks: ReadonlyArray<TickItem>, label: string): TickItem | undefined {
+  const len = ticks.length;
+  if (len === 0) {
+    return undefined;
+  }
+
+  let lo = 0;
+  let hi = len - 1;
+
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    const midTick = ticks[mid];
+    if (midTick != null && String(midTick.value) < label) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+
+  // lo is now the index of the first tick >= label.
+  // Check if the tick before lo is closer.
+  if (lo > 0 && lo < len) {
+    const prevTick = ticks[lo - 1];
+    const currTick = ticks[lo];
+    if (prevTick != null && currTick != null) {
+      const prev = String(prevTick.value);
+      const curr = String(currTick.value);
+      if (label > prev && label < curr) {
+        return prevTick;
+      }
+    }
+  }
+
+  // Clamp to valid range
+  const clampedIndex = Math.min(lo, len - 1);
+  return ticks[clampedIndex];
+}
 
 /**
  * Listens for tooltip sync events from other charts and dispatches the appropriate
@@ -33,6 +84,7 @@ function useTooltipSyncEventsListener() {
   const myEventEmitter = useAppSelector(selectEventEmitter);
   const dispatch = useAppDispatch();
   const syncMethod = useAppSelector(selectSyncMethod);
+  const syncValueFallback = useAppSelector(selectSyncValueFallback);
   const tooltipTicks = useAppSelector(selectTooltipAxisTicks);
   const layout = useChartLayout();
   const viewBox = useViewBox();
@@ -124,6 +176,17 @@ function useTooltipSyncEventsListener() {
       } else if (syncMethod === 'value') {
         // labels are always strings, tick.value might be a string or a number, depending on axis type
         activeTick = tooltipTicks.find(tick => String(tick.value) === action.payload.label);
+        if (
+          activeTick == null &&
+          syncValueFallback === 'closest' &&
+          action.payload.label != null &&
+          tooltipTicks.length > 0
+        ) {
+          // If no exact match was found, find the closest tick by comparing string values.
+          // This handles cases where the synced chart has slightly different data
+          // (e.g., one chart has 251 data points and another has 252).
+          activeTick = findClosestTick(tooltipTicks, action.payload.label);
+        }
       }
 
       const { coordinate } = action.payload;
@@ -194,7 +257,7 @@ function useTooltipSyncEventsListener() {
     return () => {
       eventCenter.off(TOOLTIP_SYNC_EVENT, listener);
     };
-  }, [className, dispatch, myEventEmitter, mySyncId, syncMethod, tooltipTicks, layout, viewBox]);
+  }, [className, dispatch, myEventEmitter, mySyncId, syncMethod, syncValueFallback, tooltipTicks, layout, viewBox]);
 }
 
 /**

--- a/src/synchronisation/useChartSynchronisation.tsx
+++ b/src/synchronisation/useChartSynchronisation.tsx
@@ -28,8 +28,18 @@ import { noop } from '../util/DataUtils';
  * This handles cases where synced charts have slightly different data arrays
  * (e.g., one chart starts a day earlier than another). Instead of hiding the tooltip
  * entirely, the receiving chart shows the nearest available data point.
+ *
+ * When a label falls between two ticks, this function deterministically returns
+ * the previous tick (the last tick whose string value is less than the label),
+ * rather than computing actual lexicographic or numeric proximity.
+ *
+ * Note: comparison is purely lexicographic (via String(tick.value) < label).
+ * This means ticks must be sorted by their string representation for correct results.
+ * Numeric labels like "Day 10" sort before "Day 2" lexicographically, which may
+ * differ from numeric ordering. In practice, axis ticks arrive in display order
+ * which matches string sort order for consistently formatted labels.
  */
-function findClosestTick(ticks: ReadonlyArray<TickItem>, label: string): TickItem | undefined {
+export function findClosestTick(ticks: ReadonlyArray<TickItem>, label: string): TickItem | undefined {
   const len = ticks.length;
   if (len === 0) {
     return undefined;

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -26,7 +26,7 @@ import type * as d3Scales from 'victory-vendor/d3-scale';
 import type { Props as DotProps } from '../shape/Dot';
 import { AxisRange } from '../state/selectors/axisSelectors';
 import { ExternalMouseEvents } from '../chart/types';
-import { SyncMethod } from '../synchronisation/types';
+import { SyncMethod, SyncValueFallback } from '../synchronisation/types';
 import { isEventKey } from './excludeEventProps';
 import { DotPoint } from '../component/Dots';
 import { SVGPropsNoEvents } from './svgPropertiesNoEvents';
@@ -1497,6 +1497,18 @@ interface BaseChartProps<DataPointType> extends DataProvider<DataPointType>, Ext
    * @defaultValue index
    */
   syncMethod?: SyncMethod;
+  /**
+   * Controls what happens when syncMethod="value" cannot find an exact label match
+   * in the receiving chart's ticks.
+   *
+   * - 'none': the tooltip is hidden (default, preserves existing behavior)
+   * - 'closest': falls back to the nearest tick by string comparison
+   *
+   * Only has an effect when syncMethod="value".
+   *
+   * @defaultValue none
+   */
+  syncValueFallback?: SyncValueFallback;
   /**
    * If and where the chart should appear in the tab order
    */

--- a/test/component/Tooltip/Tooltip.sync.spec.tsx
+++ b/test/component/Tooltip/Tooltip.sync.spec.tsx
@@ -597,6 +597,130 @@ describe('Tooltip synchronization', () => {
     });
   });
 
+  describe('when syncMethod=value with syncValueFallback=closest on both charts with slightly different data arrays', () => {
+    // Simulate the scenario: two charts with overlapping but not identical data
+    // (like stock charts where one has 251 trading days and another has 252)
+    const data1 = [
+      { date: 'Day 1', price: 100 },
+      { date: 'Day 2', price: 105 },
+      { date: 'Day 3', price: 110 },
+      { date: 'Day 4', price: 108 },
+      { date: 'Day 5', price: 112 },
+      { date: 'Day 6', price: 115 },
+    ];
+
+    // data2 is missing 'Day 1' - like a returns chart that starts one day later
+    const data2 = [
+      { date: 'Day 2', returns: 5 },
+      { date: 'Day 3', returns: 4.8 },
+      { date: 'Day 4', returns: -1.8 },
+      { date: 'Day 5', returns: 3.7 },
+      { date: 'Day 6', returns: 2.7 },
+    ];
+
+    const renderTestCase = createSynchronisedSelectorTestCase(
+      ({ children }) => (
+        <LineChart
+          syncId="stockSync"
+          syncMethod="value"
+          syncValueFallback="closest"
+          data={data1}
+          width={400}
+          height={400}
+          className="chart-1"
+        >
+          <XAxis dataKey="date" />
+          <YAxis />
+          <Tooltip />
+          {children}
+          <Line type="monotone" dataKey="price" stroke="#8884d8" />
+        </LineChart>
+      ),
+      ({ children }) => (
+        <LineChart
+          syncId="stockSync"
+          syncMethod="value"
+          syncValueFallback="closest"
+          data={data2}
+          width={400}
+          height={400}
+          className="chart-2"
+        >
+          <XAxis dataKey="date" />
+          <YAxis />
+          <Tooltip />
+          {children}
+          <Line type="monotone" dataKey="returns" stroke="#82ca9d" />
+        </LineChart>
+      ),
+    );
+
+    test('should show synced tooltip on chart B when hovering a shared data point on chart A', () => {
+      const { wrapperA, wrapperB, debug } = renderTestCase();
+
+      expectTooltipNotVisible(wrapperA);
+      expectTooltipNotVisible(wrapperB);
+
+      showTooltip(wrapperA, lineChartMouseHoverTooltipSelector, debug);
+
+      // The default hover lands on data point at index 2 (roughly middle of chart)
+      // which is 'Day 3' - a date that exists in both charts
+      expectTooltipPayload(wrapperA, 'Day 3', ['price : 110']);
+      expectTooltipPayload(wrapperB, 'Day 3', ['returns : 4.8']);
+    });
+
+    test('synced chart should show tooltip even when hovered date only exists in chart A', () => {
+      const { wrapperA, spyB, debug } = renderTestCase(selectSynchronisedTooltipState);
+
+      // Hover near the left edge to hit 'Day 1' which only exists in chart A
+      showTooltipOnCoordinate(wrapperA, lineChartMouseHoverTooltipSelector, { clientX: 70, clientY: 200 }, debug);
+
+      const syncB = spyB.mock.calls[spyB.mock.calls.length - 1][0];
+
+      // Chart B should have an active synced tooltip, even though 'Day 1' doesn't exist in its data.
+      // The fix falls back to the closest available tick in chart B.
+      expect(syncB.active).toBe(true);
+      expect(syncB.index).not.toBeNull();
+    });
+
+    test('should spy on sync state to understand what label is sent', () => {
+      const { wrapperA, spyA, spyB, debug } = renderTestCase(selectSynchronisedTooltipState);
+
+      showTooltip(wrapperA, lineChartMouseHoverTooltipSelector, debug);
+
+      // Chart A should NOT have sync state active (it's the sender)
+      const syncStateA = spyA.mock.calls[spyA.mock.calls.length - 1][0];
+      expect(syncStateA.active).toBe(false);
+
+      // Chart B SHOULD have sync state active
+      const syncStateB = spyB.mock.calls[spyB.mock.calls.length - 1][0];
+      expect(syncStateB.active).toBe(true);
+      expect(syncStateB.label).toBeDefined();
+      expect(syncStateB.index).not.toBeNull();
+    });
+
+    test('synced tooltip should remain active at all positions across the chart', () => {
+      const { wrapperA, spyB, debug } = renderTestCase(selectSynchronisedTooltipState);
+
+      // Hover at multiple positions across chart A, including the left edge
+      // where 'Day 1' exists in chart A but not in chart B
+      const positions = [
+        { clientX: 70, clientY: 200 }, // left edge - 'Day 1' (not in chart B)
+        { clientX: 130, clientY: 200 }, // 'Day 2' area
+        { clientX: 200, clientY: 200 }, // middle
+        { clientX: 300, clientY: 200 }, // 'Day 5' area
+        { clientX: 370, clientY: 200 }, // near right edge - 'Day 6'
+      ];
+
+      for (const pos of positions) {
+        showTooltipOnCoordinate(wrapperA, lineChartMouseHoverTooltipSelector, pos, debug);
+        const state = spyB.mock.calls[spyB.mock.calls.length - 1][0];
+        expect(state.active).toBe(true);
+        expect(state.index).not.toBeNull();
+      }
+    });
+  });
+
   describe('selectActiveCoordinate', () => {
     it('should return undefined for initial state', () => {
       const store = createRechartsStore();

--- a/test/synchronisation/useChartSynchronisation.spec.tsx
+++ b/test/synchronisation/useChartSynchronisation.spec.tsx
@@ -10,6 +10,8 @@ import { hideTooltip, showTooltip } from '../component/Tooltip/tooltipTestHelper
 import { barChartMouseHoverTooltipSelector } from '../component/Tooltip/tooltipMouseHoverSelectors';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 import { expectLastCalledWith } from '../helper/expectLastCalledWith';
+import { TickItem } from '../../src/util/types';
+import { findClosestTick } from '../../src/synchronisation/useChartSynchronisation';
 
 describe('useTooltipChartSynchronisation', () => {
   let eventSpy: Mock<(...args: any[]) => any>;
@@ -197,5 +199,61 @@ describe('useTooltipChartSynchronisation', () => {
       renderTestCase();
       expect(eventSpy).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('findClosestTick', () => {
+  function tick(value: string, index: number): TickItem {
+    return { value, coordinate: index * 100, index };
+  }
+
+  it('should return undefined for an empty ticks array', () => {
+    expect(findClosestTick([], 'anything')).toBeUndefined();
+  });
+
+  it('should return the only tick when array has one element', () => {
+    const ticks = [tick('B', 0)];
+    expect(findClosestTick(ticks, 'A')).toEqual(ticks[0]);
+    expect(findClosestTick(ticks, 'B')).toEqual(ticks[0]);
+    expect(findClosestTick(ticks, 'C')).toEqual(ticks[0]);
+  });
+
+  it('should return the first tick when label is before all ticks', () => {
+    const ticks = [tick('B', 0), tick('D', 1), tick('F', 2)];
+    expect(findClosestTick(ticks, 'A')).toEqual(ticks[0]);
+  });
+
+  it('should return the last tick when label is after all ticks', () => {
+    const ticks = [tick('B', 0), tick('D', 1), tick('F', 2)];
+    expect(findClosestTick(ticks, 'Z')).toEqual(ticks[2]);
+  });
+
+  it('should return the exact tick when label matches', () => {
+    const ticks = [tick('B', 0), tick('D', 1), tick('F', 2)];
+    expect(findClosestTick(ticks, 'D')).toEqual(ticks[1]);
+  });
+
+  it('should return the previous tick when label falls between two ticks', () => {
+    const ticks = [tick('B', 0), tick('D', 1), tick('F', 2)];
+    // 'C' is between 'B' and 'D' — should return 'B' (the previous tick)
+    expect(findClosestTick(ticks, 'C')).toEqual(ticks[0]);
+    // 'E' is between 'D' and 'F' — should return 'D' (the previous tick)
+    expect(findClosestTick(ticks, 'E')).toEqual(ticks[1]);
+  });
+
+  it('should use lexicographic string comparison, not numeric', () => {
+    // Lexicographically: "Day 1" < "Day 10" < "Day 2" < "Day 3"
+    const ticks = [tick('Day 1', 0), tick('Day 10', 1), tick('Day 2', 2), tick('Day 3', 3)];
+    // "Day 15" falls between "Day 10" and "Day 2" lexicographically
+    expect(findClosestTick(ticks, 'Day 15')).toEqual(ticks[1]); // "Day 10"
+  });
+
+  it('should handle date-like string labels', () => {
+    // ISO date strings sort correctly lexicographically
+    const ticks = [tick('2024-01-01', 0), tick('2024-01-03', 1), tick('2024-01-05', 2)];
+    // '2024-01-02' is between '2024-01-01' and '2024-01-03' — returns previous tick
+    expect(findClosestTick(ticks, '2024-01-02')).toEqual(ticks[0]);
+    // '2024-01-04' is between '2024-01-03' and '2024-01-05' — returns previous tick
+    expect(findClosestTick(ticks, '2024-01-04')).toEqual(ticks[1]);
   });
 });


### PR DESCRIPTION
When using `syncMethod="value"` to synchronize charts with different data arrays (e.g., one chart has 251 trading days and another has 252), the receiving chart hides its tooltip if the synced label doesn't have an exact match in its ticks. This PR adds a new `syncValueFallback` prop that lets users opt into a closest-match fallback instead.

Note that when hovering directly on a sparse chart, the tooltip already shows the nearest data point — this is because direct hover resolves via pixel-coordinate matching (`calculateActiveTickIndex`), which always finds the nearest tick. The sync path with `syncMethod="value"` instead matches by exact string comparison on labels, so without this fallback, synced charts with mismatched data hide the tooltip where direct hover would show one.

## Usage

```tsx
<LineChart syncId="mySync" syncMethod="value" syncValueFallback="closest">
```

## Prop values

- `"none"` (default) — existing behavior, tooltip is hidden when no exact match is found
- `"closest"` — falls back to the nearest tick by string comparison using binary search

## Changes

- New `SyncValueFallback` type (`'none' | 'closest'`) in `src/synchronisation/types.ts`
- New `syncValueFallback` prop on chart components, threaded through Redux state
- `findClosestTick` function: binary search on string-compared tick values
- Fallback is gated by `syncValueFallback === 'closest'` — no behavior change with default props
- Tests covering the new fallback behavior with charts that have overlapping but non-identical data arrays

## Context

This was first discussed in #7020 as a potential follow-up to the tooltip sync counter-emission fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a chart-level setting syncValueFallback (default: "none") exposed on Cartesian and Polar charts. When set to "closest", value-based synchronization will pick the nearest tick if an exact label match is missing, improving tooltip sync across charts with slightly mismatched datasets.

* **Tests**
  * Added end-to-end and unit tests covering the closest-tick fallback behavior and its edge cases to ensure reliable synchronized tooltips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->