### PR TITLE
feat: add PolarAngleAxis component storybook story

### DIFF
--- a/storybook/stories/API/polar/PolarAngleAxis.stories.tsx
+++ b/storybook/stories/API/polar/PolarAngleAxis.stories.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import { Args } from '@storybook/react-vite';
-import { PolarAngleAxis, RadialBarChart } from '../../../../src';
-import { pageData } from '../../data';
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  RadialBarChart,
+  ResponsiveContainer,
+} from '../../../../src';
+import { pageData, subjectData } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 import { PolarAngleAxisArgs } from '../arg-types/PolarAngleAxisArgs';
@@ -10,21 +18,63 @@ export default {
   argTypes: PolarAngleAxisArgs,
   component: PolarAngleAxis,
 };
+
 const [surfaceWidth, surfaceHeight] = [600, 300];
 
 export const API = {
   render: (args: Args) => {
     return (
-      <RadialBarChart width={surfaceWidth} height={surfaceHeight} data={pageData}>
-        <PolarAngleAxis {...args} />
-        <RechartsHookInspector />
-      </RadialBarChart>
+      <ResponsiveContainer width="100%" height={surfaceHeight}>
+        <RadarChart width={surfaceWidth} height={surfaceHeight} cx="50%" cy="50%" outerRadius="80%" data={subjectData}>
+          {/* All components are added to show the interaction with the PolarAngleAxis properties */}
+          <PolarGrid />
+          {/* The target component */}
+          <PolarAngleAxis dataKey="subject" {...args} />
+          <PolarRadiusAxis />
+          <Radar name="Student A" dataKey="A" stroke="#8884d8" fill="#8884d8" fillOpacity={0.6} />
+          <RechartsHookInspector />
+        </RadarChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    // This API story should have explicit values for all props
+    ...getStoryArgsFromArgsTypesObject(PolarAngleAxisArgs),
+    dataKey: 'subject',
+    axisLineType: 'polygon',
+    orientation: 'outer',
+    tick: true,
+    tickLine: true,
+    tickSize: 8,
+    stroke: '#666',
+    type: 'category',
+  },
+};
+
+export const InRadialBarChart = {
+  render: (args: Args) => {
+    return (
+      <ResponsiveContainer width="100%" height={surfaceHeight}>
+        <RadialBarChart
+          width={surfaceWidth}
+          height={surfaceHeight}
+          cx="50%"
+          cy="50%"
+          innerRadius={20}
+          outerRadius={140}
+          data={pageData}
+        >
+          {/* The target component */}
+          <PolarAngleAxis {...args} />
+          <RechartsHookInspector />
+        </RadialBarChart>
+      </ResponsiveContainer>
     );
   },
   args: {
     ...getStoryArgsFromArgsTypesObject(PolarAngleAxisArgs),
-    axisLineType: 'polygon',
-    stroke: 'green',
+    axisLineType: 'circle',
+    stroke: '#888',
     dataKey: 'uv',
     type: 'number',
   },


### PR DESCRIPTION
## Summary

- Adds a comprehensive Storybook API story for the `PolarAngleAxis` component following the `Line.stories.tsx` pattern
- Primary `API` export renders `PolarAngleAxis` inside a `RadarChart` (the main use case) with `subjectData` and all sibling components (`PolarGrid`, `PolarRadiusAxis`, `Radar`) to show real-world interactions
- Secondary `InRadialBarChart` export demonstrates `PolarAngleAxis` in a `RadialBarChart` context with `type="number"` axis
- All props flow through `PolarAngleAxisArgs` (auto-generated by `npm run omnidoc`) covering every prop from the API docs, with categories: General, Style, Events
- Uses `ResponsiveContainer`, `getStoryArgsFromArgsTypesObject`, and `RechartsHookInspector` consistent with the established pattern

Closes #3742

## Test plan

- [ ] Run `npm run omnidoc` to generate `storybook/stories/API/arg-types/PolarAngleAxisArgs.ts` (auto-generated, gitignored)
- [ ] Run `npm run storybook` and navigate to **Polar > PolarAngleAxis > API** story
- [ ] Verify all props appear in the Storybook controls panel with correct types, defaults, and categories
- [ ] Verify the radar chart renders with angle axis labels on the polygon outline
- [ ] Navigate to **Polar > PolarAngleAxis > InRadialBarChart** and verify the radial bar chart variant
- [ ] Toggle `axisLineType` between `polygon` and `circle` to confirm axis line shape changes
- [ ] Toggle `orientation` between `outer` and `inner` to confirm tick label position changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated component usage examples to demonstrate PolarAngleAxis with RadarChart layout
  * Added new example showing PolarAngleAxis implementation with alternative chart type

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recharts/recharts/pull/7243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->