### PR TITLE
feat: allow HTML attributes passthrough on ResponsiveContainer

### DIFF
--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -25,7 +25,7 @@ import {
 import { Percent, Size } from '../util/types';
 import { isPositiveNumber } from '../util/isWellBehavedNumber';
 
-export interface Props {
+export interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'id' | 'className' | 'style' | 'onResize'> {
   /**
    * width / height. If specified, the height will be calculated by width / aspect.
    */
@@ -79,7 +79,7 @@ export interface Props {
   /** The HTML element's class name */
   className?: string | number;
   /** The style of the container. */
-  style?: Omit<CSSProperties, keyof Props>;
+  style?: CSSProperties;
   /**
    * If specified provides a callback providing the updated chart width and height values.
    */
@@ -135,6 +135,7 @@ const SizeDetectorContainer = forwardRef<HTMLDivElement | null, Props>(
       className,
       onResize,
       style = {},
+      ...others
     }: Props,
     ref,
   ) => {
@@ -233,6 +234,7 @@ const SizeDetectorContainer = forwardRef<HTMLDivElement | null, Props>(
         className={clsx('recharts-responsive-container', className)}
         style={{ ...style, width, height, minWidth, minHeight, maxHeight }}
         ref={containerRef}
+        {...others}
       >
         <div style={getInnerDivStyle({ width, height })}>
           <ResponsiveContainerContextProvider width={calculatedWidth} height={calculatedHeight}>

--- a/test/component/ResponsiveContainerDataTest.spec.tsx
+++ b/test/component/ResponsiveContainerDataTest.spec.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { ResponsiveContainer, BarChart, Bar } from '../../src';
+
+describe('ResponsiveContainer Data Attributes', () => {
+  test('should pass down data-testid to the root div', () => {
+    const { container } = render(
+      <ResponsiveContainer data-testid="my-container" initialDimension={{ width: 100, height: 100 }}>
+        <BarChart width={100} height={100} data={[]}>
+          <Bar dataKey="value" />
+        </BarChart>
+      </ResponsiveContainer>,
+    );
+
+    const div = container.querySelector('[data-testid="my-container"]');
+    expect(div).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`ResponsiveContainer` previously did not accept standard HTML attributes like `data-testid`, `aria-label`, `role`, etc. Users who needed these for testing or accessibility had to wrap the container in an extra `div`.

## Changes

- Extended `Props` interface to include `React.HTMLAttributes<HTMLDivElement>` (with `Omit` for internally-managed props: `id`, `className`, `style`, `onResize`)
- Spread remaining props (`...others`) onto the root container `div`
- Simplified `style` prop type from `Omit<CSSProperties, keyof Props>` to `CSSProperties` — the previous type was overly restrictive and stripped valid CSS properties like `color` and `width` that happened to share names with component props

## Usage

```tsx
<ResponsiveContainer data-testid="my-chart" aria-label="Sales chart" role="img">
  <BarChart data={data}>...</BarChart>
</ResponsiveContainer>
```

## Tests

Added `test/component/ResponsiveContainerDataTest.spec.tsx` verifying `data-testid` passthrough.
All 26 existing ResponsiveContainer tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ResponsiveContainer now accepts and forwards additional standard HTML/div attributes (e.g., data-*, ARIA, event handlers) and uses a simplified style prop for easier styling.

* **Tests**
  * Added a test to verify ResponsiveContainer forwards custom HTML attributes and renders as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recharts/recharts/pull/7168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->