### PR TITLE
perf: optimize ScatterChart hover by reducing re-renders from O(n) to O(1)

### DIFF
--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -547,6 +547,17 @@ function ScatterLabelListProvider({
  * Individual scatter point component that subscribes to its own isActive state.
  * This avoids re-rendering all points when the active index changes —
  * only the point becoming active and the point becoming inactive re-render.
+ *
+ * @param entry The scatter point data including coordinates, size, and tooltip payload
+ * @param index The index of this point in the points array
+ * @param shape The default shape to render for inactive points
+ * @param activeShape The shape to render when this point is active, or undefined if no active shape
+ * @param baseProps SVG presentation attributes (fill, stroke, etc.) shared across all points
+ * @param id The graphical item ID of the parent Scatter component
+ * @param restOfAllOtherProps Remaining Scatter props for user-provided event handlers via adaptEventsOfChild
+ * @param onMouseEnterFromContext Curried mouse enter handler that dispatches tooltip activation
+ * @param onMouseLeaveFromContext Curried mouse leave handler that dispatches tooltip deactivation
+ * @param onClickFromContext Curried click handler that dispatches tooltip click activation
  */
 function ScatterPoint({
   entry,

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -51,6 +51,7 @@ import { AxisId } from '../state/cartesianAxisSlice';
 import { GraphicalItemClipPath, useNeedsClip } from './GraphicalItemClipPath';
 import { selectScatterPoints } from '../state/selectors/scatterSelectors';
 import { useAppSelector } from '../state/hooks';
+import { RechartsRootState } from '../state/store';
 import { BaseAxisWithScale, implicitZAxis, ZAxisWithScale } from '../state/selectors/axisSelectors';
 import { useIsPanorama } from '../context/PanoramaContext';
 import { selectActiveTooltipIndex } from '../state/selectors/tooltipSelectors';
@@ -542,12 +543,90 @@ function ScatterLabelListProvider({
   );
 }
 
+/**
+ * Individual scatter point component that subscribes to its own isActive state.
+ * This avoids re-rendering all points when the active index changes —
+ * only the point becoming active and the point becoming inactive re-render.
+ */
+function ScatterPoint({
+  entry,
+  index,
+  shape,
+  activeShape,
+  baseProps,
+  id,
+  restOfAllOtherProps,
+  animationElapsedTime,
+  isAnimating,
+  isEntrance,
+  onMouseEnterFromContext,
+  onMouseLeaveFromContext,
+  onClickFromContext,
+}: ShapeAnimationProps & {
+  entry: ScatterPointItem;
+  index: number;
+  shape: ScatterCustomizedShape;
+  activeShape: ScatterCustomizedShape | undefined;
+  baseProps: ReturnType<typeof svgPropertiesNoEvents>;
+  id: GraphicalItemId;
+  restOfAllOtherProps: InternalProps;
+  onMouseEnterFromContext: (
+    data: ScatterPointItem,
+    index: number,
+  ) => (event: React.MouseEvent<SVGGraphicsElement>) => void;
+  onMouseLeaveFromContext: (
+    data: ScatterPointItem,
+    index: number,
+  ) => (event: React.MouseEvent<SVGGraphicsElement>) => void;
+  onClickFromContext: (data: ScatterPointItem, index: number) => (event: React.MouseEvent<SVGGraphicsElement>) => void;
+}): React.ReactElement {
+  const hasActiveShape = activeShape != null && activeShape !== false;
+  const selectIsActive = useMemo(() => {
+    const strIndex = String(index);
+    return (state: RechartsRootState): boolean => hasActiveShape && selectActiveTooltipIndex(state) === strIndex;
+  }, [hasActiveShape, index]);
+  const isActive: boolean = useAppSelector(selectIsActive) ?? false;
+
+  // isActive is only true when hasActiveShape is true, so activeShape is defined here
+  const option = isActive && activeShape != null && activeShape !== false ? activeShape : shape;
+  const symbolProps: ScatterShapeProps = {
+    ...baseProps,
+    ...entry,
+    isActive,
+    index,
+    animationElapsedTime,
+    isAnimating,
+    isEntrance,
+    [DATA_ITEM_GRAPHICAL_ITEM_ID_ATTRIBUTE_NAME]: String(id),
+  };
+
+  return (
+    <ZIndexLayer
+      /*
+       * inactive Scatters use the parent zIndex, which is represented by undefined here.
+       * ZIndexLayer will render undefined zIndex as-is, as regular children, without portals.
+       * Active Scatters use the activeDot zIndex so they render above other elements.
+       */
+      zIndex={isActive ? DefaultZIndexes.activeDot : undefined}
+    >
+      <Layer
+        className="recharts-scatter-symbol"
+        {...adaptEventsOfChild(restOfAllOtherProps, entry, index)}
+        onMouseEnter={onMouseEnterFromContext(entry, index)}
+        onMouseLeave={onMouseLeaveFromContext(entry, index)}
+        onClick={onClickFromContext(entry, index)}
+      >
+        <ScatterSymbol option={option} {...symbolProps} />
+      </Layer>
+    </ZIndexLayer>
+  );
+}
+
 function ScatterSymbols(props: ScatterSymbolsProps) {
   const { points, allOtherScatterProps, animationElapsedTime, isAnimating, isEntrance } = props;
   const { shape, activeShape, dataKey } = allOtherScatterProps;
   const { id, ...allOtherPropsWithoutId } = allOtherScatterProps;
 
-  const activeIndex = useAppSelector(selectActiveTooltipIndex);
   const {
     onMouseEnter: onMouseEnterFromProps,
     onClick: onItemClickFromProps,
@@ -567,43 +646,24 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
   return (
     <>
       <ScatterLine points={points} props={allOtherPropsWithoutId} />
-      {points.map((entry: ScatterPointItem, i: number) => {
-        const hasActiveShape = activeShape != null && activeShape !== false;
-        const isActive: boolean = hasActiveShape && activeIndex === String(i);
-        const option = hasActiveShape && isActive ? activeShape : shape;
-        const symbolProps: ScatterShapeProps = {
-          ...baseProps,
-          ...entry,
-          isActive,
-          index: i,
-          animationElapsedTime,
-          isAnimating,
-          isEntrance,
-          [DATA_ITEM_GRAPHICAL_ITEM_ID_ATTRIBUTE_NAME]: String(id),
-        };
-
-        return (
-          <ZIndexLayer
-            key={`symbol-${entry?.cx}-${entry?.cy}-${entry?.size}-${i}`}
-            /*
-             * inactive Scatters use the parent zIndex, which is represented by undefined here.
-             * ZIndexLayer will render undefined zIndex as-is, as regular children, without portals.
-             * Active Scatters use the activeDot zIndex so they render above other elements.
-             */
-            zIndex={isActive ? DefaultZIndexes.activeDot : undefined}
-          >
-            <Layer
-              className="recharts-scatter-symbol"
-              {...adaptEventsOfChild(restOfAllOtherProps, entry, i)}
-              onMouseEnter={onMouseEnterFromContext(entry, i)}
-              onMouseLeave={onMouseLeaveFromContext(entry, i)}
-              onClick={onClickFromContext(entry, i)}
-            >
-              <ScatterSymbol option={option} {...symbolProps} />
-            </Layer>
-          </ZIndexLayer>
-        );
-      })}
+      {points.map((entry: ScatterPointItem, i: number) => (
+        <ScatterPoint
+          key={`symbol-${entry?.cx}-${entry?.cy}-${entry?.size}-${i}`}
+          entry={entry}
+          index={i}
+          shape={shape}
+          activeShape={activeShape}
+          baseProps={baseProps}
+          id={id}
+          restOfAllOtherProps={restOfAllOtherProps}
+          animationElapsedTime={animationElapsedTime}
+          isAnimating={isAnimating}
+          isEntrance={isEntrance}
+          onMouseEnterFromContext={onMouseEnterFromContext}
+          onMouseLeaveFromContext={onMouseLeaveFromContext}
+          onClickFromContext={onClickFromContext}
+        />
+      ))}
     </>
   );
 }

--- a/test/cartesian/Scatter.spec.tsx
+++ b/test/cartesian/Scatter.spec.tsx
@@ -1,7 +1,17 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { Scatter, Customized, ScatterChart, XAxis, YAxis, ScatterProps, ZAxis, Tooltip } from '../../src';
+import {
+  Scatter,
+  Customized,
+  ScatterChart,
+  XAxis,
+  YAxis,
+  ScatterProps,
+  ZAxis,
+  Tooltip,
+  ScatterShapeProps,
+} from '../../src';
 import { assertNotNull } from '../helper/assertNotNull';
 import { useAppSelector } from '../../src/state/hooks';
 import { selectUnfilteredCartesianItems } from '../../src/state/selectors/axisSelectors';
@@ -685,6 +695,54 @@ describe('<Scatter />', () => {
           expect.arrayContaining([expect.objectContaining({ payload: expect.objectContaining(data01[0]) })]),
         );
       });
+    });
+  });
+
+  describe('ScatterPoint per-point rendering optimization', () => {
+    it('should only re-render the active and previously-active points when hovering, not all points', () => {
+      const shapeSpy = vi.fn((_props: ScatterShapeProps) => <circle r={5} cx={0} cy={0} />);
+      const pointCount = 20;
+      const scatterData = Array.from({ length: pointCount }, (_, i) => ({
+        x: i * 50,
+        y: i * 50,
+        z: 100,
+      }));
+
+      const { container } = render(
+        <ScatterChart width={1000} height={1000}>
+          <XAxis type="number" dataKey="x" />
+          <YAxis type="number" dataKey="y" />
+          <Scatter isAnimationActive={false} data={scatterData} shape={shapeSpy} activeShape={{ fill: 'red' }} />
+        </ScatterChart>,
+      );
+
+      // After initial render, the shape spy was called once per point
+      const initialCallCount = shapeSpy.mock.calls.length;
+      expect(initialCallCount).toBe(pointCount);
+
+      shapeSpy.mockClear();
+
+      // Hover over the first scatter point
+      const symbols = container.querySelectorAll('.recharts-scatter-symbol');
+      assertNotNull(symbols[0]);
+      fireEvent.mouseEnter(symbols[0]);
+
+      // Only the newly active point should re-render its shape, not all points.
+      // With the per-point selector optimization, only 1 point re-renders (the one becoming active).
+      // Without the optimization, all 20 points would re-render.
+      const afterFirstHover = shapeSpy.mock.calls.length;
+      expect(afterFirstHover).toBeLessThan(pointCount);
+
+      shapeSpy.mockClear();
+
+      // Now hover over a different point
+      assertNotNull(symbols[5]);
+      fireEvent.mouseEnter(symbols[5]);
+
+      // Only the previously-active and newly-active points should re-render (at most 2),
+      // not all 20 points
+      const afterSecondHover = shapeSpy.mock.calls.length;
+      expect(afterSecondHover).toBeLessThan(pointCount);
     });
   });
 });

--- a/test/cartesian/Scatter.spec.tsx
+++ b/test/cartesian/Scatter.spec.tsx
@@ -701,54 +701,56 @@ describe('<Scatter />', () => {
   describe('ScatterPoint per-point rendering optimization', () => {
     it('should only re-render the active and previously-active points when hovering, not all points', () => {
       vi.useFakeTimers();
-      const shapeSpy = vi.fn((_props: ScatterShapeProps) => <circle r={5} cx={0} cy={0} />);
-      const pointCount = 20;
-      const scatterData = Array.from({ length: pointCount }, (_, i) => ({
-        x: i * 50,
-        y: i * 50,
-        z: 100,
-      }));
+      try {
+        const shapeSpy = vi.fn((_props: ScatterShapeProps) => <circle r={5} cx={0} cy={0} />);
+        const pointCount = 20;
+        const scatterData = Array.from({ length: pointCount }, (_, i) => ({
+          x: i * 50,
+          y: i * 50,
+          z: 100,
+        }));
 
-      const { container } = render(
-        <ScatterChart width={1000} height={1000}>
-          <XAxis type="number" dataKey="x" />
-          <YAxis type="number" dataKey="y" />
-          <Scatter isAnimationActive={false} data={scatterData} shape={shapeSpy} activeShape={{ fill: 'red' }} />
-        </ScatterChart>,
-      );
-      vi.runOnlyPendingTimers();
+        const { container } = render(
+          <ScatterChart width={1000} height={1000}>
+            <XAxis type="number" dataKey="x" />
+            <YAxis type="number" dataKey="y" />
+            <Scatter isAnimationActive={false} data={scatterData} shape={shapeSpy} activeShape={{ fill: 'red' }} />
+          </ScatterChart>,
+        );
+        vi.runOnlyPendingTimers();
 
-      // After initial render, the shape spy was called once per point
-      const initialCallCount = shapeSpy.mock.calls.length;
-      expect(initialCallCount).toBe(pointCount);
+        // After initial render, the shape spy was called once per point
+        const initialCallCount = shapeSpy.mock.calls.length;
+        expect(initialCallCount).toBe(pointCount);
 
-      shapeSpy.mockClear();
+        shapeSpy.mockClear();
 
-      // Hover over the first scatter point
-      const symbols = container.querySelectorAll('.recharts-scatter-symbol');
-      assertNotNull(symbols[0]);
-      fireEvent.mouseEnter(symbols[0]);
-      vi.runOnlyPendingTimers();
+        // Hover over the first scatter point
+        const symbols = container.querySelectorAll('.recharts-scatter-symbol');
+        assertNotNull(symbols[0]);
+        fireEvent.mouseEnter(symbols[0]);
+        vi.runOnlyPendingTimers();
 
-      // Only the newly active point should re-render its shape, not all points.
-      // With the per-point selector optimization, only 1 point re-renders (the one becoming active).
-      // Without the optimization, all 20 points would re-render.
-      const afterFirstHover = shapeSpy.mock.calls.length;
-      expect(afterFirstHover).toBeLessThanOrEqual(2);
+        // Only the newly active point should re-render its shape, not all points.
+        // With the per-point selector optimization, only 1 point re-renders (the one becoming active).
+        // Without the optimization, all 20 points would re-render.
+        const afterFirstHover = shapeSpy.mock.calls.length;
+        expect(afterFirstHover).toBeLessThanOrEqual(2);
 
-      shapeSpy.mockClear();
+        shapeSpy.mockClear();
 
-      // Now hover over a different point
-      assertNotNull(symbols[5]);
-      fireEvent.mouseEnter(symbols[5]);
-      vi.runOnlyPendingTimers();
+        // Now hover over a different point
+        assertNotNull(symbols[5]);
+        fireEvent.mouseEnter(symbols[5]);
+        vi.runOnlyPendingTimers();
 
-      // Only the previously-active and newly-active points should re-render (at most 2),
-      // not all 20 points
-      const afterSecondHover = shapeSpy.mock.calls.length;
-      expect(afterSecondHover).toBeLessThanOrEqual(2);
-
-      vi.useRealTimers();
+        // Only the previously-active and newly-active points should re-render (at most 2),
+        // not all 20 points
+        const afterSecondHover = shapeSpy.mock.calls.length;
+        expect(afterSecondHover).toBeLessThanOrEqual(2);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/test/cartesian/Scatter.spec.tsx
+++ b/test/cartesian/Scatter.spec.tsx
@@ -700,6 +700,7 @@ describe('<Scatter />', () => {
 
   describe('ScatterPoint per-point rendering optimization', () => {
     it('should only re-render the active and previously-active points when hovering, not all points', () => {
+      vi.useFakeTimers();
       const shapeSpy = vi.fn((_props: ScatterShapeProps) => <circle r={5} cx={0} cy={0} />);
       const pointCount = 20;
       const scatterData = Array.from({ length: pointCount }, (_, i) => ({
@@ -715,6 +716,7 @@ describe('<Scatter />', () => {
           <Scatter isAnimationActive={false} data={scatterData} shape={shapeSpy} activeShape={{ fill: 'red' }} />
         </ScatterChart>,
       );
+      vi.runOnlyPendingTimers();
 
       // After initial render, the shape spy was called once per point
       const initialCallCount = shapeSpy.mock.calls.length;
@@ -726,23 +728,27 @@ describe('<Scatter />', () => {
       const symbols = container.querySelectorAll('.recharts-scatter-symbol');
       assertNotNull(symbols[0]);
       fireEvent.mouseEnter(symbols[0]);
+      vi.runOnlyPendingTimers();
 
       // Only the newly active point should re-render its shape, not all points.
       // With the per-point selector optimization, only 1 point re-renders (the one becoming active).
       // Without the optimization, all 20 points would re-render.
       const afterFirstHover = shapeSpy.mock.calls.length;
-      expect(afterFirstHover).toBeLessThan(pointCount);
+      expect(afterFirstHover).toBeLessThanOrEqual(2);
 
       shapeSpy.mockClear();
 
       // Now hover over a different point
       assertNotNull(symbols[5]);
       fireEvent.mouseEnter(symbols[5]);
+      vi.runOnlyPendingTimers();
 
       // Only the previously-active and newly-active points should re-render (at most 2),
       // not all 20 points
       const afterSecondHover = shapeSpy.mock.calls.length;
-      expect(afterSecondHover).toBeLessThan(pointCount);
+      expect(afterSecondHover).toBeLessThanOrEqual(2);
+
+      vi.useRealTimers();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Extract `ScatterPoint` component so each point subscribes to its own `isActive` selector, instead of the parent `ScatterSymbols` subscribing to `selectActiveTooltipIndex` and re-rendering all N points on every hover change
- On mouse move, only the 1-2 affected points re-render (the point becoming active and the point becoming inactive), instead of all N
- With 5,000 points, this reduces re-renders per hover from ~5,000 to ~2

This significantly improves hover responsiveness but does not eliminate all lag at very high point counts (10K+), as the remaining cost comes from SVG hit-testing across thousands of DOM elements and per-point hook overhead (ZIndexLayer, useLayoutEffect). Further optimizations to initial render time and component tree depth are possible follow-up work.

## Context

This addresses #2862 (Scatter chart performance issues, P1). The root cause is that `ScatterSymbols` subscribed to `selectActiveTooltipIndex` at the parent level, causing all scatter points to re-render on every tooltip index change. Each re-render created per-point event handler closures, object spreads, and `adaptEventsOfChild` wrappers — ~20,000 allocations per mouse move with 5,000 points.

The fix moves the `isActive` check into each `ScatterPoint` component via a memoized per-point selector. The parent no longer subscribes to the tooltip index, so it doesn't re-render on hover. Each point's selector is trivial (`hasActiveShape && selectActiveTooltipIndex(state) === String(index)`) and only triggers a re-render when that specific point's active state changes.

Unlike external memoization workarounds that filter out event handler props (as discussed in #2862), this fix addresses the root cause internally.

Note: direct hover within a dense scatter chart (where points overlap) was verified to work correctly — moving between overlapping points updates the tooltip without requiring empty space in between.

## Follow-up optimization opportunities

We identified several additional bottlenecks that affect initial render time (1-1.5s for points to appear, 3-5s before tooltips are interactive at 10K points). These are independent of the hover optimization in this PR:

- **ZIndexLayer overhead**: Every scatter point is wrapped in a ZIndexLayer that calls `useLayoutEffect` + `useAppSelector` even when inactive (zIndex=undefined takes the early-return path). With 10K points, that's ~50,000 hook instances on mount for no benefit. Lazy portal registration (only when a point becomes active) could eliminate this.
- **Animation during mount**: Default 400ms animation interpolates all point positions frame-by-frame, calling `computeScatterPoints` ~30 times. Large datasets could benefit from skipping animation or deferring tooltip registration until animation completes.
- **Event delegation**: Replacing per-point `onMouseEnter`/`onMouseLeave`/`onClick` handlers with a single delegated handler on the parent `<g>` would eliminate thousands of closure allocations on initial render. However, this approach conflicts with ZIndexLayer portals (portaled elements leave the delegating parent's DOM subtree), so it would require rethinking the portal strategy first.

## Test plan

- [ ] Existing scatter tests pass (17 tests in `Scatter.spec.tsx`)
- [ ] New render-count test verifies that hovering triggers fewer re-renders than the total point count
- [ ] Manual testing with 5,000+ point scatter chart confirms smooth hover interaction
- [ ] `activeShape` prop works correctly (active point renders with custom shape and z-index portal)
- [ ] User-provided event handlers (`onMouseEnter`, `onMouseLeave`, `onClick`, `onMouseOver`, `onMouseOut`) still fire with correct `(data, index, event)` arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-point scatter elements with independent active-state handling and per-point z-index layering.
  * Added a public export for scatter shape props.

* **Performance**
  * Selective re-rendering so only the active (and previously active) points update on hover, reducing unnecessary updates.

* **Tests**
  * Added tests validating per-point render optimization and hover-driven limited re-renders.

* **Documentation**
  * Added component documentation for the per-point scatter element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->