### PR TITLE
fixes an issue where XAxis and YAxis padding were ignored by the clipping mask when allowDataOverflow={true} was used alongside a restricted domain

### DIFF
--- a/src/cartesian/GraphicalItemClipPath.tsx
+++ b/src/cartesian/GraphicalItemClipPath.tsx
@@ -4,7 +4,9 @@ import { useAppSelector } from '../state/hooks';
 import {
   implicitXAxis,
   implicitYAxis,
+  selectXAxisRange,
   selectXAxisSettings,
+  selectYAxisRange,
   selectYAxisSettings,
 } from '../state/selectors/axisSelectors';
 import { usePlotArea } from '../hooks';
@@ -30,6 +32,8 @@ export function GraphicalItemClipPath({ xAxisId, yAxisId, clipPathId }: Graphica
   const plotArea = usePlotArea();
 
   const { needClipX, needClipY, needClip } = useNeedsClip(xAxisId, yAxisId);
+  const xAxisRange = useAppSelector(state => selectXAxisRange(state, xAxisId, false));
+  const yAxisRange = useAppSelector(state => selectYAxisRange(state, yAxisId, false));
 
   if (!needClip || !plotArea) {
     return null;
@@ -37,14 +41,14 @@ export function GraphicalItemClipPath({ xAxisId, yAxisId, clipPathId }: Graphica
 
   const { x, y, width, height } = plotArea;
 
+  const clipX = needClipX && xAxisRange ? Math.min(xAxisRange[0], xAxisRange[1]) : x - width / 2;
+  const clipY = needClipY && yAxisRange ? Math.min(yAxisRange[0], yAxisRange[1]) : y - height / 2;
+  const clipWidth = needClipX && xAxisRange ? Math.abs(xAxisRange[1] - xAxisRange[0]) : width * 2;
+  const clipHeight = needClipY && yAxisRange ? Math.abs(yAxisRange[1] - yAxisRange[0]) : height * 2;
+
   return (
     <clipPath id={`clipPath-${clipPathId}`}>
-      <rect
-        x={needClipX ? x : x - width / 2}
-        y={needClipY ? y : y - height / 2}
-        width={needClipX ? width : width * 2}
-        height={needClipY ? height : height * 2}
-      />
+      <rect x={clipX} y={clipY} width={clipWidth} height={clipHeight} />
     </clipPath>
   );
 }

--- a/test/cartesian/XAxis/XAxis.padding_clip.spec.tsx
+++ b/test/cartesian/XAxis/XAxis.padding_clip.spec.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { Bar, BarChart, XAxis, YAxis } from '../../../src';
+
+describe('XAxis padding with allowDataOverflow', () => {
+  it('should clip data reaching into the padding area when allowDataOverflow is true', () => {
+    const { container } = render(
+      <BarChart
+        width={400}
+        height={400}
+        data={[
+          { x: 0, y: 10 },
+          { x: 100, y: 30 },
+        ]}
+      >
+        <XAxis dataKey="x" type="number" domain={[0, 100]} allowDataOverflow padding={{ left: 10, right: 50 }} />
+        <YAxis />
+        <Bar dataKey="y" isAnimationActive={false} />
+      </BarChart>,
+    );
+
+    const clipPathRect = container.querySelectorAll('clipPath rect');
+    const itemClipPath = Array.from(clipPathRect).find(rect => rect.getAttribute('width') === '270');
+
+    expect(itemClipPath).toBeDefined();
+    expect(itemClipPath?.getAttribute('x')).toBe('75');
+    expect(itemClipPath?.getAttribute('width')).toBe('270');
+  });
+
+  it('should not clip padding area when allowDataOverflow is false (default behavior)', () => {
+    const { container } = render(
+      <BarChart
+        width={400}
+        height={400}
+        data={[
+          { x: 0, y: 10 },
+          { x: 100, y: 30 },
+        ]}
+      >
+        <XAxis
+          dataKey="x"
+          type="number"
+          domain={[0, 100]}
+          allowDataOverflow={false}
+          padding={{ left: 10, right: 50 }}
+        />
+        <YAxis />
+        <Bar dataKey="y" isAnimationActive={false} />
+      </BarChart>,
+    );
+
+    const clipPathRects = Array.from(container.querySelectorAll('clipPath rect'));
+    const narrowClipPath = clipPathRects.find(rect => rect.getAttribute('width') === '270');
+
+    expect(narrowClipPath).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description

This PR fixes an issue where XAxis and YAxis padding were ignored by the clipping mask when `allowDataOverflow={true}` was used alongside a restricted domain. 

Previously, the `GraphicalItemClipPath` component calculated its clipping rectangle using the broad `plotArea` dimensions. This caused data to "bleed" into the padded areas because the mask wasn't aware of the specific padding applied to the axes. 

I updated `GraphicalItemClipPath` to use the actual computed ranges for the axes (`selectXAxisRange` and `selectYAxisRange`). This ensures the clipping rectangle strictly matches the padded boundaries, cutting off overflowing data precisely where the axis ends.

## Related Issue

<!--- Please link to the issue here: -->
Fixes #6947

## How Has This Been Tested?

I tested this locally using Vitest. 
- Created a reproduction test case with a BarChart, domain strictness, `allowDataOverflow={true}`, and `padding={{ right: 50 }}`. I verified that the rendered `<clipPath>` now correctly reduces its width/height to respect the padding (e.g., width goes from 330px to 280px).
- Ran the Recharts unit test suite: `vitest run test/cartesian/XAxis/XAxis.padding.spec.tsx` and `test/cartesian/Bar.truncateByDomain.spec.tsx` to verify that existing truncation and padding behaviors are unaffected and no regressions were introduced.

## Screenshots (if appropriate):
*(Note: You can drag and drop a before/after screenshot of the chart here if you'd like to show the visual difference)*

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipping of chart elements at plot-area boundaries by using actual axis ranges, reducing visual overflow and ensuring correct clipping when data overflow and padding are applied.
* **Tests**
  * Added tests that validate clipping behavior with padding in both allow-data-overflow enabled and disabled scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->