### PR TITLE
feat: add Label component storybook story

### DIFF
--- a/storybook/stories/API/component/Label.stories.tsx
+++ b/storybook/stories/API/component/Label.stories.tsx
@@ -10,9 +10,11 @@ import {
   PolarRadiusAxis,
   Radar,
   RadarChart,
+  Rectangle,
   ResponsiveContainer,
   XAxis,
   YAxis,
+  usePlotArea,
 } from '../../../../src';
 import { RechartsHookInspector } from '../../../storybook-addon-recharts';
 import { pageData } from '../../data';
@@ -75,4 +77,160 @@ export const PolarPositions = {
     );
   },
   args: { ...getStoryArgsFromArgsTypesObject(LabelArgs), position: 'center' },
+};
+
+/**
+ * Helper component to draw a rectangle around the plot area so that
+ * "inside" vs "outside" label positions are visually clear.
+ */
+const PlotAreaBorder = () => {
+  const plotArea = usePlotArea();
+  if (plotArea == null) {
+    return null;
+  }
+  return (
+    <Rectangle
+      x={plotArea.x}
+      y={plotArea.y}
+      width={plotArea.width}
+      height={plotArea.height}
+      stroke="#aaa"
+      strokeDasharray="4 2"
+      fill="none"
+    />
+  );
+};
+
+const ALL_CARTESIAN_POSITIONS = [
+  'top',
+  'bottom',
+  'left',
+  'right',
+  'center',
+  'insideLeft',
+  'insideRight',
+  'insideTop',
+  'insideBottom',
+  'insideTopLeft',
+  'insideTopRight',
+  'insideBottomLeft',
+  'insideBottomRight',
+  'inside',
+  'outside',
+  'middle',
+] as const;
+
+/**
+ * Shows all cartesian label positions at once inside a LineChart.
+ * The dashed rectangle marks the plot area boundary, making it easy to
+ * distinguish "inside*" positions from "outside" / "top" / "bottom" etc.
+ */
+export const AllCartesianPositions = {
+  render: () => (
+    <LineChart width={600} height={400} margin={{ top: 60, right: 80, bottom: 60, left: 80 }}>
+      <PlotAreaBorder />
+      {ALL_CARTESIAN_POSITIONS.map(pos => (
+        <Label key={pos} position={pos} value={pos} fontSize={11} fill="#333" />
+      ))}
+    </LineChart>
+  ),
+};
+
+const ALL_POLAR_POSITIONS = ['center', 'outside', 'insideStart', 'insideEnd', 'end'] as const;
+
+/**
+ * Shows all polar label positions at once inside a RadarChart.
+ */
+export const AllPolarPositions = {
+  render: () => (
+    <RadarChart width={600} height={600} data={pageData} margin={{ top: 30, right: 100, bottom: 30, left: 100 }}>
+      <Radar dataKey="uv" fill="rgba(0,200,200,0.2)" stroke="teal" />
+      <PolarGrid />
+      <PolarAngleAxis dataKey="name" />
+      <PolarRadiusAxis tick={false} />
+      {ALL_POLAR_POSITIONS.map(pos => (
+        <Label key={pos} position={pos} value={pos} fontSize={13} fill="#333" />
+      ))}
+    </RadarChart>
+  ),
+};
+
+/**
+ * Demonstrates the `formatter` prop, which transforms the raw `value`
+ * before it is rendered. Useful for units, rounding, etc.
+ */
+export const WithFormatter = {
+  render: (args: Args) => (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={pageData} margin={{ top: 80, right: 40, bottom: 40, left: 60 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Line type="monotone" dataKey="uv" stroke="#8884d8" />
+        <Label value={1234567} position="top" formatter={(v: number) => `${(v / 1000).toFixed(1)}k`} {...args} />
+        <RechartsHookInspector />
+      </LineChart>
+    </ResponsiveContainer>
+  ),
+  args: { ...getStoryArgsFromArgsTypesObject(LabelArgs) },
+};
+
+/**
+ * Demonstrates the `content` prop with a custom React element.
+ * When `content` is set to a React element or render function,
+ * it receives the full Label props and can render arbitrary SVG.
+ */
+export const WithCustomContent = {
+  render: (args: Args) => {
+    const CustomLabel = (props: any) => {
+      const { viewBox } = props;
+      if (!viewBox) return null;
+      const { x = 0, y = 0, width = 0, height = 0 } = viewBox;
+      const cx = Number(x) + Number(width) / 2;
+      const cy = Number(y) + Number(height) / 2;
+      return (
+        <g>
+          <circle cx={cx} cy={cy} r={18} fill="#8884d8" opacity={0.85} />
+          <text x={cx} y={cy} textAnchor="middle" dominantBaseline="central" fill="#fff" fontSize={11}>
+            Label
+          </text>
+        </g>
+      );
+    };
+
+    return (
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={pageData} margin={{ top: 40, right: 40, bottom: 40, left: 60 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Line type="monotone" dataKey="uv" stroke="#8884d8" />
+          <Label content={<CustomLabel />} position="center" {...args} />
+          <RechartsHookInspector />
+        </LineChart>
+      </ResponsiveContainer>
+    );
+  },
+  args: { ...getStoryArgsFromArgsTypesObject(LabelArgs) },
+};
+
+/**
+ * Demonstrates the `angle` prop for rotating labels, which is useful for
+ * vertical axis labels or other tilted annotations.
+ */
+export const WithAngle = {
+  render: (args: Args) => (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={pageData} margin={{ top: 40, right: 60, bottom: 40, left: 80 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis>
+          <Label angle={-90} value="UV Index" position="insideLeft" style={{ textAnchor: 'middle' }} {...args} />
+        </YAxis>
+        <Line type="monotone" dataKey="uv" stroke="#8884d8" />
+        <RechartsHookInspector />
+      </LineChart>
+    </ResponsiveContainer>
+  ),
+  args: { ...getStoryArgsFromArgsTypesObject(LabelArgs), angle: -90 },
 };

--- a/storybook/stories/API/component/Label.stories.tsx
+++ b/storybook/stories/API/component/Label.stories.tsx
@@ -167,7 +167,7 @@ export const WithFormatter = {
         <XAxis dataKey="name" />
         <YAxis />
         <Line type="monotone" dataKey="uv" stroke="#8884d8" />
-        <Label value={1234567} position="top" formatter={(v: number) => `${(v / 1000).toFixed(1)}k`} {...args} />
+        <Label value={1234567} position="top" formatter={v => `${(Number(v) / 1000).toFixed(1)}k`} {...args} />
         <RechartsHookInspector />
       </LineChart>
     </ResponsiveContainer>


### PR DESCRIPTION
## Summary

- Extends `storybook/stories/API/component/Label.stories.tsx` with visual position-showcase stories and prop demonstrations that serve as informational graphics for the `Label` component
- Keeps the existing `API` (CartesianPositions) and `PolarPositions` stories intact
- Adds `AllCartesianPositions` — renders all 16 cartesian label positions simultaneously in one chart with a dashed plot-area border so inside/outside positions are visually distinct
- Adds `AllPolarPositions` — renders all polar label positions simultaneously in a RadarChart
- Adds `WithFormatter` — demonstrates the `formatter` prop transforming a raw number value
- Adds `WithCustomContent` — demonstrates the `content` prop with a custom SVG React element
- Adds `WithAngle` — demonstrates the `angle` prop via a rotated Y-axis label

All props from https://recharts.org/en-US/api/Label are covered through `LabelArgs` (auto-generated by `omnidoc`).

Closes #3738

## Test plan

- [ ] Run `npm run storybook` and verify all six `Label` stories render correctly
- [ ] Verify the `AllCartesianPositions` story shows labels at each named position around and inside the plot area
- [ ] Verify the `WithFormatter` story shows "1234.6k" (formatted from 1234567)
- [ ] Verify the `WithCustomContent` story shows a purple circle with "Label" text
- [ ] Verify the `WithAngle` story shows a rotated Y-axis label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Label component examples showcasing positioning in Cartesian and polar coordinate systems
  * Added examples demonstrating formatter, custom content, and text rotation capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recharts/recharts/pull/7246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->