### PR TITLE
fix(PolarRadiusAxis): update ticks prop type

### DIFF
--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -21,6 +21,7 @@ import {
   EvaluatedAxisDomainType,
   TickProp,
   BaseTickContentProps,
+  AxisTick,
 } from '../util/types';
 import { addRadiusAxis, RadiusAxisSettings, removeRadiusAxis } from '../state/polarAxisSlice';
 import { NiceTicksAlgorithm } from '../state/cartesianAxisSlice';
@@ -196,7 +197,7 @@ export interface PolarRadiusAxisProps<DataPointType = any, DataValueType = any>
    * @defaultValue true
    */
   tick?: TickProp<BaseTickContentProps>;
-  ticks?: ReadonlyArray<TickItem>;
+  ticks?: ReadonlyArray<AxisTick>;
   /**
    * Z-Index of this component and its children. The higher the value,
    * the more on top it will be rendered.
@@ -437,7 +438,6 @@ export function PolarRadiusAxis<DataPointType = any, DataValueType = any>(
         includeHidden={props.includeHidden}
         allowDecimals={props.allowDecimals}
         niceTicks={props.niceTicks ?? 'auto'}
-        // @ts-expect-error the type does not match. Is RadiusAxis really expecting what it says?
         ticks={props.ticks}
         tickCount={props.tickCount}
         tick={props.tick}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1029,6 +1029,8 @@ export type AxisInterval =
  * Ticks can be any type when the axis is the type of category.
  *
  * Ticks must be numbers when the axis is the type of number.
+ *
+ * @inline
  */
 export type AxisTick = number | string;
 

--- a/test/polar/PolarRadiusAxis.spec.tsx
+++ b/test/polar/PolarRadiusAxis.spec.tsx
@@ -1240,7 +1240,6 @@ describe('<PolarRadiusAxis />', () => {
             name="radius-name"
             dataKey="value"
             tick={false}
-            // @ts-expect-error the type does not match. Is RadiusAxis really expecting what it says?
             ticks={exampleTicks}
             tickCount={9}
             allowDecimals


### PR DESCRIPTION
## Description

Type change only

## Related Issue

Fixes https://github.com/recharts/recharts/issues/4668


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the `ticks` prop type on PolarRadiusAxis from `TickItem` to `AxisTick` for improved type consistency.
  * Removed TypeScript error suppression comments to enforce strict type validation.

* **Documentation**
  * Enhanced `AxisTick` type documentation with inline formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->