### PR TITLE
feat: add Venn chart with docs, stories, and hover/tooltip polish

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -47,6 +47,7 @@
   "es6/chart/ScatterChart.js",
   "es6/chart/SunburstChart.js",
   "es6/chart/Treemap.js",
+  "es6/chart/Venn.js",
   "es6/chart/types.js",
   "es6/component",
   "es6/component/ActivePoints.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -47,6 +47,7 @@
   "lib/chart/ScatterChart.js",
   "lib/chart/SunburstChart.js",
   "lib/chart/Treemap.js",
+  "lib/chart/Venn.js",
   "lib/chart/types.js",
   "lib/component",
   "lib/component/ActivePoints.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -47,6 +47,7 @@
   "types/chart/ScatterChart.d.ts",
   "types/chart/SunburstChart.d.ts",
   "types/chart/Treemap.d.ts",
+  "types/chart/Venn.d.ts",
   "types/chart/types.d.ts",
   "types/component",
   "types/component/ActivePoints.d.ts",

--- a/src/chart/Venn.tsx
+++ b/src/chart/Venn.tsx
@@ -1,0 +1,1260 @@
+import * as React from 'react';
+import { CSSProperties, ReactNode, useMemo, useState } from 'react';
+import { clsx } from 'clsx';
+import { Surface } from '../container/Surface';
+import { Layer } from '../container/Layer';
+import { getValueByDataKey } from '../util/ChartUtils';
+import { COLOR_PANEL } from '../util/Constants';
+import { isNotNil } from '../util/DataUtils';
+import { ChartCoordinate, DataKey, EventThrottlingProps, Margin, Percent } from '../util/types';
+import { ReportChartMargin, ReportChartSize, useChartHeight, useChartWidth } from '../context/chartLayoutContext';
+import { TooltipPortalContext } from '../context/tooltipPortalContext';
+import { RechartsWrapper } from './RechartsWrapper';
+import { RechartsStoreProvider } from '../state/RechartsStoreProvider';
+import { ReportEventSettings } from '../state/ReportEventSettings';
+import { ChartOptions } from '../state/optionsSlice';
+import {
+  mouseLeaveItem,
+  setActiveClickItemIndex,
+  setActiveMouseOverItemIndex,
+  TooltipIndex,
+  TooltipPayloadConfiguration,
+  TooltipPayloadSearcher,
+} from '../state/tooltipSlice';
+import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
+import { useAppDispatch } from '../state/hooks';
+import { RegisterGraphicalItemId } from '../context/RegisterGraphicalItemId';
+import { WithIdRequired } from '../util/useUniqueId';
+import { RequiresDefaultProps, resolveDefaultProps } from '../util/resolveDefaultProps';
+import { initialEventSettingsState } from '../state/eventSettingsSlice';
+
+export interface VennDataItem {
+  sets: ReadonlyArray<string>;
+  size: number;
+  fill?: string;
+  color?: string;
+  [key: string]: unknown;
+}
+
+interface VennCircle {
+  setId: string;
+  x: number;
+  y: number;
+  radius: number;
+  fill: string;
+}
+
+interface NormalizedVennArea {
+  index: number;
+  sets: ReadonlyArray<string>;
+  size: number;
+  tooltipIndex: TooltipIndex;
+  fill: string;
+  explicitFill: string | undefined;
+  datum: VennDataItem;
+  label: string | undefined;
+}
+
+interface RenderedArea {
+  area: NormalizedVennArea;
+  coordinate: ChartCoordinate;
+}
+
+const vennSansFontFamily = 'system-ui, -apple-system, "Segoe UI", sans-serif';
+
+type InternalVennProps = WithIdRequired<RequiresDefaultProps<VennProps, typeof defaultVennProps>>;
+
+export interface VennProps extends EventThrottlingProps {
+  /**
+   * Input data in venn.js format:
+   * each item identifies one set or intersection with `sets` and `size`.
+   */
+  data: ReadonlyArray<VennDataItem>;
+  /**
+   * The width of chart container.
+   * Can be a number or a percent string like "100%".
+   *
+   * @see {@link https://recharts.github.io/en-US/guide/sizes/ Chart sizing guide}
+   */
+  width?: number | Percent;
+  /**
+   * The height of chart container.
+   * Can be a number or a percent string like "100%".
+   *
+   * @see {@link https://recharts.github.io/en-US/guide/sizes/ Chart sizing guide}
+   */
+  height?: number | Percent;
+  /**
+   * If true, then it will listen to container size changes and adapt the SVG chart accordingly.
+   * If false, then it renders the chart at the specified width and height and will stay that way
+   * even if the container size changes.
+   *
+   * This is similar to ResponsiveContainer but without the need for an extra wrapper component.
+   * The `responsive` prop also uses standard CSS sizing rules, instead of custom resolution logic (like ResponsiveContainer does).
+   * @default false
+   */
+  responsive?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  id?: string;
+  children?: ReactNode;
+  margin?: Margin;
+  /**
+   * Key used to read set sizes from each item.
+   * @default size
+   */
+  dataKey?: DataKey<VennDataItem, number>;
+  /**
+   * Key used to read labels from each item.
+   * If not provided, single-set entries default to the set identifier.
+   */
+  nameKey?: DataKey<VennDataItem, string>;
+  /**
+   * Fill color used when neither area item nor source set defines one.
+   */
+  fill?: string;
+  stroke?: string;
+  fillOpacity?: number;
+  intersectionFillOpacity?: number;
+  onMouseEnter?: (node: VennDataItem, e: React.MouseEvent<SVGGElement>) => void;
+  onMouseLeave?: (node: VennDataItem, e: React.MouseEvent<SVGGElement>) => void;
+  onClick?: (node: VennDataItem) => void;
+}
+
+const defaultVennMargin: Margin = {
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+};
+
+const defaultVennProps = {
+  responsive: false,
+  margin: defaultVennMargin,
+  dataKey: 'size',
+  fill: COLOR_PANEL[0] ?? '#8884d8',
+  stroke: '#ffffff',
+  fillOpacity: 0.35,
+  intersectionFillOpacity: 0.55,
+  ...initialEventSettingsState,
+} as const satisfies Partial<VennProps>;
+
+function areaKey(sets: ReadonlyArray<string>): string {
+  return [...sets].sort().join('\u0000');
+}
+
+function getPaletteColor(index: number): string {
+  return COLOR_PANEL[index % COLOR_PANEL.length] ?? '#8884d8';
+}
+
+function toSvgSafeId(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function hexToRgb(hexColor: string): { r: number; g: number; b: number } | null {
+  const normalized = hexColor.trim();
+  const shortHexMatch = /^#([0-9a-f]{3})$/i.exec(normalized);
+  if (shortHexMatch != null) {
+    const value = shortHexMatch[1] ?? '';
+    const rHex = value.charAt(0);
+    const gHex = value.charAt(1);
+    const bHex = value.charAt(2);
+    return {
+      r: Number.parseInt(rHex + rHex, 16),
+      g: Number.parseInt(gHex + gHex, 16),
+      b: Number.parseInt(bHex + bHex, 16),
+    };
+  }
+
+  const longHexMatch = /^#([0-9a-f]{6})$/i.exec(normalized);
+  if (longHexMatch == null) {
+    return null;
+  }
+  const value = longHexMatch[1] ?? '';
+  return {
+    r: Number.parseInt(value.slice(0, 2), 16),
+    g: Number.parseInt(value.slice(2, 4), 16),
+    b: Number.parseInt(value.slice(4, 6), 16),
+  };
+}
+
+function toHexChannel(value: number): string {
+  return Math.max(0, Math.min(255, Math.round(value)))
+    .toString(16)
+    .padStart(2, '0');
+}
+
+function blendHexColors(colors: ReadonlyArray<string>): string | null {
+  if (colors.length === 0) {
+    return null;
+  }
+  const parsed = colors.map(hexToRgb).filter(isNotNil);
+  if (parsed.length === 0) {
+    return null;
+  }
+  const red = parsed.reduce((sum, color) => sum + color.r, 0) / parsed.length;
+  const green = parsed.reduce((sum, color) => sum + color.g, 0) / parsed.length;
+  const blue = parsed.reduce((sum, color) => sum + color.b, 0) / parsed.length;
+  return `#${toHexChannel(red)}${toHexChannel(green)}${toHexChannel(blue)}`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function overlapArea(r1: number, r2: number, distance: number): number {
+  if (distance >= r1 + r2) {
+    return 0;
+  }
+
+  if (distance <= Math.abs(r1 - r2)) {
+    const minRadius = Math.min(r1, r2);
+    return Math.PI * minRadius * minRadius;
+  }
+
+  const alpha = Math.acos(clamp((distance * distance + r1 * r1 - r2 * r2) / (2 * distance * r1), -1, 1));
+  const beta = Math.acos(clamp((distance * distance + r2 * r2 - r1 * r1) / (2 * distance * r2), -1, 1));
+  const x = (-distance + r1 + r2) * (distance + r1 - r2) * (distance - r1 + r2) * (distance + r1 + r2);
+  const lensArea = 0.5 * Math.sqrt(Math.max(0, x));
+
+  return r1 * r1 * alpha + r2 * r2 * beta - lensArea;
+}
+
+function distanceByOverlap(r1: number, r2: number, targetArea: number): number {
+  const minArea = 0;
+  const maxArea = Math.PI * Math.min(r1, r2) * Math.min(r1, r2);
+  const clampedArea = clamp(targetArea, minArea, maxArea);
+
+  if (clampedArea === 0) {
+    return r1 + r2;
+  }
+
+  if (clampedArea === maxArea) {
+    return Math.abs(r1 - r2);
+  }
+
+  let low = Math.abs(r1 - r2);
+  let high = r1 + r2;
+  let result = (low + high) / 2;
+
+  for (let i = 0; i < 48; i += 1) {
+    const mid = (low + high) / 2;
+    const currentArea = overlapArea(r1, r2, mid);
+    result = mid;
+
+    if (Math.abs(currentArea - clampedArea) < 1e-7) {
+      break;
+    }
+
+    if (currentArea > clampedArea) {
+      low = mid;
+    } else {
+      high = mid;
+    }
+  }
+
+  return result;
+}
+
+function getTooltipIndexFromActiveIndex(activeIndex: TooltipIndex): number | null {
+  if (activeIndex == null) {
+    return null;
+  }
+
+  if (typeof activeIndex === 'number' && Number.isInteger(activeIndex) && activeIndex >= 0) {
+    return activeIndex;
+  }
+
+  if (typeof activeIndex !== 'string') {
+    return null;
+  }
+
+  const numeric = Number(activeIndex.replace(/\[/g, '').replace(/\]/g, ''));
+  if (!Number.isInteger(numeric) || numeric < 0) {
+    return null;
+  }
+  return numeric;
+}
+
+export const vennPayloadSearcher: TooltipPayloadSearcher = (
+  data: unknown,
+  activeIndex: TooltipIndex,
+): VennDataItem | undefined => {
+  if (!Array.isArray(data)) {
+    return undefined;
+  }
+
+  const index = getTooltipIndexFromActiveIndex(activeIndex);
+  if (index == null) {
+    return undefined;
+  }
+
+  const maybeData = data[index];
+  if (maybeData == null || typeof maybeData !== 'object') {
+    return undefined;
+  }
+
+  if (!('sets' in maybeData) || !('size' in maybeData)) {
+    return undefined;
+  }
+
+  const maybeSets = maybeData.sets;
+  const maybeSize = maybeData.size;
+
+  if (!Array.isArray(maybeSets) || typeof maybeSize !== 'number') {
+    return undefined;
+  }
+
+  return {
+    ...maybeData,
+    sets: maybeSets.filter((setId): setId is string => typeof setId === 'string'),
+    size: maybeSize,
+  };
+};
+
+const options: ChartOptions = {
+  chartName: 'Venn',
+  defaultTooltipEventType: 'item',
+  validateTooltipEventTypes: ['item'],
+  tooltipPayloadSearcher: vennPayloadSearcher,
+  eventEmitter: undefined,
+};
+
+function getNumericDataValue(entry: VennDataItem, dataKey: DataKey<VennDataItem, number>): number {
+  const rawValue = getValueByDataKey(entry, dataKey, 0);
+  return typeof rawValue === 'number' && Number.isFinite(rawValue) && rawValue >= 0 ? rawValue : 0;
+}
+
+function getSets(entry: VennDataItem): ReadonlyArray<string> {
+  if (!Array.isArray(entry.sets)) {
+    return [];
+  }
+
+  return entry.sets.filter((setId): setId is string => typeof setId === 'string' && setId.length > 0);
+}
+
+function getLabel(entry: VennDataItem, nameKey: DataKey<VennDataItem, string> | undefined): string | undefined {
+  if (nameKey == null) {
+    return undefined;
+  }
+
+  const value = getValueByDataKey(entry, nameKey, undefined);
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getDefaultIntersectionName(entry: VennDataItem): string {
+  const sets = getSets(entry);
+  if (sets.length === 0) {
+    return '';
+  }
+  return sets.join(' \u2229 ');
+}
+
+function getTrilateration(
+  d12: number,
+  d13: number,
+  d23: number,
+): {
+  x: number;
+  y: number;
+} {
+  const safeD12 = d12 <= 0 ? 1e-9 : d12;
+  const x = (d13 * d13 - d23 * d23 + safeD12 * safeD12) / (2 * safeD12);
+  const ySquared = Math.max(0, d13 * d13 - x * x);
+  return {
+    x,
+    y: Math.sqrt(ySquared),
+  };
+}
+
+type CircleSeed = { setId: string; radius: number; fill: string };
+
+type PairConstraintType = 'normal' | 'disjoint' | 'subset';
+
+interface PairConstraint {
+  i: number;
+  j: number;
+  targetDistance: number;
+  type: PairConstraintType;
+}
+
+function optimizeMultiSetLayout(
+  singletonWithRadius: ReadonlyArray<CircleSeed>,
+  pairAreas: ReadonlyMap<string, NormalizedVennArea>,
+): ReadonlyArray<VennCircle> {
+  const count = singletonWithRadius.length;
+  const constraints: Array<PairConstraint> = [];
+
+  for (let i = 0; i < count; i += 1) {
+    for (let j = i + 1; j < count; j += 1) {
+      const left = singletonWithRadius[i];
+      const right = singletonWithRadius[j];
+      if (left == null || right == null) {
+        continue;
+      }
+      const overlap = pairAreas.get(areaKey([left.setId, right.setId]))?.size ?? 0;
+      const maxOverlap = Math.PI * Math.min(left.radius, right.radius) ** 2;
+      const targetDistance = distanceByOverlap(left.radius, right.radius, overlap);
+
+      let type: PairConstraintType = 'normal';
+      if (overlap <= 1e-9) {
+        type = 'disjoint';
+      } else if (maxOverlap > 0 && overlap >= maxOverlap * 0.999) {
+        type = 'subset';
+      }
+
+      constraints.push({ i, j, targetDistance, type });
+    }
+  }
+
+  const averageDistance =
+    constraints.length > 0
+      ? constraints.reduce((sum, constraint) => sum + constraint.targetDistance, 0) / constraints.length
+      : Math.max(...singletonWithRadius.map(circle => circle.radius), 1) * 1.5;
+  const seedRadius = Math.max(averageDistance * 0.9, 1e-3);
+
+  const makeInitial = (phase: number) =>
+    singletonWithRadius.map((_, index) => {
+      const angle = (index / count) * Math.PI * 2 + phase;
+      return { x: Math.cos(angle) * seedRadius, y: Math.sin(angle) * seedRadius };
+    });
+
+  const evaluate = (points: ReadonlyArray<{ x: number; y: number }>) => {
+    let loss = 0;
+    constraints.forEach(constraint => {
+      const p1 = points[constraint.i];
+      const p2 = points[constraint.j];
+      if (p1 == null || p2 == null) {
+        return;
+      }
+      const dx = p1.x - p2.x;
+      const dy = p1.y - p2.y;
+      const distSquared = dx * dx + dy * dy;
+      const targetSquared = constraint.targetDistance ** 2;
+      const error = distSquared - targetSquared;
+
+      if (constraint.type === 'disjoint' && distSquared >= targetSquared) {
+        return;
+      }
+      if (constraint.type === 'subset' && distSquared <= targetSquared) {
+        return;
+      }
+
+      loss += error * error;
+    });
+    return loss;
+  };
+
+  const runOptimization = (initialPoints: ReadonlyArray<{ x: number; y: number }>) => {
+    const points = initialPoints.map(point => ({ ...point }));
+    const learningRate = 0.0025;
+    const gradientClip = 1000;
+
+    for (let iter = 0; iter < 800; iter += 1) {
+      const gradients = points.map(() => ({ x: 0, y: 0 }));
+
+      constraints.forEach(constraint => {
+        const { i, j } = constraint;
+        const p1 = points[i];
+        const p2 = points[j];
+        if (p1 == null || p2 == null) {
+          return;
+        }
+        const dx = p1.x - p2.x;
+        const dy = p1.y - p2.y;
+        const distSquared = dx * dx + dy * dy;
+        const targetSquared = constraint.targetDistance ** 2;
+
+        if (constraint.type === 'disjoint' && distSquared >= targetSquared) {
+          return;
+        }
+        if (constraint.type === 'subset' && distSquared <= targetSquared) {
+          return;
+        }
+
+        const error = distSquared - targetSquared;
+        const gradX = 4 * error * dx;
+        const gradY = 4 * error * dy;
+        const firstGradient = gradients[i];
+        const secondGradient = gradients[j];
+        if (firstGradient == null || secondGradient == null) {
+          return;
+        }
+        firstGradient.x += gradX;
+        firstGradient.y += gradY;
+        secondGradient.x -= gradX;
+        secondGradient.y -= gradY;
+      });
+
+      for (let idx = 0; idx < points.length; idx += 1) {
+        const point = points[idx];
+        const gradient = gradients[idx];
+        if (point == null || gradient == null) {
+          continue;
+        }
+        const magnitude = Math.hypot(gradient.x, gradient.y);
+        if (magnitude > gradientClip && magnitude > 0) {
+          const scale = gradientClip / magnitude;
+          gradient.x *= scale;
+          gradient.y *= scale;
+        }
+        point.x -= gradient.x * learningRate;
+        point.y -= gradient.y * learningRate;
+      }
+
+      const centerX = points.reduce((sum, point) => sum + point.x, 0) / points.length;
+      const centerY = points.reduce((sum, point) => sum + point.y, 0) / points.length;
+      for (let idx = 0; idx < points.length; idx += 1) {
+        const point = points[idx];
+        if (point == null) {
+          continue;
+        }
+        point.x -= centerX;
+        point.y -= centerY;
+      }
+    }
+
+    return points;
+  };
+
+  let bestPoints = makeInitial(0);
+  let bestLoss = evaluate(bestPoints);
+  const phases = [0, Math.PI / 7, Math.PI / 5, Math.PI / 3, Math.PI / 2];
+
+  phases.forEach(phase => {
+    const points = runOptimization(makeInitial(phase));
+    const loss = evaluate(points);
+    if (loss < bestLoss) {
+      bestLoss = loss;
+      bestPoints = points;
+    }
+  });
+
+  return singletonWithRadius.map((entry, idx) => {
+    const point = bestPoints[idx];
+    return {
+      setId: entry.setId,
+      radius: entry.radius,
+      fill: entry.fill,
+      x: point?.x ?? 0,
+      y: point?.y ?? 0,
+    };
+  });
+}
+
+function normalizeCircles(
+  circles: ReadonlyArray<VennCircle>,
+  width: number,
+  height: number,
+): ReadonlyArray<VennCircle> {
+  if (circles.length === 0) {
+    return circles;
+  }
+
+  let minX = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  circles.forEach(circle => {
+    minX = Math.min(minX, circle.x - circle.radius);
+    maxX = Math.max(maxX, circle.x + circle.radius);
+    minY = Math.min(minY, circle.y - circle.radius);
+    maxY = Math.max(maxY, circle.y + circle.radius);
+  });
+
+  const rawWidth = Math.max(maxX - minX, 1e-9);
+  const rawHeight = Math.max(maxY - minY, 1e-9);
+  const padding = 8;
+  const scale = Math.min((width - padding * 2) / rawWidth, (height - padding * 2) / rawHeight);
+  const chartScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+  const scaledWidth = rawWidth * chartScale;
+  const scaledHeight = rawHeight * chartScale;
+  const offsetX = (width - scaledWidth) / 2;
+  const offsetY = (height - scaledHeight) / 2;
+
+  return circles.map(circle => ({
+    ...circle,
+    x: (circle.x - minX) * chartScale + offsetX,
+    y: (circle.y - minY) * chartScale + offsetY,
+    radius: circle.radius * chartScale,
+  }));
+}
+
+function layoutVennCircles(
+  singletonAreas: ReadonlyArray<NormalizedVennArea>,
+  pairAreas: ReadonlyMap<string, NormalizedVennArea>,
+  width: number,
+  height: number,
+): ReadonlyArray<VennCircle> {
+  if (singletonAreas.length === 0) {
+    return [];
+  }
+
+  const setColors = new Map<string, string>();
+  singletonAreas.forEach((area, index) => {
+    const setId = area.sets[0];
+    if (setId == null) {
+      return;
+    }
+    const color = area.datum.fill ?? area.datum.color ?? getPaletteColor(index);
+    setColors.set(setId, color);
+  });
+
+  const singletonWithRadius: Array<{ setId: string; radius: number; fill: string }> = [];
+  singletonAreas.forEach((area, index) => {
+    const setId = area.sets[0];
+    if (setId == null) {
+      return;
+    }
+    const areaFill = setColors.get(setId) ?? getPaletteColor(index);
+    singletonWithRadius.push({
+      setId,
+      radius: Math.sqrt(area.size / Math.PI),
+      fill: areaFill,
+    });
+  });
+
+  if (singletonWithRadius.length === 0) {
+    return [];
+  }
+
+  let circles: ReadonlyArray<VennCircle>;
+
+  if (singletonWithRadius.length === 1) {
+    const single = singletonWithRadius[0];
+    if (single == null) {
+      return [];
+    }
+    circles = [
+      {
+        setId: single.setId,
+        x: 0,
+        y: 0,
+        radius: single.radius,
+        fill: single.fill,
+      },
+    ];
+  } else if (singletonWithRadius.length === 2) {
+    const first = singletonWithRadius[0];
+    const second = singletonWithRadius[1];
+    if (first == null || second == null) {
+      return [];
+    }
+    const key = areaKey([first.setId, second.setId]);
+    const pairArea = pairAreas.get(key);
+    const targetOverlap = pairArea?.size ?? 0;
+    const distance = distanceByOverlap(first.radius, second.radius, targetOverlap);
+    circles = [
+      { setId: first.setId, x: -distance / 2, y: 0, radius: first.radius, fill: first.fill },
+      { setId: second.setId, x: distance / 2, y: 0, radius: second.radius, fill: second.fill },
+    ];
+  } else if (singletonWithRadius.length === 3) {
+    const first = singletonWithRadius[0];
+    const second = singletonWithRadius[1];
+    const third = singletonWithRadius[2];
+    if (first == null || second == null || third == null) {
+      return [];
+    }
+    const d12 = distanceByOverlap(
+      first.radius,
+      second.radius,
+      pairAreas.get(areaKey([first.setId, second.setId]))?.size ?? 0,
+    );
+    const d13 = distanceByOverlap(
+      first.radius,
+      third.radius,
+      pairAreas.get(areaKey([first.setId, third.setId]))?.size ?? 0,
+    );
+    const d23 = distanceByOverlap(
+      second.radius,
+      third.radius,
+      pairAreas.get(areaKey([second.setId, third.setId]))?.size ?? 0,
+    );
+    const point3 = getTrilateration(d12, d13, d23);
+    circles = [
+      { setId: first.setId, x: 0, y: 0, radius: first.radius, fill: first.fill },
+      { setId: second.setId, x: d12, y: 0, radius: second.radius, fill: second.fill },
+      { setId: third.setId, x: point3.x, y: point3.y, radius: third.radius, fill: third.fill },
+    ];
+  } else {
+    circles = optimizeMultiSetLayout(singletonWithRadius, pairAreas);
+  }
+
+  return normalizeCircles(circles, width, height);
+}
+
+function getAreaCoordinate(
+  sets: ReadonlyArray<string>,
+  circlesBySet: ReadonlyMap<string, VennCircle>,
+): ChartCoordinate | null {
+  const mappedCircles = sets.map(setId => circlesBySet.get(setId)).filter(isNotNil);
+  if (mappedCircles.length === 0) {
+    return null;
+  }
+
+  const x = mappedCircles.reduce((sum, circle) => sum + circle.x, 0) / mappedCircles.length;
+  const y = mappedCircles.reduce((sum, circle) => sum + circle.y, 0) / mappedCircles.length;
+  return { x, y };
+}
+
+function getTweakedLabelCoordinate(
+  area: NormalizedVennArea,
+  baseCoordinate: ChartCoordinate,
+  circlesBySet: ReadonlyMap<string, VennCircle>,
+  allAreas: ReadonlyArray<NormalizedVennArea>,
+): ChartCoordinate {
+  if (area.sets.length !== 1) {
+    return baseCoordinate;
+  }
+
+  const setId = area.sets[0];
+  if (setId == null) {
+    return baseCoordinate;
+  }
+
+  const currentCircle = circlesBySet.get(setId);
+  if (currentCircle == null) {
+    return baseCoordinate;
+  }
+
+  let repelX = 0;
+  let repelY = 0;
+  let hasRepel = false;
+
+  allAreas
+    .filter(candidate => candidate.sets.length === 1)
+    .forEach(candidate => {
+      const otherSetId = candidate.sets[0];
+      if (otherSetId == null || otherSetId === setId) {
+        return;
+      }
+
+      const otherCircle = circlesBySet.get(otherSetId);
+      if (otherCircle == null) {
+        return;
+      }
+
+      // Keep smaller inner-circle labels near center; move larger-circle label away.
+      if (currentCircle.radius < otherCircle.radius) {
+        return;
+      }
+
+      const dx = currentCircle.x - otherCircle.x;
+      const dy = currentCircle.y - otherCircle.y;
+      const centerDistance = Math.hypot(dx, dy);
+      const overlapDistance = currentCircle.radius + otherCircle.radius - centerDistance;
+
+      if (overlapDistance <= 0) {
+        return;
+      }
+
+      const strength = overlapDistance / (currentCircle.radius + otherCircle.radius);
+      const safeDistance = centerDistance > 1e-6 ? centerDistance : 1;
+      repelX += (dx / safeDistance) * strength;
+      repelY += (dy / safeDistance) * strength;
+      hasRepel = true;
+    });
+
+  if (!hasRepel) {
+    return baseCoordinate;
+  }
+
+  const repelMagnitude = Math.hypot(repelX, repelY);
+  if (repelMagnitude <= 1e-6) {
+    return baseCoordinate;
+  }
+
+  const offset = Math.min(currentCircle.radius * 0.4, Math.max(currentCircle.radius * 0.16, repelMagnitude * 20));
+  const shiftedX = baseCoordinate.x + (repelX / repelMagnitude) * offset;
+  const shiftedY = baseCoordinate.y + (repelY / repelMagnitude) * offset;
+
+  const fromCenterX = shiftedX - currentCircle.x;
+  const fromCenterY = shiftedY - currentCircle.y;
+  const fromCenterMagnitude = Math.hypot(fromCenterX, fromCenterY);
+  const maxDistance = currentCircle.radius * 0.72;
+
+  if (fromCenterMagnitude <= maxDistance || fromCenterMagnitude <= 1e-6) {
+    return { x: shiftedX, y: shiftedY };
+  }
+
+  const clampedScale = maxDistance / fromCenterMagnitude;
+  return {
+    x: currentCircle.x + fromCenterX * clampedScale,
+    y: currentCircle.y + fromCenterY * clampedScale,
+  };
+}
+
+function renderAreaShape(
+  area: NormalizedVennArea,
+  circlesBySet: ReadonlyMap<string, VennCircle>,
+  setClipPathIds: ReadonlyMap<string, string>,
+  className: string,
+  shapeProps?: {
+    fill?: string;
+    stroke?: string;
+    strokeWidth?: number;
+  },
+): React.ReactElement | null {
+  const [firstSet, ...restSets] = area.sets;
+  if (firstSet == null) {
+    return null;
+  }
+
+  const firstCircle = circlesBySet.get(firstSet);
+  if (firstCircle == null) {
+    return null;
+  }
+
+  let node: React.ReactElement = (
+    <circle
+      cx={firstCircle.x}
+      cy={firstCircle.y}
+      r={firstCircle.radius}
+      className={className}
+      fill={shapeProps?.fill ?? area.fill}
+      stroke={shapeProps?.stroke ?? 'none'}
+      strokeWidth={shapeProps?.strokeWidth}
+    />
+  );
+
+  restSets.forEach(setId => {
+    const clipPathId = setClipPathIds.get(setId);
+    if (clipPathId == null) {
+      return;
+    }
+
+    node = (
+      <g clipPath={`url(#${clipPathId})`} key={`clipped-${area.tooltipIndex}-${setId}`}>
+        {node}
+      </g>
+    );
+  });
+
+  return node;
+}
+
+function renderIntersectionOutline(
+  area: NormalizedVennArea,
+  circlesBySet: ReadonlyMap<string, VennCircle>,
+  setClipPathIds: ReadonlyMap<string, string>,
+): React.ReactElement | null {
+  if (area.sets.length < 2) {
+    return null;
+  }
+
+  const outlineSegments = area.sets
+    .map(setId => {
+      const circle = circlesBySet.get(setId);
+      if (circle == null) {
+        return null;
+      }
+
+      let segment: React.ReactElement = (
+        <circle
+          cx={circle.x}
+          cy={circle.y}
+          r={circle.radius}
+          fill="none"
+          stroke="#ffffff"
+          strokeWidth={2}
+          strokeDasharray="6 4"
+          strokeLinecap="round"
+          style={{ pointerEvents: 'none' }}
+        />
+      );
+
+      area.sets.forEach(otherSetId => {
+        if (otherSetId === setId) {
+          return;
+        }
+        const clipPathId = setClipPathIds.get(otherSetId);
+        if (clipPathId == null) {
+          return;
+        }
+        segment = <g clipPath={`url(#${clipPathId})`}>{segment}</g>;
+      });
+
+      return <g key={`intersection-outline-segment-${area.tooltipIndex}-${setId}`}>{segment}</g>;
+    })
+    .filter(isNotNil);
+
+  if (outlineSegments.length === 0) {
+    return null;
+  }
+
+  return <g className="recharts-venn-intersection-outline">{outlineSegments}</g>;
+}
+
+function SetVennTooltipEntrySettings({
+  data,
+  dataKey,
+  nameKey,
+  id,
+  positions,
+  fill,
+  stroke,
+}: {
+  data: ReadonlyArray<VennDataItem>;
+  dataKey: DataKey<VennDataItem, number>;
+  nameKey?: DataKey<VennDataItem, string>;
+  id: string;
+  positions: ReadonlyMap<TooltipIndex, ChartCoordinate>;
+  fill: string;
+  stroke: string;
+}) {
+  const tooltipEntrySettings: TooltipPayloadConfiguration = {
+    dataDefinedOnItem: data,
+    getPosition: index => positions.get(index),
+    settings: {
+      stroke,
+      strokeWidth: undefined,
+      fill,
+      nameKey,
+      dataKey,
+      name: undefined,
+      hide: false,
+      type: undefined,
+      color: fill,
+      unit: '',
+      graphicalItemId: id,
+    },
+  };
+
+  return <SetTooltipEntrySettings tooltipEntrySettings={tooltipEntrySettings} />;
+}
+
+const VennImpl = ({
+  className,
+  data,
+  dataKey,
+  nameKey,
+  fill,
+  stroke,
+  fillOpacity,
+  intersectionFillOpacity,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  id,
+  children,
+}: InternalVennProps) => {
+  const width = useChartWidth();
+  const height = useChartHeight();
+  const dispatch = useAppDispatch();
+  const [hoveredAreaIndex, setHoveredAreaIndex] = useState<TooltipIndex | null>(null);
+  const tooltipNameKey: DataKey<VennDataItem, string> = nameKey ?? getDefaultIntersectionName;
+
+  const rendered = useMemo(() => {
+    if (width == null || height == null) {
+      return null;
+    }
+
+    const normalizedAreasPreFill = data
+      .map((datum, index): NormalizedVennArea | null => {
+        const sets = getSets(datum);
+        if (sets.length === 0) {
+          return null;
+        }
+
+        const value = getNumericDataValue(datum, dataKey);
+        if (value <= 0) {
+          return null;
+        }
+
+        const indexAsTooltipIndex: TooltipIndex = `[${index}]`;
+        const labelFromKey = getLabel(datum, nameKey);
+        const derivedLabel = labelFromKey ?? (sets.length === 1 ? sets[0] : undefined);
+        const explicitFill = datum.fill ?? datum.color;
+
+        return {
+          index,
+          sets: [...sets].sort(),
+          size: value,
+          tooltipIndex: indexAsTooltipIndex,
+          fill,
+          explicitFill,
+          datum,
+          label: derivedLabel,
+        };
+      })
+      .filter(isNotNil);
+
+    const singletonAreasPreFill = normalizedAreasPreFill.filter(area => area.sets.length === 1);
+    const setColorMap = new Map<string, string>();
+    singletonAreasPreFill.forEach((area, index) => {
+      const setId = area.sets[0];
+      if (setId == null) {
+        return;
+      }
+      setColorMap.set(setId, area.explicitFill ?? getPaletteColor(index));
+    });
+
+    const normalizedAreas: ReadonlyArray<NormalizedVennArea> = normalizedAreasPreFill.map((area, index) => {
+      if (area.explicitFill != null) {
+        return {
+          ...area,
+          fill: area.explicitFill,
+        };
+      }
+
+      if (area.sets.length === 1) {
+        const setId = area.sets[0];
+        return {
+          ...area,
+          fill: setId != null ? (setColorMap.get(setId) ?? getPaletteColor(index)) : getPaletteColor(index),
+        };
+      }
+
+      const setColors = area.sets.map(setId => setColorMap.get(setId)).filter(isNotNil);
+      const blended = blendHexColors(setColors);
+      return {
+        ...area,
+        fill: blended ?? getPaletteColor(index),
+      };
+    });
+
+    const singletonAreas = normalizedAreas.filter(area => area.sets.length === 1);
+    const pairAreasMap = new Map<string, NormalizedVennArea>();
+    normalizedAreas
+      .filter(area => area.sets.length === 2)
+      .forEach(area => {
+        pairAreasMap.set(areaKey(area.sets), area);
+      });
+
+    const circles = layoutVennCircles(singletonAreas, pairAreasMap, width, height);
+    const circlesBySet = new Map(circles.map(circle => [circle.setId, circle]));
+
+    const sortedAreas = [...normalizedAreas].sort((left, right) => left.sets.length - right.sets.length);
+    const renderedAreas: ReadonlyArray<RenderedArea> = sortedAreas
+      .map(area => {
+        const coordinate = getAreaCoordinate(area.sets, circlesBySet);
+        if (coordinate == null) {
+          return null;
+        }
+
+        return {
+          area,
+          coordinate,
+        };
+      })
+      .filter(isNotNil);
+
+    const positions = new Map<TooltipIndex, ChartCoordinate>(
+      renderedAreas.map(item => [item.area.tooltipIndex, item.coordinate]),
+    );
+
+    return {
+      circles,
+      circlesBySet,
+      renderedAreas,
+      positions,
+    };
+  }, [data, dataKey, fill, height, nameKey, width]);
+
+  if (width == null || height == null || rendered == null) {
+    return null;
+  }
+
+  const { circles, circlesBySet, renderedAreas, positions } = rendered;
+  const layerClassName = clsx('recharts-venn', className);
+
+  const setClipPathIds = new Map<string, string>(
+    circles.map((circle, index) => [circle.setId, `${id}-clip-${index}-${toSvgSafeId(circle.setId)}`]),
+  );
+
+  return (
+    <Surface width={width} height={height}>
+      <defs>
+        {circles.map(circle => {
+          const clipPathId = setClipPathIds.get(circle.setId);
+          if (clipPathId == null) {
+            return null;
+          }
+          return (
+            <clipPath id={clipPathId} key={`clip-path-${circle.setId}`}>
+              <circle cx={circle.x} cy={circle.y} r={circle.radius} />
+            </clipPath>
+          );
+        })}
+      </defs>
+      <Layer className={layerClassName}>
+        {renderedAreas.map(({ area, coordinate }) => {
+          const isSingleSet = area.sets.length === 1;
+          const opacity = isSingleSet ? fillOpacity : intersectionFillOpacity;
+          const shape = isSingleSet
+            ? (() => {
+                const setId = area.sets[0];
+                if (setId == null) {
+                  return null;
+                }
+                const circle = circlesBySet.get(setId);
+                if (circle == null) {
+                  return null;
+                }
+                return (
+                  <circle
+                    cx={circle.x}
+                    cy={circle.y}
+                    r={circle.radius}
+                    className="recharts-venn-set"
+                    fill={area.fill}
+                    stroke={stroke}
+                  />
+                );
+              })()
+            : renderAreaShape(area, circlesBySet, setClipPathIds, 'recharts-venn-intersection');
+
+          if (shape == null) {
+            return null;
+          }
+
+          return (
+            <g
+              key={`venn-area-${area.tooltipIndex}`}
+              opacity={opacity}
+              onMouseEnter={event => {
+                setHoveredAreaIndex(area.tooltipIndex);
+                onMouseEnter?.(area.datum, event);
+                dispatch(
+                  setActiveMouseOverItemIndex({
+                    activeIndex: area.tooltipIndex,
+                    activeDataKey: dataKey,
+                    activeCoordinate: coordinate,
+                    activeGraphicalItemId: id,
+                  }),
+                );
+              }}
+              onMouseLeave={event => {
+                setHoveredAreaIndex(null);
+                onMouseLeave?.(area.datum, event);
+                dispatch(mouseLeaveItem());
+              }}
+              onClick={() => {
+                onClick?.(area.datum);
+                dispatch(
+                  setActiveClickItemIndex({
+                    activeIndex: area.tooltipIndex,
+                    activeDataKey: dataKey,
+                    activeCoordinate: coordinate,
+                    activeGraphicalItemId: id,
+                  }),
+                );
+              }}
+            >
+              {shape}
+            </g>
+          );
+        })}
+        {renderedAreas.map(({ area, coordinate }) => {
+          const { label, tooltipIndex } = area;
+          if (label == null || label.length === 0) {
+            return null;
+          }
+          const labelCoordinate = getTweakedLabelCoordinate(
+            area,
+            coordinate,
+            circlesBySet,
+            renderedAreas.map(item => item.area),
+          );
+
+          return (
+            <text
+              key={`venn-label-${tooltipIndex}`}
+              x={labelCoordinate.x}
+              y={labelCoordinate.y}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fill="#000000"
+              className="recharts-venn-label"
+              style={{ pointerEvents: 'none', fontFamily: vennSansFontFamily }}
+            >
+              {label}
+            </text>
+          );
+        })}
+        {(() => {
+          const hoveredArea = renderedAreas.find(areaNode => areaNode.area.tooltipIndex === hoveredAreaIndex);
+          if (hoveredArea == null || hoveredArea.area.sets.length < 2) {
+            return null;
+          }
+          return renderIntersectionOutline(hoveredArea.area, circlesBySet, setClipPathIds);
+        })()}
+      </Layer>
+      <SetVennTooltipEntrySettings
+        data={data}
+        dataKey={dataKey}
+        nameKey={tooltipNameKey}
+        id={id}
+        positions={positions}
+        fill={fill}
+        stroke={stroke}
+      />
+      {children}
+    </Surface>
+  );
+};
+
+/**
+ * Venn charts visualize overlap between two or more sets.
+ * Pass data in venn.js format where each item defines a set or an intersection.
+ *
+ * @consumes ResponsiveContainerContext
+ * @provides TooltipEntrySettings
+ */
+export const Venn = (outsideProps: VennProps) => {
+  const props = resolveDefaultProps(outsideProps, defaultVennProps);
+  const { width, height, responsive, className, style, id: externalId, margin, throttleDelay, throttledEvents } = props;
+  const wrapperStyle = {
+    fontFamily: vennSansFontFamily,
+    ...style,
+  };
+  const [tooltipPortal, setTooltipPortal] = useState<HTMLElement | null>(null);
+
+  return (
+    <RechartsStoreProvider
+      preloadedState={{
+        options,
+      }}
+      reduxStoreName={className ?? 'Venn'}
+    >
+      <ReportChartSize width={width} height={height} />
+      <ReportChartMargin margin={margin} />
+      <ReportEventSettings throttleDelay={throttleDelay} throttledEvents={throttledEvents} />
+      <TooltipPortalContext.Provider value={tooltipPortal}>
+        <RechartsWrapper
+          className={className}
+          width={width}
+          height={height}
+          responsive={responsive}
+          style={wrapperStyle}
+          ref={(node: HTMLDivElement) => {
+            if (tooltipPortal == null && node != null) {
+              setTooltipPortal(node);
+            }
+          }}
+          onMouseEnter={undefined}
+          onMouseLeave={undefined}
+          onClick={undefined}
+          onMouseMove={undefined}
+          onMouseDown={undefined}
+          onMouseUp={undefined}
+          onContextMenu={undefined}
+          onDoubleClick={undefined}
+          onTouchStart={undefined}
+          onTouchMove={undefined}
+          onTouchEnd={undefined}
+        >
+          <RegisterGraphicalItemId id={externalId} type="venn">
+            {id => <VennImpl {...props} id={id} />}
+          </RegisterGraphicalItemId>
+        </RechartsWrapper>
+      </TooltipPortalContext.Provider>
+    </RechartsStoreProvider>
+  );
+};
+
+export const VennChart = Venn;

--- a/src/chart/Venn.tsx
+++ b/src/chart/Venn.tsx
@@ -66,8 +66,10 @@ type InternalVennProps = WithIdRequired<RequiresDefaultProps<VennProps, typeof d
 
 export interface VennProps extends EventThrottlingProps {
   /**
-   * Input data in venn.js format:
-   * each item identifies one set or intersection with `sets` and `size`.
+   * The source data. Each element should be an object.
+   * The properties of each object represent the values of different data dimensions.
+   *
+   * Use the `dataKey` prop to specify which properties to use.
    */
   data: ReadonlyArray<VennDataItem>;
   /**
@@ -91,7 +93,6 @@ export interface VennProps extends EventThrottlingProps {
    *
    * This is similar to ResponsiveContainer but without the need for an extra wrapper component.
    * The `responsive` prop also uses standard CSS sizing rules, instead of custom resolution logic (like ResponsiveContainer does).
-   * @default false
    */
   responsive?: boolean;
   className?: string;
@@ -100,17 +101,31 @@ export interface VennProps extends EventThrottlingProps {
   children?: ReactNode;
   margin?: Margin;
   /**
-   * Key used to read set sizes from each item.
+   * The data that you provide via the `data` prop is an array of objects.
+   * Each object can have multiple properties, each representing a different data dimension.
+   * Use the `dataKey` prop to specify which property (or dimension) to use for this component.
+   *
+   * Typically, you will want to have one dataKey on the X axis, and different dataKey on the Y axis,
+   * where they extract different values from the same data objects.
+   *
+   * Decides how to extract the value from the data:
+   * - `string`: the name of the field in the data object;
+   * - `number`: the index of the field in the data;
+   * - `function`: a function that receives the data object and returns the value.
    * @default size
    */
   dataKey?: DataKey<VennDataItem, number>;
   /**
-   * Key used to read labels from each item.
-   * If not provided, single-set entries default to the set identifier.
+   * Name represents each sector in the tooltip.
+   * This allows you to extract the name from the data:
+   *
+   * - `string`: the name of the field in the data object;
+   * - `number`: the index of the field in the data;
+   * - `function`: a function that receives the data object and returns the name.
    */
   nameKey?: DataKey<VennDataItem, string>;
   /**
-   * Fill color used when neither area item nor source set defines one.
+   * The background color used to fill the space between grid lines
    */
   fill?: string;
   stroke?: string;
@@ -1256,5 +1271,3 @@ export const Venn = (outsideProps: VennProps) => {
     </RechartsStoreProvider>
   );
 };
-
-export const VennChart = Venn;

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ export { RadialBarChart } from './chart/RadialBarChart';
 export { ComposedChart } from './chart/ComposedChart';
 export { SunburstChart } from './chart/SunburstChart';
 export type { SunburstData, SunburstChartProps } from './chart/SunburstChart';
-export { Venn, VennChart } from './chart/Venn';
+export { Venn } from './chart/Venn';
 export type { VennDataItem, VennProps } from './chart/Venn';
 
 export { Funnel } from './cartesian/Funnel';

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,8 @@ export { RadialBarChart } from './chart/RadialBarChart';
 export { ComposedChart } from './chart/ComposedChart';
 export { SunburstChart } from './chart/SunburstChart';
 export type { SunburstData, SunburstChartProps } from './chart/SunburstChart';
+export { Venn, VennChart } from './chart/Venn';
+export type { VennDataItem, VennProps } from './chart/Venn';
 
 export { Funnel } from './cartesian/Funnel';
 export type { Props as FunnelProps, FunnelTrapezoidItem } from './cartesian/Funnel';

--- a/storybook/stories/API/ResponsiveContainer.mdx
+++ b/storybook/stories/API/ResponsiveContainer.mdx
@@ -34,6 +34,7 @@ The ResponsiveContainer can be used with the following child components:
 - `<ScatterChart/>`
 - `<SunburstChart/>`
 - `<Treemap/>`
+- `<Venn/>`
 
 ## Props
 

--- a/storybook/stories/API/chart/Venn.mdx
+++ b/storybook/stories/API/chart/Venn.mdx
@@ -7,15 +7,22 @@ import * as ComponentStories from './Venn.stories';
 
 <Canvas of={ComponentStories.API} layout="padded" />
 
+## Description
+
+<p>
+  Venn charts visualize overlap between two or more sets. Pass data in venn.js format where each item defines a set or
+  an intersection.
+</p>
+
 ## Parent Component
 
-The Venn chart can be used within the following parent components:
+The Venn can be used within the following parent components:
 
 - `<ResponsiveContainer/>`
 
 ## Child Components
 
-The Venn chart can be used with the following child components:
+The Venn can be used with the following child components:
 
 - `<Tooltip/>`
 

--- a/storybook/stories/API/chart/Venn.mdx
+++ b/storybook/stories/API/chart/Venn.mdx
@@ -1,0 +1,24 @@
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
+import * as ComponentStories from './Venn.stories';
+
+# Venn
+
+<Meta of={ComponentStories} />
+
+<Canvas of={ComponentStories.API} layout="padded" />
+
+## Parent Component
+
+The Venn chart can be used within the following parent components:
+
+- `<ResponsiveContainer/>`
+
+## Child Components
+
+The Venn chart can be used with the following child components:
+
+- `<Tooltip/>`
+
+## Props
+
+<Controls of={ComponentStories.API} />

--- a/storybook/stories/API/chart/Venn.stories.tsx
+++ b/storybook/stories/API/chart/Venn.stories.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Args } from '@storybook/react-vite';
 import { ResponsiveContainer, Tooltip, Venn } from '../../../../src';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
+import { VennArgs } from '../arg-types/VennArgs';
+import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 
 const threeSetData = [
   { sets: ['Search'], size: 18, label: 'Search' },
@@ -47,6 +49,7 @@ const fourSetData = [
 ];
 
 export default {
+  argTypes: VennArgs,
   component: Venn,
 };
 
@@ -63,28 +66,46 @@ export const API = {
   name: 'Three Sets',
   render: renderChart,
   args: {
+    ...getStoryArgsFromArgsTypesObject(VennArgs),
     data: threeSetData,
+    margin: { top: 8, right: 8, bottom: 8, left: 8 },
+    className: 'venn-api-three-sets',
+    style: { backgroundColor: '#f8fafc' },
   },
 };
 
 export const TwoSets = {
   render: renderChart,
   args: {
+    ...getStoryArgsFromArgsTypesObject(VennArgs),
     data: twoSetData,
+    fillOpacity: 0.4,
+    intersectionFillOpacity: 0.65,
+    className: 'venn-api-two-sets',
   },
 };
 
 export const DisjointAndSubsetEuler = {
   render: renderChart,
   args: {
+    ...getStoryArgsFromArgsTypesObject(VennArgs),
     data: disjointAndSubsetData,
+    stroke: '#f8fafc',
+    dataKey: 'size',
+    nameKey: 'label',
+    className: 'venn-api-euler',
   },
 };
 
 export const FourSetsApproximate = {
   render: renderChart,
   args: {
+    ...getStoryArgsFromArgsTypesObject(VennArgs),
     data: fourSetData,
+    responsive: true,
+    fillOpacity: 0.38,
+    intersectionFillOpacity: 0.6,
+    className: 'venn-api-four-sets',
   },
   parameters: {
     docs: {

--- a/storybook/stories/API/chart/Venn.stories.tsx
+++ b/storybook/stories/API/chart/Venn.stories.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { Args } from '@storybook/react-vite';
+import { ResponsiveContainer, Tooltip, Venn } from '../../../../src';
+import { RechartsHookInspector } from '../../../storybook-addon-recharts';
+
+const threeSetData = [
+  { sets: ['Search'], size: 18, label: 'Search' },
+  { sets: ['Checkout'], size: 16, label: 'Checkout' },
+  { sets: ['Support'], size: 14, label: 'Support' },
+  { sets: ['Search', 'Checkout'], size: 6, label: 'Search ∩ Checkout' },
+  { sets: ['Search', 'Support'], size: 5, label: 'Search ∩ Support' },
+  { sets: ['Checkout', 'Support'], size: 4, label: 'Checkout ∩ Support' },
+  { sets: ['Search', 'Checkout', 'Support'], size: 2, label: 'All' },
+];
+
+const twoSetData = [
+  { sets: ['Returning Users'], size: 42, label: 'Returning Users' },
+  { sets: ['Paying Users'], size: 26, label: 'Paying Users' },
+  { sets: ['Returning Users', 'Paying Users'], size: 18, label: 'Retained & Paying' },
+];
+
+const disjointAndSubsetData = [
+  { sets: ['Core'], size: 30, label: 'Core' },
+  { sets: ['Core Add-ons'], size: 10, label: 'Core Add-ons' },
+  { sets: ['Seasonal'], size: 12, label: 'Seasonal' },
+  // subset relationship (Core Add-ons inside Core)
+  { sets: ['Core', 'Core Add-ons'], size: 10, label: 'Core + Add-ons' },
+  // disjoint relationship (Seasonal separate from Core Add-ons)
+  { sets: ['Core Add-ons', 'Seasonal'], size: 0, label: 'No overlap' },
+  // small overlap with Core only
+  { sets: ['Core', 'Seasonal'], size: 3, label: 'Core + Seasonal' },
+];
+
+const fourSetData = [
+  { sets: ['A'], size: 16, label: 'A' },
+  { sets: ['B'], size: 14, label: 'B' },
+  { sets: ['C'], size: 13, label: 'C' },
+  { sets: ['D'], size: 12, label: 'D' },
+  { sets: ['A', 'B'], size: 6, label: 'A∩B' },
+  { sets: ['A', 'C'], size: 5, label: 'A∩C' },
+  { sets: ['A', 'D'], size: 4, label: 'A∩D' },
+  { sets: ['B', 'C'], size: 3, label: 'B∩C' },
+  { sets: ['B', 'D'], size: 4, label: 'B∩D' },
+  { sets: ['C', 'D'], size: 3, label: 'C∩D' },
+  { sets: ['A', 'B', 'C'], size: 2, label: 'A∩B∩C' },
+  { sets: ['A', 'B', 'D'], size: 1, label: 'A∩B∩D' },
+];
+
+export default {
+  component: Venn,
+};
+
+const renderChart = (args: Args) => (
+  <ResponsiveContainer width="100%" height={380}>
+    <Venn {...args} data={args.data}>
+      <Tooltip />
+      <RechartsHookInspector />
+    </Venn>
+  </ResponsiveContainer>
+);
+
+export const API = {
+  name: 'Three Sets',
+  render: renderChart,
+  args: {
+    data: threeSetData,
+  },
+};
+
+export const TwoSets = {
+  render: renderChart,
+  args: {
+    data: twoSetData,
+  },
+};
+
+export const DisjointAndSubsetEuler = {
+  render: renderChart,
+  args: {
+    data: disjointAndSubsetData,
+  },
+};
+
+export const FourSetsApproximate = {
+  render: renderChart,
+  args: {
+    data: fourSetData,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'For 4+ sets, area-proportional layouts are approximate and can have multiple local optima. Prefer validating the visual against your intended relationships.',
+      },
+    },
+  },
+};

--- a/storybook/stories/Examples/Venn/Venn.stories.tsx
+++ b/storybook/stories/Examples/Venn/Venn.stories.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { ResponsiveContainer, Tooltip, Venn } from '../../../../src';
+
+export default {
+  title: 'Examples/Venn',
+};
+
+const audienceOverlapData = [
+  { sets: ['Web'], size: 120, label: 'Web' },
+  { sets: ['Mobile'], size: 90, label: 'Mobile' },
+  { sets: ['In-store'], size: 70, label: 'In-store' },
+  { sets: ['Web', 'Mobile'], size: 38, label: 'Web + Mobile' },
+  { sets: ['Web', 'In-store'], size: 25, label: 'Web + In-store' },
+  { sets: ['Mobile', 'In-store'], size: 17, label: 'Mobile + In-store' },
+  { sets: ['Web', 'Mobile', 'In-store'], size: 9, label: 'All channels' },
+];
+
+const retentionVsRevenueData = [
+  { sets: ['30-day retained'], size: 52, label: '30-day retained' },
+  { sets: ['High LTV'], size: 28, label: 'High LTV' },
+  { sets: ['30-day retained', 'High LTV'], size: 19, label: 'Retained + High LTV' },
+];
+
+const productPackagingData = [
+  { sets: ['Starter'], size: 45, label: 'Starter' },
+  { sets: ['Pro'], size: 24, label: 'Pro' },
+  { sets: ['Enterprise'], size: 14, label: 'Enterprise' },
+  { sets: ['Starter', 'Pro'], size: 12, label: 'Starter + Pro' },
+  { sets: ['Pro', 'Enterprise'], size: 8, label: 'Pro + Enterprise' },
+  { sets: ['Starter', 'Enterprise'], size: 0, label: 'No overlap' },
+  { sets: ['Starter', 'Pro', 'Enterprise'], size: 4, label: 'All tiers' },
+];
+
+function ExampleChart({ data }: { data: Array<{ sets: string[]; size: number; label: string }> }) {
+  return (
+    <ResponsiveContainer width="100%" height={360}>
+      <Venn data={data}>
+        <Tooltip />
+      </Venn>
+    </ResponsiveContainer>
+  );
+}
+
+export const AudienceOverlap = {
+  render: () => <ExampleChart data={audienceOverlapData} />,
+};
+
+export const RetentionVsRevenue = {
+  render: () => <ExampleChart data={retentionVsRevenueData} />,
+};
+
+export const DisjointAndSubsetSignals = {
+  render: () => <ExampleChart data={productPackagingData} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Useful for Euler-style data where some overlaps are intentionally zero. Keep set counts small when exact area fidelity is important.',
+      },
+    },
+  },
+};

--- a/test/_data.ts
+++ b/test/_data.ts
@@ -198,6 +198,12 @@ export const exampleSunburstData: SunburstData = {
   ],
 };
 
+export const exampleVennData = [
+  { sets: ['A'], size: 12, label: 'A' },
+  { sets: ['B'], size: 12, label: 'B' },
+  { sets: ['A', 'B'], size: 2, label: 'A∩B' },
+];
+
 export const exampleRadarData = [
   { name: 'iPhone 3GS', value: 420, half: 210 },
   { name: 'iPhone 4', value: 460, half: 230 },

--- a/test/chart/Venn.spec.tsx
+++ b/test/chart/Venn.spec.tsx
@@ -4,7 +4,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { Customized, Tooltip, Venn } from '../../src';
 import { exampleVennData } from '../_data';
 import { useAppSelector } from '../../src/state/hooks';
-import { TooltipInteractionState } from '../../src/state/tooltipSlice';
 import { assertNotNull } from '../helper/assertNotNull';
 import { rechartsTestRender } from '../helper/createSelectorTestCase';
 import { expectLastCalledWith } from '../helper/expectLastCalledWith';
@@ -46,8 +45,7 @@ describe('<Venn />', () => {
   });
 
   it('should expose tooltip payload on hover', () => {
-    const tooltipStateSpy =
-      vi.fn<[(state: { click: TooltipInteractionState; hover: TooltipInteractionState } | undefined) => void]>();
+    const tooltipStateSpy = vi.fn();
 
     const Comp = (): null => {
       tooltipStateSpy(useAppSelector(state => state.tooltip.itemInteraction));
@@ -65,7 +63,7 @@ describe('<Venn />', () => {
     assertNotNull(firstArea);
 
     fireEvent.mouseEnter(firstArea);
-    expectLastCalledWith(tooltipStateSpy, {
+    expect(tooltipStateSpy).toHaveBeenLastCalledWith({
       click: {
         active: false,
         index: null,

--- a/test/chart/Venn.spec.tsx
+++ b/test/chart/Venn.spec.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Customized, Tooltip, Venn } from '../../src';
+import { exampleVennData } from '../_data';
+import { useAppSelector } from '../../src/state/hooks';
+import { TooltipInteractionState } from '../../src/state/tooltipSlice';
+import { assertNotNull } from '../helper/assertNotNull';
+import { rechartsTestRender } from '../helper/createSelectorTestCase';
+import { expectLastCalledWith } from '../helper/expectLastCalledWith';
+
+describe('<Venn />', () => {
+  it('renders circles and intersections', () => {
+    const { container } = rechartsTestRender(<Venn width={500} height={300} data={exampleVennData} />);
+
+    expect(container.querySelectorAll('.recharts-venn-set')).toHaveLength(2);
+    expect(container.querySelectorAll('.recharts-venn-intersection')).toHaveLength(1);
+  });
+
+  it('fires callbacks on hover and click', () => {
+    const onMouseEnter = vi.fn();
+    const onMouseLeave = vi.fn();
+    const onClick = vi.fn();
+    const { container } = rechartsTestRender(
+      <Venn
+        width={500}
+        height={300}
+        data={exampleVennData}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      />,
+    );
+
+    const firstArea = container.querySelector('g[opacity]');
+    assertNotNull(firstArea);
+
+    fireEvent.mouseEnter(firstArea);
+    expectLastCalledWith(onMouseEnter, exampleVennData[0], expect.any(Object));
+
+    fireEvent.mouseLeave(firstArea);
+    expectLastCalledWith(onMouseLeave, exampleVennData[0], expect.any(Object));
+
+    fireEvent.click(firstArea);
+    expectLastCalledWith(onClick, exampleVennData[0]);
+  });
+
+  it('should expose tooltip payload on hover', () => {
+    const tooltipStateSpy =
+      vi.fn<[(state: { click: TooltipInteractionState; hover: TooltipInteractionState } | undefined) => void]>();
+
+    const Comp = (): null => {
+      tooltipStateSpy(useAppSelector(state => state.tooltip.itemInteraction));
+      return null;
+    };
+
+    const { container } = rechartsTestRender(
+      <Venn width={500} height={300} data={exampleVennData}>
+        <Tooltip />
+        <Customized component={<Comp />} />
+      </Venn>,
+    );
+
+    const firstArea = container.querySelector('g[opacity]');
+    assertNotNull(firstArea);
+
+    fireEvent.mouseEnter(firstArea);
+    expectLastCalledWith(tooltipStateSpy, {
+      click: {
+        active: false,
+        index: null,
+        dataKey: undefined,
+        coordinate: undefined,
+        graphicalItemId: undefined,
+      },
+      hover: {
+        active: true,
+        index: '[0]',
+        dataKey: 'size',
+        coordinate: expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) }),
+        graphicalItemId: expect.stringMatching(/^recharts-venn-.+/),
+      },
+    });
+  });
+});

--- a/test/chart/Venn.typed.spec.tsx
+++ b/test/chart/Venn.typed.spec.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { describe, it } from 'vitest';
+import { Venn } from '../../src';
+import { exampleVennData } from '../_data';
+
+describe('Venn types', () => {
+  it('should type event handlers', () => {
+    <Venn
+      width={400}
+      height={240}
+      data={exampleVennData}
+      onClick={_node => {}}
+      onMouseEnter={(_node, _event) => {}}
+      onMouseLeave={(_node, _event) => {}}
+    />;
+  });
+});

--- a/www/src/docs/apiCates.ts
+++ b/www/src/docs/apiCates.ts
@@ -14,6 +14,7 @@ export const apiCates = [
       'Treemap',
       'Sankey',
       'SunburstChart',
+      'Venn',
     ],
   },
   {

--- a/www/src/docs/apiExamples/Venn/VennExample.tsx
+++ b/www/src/docs/apiExamples/Venn/VennExample.tsx
@@ -1,7 +1,7 @@
 import { RechartsDevtools } from '@recharts/devtools';
-import { ResponsiveContainer, Tooltip, Venn } from 'recharts';
+import { Tooltip, Venn, VennDataItem, VennProps } from 'recharts';
 
-const vennData = [
+const vennData: VennDataItem[] = [
   { sets: ['Search'], size: 18, label: 'Search' },
   { sets: ['Checkout'], size: 16, label: 'Checkout' },
   { sets: ['Support'], size: 14, label: 'Support' },
@@ -11,13 +11,34 @@ const vennData = [
   { sets: ['Search', 'Checkout', 'Support'], size: 2, label: 'All' },
 ];
 
+const vennDefaults: Pick<VennProps, 'fill' | 'stroke' | 'margin'> = {
+  fill: '#4f83cc',
+  stroke: '#ffffff',
+  margin: { top: 12, right: 16, bottom: 12, left: 16 },
+};
+
 export default function VennExample() {
   return (
-    <ResponsiveContainer width="100%" height={380}>
-      <Venn data={vennData}>
-        <Tooltip />
-        <RechartsDevtools />
-      </Venn>
-    </ResponsiveContainer>
+    <Venn
+      data={vennData}
+      dataKey="size"
+      nameKey="label"
+      className="venn-api-example"
+      style={{ maxWidth: 760, width: '100%', height: '62vh', backgroundColor: '#f8fafc' }}
+      id="venn-api-example"
+      width="100%"
+      height={380}
+      responsive
+      fill={vennDefaults.fill}
+      stroke={vennDefaults.stroke}
+      fillOpacity={0.4}
+      intersectionFillOpacity={0.62}
+      margin={vennDefaults.margin}
+      throttleDelay={32}
+      throttledEvents={['mousemove', 'pointermove']}
+    >
+      <Tooltip />
+      <RechartsDevtools />
+    </Venn>
   );
 }

--- a/www/src/docs/apiExamples/Venn/VennExample.tsx
+++ b/www/src/docs/apiExamples/Venn/VennExample.tsx
@@ -1,0 +1,23 @@
+import { RechartsDevtools } from '@recharts/devtools';
+import { ResponsiveContainer, Tooltip, Venn } from 'recharts';
+
+const vennData = [
+  { sets: ['Search'], size: 18, label: 'Search' },
+  { sets: ['Checkout'], size: 16, label: 'Checkout' },
+  { sets: ['Support'], size: 14, label: 'Support' },
+  { sets: ['Search', 'Checkout'], size: 6, label: 'Search ∩ Checkout' },
+  { sets: ['Search', 'Support'], size: 5, label: 'Search ∩ Support' },
+  { sets: ['Checkout', 'Support'], size: 4, label: 'Checkout ∩ Support' },
+  { sets: ['Search', 'Checkout', 'Support'], size: 2, label: 'All' },
+];
+
+export default function VennExample() {
+  return (
+    <ResponsiveContainer width="100%" height={380}>
+      <Venn data={vennData}>
+        <Tooltip />
+        <RechartsDevtools />
+      </Venn>
+    </ResponsiveContainer>
+  );
+}

--- a/www/src/docs/apiExamples/Venn/index.tsx
+++ b/www/src/docs/apiExamples/Venn/index.tsx
@@ -1,0 +1,11 @@
+import { ChartExample } from '../../exampleComponents/types';
+import VennExample from './VennExample';
+import vennExampleSource from './VennExample?raw';
+
+export const vennApiExamples: ReadonlyArray<ChartExample> = [
+  {
+    Component: VennExample,
+    sourceCode: vennExampleSource,
+    name: 'Venn Example',
+  },
+];

--- a/www/src/docs/apiExamples/index.tsx
+++ b/www/src/docs/apiExamples/index.tsx
@@ -39,6 +39,7 @@ import { useAxisInverseDataSnapScaleApiExamples } from './useAxisInverseDataSnap
 import { useAxisInverseTickSnapScaleApiExamples } from './useAxisInverseTickSnapScale';
 import { useXAxisTicksApiExamples } from './useXAxisTicks';
 import { useYAxisTicksApiExamples } from './useYAxisTicks';
+import { vennApiExamples } from './Venn';
 
 export const allApiExamples: Record<string, ReadonlyArray<ChartExample>> = {
   AreaChart: areaChartApiExamples,
@@ -64,6 +65,7 @@ export const allApiExamples: Record<string, ReadonlyArray<ChartExample>> = {
   FunnelChart: funnelChartApiExamples,
   Sankey: sankeyApiExamples,
   SunburstChart: sunburstChartApiExamples,
+  Venn: vennApiExamples,
   ZIndexLayer: zIndexLayerApiExamples,
   DefaultZIndexes: defaultZIndexesApiExamples,
   useIsTooltipActive: useIsTooltipActiveApiExamples,


### PR DESCRIPTION
## Description

<img width="1819" height="1522" alt="Screenshot 2026-04-09 at 4 28 09 AM" src="https://github.com/user-attachments/assets/15ac6be2-d75f-4692-9efe-9eef178cf4b5" />

Adds a new public `Venn` chart to Recharts, including layout/rendering, tooltip integration, interactions, API docs wiring, and Storybook + website examples.

This branch also includes follow-up polish from review iterations:
- improved label positioning/legibility and sans-serif labels
- richer tooltip labeling for intersections
- dashed white hover outline for intersection regions (rendered on top)
- improved color variation and intersection color blending
- additional API + Examples stories and docs examples

## Related Issue
Closes #2789

## Motivation / Context
Recharts did not provide a built-in Venn/Euler-style chart, and users requested first-class support. This adds a declarative Venn component aligned with existing Recharts API conventions and documentation flow.

## Implementation Notes
- New public chart: `Venn` (exported from `src/index.ts`)
- Includes typed/unit tests and generated docs integration
- Added/updated Storybook API and Examples usage for better prop coverage
- Added website API example coverage for omnidoc example checks

## Testing
- `npm run test -- test/chart/Venn.spec.tsx`
- `npm run test -- test/chart/Venn.typed.spec.tsx`
- `npm run test-omnidoc`
- pre-push pipeline run (build + tests + typechecks) before branch publish

## Change Type
- [x] New feature
- [x] Documentation update
- [x] Tests

## Checklist
- [x] Branch is based on `main`
- [x] Public export added in `src/index.ts`
- [x] Storybook/API docs + website examples updated
- [x] Relevant tests added/updated

## Credits / References
- Original Recharts request: https://github.com/recharts/recharts/issues/2789
- Ben Frederickson blog posts: 
  - https://www.benfrederickson.com/venn-diagrams-with-d3.js/
  - https://www.benfrederickson.com/better-venn-diagrams/
- `venn.js` implementation inspiration: https://github.com/benfred/venn.js


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new Venn chart component for visualizing set relationships and intersections, with full support for customizable colors, opacity levels, interactive hover and click behaviors, and integrated tooltip functionality.

* **Documentation**
  * Added comprehensive Storybook documentation, API reference, and interactive examples showcasing Venn chart usage patterns and configuration options.

* **Tests**
  * Added test coverage for rendering, event handling, tooltip state management, and TypeScript type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->