### PR TITLE
feat(types): make TooltipPayload generic for type-safe tooltip content

### DIFF
--- a/src/component/Tooltip.tsx
+++ b/src/component/Tooltip.tsx
@@ -45,7 +45,7 @@ export type TooltipContentProps<TValue extends ValueType = ValueType, TName exte
   TName
 > & {
   label?: string | number;
-  payload: TooltipPayload;
+  payload: TooltipPayload<TValue, TName>;
   coordinate: Coordinate | undefined;
   active: boolean;
   accessibilityLayer: boolean;

--- a/src/state/tooltipSlice.ts
+++ b/src/state/tooltipSlice.ts
@@ -27,7 +27,9 @@ export type TooltipEntrySettings = Omit<TooltipPayloadEntry, 'payload' | 'value'
 /**
  * This is what Tooltip renders.
  */
-export type TooltipPayload = ReadonlyArray<TooltipPayloadEntry>;
+export type TooltipPayload<TValue extends ValueType = ValueType, TName extends NameType = NameType> = ReadonlyArray<
+  Payload<TValue, TName>
+>;
 
 /**
  * null means no active index

--- a/test/component/Tooltip.spec-d.tsx
+++ b/test/component/Tooltip.spec-d.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { describe, it, expectTypeOf } from 'vitest';
+import { ContentType, TooltipContentProps } from '../../src/component/Tooltip';
+import { Payload } from '../../src/component/DefaultTooltipContent';
+import { TooltipPayload } from '../../src/state/tooltipSlice';
+
+describe('TooltipContentProps payload type', () => {
+  it('should preserve generic type parameters in payload', () => {
+    type MyValue = number;
+    type MyName = string;
+
+    type Props = TooltipContentProps<MyValue, MyName>;
+    expectTypeOf<Props['payload']>().toEqualTypeOf<TooltipPayload<MyValue, MyName>>();
+    expectTypeOf<Props['payload']>().toEqualTypeOf<ReadonlyArray<Payload<MyValue, MyName>>>();
+  });
+
+  it('should default to ValueType and NameType when no generics are provided', () => {
+    type Props = TooltipContentProps;
+    expectTypeOf<Props['payload']>().toEqualTypeOf<TooltipPayload>();
+  });
+
+  it('should pass generic types through ContentType callback', () => {
+    type MyValue = number;
+    type MyName = string;
+
+    type MyContent = ContentType<MyValue, MyName>;
+    type CallbackContent = Extract<MyContent, (props: TooltipContentProps<MyValue, MyName>) => React.ReactNode>;
+    expectTypeOf<Parameters<CallbackContent>[0]['payload']>().toEqualTypeOf<ReadonlyArray<Payload<MyValue, MyName>>>();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #7132

`TooltipContentProps<TValue, TName>` was already generic over value and name types, but its `payload` property was typed as the non-generic `TooltipPayload` (i.e. `ReadonlyArray<Payload<ValueType, NameType>>`). This discarded all the type information and required users to cast payload items when using a custom tooltip:

```tsx
// Before — no type inference, requires cast:
const MyTooltip = ({ payload }: TooltipContentProps<number, string>) => {
  const value = payload?.[0].value; // type: ValueType = string | number | (string | number)[]
};
```

With this change:
```tsx
// After — correctly typed:
const MyTooltip = ({ payload }: TooltipContentProps<number, string>) => {
  const value = payload?.[0].value; // type: number ✓
};
```

## Changes

- **`src/state/tooltipSlice.ts`**: Made `TooltipPayload` generic with default type params for full backward compatibility (`TooltipPayload<TValue extends ValueType = ValueType, TName extends NameType = NameType>`)
- **`src/component/Tooltip.tsx`**: Updated `TooltipContentProps.payload` to use `TooltipPayload<TValue, TName>`
- **`test/component/Tooltip.spec-d.tsx`**: Added type tests verifying the generic typing works end-to-end

## Backward compatibility

All existing code using `TooltipPayload` without type arguments continues to work — the defaults resolve to the original `Payload<ValueType, NameType>` type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced tooltip component type definitions with improved generic type support, providing better type safety and flexibility.

* **Tests**
  * Added comprehensive type validation tests to ensure tooltip payload types are correctly preserved across generic parameters and callback functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->