### PR TITLE
docs: add session storage support for controls state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@eslint/compat": "^1.3.2",
         "@eslint/js": "^9.35.0",
         "@playwright/experimental-ct-react": "1.59.1",
-        "@recharts/devtools": "^0.0.11",
+        "@recharts/devtools": "^0.0.12",
         "@reduxjs/toolkit": "^1.9.7",
         "@rollup/plugin-babel": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
@@ -2665,6 +2665,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3891,9 +3892,9 @@
       "dev": true
     },
     "node_modules/@recharts/devtools": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@recharts/devtools/-/devtools-0.0.11.tgz",
-      "integrity": "sha512-Vik/TqCrEets3VmD6yZQkD0LUYnVrB+NtgsdvfrxmTnZmEy2PkwRQVzFbAwvxmPrqYdW0O9c+ep2uQisdMYGMQ==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@recharts/devtools/-/devtools-0.0.12.tgz",
+      "integrity": "sha512-QSx8I6N9wPehKc4vVlgpwpslmhiTvM2124gxPvkQWefhtWQ9hcceqW0NkBE0fwf8TO+hmrQMVifDi1/Ujj08Ow==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -15380,6 +15381,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15397,6 +15399,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15414,6 +15417,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15431,6 +15435,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15448,6 +15453,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15465,6 +15471,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15482,6 +15489,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15499,6 +15507,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15516,6 +15525,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15533,6 +15543,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15550,6 +15561,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15567,6 +15579,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15584,6 +15597,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15601,6 +15615,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15618,6 +15633,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15635,6 +15651,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15652,6 +15669,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15669,6 +15687,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15686,6 +15705,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15703,6 +15723,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15720,6 +15741,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15737,6 +15759,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15754,6 +15777,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15771,6 +15795,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15788,6 +15813,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@eslint/compat": "^1.3.2",
     "@eslint/js": "^9.35.0",
     "@playwright/experimental-ct-react": "1.59.1",
-    "@recharts/devtools": "^0.0.11",
+    "@recharts/devtools": "^0.0.12",
     "@reduxjs/toolkit": "^1.9.7",
     "@rollup/plugin-babel": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",

--- a/www/src/components/CodeEditorWithPreview.tsx
+++ b/www/src/components/CodeEditorWithPreview.tsx
@@ -92,7 +92,7 @@ export function CodeEditorWithPreview<T>({
   const [codeToRun, setCodeToRun] = useState<string | null>(null);
   const [Runner, setRunner] = useState<any>(null);
   const [activeTool, setActiveTool] = useState<ToolType>(defaultTool);
-  const [controlsState, setControlsState] = useSessionStorageState(encodeURIComponent(stackBlitzTitle), null);
+  const [controlsState, setControlsState] = useSessionStorageState<T | null>(encodeURIComponent(stackBlitzTitle), null);
 
   // Lazy load react-runner when entering edit mode
   useEffect(() => {

--- a/www/src/components/CodeEditorWithPreview.tsx
+++ b/www/src/components/CodeEditorWithPreview.tsx
@@ -4,6 +4,7 @@ import * as D3ShapeScope from 'd3-shape';
 import * as RechartsDevtoolsScope from '@recharts/devtools';
 import { RechartsDevtoolsContext } from '@recharts/devtools';
 import { LuPencil, LuPlay, LuShare2 } from 'react-icons/lu';
+import { useSessionStorageState } from '@recharts/devtools/dist/hooks/useSessionStorageState';
 import { StackBlitzLink } from './Shared/StackBlitzLink';
 import { sendEvent } from './analytics';
 import { ToolFrame, ToolType, ToolItem } from './Playground/ToolFrame';
@@ -23,7 +24,7 @@ type CodeEditorWithPreviewProps<ControlsType> = {
   /**
    * This component renders knobs, controls, and various other activities that change the chart
    */
-  Controls?: ComponentType<{ onChange: (values: ControlsType) => void }>;
+  Controls?: ComponentType<{ onChange: (values: ControlsType) => void; sessionStoreValues: ControlsType | null }>;
   /**
    * The source code of the component.
    */
@@ -91,7 +92,7 @@ export function CodeEditorWithPreview<T>({
   const [codeToRun, setCodeToRun] = useState<string | null>(null);
   const [Runner, setRunner] = useState<any>(null);
   const [activeTool, setActiveTool] = useState<ToolType>(defaultTool);
-  const [controlsState, setControlsState] = useState<T | null>(null);
+  const [controlsState, setControlsState] = useSessionStorageState(encodeURIComponent(stackBlitzTitle), null);
 
   // Lazy load react-runner when entering edit mode
   useEffect(() => {
@@ -197,7 +198,7 @@ export function CodeEditorWithPreview<T>({
       label: 'Controls',
       component: (
         <div style={{ padding: '10px', height: '100%', overflow: 'auto' }}>
-          <Controls onChange={setControlsState} />
+          <Controls onChange={setControlsState} sessionStoreValues={controlsState} />
         </div>
       ),
     });

--- a/www/src/components/GuideView/Animations/AnimationsExample.tsx
+++ b/www/src/components/GuideView/Animations/AnimationsExample.tsx
@@ -74,8 +74,14 @@ const defaultState: ControlsType = {
   replayKey: 0,
 };
 
-export function AnimationsControls({ onChange }: { onChange: (values: ControlsType) => void }) {
-  const [state, setState] = React.useState<ControlsType>(defaultState);
+export function AnimationsControls({
+  onChange,
+  sessionStoreValues,
+}: {
+  onChange: (values: ControlsType) => void;
+  sessionStoreValues: ControlsType | null;
+}) {
+  const [state, setState] = React.useState<ControlsType>(sessionStoreValues ?? defaultState);
 
   const handleChange = (nextValues: Partial<ControlsType>) => {
     const newState = { ...state, ...nextValues };

--- a/www/src/components/GuideView/AxisTicks/CustomAxisTicks.tsx
+++ b/www/src/components/GuideView/AxisTicks/CustomAxisTicks.tsx
@@ -36,8 +36,14 @@ export default function CustomAxisTicks(props: Partial<AxisTicksControlsType>) {
   );
 }
 
-export function CustomAxisTicksControls({ onChange }: { onChange: (values: AxisTicksControlsType) => void }) {
-  const [state, setState] = React.useState<AxisTicksControlsType>(defaultState);
+export function CustomAxisTicksControls({
+  onChange,
+  sessionStoreValues,
+}: {
+  onChange: (values: AxisTicksControlsType) => void;
+  sessionStoreValues: AxisTicksControlsType | null;
+}) {
+  const [state, setState] = React.useState<AxisTicksControlsType>(sessionStoreValues ?? defaultState);
 
   const updateState = (nextValues: Partial<AxisTicksControlsType>) => {
     const nextState = { ...state, ...nextValues };

--- a/www/src/components/GuideView/AxisTicks/NiceTicksPlayground.tsx
+++ b/www/src/components/GuideView/AxisTicks/NiceTicksPlayground.tsx
@@ -45,8 +45,14 @@ export default function AxisTicksPlayground(props: Partial<AxisTicksControlsType
   );
 }
 
-export function AxisTicksControls({ onChange }: { onChange: (values: AxisTicksControlsType) => void }) {
-  const [state, setState] = React.useState<AxisTicksControlsType>(defaultState);
+export function AxisTicksControls({
+  onChange,
+  sessionStoreValues,
+}: {
+  onChange: (values: AxisTicksControlsType) => void;
+  sessionStoreValues: AxisTicksControlsType | null;
+}) {
+  const [state, setState] = React.useState<AxisTicksControlsType>(sessionStoreValues ?? defaultState);
 
   const updateState = (nextValues: Partial<AxisTicksControlsType>) => {
     const nextState = { ...state, ...nextValues };

--- a/www/src/components/GuideView/BarAlign/CustomBandScaleExample.tsx
+++ b/www/src/components/GuideView/BarAlign/CustomBandScaleExample.tsx
@@ -46,16 +46,25 @@ type ControlsType = {
  * Each property is a slider input, ranging from 0 to 1 in 0.01 steps.
  * Calls onChange with the new values when an input changes.
  * @param onChange
+ * @param sessionStoreValues data from session storage, or null if this is the first visit
  * @constructor
  */
-export function BarAlignControls({ onChange }: { onChange: (values: ControlsType) => void }) {
-  const [state, setState] = React.useState<ControlsType>({
-    paddingInner: 0,
-    paddingOuter: 0.8,
-    align: 0.7,
-    barGap: 0.1,
-    barCategoryGap: 0.1,
-  });
+export function BarAlignControls({
+  onChange,
+  sessionStoreValues,
+}: {
+  onChange: (values: ControlsType) => void;
+  sessionStoreValues: ControlsType | null;
+}) {
+  const [state, setState] = React.useState<ControlsType>(
+    sessionStoreValues ?? {
+      paddingInner: 0,
+      paddingOuter: 0.8,
+      align: 0.7,
+      barGap: 0.1,
+      barCategoryGap: 0.1,
+    },
+  );
 
   const handleChange = (key: keyof ControlsType, value: number) => {
     const newState = { ...state, [key]: value };

--- a/www/src/docs/exampleComponents/types.ts
+++ b/www/src/docs/exampleComponents/types.ts
@@ -11,7 +11,7 @@ export type ChartExample<ControlsType = any> = {
   /**
    * This component renders knobs, controls, and various other activities that change the chart
    */
-  Controls?: ComponentType<{ onChange: (values: ControlsType) => void }>;
+  Controls?: ComponentType<{ onChange: (values: ControlsType) => void; sessionStoreValues: ControlsType | null }>;
   /**
    * The source code of the example.
    */


### PR DESCRIPTION
closes https://github.com/recharts/recharts/issues/7277

website changes only

AI summary below

This pull request introduces session storage for chart controls in the code editor and playground examples, allowing users' control states to persist across page reloads within a session. The main changes include updating the controls' component signatures, wiring up session storage state, and ensuring all relevant controls use the persisted state as their initial value.

**Session storage integration for controls:**

* Updated the `Controls` prop type in both `CodeEditorWithPreview` and `ChartExample` to accept an additional `sessionStoreValues` prop, which provides the persisted state from session storage. [[1]](diffhunk://#diff-b414d4ae5de7b57d80068da0dfa3f662789c0ce3bebece3a6737af4e5e24ea5eL26-R27) [[2]](diffhunk://#diff-08985564af84bdf191855fb42d9ab42514dc7505a78b8dc75d043b685b88fc8eL14-R14)
* Replaced the local `useState` for `controlsState` in `CodeEditorWithPreview` with the new `useSessionStorageState` hook, using the encoded `stackBlitzTitle` as the key for storage.
* Passed the `sessionStoreValues` prop to all control components in `CodeEditorWithPreview`, ensuring they receive the persisted state.

**Control component updates:**

* Updated all relevant control components (`AnimationsControls`, `CustomAxisTicksControls`, `AxisTicksControls`, `BarAlignControls`) to accept the new `sessionStoreValues` prop and initialize their local state from session storage if available. [[1]](diffhunk://#diff-ba788c24c2d7756e72886f9b1d6e3c0143381ec00082d3d1e7f1c10861c8fbaaL77-R84) [[2]](diffhunk://#diff-1afa4ec8a39045860f35bd8337e23eb895b474e741b673c62b89ca98a8697a1aL39-R46) [[3]](diffhunk://#diff-fcccc82beae3eb9292bdbd58c93936baa689705cd330462a5e558acdfa8684dbL48-R55) [[4]](diffhunk://#diff-e7ae4c85d3f4d2787b168562a825525c14fb4f69c260cb2d68b417e457d439e5R49-R67)

**Supporting changes:**

* Imported the `useSessionStorageState` hook from `@recharts/devtools` to enable session storage functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Interactive example controls now persist across navigation and refreshes; your adjustments (animations, axis ticks, bar settings, etc.) are restored when you return within the same session.
  * Examples initialize with previously saved control values so previews reflect your last-used settings on load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->