### PR TITLE
docs: add Windows install workaround to DEVELOPING.md

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -8,6 +8,7 @@ git clone https://github.com/recharts/recharts.git
 cd recharts
 npm install # the right Node version can be found in .nvmrc file
 ```
+**Note for Windows users:** `npm install` may fail because `@codecov/bundle-analyzer` is only supported on Linux/Darwin. If that happens, run `npm install --force` to continue the setup.
 
 # Linting and types
 


### PR DESCRIPTION
## Description
This PR updates `DEVELOPING.md` to include a troubleshooting note for Windows users. 

Currently, `npm install` fails on Windows environments because `@codecov/bundle-analyzer` requires a Darwin or Linux platform. Since this package is primarily used for CI, maintainers have confirmed that using `--force` is a safe workaround for local development.
## Related Issue

- **Issue/Discussion:** Fixes #7321 
<!--- Please link to the issue here: -->

## Motivation and Context
Currently, Windows contributors unable to perform `npm install` because `@codecov/bundle-analyzer` has strict platform dependency which requires Linux or Darwin platform. Since this dependency is only used in CI (confirmed [here](https://github.com/recharts/recharts/issues/7321#issuecomment-4430007671) ). It shouldn't act as a barrier for the windows based contributors

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup documentation with a note for Windows users regarding potential installation issues and the recommended workaround.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recharts/recharts/pull/7324)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->