### PR TITLE
feat: add LabelList component Storybook story

### DIFF
--- a/storybook/stories/API/component/LabelList.stories.tsx
+++ b/storybook/stories/API/component/LabelList.stories.tsx
@@ -1,8 +1,24 @@
 import React from 'react';
 import { Args } from '@storybook/react-vite';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  LabelList,
+  LabelProps,
+  Line,
+  LineChart,
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from '../../../../src';
+import { pageData, subjectData } from '../../data';
 import { getStoryArgsFromArgsTypesObject } from '../props/utils';
-import { ResponsiveContainer, LabelList, LineChart, Line } from '../../../../src';
-import { pageData } from '../../data';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 import { LabelListArgs } from '../arg-types/LabelListArgs';
 
@@ -27,6 +43,8 @@ export const API = {
           }}
           data={pageData}
         >
+          <XAxis dataKey="name" />
+          <YAxis />
           {/* The target component */}
           <Line dataKey="uv">
             <LabelList {...args} />
@@ -39,6 +57,155 @@ export const API = {
   args: {
     ...getStoryArgsFromArgsTypesObject(LabelListArgs),
     // This API story should have explicit values for all props
+    dataKey: 'uv',
+    position: 'top',
+    offset: 5,
+    angle: 0,
+    textBreakAll: false,
+    zIndex: 2000,
+  },
+};
+
+export const OnBarChart = {
+  render: (args: Args) => {
+    const [surfaceWidth, surfaceHeight] = [600, 300];
+    return (
+      <ResponsiveContainer width="100%" height={surfaceHeight}>
+        <BarChart
+          width={surfaceWidth}
+          height={surfaceHeight}
+          margin={{
+            top: 20,
+            right: 20,
+            bottom: 20,
+            left: 20,
+          }}
+          data={pageData}
+        >
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          {/* The target component */}
+          <Bar dataKey="uv" fill="#8884d8">
+            <LabelList {...args} />
+          </Bar>
+          <RechartsHookInspector />
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(LabelListArgs),
+    dataKey: 'uv',
+    position: 'top',
+    offset: 5,
+  },
+};
+
+export const OnRadarChart = {
+  render: (args: Args) => {
+    return (
+      <RadarChart width={500} height={400} data={subjectData}>
+        <PolarGrid />
+        <PolarAngleAxis dataKey="subject" />
+        <PolarRadiusAxis />
+        {/* The target component */}
+        <Radar name="A" dataKey="A" stroke="#8884d8" fill="#8884d8" fillOpacity={0.6}>
+          <LabelList {...args} />
+        </Radar>
+        <RechartsHookInspector />
+      </RadarChart>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(LabelListArgs),
+    dataKey: 'A',
+    position: 'outside',
+    clockWise: true,
+  },
+};
+
+export const WithCustomContent = {
+  render: (args: Args) => {
+    const renderCustomLabel = (props: LabelProps) => {
+      const { x, y, width, value } = props;
+      if (value == null) {
+        return null;
+      }
+      const xPos = Number(x) + Number(width) / 2;
+      const yPos = Number(y) - 14;
+      return (
+        <g>
+          <circle cx={xPos} cy={yPos} r={10} fill="#8884d8" />
+          <text x={xPos} y={yPos} fill="#fff" textAnchor="middle" dominantBaseline="middle" fontSize={10}>
+            {value}
+          </text>
+        </g>
+      );
+    };
+
+    const [surfaceWidth, surfaceHeight] = [600, 300];
+    return (
+      <ResponsiveContainer width="100%" height={surfaceHeight}>
+        <BarChart
+          width={surfaceWidth}
+          height={surfaceHeight}
+          margin={{
+            top: 30,
+            right: 20,
+            bottom: 20,
+            left: 20,
+          }}
+          data={pageData}
+        >
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          {/* The target component with custom content renderer */}
+          <Bar dataKey="pv" fill="#82ca9d">
+            <LabelList {...args} content={renderCustomLabel} />
+          </Bar>
+          <RechartsHookInspector />
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(LabelListArgs),
+    dataKey: 'pv',
+  },
+};
+
+export const WithFormatter = {
+  render: (args: Args) => {
+    const [surfaceWidth, surfaceHeight] = [600, 300];
+    return (
+      <ResponsiveContainer width="100%" height={surfaceHeight}>
+        <BarChart
+          width={surfaceWidth}
+          height={surfaceHeight}
+          margin={{
+            top: 20,
+            right: 20,
+            bottom: 20,
+            left: 20,
+          }}
+          data={pageData}
+        >
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          {/* The target component with formatter */}
+          <Bar dataKey="uv" fill="#8884d8">
+            <LabelList {...args} formatter={value => (value != null ? `${value} visitors` : '')} />
+          </Bar>
+          <RechartsHookInspector />
+        </BarChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(LabelListArgs),
     dataKey: 'uv',
     position: 'top',
   },


### PR DESCRIPTION
## Summary

- Implements Storybook API story for the `LabelList` component, resolving #3739
- Covers all props from the [recharts API docs](https://recharts.org/en-US/api/LabelList): `angle`, `clockWise`, `content`, `dataKey`, `formatter`, `id`, `offset`, `position`, `textBreakAll`, `valueAccessor`, `zIndex`
- Uses `LabelListArgs` (auto-generated by `omnidoc`) for argTypes, following the same pattern as `Line.stories.tsx`

## Stories added

| Story | Chart type | Purpose |
|-------|------------|---------|
| `API` | `LineChart` | Main API story with all props controlled via argTypes |
| `OnBarChart` | `BarChart` | Shows LabelList in the most common use-case (bar labels) |
| `OnRadarChart` | `RadarChart` | Demonstrates `clockWise` prop in a polar/radar context |
| `WithCustomContent` | `BarChart` | Shows the `content` prop with a custom renderer |
| `WithFormatter` | `BarChart` | Shows the `formatter` prop for custom label text |

## Test plan

- [ ] Run `npm run omnidoc` to generate `storybook/stories/API/arg-types/LabelListArgs.ts`
- [ ] Run `npm run storybook` and navigate to **Component / LabelList**
- [ ] Verify all 5 stories render correctly and argType controls are visible in the Controls panel
- [ ] Verify the `API` story exposes all LabelList props with correct default values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded LabelList component Storybook stories with new examples showcasing usage in bar charts, radar charts, and custom content scenarios.
  * Added documentation for additional LabelList configuration options including offset, angle, text breaking, and z-index.
  * Introduced formatter function example for enhanced customization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recharts/recharts/pull/7244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->