### PR TITLE
docs: add @since 3.9 annotation to hooks

### DIFF
--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -154,7 +154,7 @@ export const useChartLayout = (): LayoutType | undefined => useAppSelector(selec
  *
  * Returns `horizontal` or `vertical` for Cartesian charts.
  * Returns `undefined` for non-Cartesian charts or outside chart context.
- * 
+ *
  * @since 3.9
  *
  * @returns {CartesianLayout | undefined} The Cartesian chart layout, or `undefined`.
@@ -182,7 +182,7 @@ export const selectPolarChartLayout = (state: RechartsRootState): PolarLayout | 
  * Returns `undefined` for non-Polar charts or outside chart context.
  *
  * @returns {PolarLayout | undefined} The Polar chart layout, or `undefined`.
- * 
+ *
  * @since 3.9
  */
 export const usePolarChartLayout = (): PolarLayout | undefined => {

--- a/src/context/chartLayoutContext.tsx
+++ b/src/context/chartLayoutContext.tsx
@@ -154,6 +154,8 @@ export const useChartLayout = (): LayoutType | undefined => useAppSelector(selec
  *
  * Returns `horizontal` or `vertical` for Cartesian charts.
  * Returns `undefined` for non-Cartesian charts or outside chart context.
+ * 
+ * @since 3.9
  *
  * @returns {CartesianLayout | undefined} The Cartesian chart layout, or `undefined`.
  */
@@ -180,6 +182,8 @@ export const selectPolarChartLayout = (state: RechartsRootState): PolarLayout | 
  * Returns `undefined` for non-Polar charts or outside chart context.
  *
  * @returns {PolarLayout | undefined} The Polar chart layout, or `undefined`.
+ * 
+ * @since 3.9
  */
 export const usePolarChartLayout = (): PolarLayout | undefined => {
   return useAppSelector(selectPolarChartLayout);


### PR DESCRIPTION
Docs only

https://github.com/recharts/recharts/discussions/7325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "since 3.9" version annotations to public API documentation to improve clarity for consumers and tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recharts/recharts/pull/7326)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->