### PR TITLE
fix: use originalDataIndex for tooltip dispatch in Bar

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -503,13 +503,13 @@ function BarBackground(props: BarBackgroundProps) {
           return null;
         }
 
-        const onMouseEnter = onMouseEnterFromContext(entry, i);
-        const onMouseLeave = onMouseLeaveFromContext(entry, i);
-        const onClick = onClickFromContext(entry, i);
+        const onMouseEnter = onMouseEnterFromContext(entry, entry.originalDataIndex);
+        const onMouseLeave = onMouseLeaveFromContext(entry, entry.originalDataIndex);
+        const onClick = onClickFromContext(entry, entry.originalDataIndex);
 
         const barRectangleProps: BarRectangleProps = {
           option: backgroundFromProps,
-          isActive: String(i) === activeIndex,
+          isActive: String(entry.originalDataIndex) === activeIndex,
           ...rest,
           // @ts-expect-error backgroundProps is contributing unknown props
           fill: '#eee',
@@ -728,9 +728,9 @@ function BarRectangles({
             key={`rectangle-${entry?.x}-${entry?.y}-${entry?.value}-${i}`}
             className="recharts-bar-rectangle"
             {...adaptEventsOfChild(restOfAllOtherProps, entry, i)}
-            onMouseEnter={onMouseEnterFromContext(entry, i)}
-            onMouseLeave={onMouseLeaveFromContext(entry, i)}
-            onClick={onClickFromContext(entry, i)}
+            onMouseEnter={onMouseEnterFromContext(entry, entry.originalDataIndex)}
+            onMouseLeave={onMouseLeaveFromContext(entry, entry.originalDataIndex)}
+            onClick={onClickFromContext(entry, entry.originalDataIndex)}
           >
             {activeBar ? (
               <BarRectangleWithActiveState

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -1519,16 +1519,26 @@ describe('Tooltip payload', () => {
         );
 
         // There are two Bar groups. bar1 renders one rect (row A), bar2 renders one rect (row B).
-        // We need to hover over bar2's rect specifically.
         const barGroups = container.querySelectorAll('.recharts-bar');
-        const bar2Group = barGroups[1]; // second Bar component = bar2
+
+        // Hover bar1 (row A) — should show bar1's payload
+        const bar1Group = barGroups[0];
+        const bar1Rect = bar1Group.querySelector(barMouseHoverTooltipSelector);
+        assertNotNull(bar1Rect);
+        fireEvent.mouseOver(bar1Rect, { clientX: 100, clientY: 100 });
+        act(() => {
+          vi.runOnlyPendingTimers();
+        });
+        expectTooltipPayload(container, '', ['bar1 : 0 ~ 10']);
+
+        // Hover bar2 (row B) — should show bar2's payload, not bar1's
+        const bar2Group = barGroups[1];
         const bar2Rect = bar2Group.querySelector(barMouseHoverTooltipSelector);
         assertNotNull(bar2Rect);
         fireEvent.mouseOver(bar2Rect, { clientX: 200, clientY: 200 });
         act(() => {
           vi.runOnlyPendingTimers();
         });
-
         expectTooltipPayload(container, '', ['bar2 : 5 ~ 20']);
       });
     });

--- a/test/component/Tooltip/Tooltip.payload.spec.tsx
+++ b/test/component/Tooltip/Tooltip.payload.spec.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentType, ReactNode } from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render } from '@testing-library/react';
+import { assertNotNull } from '../../helper/assertNotNull';
 import {
   Area,
   AreaChart,
@@ -1499,6 +1500,36 @@ describe('Tooltip payload', () => {
         const expectedTooltipTitle = '';
         const expectedTooltipContent = ['uv : 400kg'];
         expectTooltipPayload(container, expectedTooltipTitle, expectedTooltipContent);
+      });
+
+      it('when false in vertical layout with sparse data, should show correct payload for each bar (issue #7261)', () => {
+        const sparseData = [
+          { category: 'A', bar1: [0, 10] },
+          { category: 'B', bar2: [5, 20] },
+        ];
+
+        const { container } = render(
+          <BarChart layout="vertical" {...commonChartProps} data={sparseData}>
+            <XAxis type="number" domain={[0, 30]} />
+            <YAxis type="category" dataKey="category" />
+            <Bar dataKey="bar1" />
+            <Bar dataKey="bar2" />
+            <Tooltip shared={false} filterNull={false} />
+          </BarChart>,
+        );
+
+        // There are two Bar groups. bar1 renders one rect (row A), bar2 renders one rect (row B).
+        // We need to hover over bar2's rect specifically.
+        const barGroups = container.querySelectorAll('.recharts-bar');
+        const bar2Group = barGroups[1]; // second Bar component = bar2
+        const bar2Rect = bar2Group.querySelector(barMouseHoverTooltipSelector);
+        assertNotNull(bar2Rect);
+        fireEvent.mouseOver(bar2Rect, { clientX: 200, clientY: 200 });
+        act(() => {
+          vi.runOnlyPendingTimers();
+        });
+
+        expectTooltipPayload(container, '', ['bar2 : 5 ~ 20']);
       });
     });
 


### PR DESCRIPTION
Fixes #7261

## Description

When `Bar` renders with sparse data (some entries filtered out as zero-dimension), the tooltip event handlers (`onMouseEnter`, `onMouseLeave`, `onClick`) dispatch the render-array index `i` as the active tooltip index. After `.filter(Boolean)` removes null entries, this index no longer matches the original data array, so the tooltip resolves the wrong data entry.

For example, with this data:

```js
const data = [
  { category: 'A', bar1: [0, 10] },
  { category: 'B', bar2: [5, 20] },
];
```

`<Bar dataKey="bar2" />` only renders one rectangle (for row B). That rectangle gets render index `i=0`, but its actual position in the data array is `1`. Hovering it dispatches `activeIndex: "0"`, which resolves to row A instead of row B.

The `isActive` check on line 598-600 already handles this correctly by using `entry.originalDataIndex` instead of the render index. This PR applies the same fix to the event handlers.

Also fixed the same issue in `BarBackground` where `isActive` and event handlers had the same render-index problem.

## Test Plan

Added a regression test for vertical `BarChart` with `shared={false}` and sparse data — verifies that hovering bar2 (row B) shows bar2's payload, not bar1's.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tooltip and bar highlight inconsistencies so hover, active state, and mouse events remain consistent when bars are filtered or reordered, preventing incorrect highlights or stale tooltip content.

* **Tests**
  * Added a regression test that simulates successive hovers on sparse vertical bar charts to ensure tooltips update reliably and no stale payloads are shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->