### PR TITLE
fix: resolve TypeScript 6 deprecation errors in tsconfig files

### DIFF
--- a/scripts/snapshots/markdownFiles.txt
+++ b/scripts/snapshots/markdownFiles.txt
@@ -1,6 +1,7 @@
 [
   "AGENTS.md",
   "CHANGELOG.md",
+  "CLAUDE.md",
   "CONTRIBUTING.md",
   "DEVELOPING.md",
   "README.md",

--- a/scripts/snapshots/markdownFiles.txt
+++ b/scripts/snapshots/markdownFiles.txt
@@ -1,7 +1,6 @@
 [
   "AGENTS.md",
   "CHANGELOG.md",
-  "CLAUDE.md",
   "CONTRIBUTING.md",
   "DEVELOPING.md",
   "README.md",

--- a/storybook/css.d.ts
+++ b/storybook/css.d.ts
@@ -1,0 +1,4 @@
+// Ambient CSS module declaration for Vite-bundled storybook.
+// TypeScript 6 added noUncheckedSideEffectImports to strict mode, which requires
+// type declarations for side-effect CSS imports handled by the bundler at runtime.
+declare module '*.css';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
     "jsx": "react",
     "module": "commonjs",
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports": false /* Must be disabled to prevent type issues at dependants. */,
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "declarationDir": "./types" /* Output directory for generated declaration files. */,
     "outDir": "./build/",
+    "rootDir": "./src",
     "preserveConstEnums": true,
     "removeComments": false,
     "sourceMap": true,

--- a/www/tsconfig.json
+++ b/www/tsconfig.json
@@ -21,7 +21,6 @@
     "noFallthroughCasesInSwitch": true,
 
     "types": ["vite/client"],
-    "baseUrl": ".",
     "paths": {
       /*
        * Recharts package path mapping points to the types folder in the main Recharts package.


### PR DESCRIPTION
## Description
- Remove deprecated `baseUrl: "."` from tsconfig.base.json and www/tsconfig.json (baseUrl is deprecated in TS6; paths with relative values work without it under moduleResolution: bundler, and there were no paths relying on it in base)
- Remove deprecated `allowSyntheticDefaultImports: false` from tsconfig.json (deprecated in TS6; CommonJS module mode already defaults to false)
- Add explicit `rootDir: "./src"` to tsconfig.json (required by TS6 when outDir/declarationDir are set)
- Add storybook/css.d.ts ambient CSS module declaration (TS6 adds noUncheckedSideEffectImports to strict mode, requiring type declarations for CSS side-effect imports in the Vite-bundled storybook)

Verified: `npm run check-types` passes with zero errors under TypeScript 6.0.3 and continues to pass under TypeScript 5.9.3.

## Related Issue
Closes #7253

## How Has This Been Tested?
This is tested through https://github.com/recharts/recharts-integ/pull/93

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes
