### PR TITLE
feat(RadialBar): add minAngle prop for minimum bar angle

### DIFF
--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -355,6 +355,11 @@ interface InternalRadialBarProps<DataPointType = any, DataValueType = any>
   legendType?: LegendType;
   maxBarSize?: number;
   /**
+   * The minimum angle of each unzero bar.
+   * @defaultValue 0
+   */
+  minAngle?: number;
+  /**
    * @defaultValue 0
    */
   minPointSize?: number;
@@ -535,6 +540,7 @@ function RadialBarImpl(props: WithIdRequired<PropsWithDefaults>) {
       hide: false,
       id: props.id,
       dataKey: props.dataKey,
+      minAngle: props.minAngle,
       minPointSize: props.minPointSize,
       stackId: getNormalizedStackId(props.stackId),
       maxBarSize: props.maxBarSize,
@@ -546,6 +552,7 @@ function RadialBarImpl(props: WithIdRequired<PropsWithDefaults>) {
     [
       props.id,
       props.dataKey,
+      props.minAngle,
       props.minPointSize,
       props.stackId,
       props.maxBarSize,
@@ -589,6 +596,7 @@ export const defaultRadialBarProps = {
   isAnimationActive: 'auto',
   label: false,
   legendType: 'rect',
+  minAngle: 0,
   minPointSize: 0,
   radiusAxisId: 0,
   zIndex: DefaultZIndexes.bar,
@@ -612,6 +620,7 @@ export function computeRadialBarDataItems({
   bandSize,
   pos,
   angleAxis,
+  minAngle,
   minPointSize,
   cx,
   cy,
@@ -632,6 +641,7 @@ export function computeRadialBarDataItems({
   bandSize: number;
   pos: BarPositionPosition;
   angleAxis: BaseAxisWithScale;
+  minAngle: number;
   minPointSize: number;
   cx: number;
   cy: number;
@@ -677,7 +687,10 @@ export function computeRadialBarDataItems({
         outerRadius = innerRadius + pos.size;
         const deltaAngle = endAngle - startAngle;
 
-        if (Math.abs(minPointSize) > 0 && Math.abs(deltaAngle) < Math.abs(minPointSize)) {
+        if (Math.abs(minAngle) > 0 && Math.abs(deltaAngle) < Math.abs(minAngle)) {
+          const delta = mathSign(deltaAngle || minAngle) * (Math.abs(minAngle) - Math.abs(deltaAngle));
+          endAngle += delta;
+        } else if (Math.abs(minPointSize) > 0 && Math.abs(deltaAngle) < Math.abs(minPointSize)) {
           const delta = mathSign(deltaAngle || minPointSize) * (Math.abs(minPointSize) - Math.abs(deltaAngle));
 
           endAngle += delta;
@@ -759,6 +772,7 @@ export function RadialBar<DataPointType = any, DataValueType = any>(
             radiusAxisId={props.radiusAxisId ?? defaultRadialBarProps.radiusAxisId}
             stackId={getNormalizedStackId(props.stackId)}
             barSize={props.barSize}
+            minAngle={props.minAngle}
             minPointSize={props.minPointSize}
             maxBarSize={props.maxBarSize}
           />

--- a/src/state/selectors/radialBarSelectors.ts
+++ b/src/state/selectors/radialBarSelectors.ts
@@ -406,7 +406,7 @@ export const selectRadialBarSectors: (
     ) {
       return [];
     }
-    const { dataKey, minPointSize } = radialBarSettings;
+    const { dataKey, minAngle, minPointSize } = radialBarSettings;
     const { cx, cy, startAngle, endAngle } = polarViewBox;
     const displayedData = chartData.slice(dataStartIndex, dataEndIndex + 1);
     const numericAxis = layout === 'centric' ? radiusAxis : angleAxis;
@@ -424,6 +424,7 @@ export const selectRadialBarSectors: (
       displayedData,
       endAngle,
       layout,
+      minAngle,
       minPointSize,
       pos,
       radiusAxis,

--- a/src/state/types/RadialBarSettings.ts
+++ b/src/state/types/RadialBarSettings.ts
@@ -4,5 +4,6 @@ import { BasePolarGraphicalItemSettings } from '../graphicalItemsSlice';
 export interface RadialBarSettings extends BasePolarGraphicalItemSettings, MaybeStackedGraphicalItem {
   type: 'radialBar';
   minPointSize: number;
+  minAngle: number;
   maxBarSize: number | undefined;
 }

--- a/storybook/stories/Examples/RadialBarChart/RadialBarChart.stories.tsx
+++ b/storybook/stories/Examples/RadialBarChart/RadialBarChart.stories.tsx
@@ -79,6 +79,26 @@ export const RadialBarWithAxesAndGrid: StoryObj = {
   },
 };
 
+export const RadialBarWithMinAngle: StoryObj = {
+  render: () => {
+    const mixedData = [
+      { name: 'tiny', pv: 1, fill: '#8884d8' },
+      { name: 'small', pv: 50, fill: '#83a6ed' },
+      { name: 'medium', pv: 500, fill: '#8dd1e1' },
+      { name: 'large', pv: 3000, fill: '#82ca9d' },
+    ];
+    return (
+      <RadialBarChart width={500} height={500} data={mixedData} innerRadius={60} outerRadius={200}>
+        <PolarAngleAxis type="number" domain={[0, 3000]} />
+        <PolarRadiusAxis type="category" dataKey="name" />
+        <RadialBar dataKey="pv" minAngle={15} label={{ position: 'insideStart', fill: '#fff' }} />
+        <Legend />
+        <RechartsHookInspector />
+      </RadialBarChart>
+    );
+  },
+};
+
 export const RadialBarChartWithChangingDataKey: StoryObj = {
   render: (args: Args) => {
     const [dataKey, setDataKey] = React.useState('amt');

--- a/test/polar/PolarAngleAxis/PolarAngleAxis.spec.tsx
+++ b/test/polar/PolarAngleAxis/PolarAngleAxis.spec.tsx
@@ -1754,6 +1754,7 @@ describe('<PolarAngleAxis />', () => {
           {
             id: expect.stringMatching('radialBar-'),
             maxBarSize: undefined,
+            minAngle: 0,
             minPointSize: 0,
             barSize: undefined,
             stackId: undefined,
@@ -1927,6 +1928,7 @@ describe('<PolarAngleAxis />', () => {
           {
             id: expect.stringMatching('radialBar-'),
             maxBarSize: undefined,
+            minAngle: 0,
             minPointSize: 0,
             barSize: undefined,
             stackId: undefined,
@@ -2036,6 +2038,7 @@ describe('<PolarAngleAxis />', () => {
           {
             id: expect.stringMatching('radialBar-'),
             maxBarSize: undefined,
+            minAngle: 0,
             minPointSize: 0,
             barSize: undefined,
             stackId: undefined,

--- a/test/polar/RadialBar/RadialBar.spec.tsx
+++ b/test/polar/RadialBar/RadialBar.spec.tsx
@@ -51,6 +51,7 @@ describe('<RadialBar />', () => {
     const radialBarSettings: RadialBarSettings = {
       id: 'radial-bar-uv',
       dataKey: 'pv',
+      minAngle: 0,
       minPointSize: 0,
       stackId: undefined,
       maxBarSize: undefined,
@@ -75,6 +76,7 @@ describe('<RadialBar />', () => {
         {
           id: expect.stringMatching('radialBar-'),
           maxBarSize: undefined,
+          minAngle: 0,
           minPointSize: 0,
           angleAxisId: 0,
           barSize: undefined,
@@ -440,6 +442,7 @@ describe('<RadialBar />', () => {
     const radialBarSettings: RadialBarSettings = {
       id: 'my-radial-bar',
       dataKey: 'pv',
+      minAngle: 0,
       minPointSize: 0,
       stackId: undefined,
       maxBarSize: undefined,
@@ -474,6 +477,7 @@ describe('<RadialBar />', () => {
           stackId: undefined,
           type: 'radialBar',
           maxBarSize: undefined,
+          minAngle: 0,
           minPointSize: 0,
         },
       ]);
@@ -826,6 +830,7 @@ describe('<RadialBar />', () => {
     const radialBarSettings: RadialBarSettings = {
       id: 'my-radial-bar',
       dataKey: 'rings',
+      minAngle: 0,
       minPointSize: 0,
       stackId: undefined,
       maxBarSize: undefined,
@@ -861,6 +866,7 @@ describe('<RadialBar />', () => {
           stackId: undefined,
           type: 'radialBar',
           maxBarSize: undefined,
+          minAngle: 0,
           minPointSize: 0,
         },
       ]);
@@ -1304,6 +1310,7 @@ describe('<RadialBar />', () => {
         dataKey: 'value',
         hide: false,
         radiusAxisId: 0,
+        minAngle: 0,
         minPointSize: 0,
         maxBarSize: undefined,
       };

--- a/test/state/selectors/radialBarSelectors.spec.tsx
+++ b/test/state/selectors/radialBarSelectors.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import { RadialBarChart, RadialBar, PolarAngleAxis } from '../../../src';
 import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
 import { selectRadialBarSectors } from '../../../src/state/selectors/radialBarSelectors';
@@ -92,6 +92,7 @@ describe('minAngle prop', () => {
     const { spy } = renderWithMinAngle(state => selectRadialBarSectors(state, 0, 0, settingsWithMinAngle, undefined));
     const sectors = spy.mock.lastCall?.[0];
     expect(sectors).toBeDefined();
+    assert(sectors != null);
     expect(sectors).toHaveLength(2);
 
     // The tiny bar (value=1) should have its angle extended to at least minAngle=10 degrees
@@ -113,6 +114,8 @@ describe('minAngle prop', () => {
 
     expect(sectorsWithMin).toBeDefined();
     expect(sectorsNoMin).toBeDefined();
+    assert(sectorsWithMin != null);
+    assert(sectorsNoMin != null);
 
     // The large bar should have the same endAngle regardless of minAngle
     expect(sectorsWithMin[1].endAngle).toBeCloseTo(sectorsNoMin[1].endAngle, 5);

--- a/test/state/selectors/radialBarSelectors.spec.tsx
+++ b/test/state/selectors/radialBarSelectors.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { describe, it } from 'vitest';
-import { RadialBarChart, RadialBar } from '../../../src';
+import { describe, expect, it } from 'vitest';
+import { RadialBarChart, RadialBar, PolarAngleAxis } from '../../../src';
 import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
 import { selectRadialBarSectors } from '../../../src/state/selectors/radialBarSelectors';
 import { RadialBarSettings } from '../../../src/state/types/RadialBarSettings';
@@ -10,6 +10,7 @@ describe('selectRadialBarSectors', () => {
   const radialBarSettings: RadialBarSettings = {
     id: 'radial-bar-uv',
     dataKey: 'pv',
+    minAngle: 0,
     minPointSize: 0,
     stackId: undefined,
     maxBarSize: undefined,
@@ -37,5 +38,88 @@ describe('selectRadialBarSectors', () => {
     assertStableBetweenRenders(renderTestCase, state =>
       selectRadialBarSectors(state, 0, 0, radialBarSettings, undefined),
     );
+  });
+});
+
+describe('minAngle prop', () => {
+  /**
+   * Data where one bar has a very small value that would normally produce a tiny angle.
+   * The angle axis domain will be [0, 1000], so a value of 1 would map to ~0.36 degrees.
+   * minAngle: 10 should extend that bar's endAngle to cover at least 10 degrees.
+   */
+  const data = [
+    { name: 'tiny', pv: 1 },
+    { name: 'large', pv: 1000 },
+  ];
+
+  const settingsWithMinAngle: RadialBarSettings = {
+    id: 'radial-bar-pv',
+    dataKey: 'pv',
+    minAngle: 10,
+    minPointSize: 0,
+    stackId: undefined,
+    maxBarSize: undefined,
+    barSize: undefined,
+    type: 'radialBar',
+    angleAxisId: 0,
+    radiusAxisId: 0,
+    data: undefined,
+    hide: false,
+  };
+
+  const settingsNoMinAngle: RadialBarSettings = {
+    ...settingsWithMinAngle,
+    minAngle: 0,
+  };
+
+  const renderWithMinAngle = createSelectorTestCase(({ children }) => (
+    <RadialBarChart width={500} height={500} data={data}>
+      <PolarAngleAxis type="number" domain={[0, 1000]} />
+      <RadialBar dataKey="pv" minAngle={10} isAnimationActive={false} />
+      {children}
+    </RadialBarChart>
+  ));
+
+  const renderNoMinAngle = createSelectorTestCase(({ children }) => (
+    <RadialBarChart width={500} height={500} data={data}>
+      <PolarAngleAxis type="number" domain={[0, 1000]} />
+      <RadialBar dataKey="pv" isAnimationActive={false} />
+      {children}
+    </RadialBarChart>
+  ));
+
+  it('should apply minAngle to bars with small values in radial layout', () => {
+    const { spy } = renderWithMinAngle(state => selectRadialBarSectors(state, 0, 0, settingsWithMinAngle, undefined));
+    const sectors = spy.mock.lastCall?.[0];
+    expect(sectors).toBeDefined();
+    expect(sectors).toHaveLength(2);
+
+    // The tiny bar (value=1) should have its angle extended to at least minAngle=10 degrees
+    const tinySector = sectors[0];
+    const tinyDeltaAngle = Math.abs(tinySector.endAngle - tinySector.startAngle);
+    expect(tinyDeltaAngle).toBeGreaterThanOrEqual(10);
+  });
+
+  it('should not affect bars that already exceed minAngle', () => {
+    const { spy: spyWithMin } = renderWithMinAngle(state =>
+      selectRadialBarSectors(state, 0, 0, settingsWithMinAngle, undefined),
+    );
+    const { spy: spyNoMin } = renderNoMinAngle(state =>
+      selectRadialBarSectors(state, 0, 0, settingsNoMinAngle, undefined),
+    );
+
+    const sectorsWithMin = spyWithMin.mock.lastCall?.[0];
+    const sectorsNoMin = spyNoMin.mock.lastCall?.[0];
+
+    expect(sectorsWithMin).toBeDefined();
+    expect(sectorsNoMin).toBeDefined();
+
+    // The large bar should have the same endAngle regardless of minAngle
+    expect(sectorsWithMin[1].endAngle).toBeCloseTo(sectorsNoMin[1].endAngle, 5);
+
+    // The tiny bar should have a larger angle when minAngle is set
+    const tinyDeltaWithMin = Math.abs(sectorsWithMin[0].endAngle - sectorsWithMin[0].startAngle);
+    const tinyDeltaNoMin = Math.abs(sectorsNoMin[0].endAngle - sectorsNoMin[0].startAngle);
+    expect(tinyDeltaWithMin).toBeGreaterThan(tinyDeltaNoMin);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #2986

The `RadialBar` component was missing the documented `minAngle` prop. The recharts API docs ([RadialBar#minAngle](https://recharts.org/en-US/api/RadialBar#minAngle)) list this prop, but it had never been implemented.

## Changes

- Added `minAngle?: number` prop to `RadialBarProps` (default: `0`)
- Added `minAngle: number` to `RadialBarSettings` interface
- In radial layout (the default for RadialBarChart), when a bar's `deltaAngle` is less than `minAngle`, the `endAngle` is extended to meet the minimum — ensuring small-value bars remain visible
- Wired `minAngle` through `RadialBarImpl`, `SetPolarGraphicalItem`, and `selectRadialBarSectors`
- Added unit tests verifying the behaviour
- Added a Storybook story demonstrating the prop with mixed-magnitude data

## How to test

```tsx
<RadialBarChart width={500} height={500} data={data}>
  <RadialBar dataKey="value" minAngle={15} />
</RadialBarChart>
```

Any bar whose natural angle falls below 15° will be extended to 15° so it stays visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `minAngle` prop to RadialBar component, allowing you to enforce a minimum angular width for radial bar segments. Bars smaller than the specified minimum angle will be automatically adjusted to meet the threshold, ensuring better visibility of small values in your radial charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->