### PR TITLE
fix: update element offset on resize

### DIFF
--- a/src/util/useElementOffset.ts
+++ b/src/util/useElementOffset.ts
@@ -3,36 +3,25 @@ import { useCallback, useRef, useState } from 'react';
 const EPS = 1;
 
 /**
- * TODO this documentation does not reflect what this hook is doing, update it.
- * Stores the `offsetHeight`, `offsetLeft`, `offsetTop`, and `offsetWidth` of a DOM element.
+ * Stores DOMRect dimensions from `getBoundingClientRect()`.
+ *
+ * These values are viewport-relative and may be fractional, matching DOMRect semantics.
  */
 export type ElementOffset = {
   /**
-   * Height of an element, including vertical padding and borders, as an integer.
-   *
-   * Typically, offsetHeight is a measurement in pixels of the element's CSS height, including any borders, padding, and horizontal scrollbars (if rendered). It does not include the height of pseudo-elements such as ::before or ::after
-   *
-   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight
+   * Element border-box height in CSS pixels, from `DOMRect.height`.
    */
   height: number;
   /**
-   * Number of pixels that the upper left corner of the current element is offset to the left within the HTMLElement.offsetParent node
-   *
-   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetLeft
+   * Distance in CSS pixels from the viewport's left edge to the element's border-box left edge, from `DOMRect.left`.
    */
   left: number;
   /**
-   * Distance from the outer border of the current element (including its margin) to the top padding edge of the offsetParent, the closest positioned ancestor element.
-   *
-   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetTop
+   * Distance in CSS pixels from the viewport's top edge to the element's border-box top edge, from `DOMRect.top`.
    */
   top: number;
   /**
-   * Layout width of an element as an integer.
-   *
-   * Typically, offsetWidth is a measurement in pixels of the element's CSS width, including any borders, padding, and vertical scrollbars (if rendered). It does not include the width of pseudo-elements such as ::before or ::after.
-   *
-   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetWidth
+   * Element border-box width in CSS pixels, from `DOMRect.width`.
    */
   width: number;
 };
@@ -65,14 +54,17 @@ export function useElementOffset(extraDependencies: ReadonlyArray<unknown> = [])
             top: rect.top,
             width: rect.width,
           };
-          if (
-            Math.abs(box.height - lastBoundingBox.height) > EPS ||
-            Math.abs(box.left - lastBoundingBox.left) > EPS ||
-            Math.abs(box.top - lastBoundingBox.top) > EPS ||
-            Math.abs(box.width - lastBoundingBox.width) > EPS
-          ) {
-            setLastBoundingBox({ height: box.height, left: box.left, top: box.top, width: box.width });
-          }
+          setLastBoundingBox(previousBoundingBox => {
+            if (
+              Math.abs(box.height - previousBoundingBox.height) > EPS ||
+              Math.abs(box.left - previousBoundingBox.left) > EPS ||
+              Math.abs(box.top - previousBoundingBox.top) > EPS ||
+              Math.abs(box.width - previousBoundingBox.width) > EPS
+            ) {
+              return { height: box.height, left: box.left, top: box.top, width: box.width };
+            }
+            return previousBoundingBox;
+          });
         };
 
         updateBox();
@@ -84,7 +76,7 @@ export function useElementOffset(extraDependencies: ReadonlyArray<unknown> = [])
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [lastBoundingBox.width, lastBoundingBox.height, lastBoundingBox.top, lastBoundingBox.left, ...extraDependencies],
+    [...extraDependencies],
   );
   return [lastBoundingBox, updateBoundingBox];
 }

--- a/src/util/useElementOffset.ts
+++ b/src/util/useElementOffset.ts
@@ -28,6 +28,15 @@ export type ElementOffset = {
 
 export type SetElementOffset = (node: HTMLElement | null) => void;
 
+export function hasElementOffsetChanged(previous: ElementOffset, next: ElementOffset, epsilon: number): boolean {
+  return (
+    Math.abs(next.height - previous.height) > epsilon ||
+    Math.abs(next.left - previous.left) > epsilon ||
+    Math.abs(next.top - previous.top) > epsilon ||
+    Math.abs(next.width - previous.width) > epsilon
+  );
+}
+
 /**
  * Use this to listen to element layout changes.
  *
@@ -54,17 +63,9 @@ export function useElementOffset(extraDependencies: ReadonlyArray<unknown> = [])
             top: rect.top,
             width: rect.width,
           };
-          setLastBoundingBox(previousBoundingBox => {
-            if (
-              Math.abs(box.height - previousBoundingBox.height) > EPS ||
-              Math.abs(box.left - previousBoundingBox.left) > EPS ||
-              Math.abs(box.top - previousBoundingBox.top) > EPS ||
-              Math.abs(box.width - previousBoundingBox.width) > EPS
-            ) {
-              return { height: box.height, left: box.left, top: box.top, width: box.width };
-            }
-            return previousBoundingBox;
-          });
+          setLastBoundingBox(previousBoundingBox =>
+            hasElementOffsetChanged(previousBoundingBox, box, EPS) ? box : previousBoundingBox,
+          );
         };
 
         updateBox();

--- a/src/util/useElementOffset.ts
+++ b/src/util/useElementOffset.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 const EPS = 1;
 
@@ -49,23 +49,37 @@ export type SetElementOffset = (node: HTMLElement | null) => void;
  */
 export function useElementOffset(extraDependencies: ReadonlyArray<unknown> = []): [ElementOffset, SetElementOffset] {
   const [lastBoundingBox, setLastBoundingBox] = useState<ElementOffset>({ height: 0, left: 0, top: 0, width: 0 });
+  const observerRef = useRef<ResizeObserver | null>(null);
+
   const updateBoundingBox = useCallback(
     (node: HTMLElement | null) => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+
       if (node != null) {
-        const rect = node.getBoundingClientRect();
-        const box: ElementOffset = {
-          height: rect.height,
-          left: rect.left,
-          top: rect.top,
-          width: rect.width,
+        const updateBox = () => {
+          const rect = node.getBoundingClientRect();
+          const box: ElementOffset = {
+            height: rect.height,
+            left: rect.left,
+            top: rect.top,
+            width: rect.width,
+          };
+          if (
+            Math.abs(box.height - lastBoundingBox.height) > EPS ||
+            Math.abs(box.left - lastBoundingBox.left) > EPS ||
+            Math.abs(box.top - lastBoundingBox.top) > EPS ||
+            Math.abs(box.width - lastBoundingBox.width) > EPS
+          ) {
+            setLastBoundingBox({ height: box.height, left: box.left, top: box.top, width: box.width });
+          }
         };
-        if (
-          Math.abs(box.height - lastBoundingBox.height) > EPS ||
-          Math.abs(box.left - lastBoundingBox.left) > EPS ||
-          Math.abs(box.top - lastBoundingBox.top) > EPS ||
-          Math.abs(box.width - lastBoundingBox.width) > EPS
-        ) {
-          setLastBoundingBox({ height: box.height, left: box.left, top: box.top, width: box.width });
+
+        updateBox();
+
+        if (typeof ResizeObserver !== 'undefined') {
+          observerRef.current = new ResizeObserver(updateBox);
+          observerRef.current.observe(node);
         }
       }
     },

--- a/test/util/useElementOffset.spec.tsx
+++ b/test/util/useElementOffset.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { useElementOffset } from '../../src/util/useElementOffset';
+import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 
 function TestComponent() {
   const [box, updateBox] = useElementOffset();
@@ -31,17 +32,7 @@ describe('useElementOffset', () => {
       render(<TestComponent />);
       const target = screen.getByTestId('target');
 
-      vi.spyOn(target, 'getBoundingClientRect').mockReturnValue({
-        bottom: 20,
-        height: 20,
-        left: 0,
-        right: 100,
-        top: 0,
-        width: 100,
-        x: 0,
-        y: 0,
-        toJSON: () => undefined,
-      });
+      mockGetBoundingClientRect({ height: 20, width: 100 });
 
       act(() => {
         resizeCallback?.([], {} as ResizeObserver);
@@ -49,17 +40,7 @@ describe('useElementOffset', () => {
 
       expect(screen.getByTestId('size')).toHaveTextContent('100x20');
 
-      vi.spyOn(target, 'getBoundingClientRect').mockReturnValue({
-        bottom: 60,
-        height: 60,
-        left: 0,
-        right: 80,
-        top: 0,
-        width: 80,
-        x: 0,
-        y: 0,
-        toJSON: () => undefined,
-      });
+      mockGetBoundingClientRect({ height: 60, width: 80 });
 
       act(() => {
         resizeCallback?.([], {} as ResizeObserver);

--- a/test/util/useElementOffset.spec.tsx
+++ b/test/util/useElementOffset.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { useElementOffset } from '../../src/util/useElementOffset';
+import { hasElementOffsetChanged, useElementOffset } from '../../src/util/useElementOffset';
 import { mockGetBoundingClientRect } from '../helper/mockGetBoundingClientRect';
 
 function TestComponent() {
@@ -14,6 +14,15 @@ function TestComponent() {
     </>
   );
 }
+
+describe('hasElementOffsetChanged', () => {
+  it('detects measurements that differ by more than the epsilon', () => {
+    const previous = { height: 20, left: 4, top: 8, width: 100 };
+
+    expect(hasElementOffsetChanged(previous, { ...previous, width: 100.5 }, 1)).toBe(false);
+    expect(hasElementOffsetChanged(previous, { ...previous, width: 101.5 }, 1)).toBe(true);
+  });
+});
 
 describe('useElementOffset', () => {
   it('updates the measured box when ResizeObserver reports a layout change', () => {

--- a/test/util/useElementOffset.spec.tsx
+++ b/test/util/useElementOffset.spec.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useElementOffset } from '../../src/util/useElementOffset';
+
+function TestComponent() {
+  const [box, updateBox] = useElementOffset();
+
+  return (
+    <>
+      <div data-testid="target" ref={updateBox} />
+      <output data-testid="size">{`${box.width}x${box.height}`}</output>
+    </>
+  );
+}
+
+describe('useElementOffset', () => {
+  it('updates the measured box when ResizeObserver reports a layout change', () => {
+    let resizeCallback: ResizeObserverCallback | undefined;
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+
+    const ResizeObserverMock = vi.fn().mockImplementation((callback: ResizeObserverCallback) => {
+      resizeCallback = callback;
+      return { observe, disconnect };
+    });
+
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+
+    try {
+      render(<TestComponent />);
+      const target = screen.getByTestId('target');
+
+      vi.spyOn(target, 'getBoundingClientRect').mockReturnValue({
+        bottom: 20,
+        height: 20,
+        left: 0,
+        right: 100,
+        top: 0,
+        width: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => undefined,
+      });
+
+      act(() => {
+        resizeCallback?.([], {} as ResizeObserver);
+      });
+
+      expect(screen.getByTestId('size')).toHaveTextContent('100x20');
+
+      vi.spyOn(target, 'getBoundingClientRect').mockReturnValue({
+        bottom: 60,
+        height: 60,
+        left: 0,
+        right: 80,
+        top: 0,
+        width: 80,
+        x: 0,
+        y: 0,
+        toJSON: () => undefined,
+      });
+
+      act(() => {
+        resizeCallback?.([], {} as ResizeObserver);
+      });
+
+      expect(screen.getByTestId('size')).toHaveTextContent('80x60');
+      expect(ResizeObserverMock).toHaveBeenCalled();
+      expect(observe).toHaveBeenCalledWith(target);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Observe element layout changes in `useElementOffset` so components such as `Legend` can update their measured size after wrapping on container resize. This lets chart offsets recalculate when a horizontal legend grows taller, preventing overlap with chart content.

## Changes

- Adds a `ResizeObserver` subscription inside `useElementOffset` while preserving the existing synchronous initial measurement.
- Disconnects the observer when the ref changes or unmounts.
- Adds a unit test that verifies resize observer notifications update the measured box.

## Testing

- `npm run test-lib -- test/util/useElementOffset.spec.tsx`
- `npm run check-types-test -- --pretty false`
- Pre-push hook also ran `npm run build`, `npm run test`, `npm run check-types`, and `npm run lint` successfully. Lint reported existing no-console warnings in website examples only.

Fixes recharts/recharts#7200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  - Improved element-offset measurement: persistent observation across target changes, immediate initial measurement, more robust resize detection, and simplified update logic for stability and fewer redundant updates.

* **New Features**
  - Added a helper to detect when an element’s measured offset changes using an epsilon tolerance.

* **Tests**
  - Added unit tests validating measurements, observer instantiation/observation, reactive updates on size changes, and cleanup.

* **Documentation**
  - Clarified that element-offset values use viewport-relative DOMRect semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->