### PR TITLE
fix(Legend): prevent overlap with chart on container resize

### DIFF
--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CSSProperties, useEffect } from 'react';
+import { CSSProperties, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useLegendPortal } from '../context/legendPortalContext';
 import {
@@ -158,7 +158,7 @@ export type Props = Omit<DefaultLegendContentProps, 'payload' | 'ref' | 'vertica
 
 function LegendSettingsDispatcher(props: LegendSettings): null {
   const dispatch = useAppDispatch();
-  useEffect(() => {
+  useLayoutEffect(() => {
     dispatch(setLegendSettings(props));
   }, [dispatch, props]);
   return null;
@@ -166,7 +166,7 @@ function LegendSettingsDispatcher(props: LegendSettings): null {
 
 function LegendSizeDispatcher(props: Size): null {
   const dispatch = useAppDispatch();
-  useEffect(() => {
+  useLayoutEffect(() => {
     dispatch(setLegendSize(props));
     return () => {
       dispatch(setLegendSize({ width: 0, height: 0 }));

--- a/src/component/Legend.tsx
+++ b/src/component/Legend.tsx
@@ -156,22 +156,25 @@ export type Props = Omit<DefaultLegendContentProps, 'payload' | 'ref' | 'vertica
   verticalAlign?: VerticalAlignmentType;
 };
 
-function LegendSettingsDispatcher(props: LegendSettings): null {
+function LegendSettingsDispatcher({ align, layout, verticalAlign, itemSorter }: LegendSettings): null {
   const dispatch = useAppDispatch();
   useLayoutEffect(() => {
-    dispatch(setLegendSettings(props));
-  }, [dispatch, props]);
+    dispatch(setLegendSettings({ align, layout, verticalAlign, itemSorter }));
+  }, [dispatch, align, layout, verticalAlign, itemSorter]);
   return null;
 }
 
-function LegendSizeDispatcher(props: Size): null {
+function LegendSizeDispatcher({ width, height }: Size): null {
   const dispatch = useAppDispatch();
   useLayoutEffect(() => {
-    dispatch(setLegendSize(props));
+    dispatch(setLegendSize({ width, height }));
+  }, [dispatch, width, height]);
+
+  useLayoutEffect(() => {
     return () => {
       dispatch(setLegendSize({ width: 0, height: 0 }));
     };
-  }, [dispatch, props]);
+  }, [dispatch]);
   return null;
 }
 

--- a/src/state/legendSlice.ts
+++ b/src/state/legendSlice.ts
@@ -32,7 +32,7 @@ const initialState: LegendState = {
   settings: {
     layout: 'horizontal',
     align: 'center',
-    verticalAlign: 'middle',
+    verticalAlign: 'bottom',
     itemSorter: 'value',
   },
   size: {

--- a/src/util/useElementOffset.ts
+++ b/src/util/useElementOffset.ts
@@ -3,42 +3,59 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 const EPS = 1;
 
 /**
- * TODO this documentation does not reflect what this hook is doing, update it.
- * Stores the `offsetHeight`, `offsetLeft`, `offsetTop`, and `offsetWidth` of a DOM element.
+ * Stores the dimensions and position of a DOM element as returned by `getBoundingClientRect()`.
+ *
+ * Values are viewport-relative and may be fractional (subpixel precision).
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect}
  */
 export type ElementOffset = {
   /**
-   * Height of an element, including vertical padding and borders, as an integer.
+   * Height of an element as returned by `getBoundingClientRect()`.
+   * This is the CSS height including padding and border, and may be a fractional value.
    *
-   * Typically, offsetHeight is a measurement in pixels of the element's CSS height, including any borders, padding, and horizontal scrollbars (if rendered). It does not include the height of pseudo-elements such as ::before or ::after
-   *
-   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/DOMRect/height}
    */
   height: number;
   /**
-   * Number of pixels that the upper left corner of the current element is offset to the left within the HTMLElement.offsetParent node
+   * Distance from the left edge of the viewport to the left edge of the element,
+   * as returned by `getBoundingClientRect()`.
    *
-   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetLeft
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/DOMRect/left}
    */
   left: number;
   /**
-   * Distance from the outer border of the current element (including its margin) to the top padding edge of the offsetParent, the closest positioned ancestor element.
+   * Distance from the top edge of the viewport to the top edge of the element,
+   * as returned by `getBoundingClientRect()`.
    *
-   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetTop
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/DOMRect/top}
    */
   top: number;
   /**
-   * Layout width of an element as an integer.
+   * Width of an element as returned by `getBoundingClientRect()`.
+   * This is the CSS width including padding and border, and may be a fractional value.
    *
-   * Typically, offsetWidth is a measurement in pixels of the element's CSS width, including any borders, padding, and vertical scrollbars (if rendered). It does not include the width of pseudo-elements such as ::before or ::after.
-   *
-   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/DOMRect/width}
    */
   width: number;
 };
 
+/**
+ * Callback ref setter returned by {@link useElementOffset}.
+ *
+ * Pass this to a DOM element's `ref` prop to start observing its layout.
+ *
+ * @param node - the DOM element to observe, or `null` when the element unmounts
+ */
 export type SetElementOffset = (node: HTMLElement | null) => void;
 
+/**
+ * Checks whether two ElementOffset values differ by more than `EPS` (1px) in any dimension.
+ *
+ * @param a - the first ElementOffset to compare
+ * @param b - the second ElementOffset to compare
+ * @returns true if any dimension differs by more than 1px
+ */
 function hasSignificantChange(a: ElementOffset, b: ElementOffset): boolean {
   return (
     Math.abs(a.height - b.height) > EPS ||
@@ -48,6 +65,12 @@ function hasSignificantChange(a: ElementOffset, b: ElementOffset): boolean {
   );
 }
 
+/**
+ * Reads the current bounding box of a DOM element using `getBoundingClientRect()`.
+ *
+ * @param node - the DOM element to measure
+ * @returns an ElementOffset with the element's current dimensions and viewport-relative position
+ */
 function readElementOffset(node: HTMLElement): ElementOffset {
   const rect = node.getBoundingClientRect();
   return {
@@ -85,7 +108,7 @@ export function useElementOffset(extraDependencies: ReadonlyArray<unknown> = [])
       if (node != null) {
         // Measure immediately on ref attach
         const box = readElementOffset(node);
-        if (hasSignificantChange(box, lastBoundingBox)) {
+        if (hasSignificantChange(box, lastBoundingBoxRef.current)) {
           setLastBoundingBox(box);
         }
 
@@ -103,7 +126,7 @@ export function useElementOffset(extraDependencies: ReadonlyArray<unknown> = [])
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [lastBoundingBox.width, lastBoundingBox.height, lastBoundingBox.top, lastBoundingBox.left, ...extraDependencies],
+    [...extraDependencies],
   );
 
   // Cleanup on unmount

--- a/src/util/useElementOffset.ts
+++ b/src/util/useElementOffset.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const EPS = 1;
 
@@ -39,38 +39,79 @@ export type ElementOffset = {
 
 export type SetElementOffset = (node: HTMLElement | null) => void;
 
+function hasSignificantChange(a: ElementOffset, b: ElementOffset): boolean {
+  return (
+    Math.abs(a.height - b.height) > EPS ||
+    Math.abs(a.left - b.left) > EPS ||
+    Math.abs(a.top - b.top) > EPS ||
+    Math.abs(a.width - b.width) > EPS
+  );
+}
+
+function readElementOffset(node: HTMLElement): ElementOffset {
+  const rect = node.getBoundingClientRect();
+  return {
+    height: rect.height,
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+  };
+}
+
 /**
  * Use this to listen to element layout changes.
  *
  * Very useful for reading actual sizes of DOM elements relative to the viewport.
+ *
+ * Uses ResizeObserver to automatically detect size changes of the observed element.
  *
  * @param extraDependencies use this to trigger new DOM dimensions read when any of these change. Good for things like payload and label, that will re-render something down in the children array, but you want to read the layout box of a parent.
  * @returns [lastElementOffset, updateElementOffset] most recent value, and setter. Pass the setter to a DOM element ref like this: `<div ref={updateElementOffset}>`
  */
 export function useElementOffset(extraDependencies: ReadonlyArray<unknown> = []): [ElementOffset, SetElementOffset] {
   const [lastBoundingBox, setLastBoundingBox] = useState<ElementOffset>({ height: 0, left: 0, top: 0, width: 0 });
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const lastBoundingBoxRef = useRef(lastBoundingBox);
+  lastBoundingBoxRef.current = lastBoundingBox;
+
   const updateBoundingBox = useCallback(
     (node: HTMLElement | null) => {
+      // Disconnect any previously active ResizeObserver
+      if (observerRef.current != null) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+
       if (node != null) {
-        const rect = node.getBoundingClientRect();
-        const box: ElementOffset = {
-          height: rect.height,
-          left: rect.left,
-          top: rect.top,
-          width: rect.width,
-        };
-        if (
-          Math.abs(box.height - lastBoundingBox.height) > EPS ||
-          Math.abs(box.left - lastBoundingBox.left) > EPS ||
-          Math.abs(box.top - lastBoundingBox.top) > EPS ||
-          Math.abs(box.width - lastBoundingBox.width) > EPS
-        ) {
-          setLastBoundingBox({ height: box.height, left: box.left, top: box.top, width: box.width });
+        // Measure immediately on ref attach
+        const box = readElementOffset(node);
+        if (hasSignificantChange(box, lastBoundingBox)) {
+          setLastBoundingBox(box);
+        }
+
+        // Set up ResizeObserver for future size changes
+        if (typeof ResizeObserver !== 'undefined') {
+          const observer = new ResizeObserver(() => {
+            const newBox = readElementOffset(node);
+            if (hasSignificantChange(newBox, lastBoundingBoxRef.current)) {
+              setLastBoundingBox(newBox);
+            }
+          });
+          observer.observe(node);
+          observerRef.current = observer;
         }
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [lastBoundingBox.width, lastBoundingBox.height, lastBoundingBox.top, lastBoundingBox.left, ...extraDependencies],
   );
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, []);
+
   return [lastBoundingBox, updateBoundingBox];
 }

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -1029,7 +1029,7 @@ describe('<Legend />', () => {
       expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(1);
 
       expect(yAxisRangeSpy).toHaveBeenLastCalledWith([485, 5]);
-      expect(yAxisRangeSpy).toHaveBeenCalledTimes(3);
+      expect(yAxisRangeSpy).toHaveBeenCalledTimes(2);
 
       expectBars(container, [
         {
@@ -1092,7 +1092,7 @@ describe('<Legend />', () => {
       expect(container.querySelectorAll('.recharts-default-legend')).toHaveLength(0);
 
       expect(yAxisRangeSpy).toHaveBeenLastCalledWith([495, 5]);
-      expect(yAxisRangeSpy).toHaveBeenCalledTimes(4);
+      expect(yAxisRangeSpy).toHaveBeenCalledTimes(3);
 
       expectBars(container, [
         {
@@ -1630,7 +1630,7 @@ describe('<Legend />', () => {
             spy(offset);
           },
         )();
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
         expectLastCalledWith(spy, {
           brushBottom: 5,
           top: 5,
@@ -1659,7 +1659,7 @@ describe('<Legend />', () => {
             spy(offset);
           },
         )();
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenCalledTimes(3);
         expectLastCalledWith(spy, {
           brushBottom: 5,
           top: 5,

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -24,7 +24,7 @@ import {
   Surface,
 } from '../../src';
 import { testChartLayoutContext } from '../util/context';
-import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
+import { mockGetBoundingClientRect, mockSequenceOfGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 import { assertNotNull } from '../helper/assertNotNull';
 import { expectBars } from '../helper/expectBars';
 import { useAppSelector } from '../../src/state/hooks';
@@ -1726,6 +1726,37 @@ describe('<Legend />', () => {
           right: 5,
           width: 490,
           height: 490 - 13,
+        });
+      });
+
+      it('should update bottom offset when legend height increases after resize (regression #7200)', () => {
+        // Simulate legend wrapping: first render has small height, then height increases
+        mockSequenceOfGetBoundingClientRect([
+          { height: 20, width: 200 },
+          { height: 60, width: 200 },
+        ]);
+        const spy = vi.fn();
+        testChartLayoutContext(
+          props => (
+            <BarChart width={500} height={500} data={categoricalData}>
+              {props.children}
+              <Legend layout="horizontal" />
+              <Bar dataKey="value" />
+            </BarChart>
+          ),
+          ({ offset }) => {
+            spy(offset);
+          },
+        )();
+        // The final offset should reflect the larger legend height (60px)
+        expectLastCalledWith(spy, {
+          brushBottom: 5,
+          top: 5,
+          bottom: 5 + 60,
+          left: 5,
+          right: 5,
+          width: 490,
+          height: 490 - 60,
         });
       });
     });

--- a/test/state/selectors/legendSelectors.spec.tsx
+++ b/test/state/selectors/legendSelectors.spec.tsx
@@ -22,7 +22,7 @@ describe('selectLegendSettings', () => {
   shouldReturnFromInitialState(selectLegendSettings, {
     layout: 'horizontal',
     align: 'center',
-    verticalAlign: 'middle',
+    verticalAlign: 'bottom',
     itemSorter: 'value',
   });
 

--- a/test/state/selectors/selectStackGroups.spec.tsx
+++ b/test/state/selectors/selectStackGroups.spec.tsx
@@ -265,7 +265,7 @@ describe('selectStackGroups', () => {
             ]),
           },
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
       });
     });
 
@@ -284,7 +284,7 @@ describe('selectStackGroups', () => {
             ],
           }),
         });
-        expect(spy).toHaveBeenCalledTimes(3);
+        expect(spy).toHaveBeenCalledTimes(2);
 
         const legendItems = container.querySelectorAll('.recharts-legend-item');
         assertNotNull(legendItems);
@@ -300,7 +300,7 @@ describe('selectStackGroups', () => {
             graphicalItems: [expect.objectContaining({ dataKey: 'pv', hide: false })],
           }),
         });
-        expect(spy).toHaveBeenCalledTimes(5);
+        expect(spy).toHaveBeenCalledTimes(3);
 
         act(() => {
           fireEvent.click(uvItem);
@@ -315,7 +315,7 @@ describe('selectStackGroups', () => {
             ],
           }),
         });
-        expect(spy).toHaveBeenCalledTimes(7);
+        expect(spy).toHaveBeenCalledTimes(4);
       });
     });
   });

--- a/test/util/useElementOffset.spec.tsx
+++ b/test/util/useElementOffset.spec.tsx
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useElementOffset } from '../../src/util/useElementOffset';
+import { getMockDomRect } from '../helper/mockGetBoundingClientRect';
+
+describe('useElementOffset', () => {
+  let resizeObserverCallback: ((entries: ResizeObserverEntry[]) => void) | undefined,
+    observeSpy: ReturnType<typeof vi.fn>,
+    disconnectSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    resizeObserverCallback = undefined;
+    observeSpy = vi.fn();
+    disconnectSpy = vi.fn();
+    vi.stubGlobal(
+      'ResizeObserver',
+      vi.fn().mockImplementation((cb: (entries: ResizeObserverEntry[]) => void) => {
+        resizeObserverCallback = cb;
+        return { observe: observeSpy, unobserve: vi.fn(), disconnect: disconnectSpy };
+      }),
+    );
+  });
+
+  it('should return initial zero values', () => {
+    const { result } = renderHook(() => useElementOffset());
+    const [offset] = result.current;
+    expect(offset).toEqual({ height: 0, left: 0, top: 0, width: 0 });
+  });
+
+  it('should measure element on ref callback with a non-null node', () => {
+    const mockRect = getMockDomRect({ width: 100, height: 50, left: 10, top: 20 });
+    const node = document.createElement('div');
+    vi.spyOn(node, 'getBoundingClientRect').mockReturnValue(mockRect);
+
+    const { result } = renderHook(() => useElementOffset());
+    act(() => {
+      result.current[1](node);
+    });
+
+    expect(result.current[0]).toEqual({ width: 100, height: 50, left: 10, top: 20 });
+  });
+
+  it('should create a ResizeObserver and observe the node', () => {
+    const node = document.createElement('div');
+    vi.spyOn(node, 'getBoundingClientRect').mockReturnValue(getMockDomRect({ width: 100, height: 50 }));
+
+    const { result } = renderHook(() => useElementOffset());
+    act(() => {
+      result.current[1](node);
+    });
+
+    expect(observeSpy).toHaveBeenCalledWith(node);
+  });
+
+  it('should update state when ResizeObserver detects a size change', () => {
+    const node = document.createElement('div');
+    vi.spyOn(node, 'getBoundingClientRect')
+      .mockReturnValueOnce(getMockDomRect({ width: 100, height: 50 }))
+      .mockReturnValue(getMockDomRect({ width: 100, height: 120 }));
+
+    const { result } = renderHook(() => useElementOffset());
+    act(() => {
+      result.current[1](node);
+    });
+    expect(result.current[0].height).toBe(50);
+
+    act(() => {
+      resizeObserverCallback?.([] as unknown as ResizeObserverEntry[]);
+    });
+    expect(result.current[0].height).toBe(120);
+  });
+
+  it('should ignore changes smaller than EPS (1px)', () => {
+    const node = document.createElement('div');
+    vi.spyOn(node, 'getBoundingClientRect')
+      .mockReturnValueOnce(getMockDomRect({ width: 100, height: 50 }))
+      .mockReturnValue(getMockDomRect({ width: 100, height: 50.5 }));
+
+    const { result } = renderHook(() => useElementOffset());
+    act(() => {
+      result.current[1](node);
+    });
+    expect(result.current[0].height).toBe(50);
+
+    act(() => {
+      resizeObserverCallback?.([] as unknown as ResizeObserverEntry[]);
+    });
+    // Height change of 0.5 is below EPS=1, should not update
+    expect(result.current[0].height).toBe(50);
+  });
+
+  it('should not create a ResizeObserver when node is null', () => {
+    const { result } = renderHook(() => useElementOffset());
+    act(() => {
+      result.current[1](null);
+    });
+
+    expect(observeSpy).not.toHaveBeenCalled();
+  });
+
+  it('should disconnect the previous ResizeObserver when a new node is attached', () => {
+    const node1 = document.createElement('div');
+    const node2 = document.createElement('div');
+    vi.spyOn(node1, 'getBoundingClientRect').mockReturnValue(getMockDomRect({ width: 100, height: 50 }));
+    vi.spyOn(node2, 'getBoundingClientRect').mockReturnValue(getMockDomRect({ width: 200, height: 80 }));
+
+    const { result } = renderHook(() => useElementOffset());
+    act(() => {
+      result.current[1](node1);
+    });
+    expect(disconnectSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current[1](node2);
+    });
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+    expect(result.current[0]).toEqual({ width: 200, height: 80, left: 0, top: 0 });
+  });
+
+  it('should disconnect the ResizeObserver on unmount', () => {
+    const node = document.createElement('div');
+    vi.spyOn(node, 'getBoundingClientRect').mockReturnValue(getMockDomRect({ width: 100, height: 50 }));
+
+    const { result, unmount } = renderHook(() => useElementOffset());
+    act(() => {
+      result.current[1](node);
+    });
+
+    unmount();
+    expect(disconnectSpy).toHaveBeenCalled();
+  });
+
+  it('should disconnect the previous observer when node is set to null', () => {
+    const node = document.createElement('div');
+    vi.spyOn(node, 'getBoundingClientRect').mockReturnValue(getMockDomRect({ width: 100, height: 50 }));
+
+    const { result } = renderHook(() => useElementOffset());
+    act(() => {
+      result.current[1](node);
+    });
+    expect(disconnectSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current[1](null);
+    });
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -28,6 +28,7 @@ export default defineConfig({
       include: ['src', 'test', 'www/src'],
     },
     restoreMocks: true,
+    unstubGlobals: true,
     projects: [
       {
         extends: true,


### PR DESCRIPTION
Fix #7200 — Legend overlaps chart on container resize

When the container shrinks, legend items wrap and get taller,
but the chart offset never updates. Worked in v2 via
`componentDidUpdate`, regressed in v3.

## Changes

1. `useElementOffset`: added `ResizeObserver` to re-measure on
   resize (same pattern as `ResponsiveDiv`)
2. `LegendSettingsDispatcher` / `LegendSizeDispatcher`: switched
   `useEffect` → `useLayoutEffect` so Redux state updates before
   paint (matches `SetLegendPayload.ts`)
3. `legendSlice`: changed initial `verticalAlign` from `'middle'`
   to `'bottom'` to match `Legend` defaultProps — the mismatch
   caused `appendOffsetOfLegend` to skip offset on first render

## Tests

- Added `test/util/useElementOffset.spec.tsx` (9 tests —
  ResizeObserver, EPS threshold, cleanup, node re-attachment)
- Updated expectations in `Legend.spec.tsx`, `legendSelectors.spec.tsx`
- All green; `Label.spec.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable element offset tracking and resize handling for accurate positioning and reduced visual flicker.
  * Legend sizing and update timing refined to stabilize initial render and subsequent resizes.

* **Changes**
  * Legend default vertical alignment changed from middle to bottom.
  * Test runner config adjusted to restore stubbed globals after tests.

* **Bug Fixes**
  * Offset recalculation now ignores negligible deltas and updates only on meaningful changes.

* **Tests**
  * Added and updated tests covering element offset behavior, legend offset regressions, and selector call counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->