### PR TITLE
Added effect in cartesian YAxis to update width to initial size on data change

### DIFF
--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -1,40 +1,28 @@
+import { clsx } from 'clsx';
 import * as React from 'react';
 import {
-  ReactElement,
   isValidElement,
+  ReactElement,
   SVGProps,
+  useCallback,
+  useInsertionEffect,
   useLayoutEffect,
   useMemo,
   useRef,
-  useInsertionEffect,
-  useCallback,
 } from 'react';
-import { clsx } from 'clsx';
-import {
-  AxisDomainTypeInput,
-  AxisInterval,
-  AxisTick,
-  RenderableAxisProps,
-  PresentationAttributesAdaptChildEvent,
-  Size,
-  AxisDomain,
-  ScaleType,
-  EvaluatedAxisDomainType,
-  TickProp,
-  YAxisTickContentProps,
-  TickItem,
-} from '../util/types';
-import { CartesianAxis, CartesianAxisRef, defaultCartesianAxisProps } from './CartesianAxis';
+import { isLabelContentAFunction } from '../component/Label';
+import { useCartesianChartLayout } from '../context/chartLayoutContext';
+import { useIsPanorama } from '../context/PanoramaContext';
 import {
   addYAxis,
-  replaceYAxis,
+  NiceTicksAlgorithm,
   removeYAxis,
+  replaceYAxis,
   updateYAxisWidth,
   YAxisOrientation,
   YAxisPadding,
   YAxisSettings,
   YAxisWidth,
-  NiceTicksAlgorithm,
 } from '../state/cartesianAxisSlice';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import {
@@ -45,14 +33,26 @@ import {
   selectYAxisSize,
 } from '../state/selectors/axisSelectors';
 import { selectAxisViewBox } from '../state/selectors/selectChartOffsetInternal';
-import { useIsPanorama } from '../context/PanoramaContext';
-import { isLabelContentAFunction } from '../component/Label';
-import { RequiresDefaultProps, resolveDefaultProps } from '../util/resolveDefaultProps';
 import { axisPropsAreEqual } from '../util/axisPropsAreEqual';
-import { CustomScaleDefinition } from '../util/scale/CustomScaleDefinition';
-import { useCartesianChartLayout } from '../context/chartLayoutContext';
-import { getAxisTypeBasedOnLayout } from '../util/getAxisTypeBasedOnLayout';
 import { DEFAULT_Y_AXIS_WIDTH } from '../util/Constants';
+import { getAxisTypeBasedOnLayout } from '../util/getAxisTypeBasedOnLayout';
+import { RequiresDefaultProps, resolveDefaultProps } from '../util/resolveDefaultProps';
+import { CustomScaleDefinition } from '../util/scale/CustomScaleDefinition';
+import {
+  AxisDomain,
+  AxisDomainTypeInput,
+  AxisInterval,
+  AxisTick,
+  EvaluatedAxisDomainType,
+  PresentationAttributesAdaptChildEvent,
+  RenderableAxisProps,
+  ScaleType,
+  Size,
+  TickItem,
+  TickProp,
+  YAxisTickContentProps,
+} from '../util/types';
+import { CartesianAxis, CartesianAxisRef, defaultCartesianAxisProps } from './CartesianAxis';
 
 interface YAxisProps<DataPointType = any, DataValueType = any> extends Omit<
   RenderableAxisProps<DataPointType, DataValueType>,
@@ -314,7 +314,7 @@ function YAxisImpl(props: PropsWithDefaults) {
   });
 
   useLayoutEffect(() => {
-    if (!chartDataLengthEmpty && width === 'auto') {
+    if (chartDataLengthEmpty === false && width === 'auto') {
       resetYAxisWidth();
     }
   }, [chartDataLengthEmpty, width, resetYAxisWidth]);

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -271,22 +271,6 @@ function SetYAxisSettings(props: Omit<YAxisSettings, 'type'> & { type: AxisDomai
   return null;
 }
 
-function useEffectEventPolyfill<Args extends unknown[], R>(fn: (...args: Args) => R) {
-  const latestFn = useRef<(...args: Args) => R>(() => {
-    throw new Error('Cannot call an event handler while rendering.');
-  });
-  useInsertionEffect(() => {
-    latestFn.current = fn;
-  }, [fn]);
-
-  return useCallback((...args: Args) => {
-    if (typeof latestFn.current === 'function') {
-      return latestFn.current(...args);
-    }
-    return undefined;
-  }, []);
-}
-
 function YAxisImpl(props: PropsWithDefaults) {
   const { yAxisId, className, width, label } = props;
 
@@ -309,13 +293,19 @@ function YAxisImpl(props: PropsWithDefaults) {
   const synchronizedSettings = useAppSelector(state => selectYAxisSettingsNoDefaults(state, yAxisId));
   const chartDataLengthEmpty = useAppSelector(state => !state.chartData.chartData?.length);
 
-  const resetYAxisWidth = useEffectEventPolyfill(() => {
-    dispatch(updateYAxisWidth({ id: yAxisId, width: DEFAULT_Y_AXIS_WIDTH }));
-  });
+  const resetYAxisWidth = useCallback(
+    () => dispatch(updateYAxisWidth({ id: yAxisId, width: DEFAULT_Y_AXIS_WIDTH })),
+    [dispatch, yAxisId],
+  );
+
+  const stableResetYAxisWidth = useRef<typeof resetYAxisWidth>(resetYAxisWidth);
+  useInsertionEffect(() => {
+    stableResetYAxisWidth.current = resetYAxisWidth;
+  }, [resetYAxisWidth]);
 
   useLayoutEffect(() => {
     if (chartDataLengthEmpty === false && width === 'auto') {
-      resetYAxisWidth();
+      stableResetYAxisWidth.current();
     }
   }, [chartDataLengthEmpty, width, resetYAxisWidth]);
 

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -1,5 +1,14 @@
 import * as React from 'react';
-import { ReactElement, isValidElement, SVGProps, useLayoutEffect, useMemo, useRef } from 'react';
+import {
+  ReactElement,
+  isValidElement,
+  SVGProps,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useInsertionEffect,
+  useCallback,
+} from 'react';
 import { clsx } from 'clsx';
 import {
   AxisDomainTypeInput,
@@ -43,6 +52,7 @@ import { axisPropsAreEqual } from '../util/axisPropsAreEqual';
 import { CustomScaleDefinition } from '../util/scale/CustomScaleDefinition';
 import { useCartesianChartLayout } from '../context/chartLayoutContext';
 import { getAxisTypeBasedOnLayout } from '../util/getAxisTypeBasedOnLayout';
+import { DEFAULT_Y_AXIS_WIDTH } from '../util/Constants';
 
 interface YAxisProps<DataPointType = any, DataValueType = any> extends Omit<
   RenderableAxisProps<DataPointType, DataValueType>,
@@ -261,6 +271,22 @@ function SetYAxisSettings(props: Omit<YAxisSettings, 'type'> & { type: AxisDomai
   return null;
 }
 
+function useEffectEventPolyfill<Args extends unknown[], R>(fn: (...args: Args) => R) {
+  const latestFn = useRef<(...args: Args) => R>(() => {
+    throw new Error('Cannot call an event handler while rendering.');
+  });
+  useInsertionEffect(() => {
+    latestFn.current = fn;
+  }, [fn]);
+
+  return useCallback((...args: Args) => {
+    if (typeof latestFn.current === 'function') {
+      return latestFn.current(...args);
+    }
+    return undefined;
+  }, []);
+}
+
 function YAxisImpl(props: PropsWithDefaults) {
   const { yAxisId, className, width, label } = props;
 
@@ -281,6 +307,17 @@ function YAxisImpl(props: PropsWithDefaults) {
    * https://github.com/recharts/recharts/issues/6257
    */
   const synchronizedSettings = useAppSelector(state => selectYAxisSettingsNoDefaults(state, yAxisId));
+  const chartDataLengthEmpty = useAppSelector(state => !state.chartData.chartData?.length);
+
+  const resetYAxisWidth = useEffectEventPolyfill(() => {
+    dispatch(updateYAxisWidth({ id: yAxisId, width: DEFAULT_Y_AXIS_WIDTH }));
+  });
+
+  useLayoutEffect(() => {
+    if (!chartDataLengthEmpty && width === 'auto') {
+      resetYAxisWidth();
+    }
+  }, [chartDataLengthEmpty, width, resetYAxisWidth]);
 
   useLayoutEffect(() => {
     // No dynamic width calculation is done when width !== 'auto'

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -1,15 +1,6 @@
 import { clsx } from 'clsx';
 import * as React from 'react';
-import {
-  isValidElement,
-  ReactElement,
-  SVGProps,
-  useCallback,
-  useInsertionEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import { isValidElement, ReactElement, SVGProps, useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 import { isLabelContentAFunction } from '../component/Label';
 import { useCartesianChartLayout } from '../context/chartLayoutContext';
 import { useIsPanorama } from '../context/PanoramaContext';
@@ -299,9 +290,7 @@ function YAxisImpl(props: PropsWithDefaults) {
   );
 
   const stableResetYAxisWidth = useRef<typeof resetYAxisWidth>(resetYAxisWidth);
-  useInsertionEffect(() => {
-    stableResetYAxisWidth.current = resetYAxisWidth;
-  }, [resetYAxisWidth]);
+  stableResetYAxisWidth.current = resetYAxisWidth;
 
   useLayoutEffect(() => {
     if (chartDataLengthEmpty === false && width === 'auto') {

--- a/test/cartesian/YAxis/YAxis.spec.tsx
+++ b/test/cartesian/YAxis/YAxis.spec.tsx
@@ -1,5 +1,5 @@
-import React, { ReactNode } from 'react';
 import { fireEvent, render } from '@testing-library/react';
+import React, { ComponentProps, ReactNode } from 'react';
 import { describe, expect, it, test, vi } from 'vitest';
 import {
   Area,
@@ -19,8 +19,8 @@ import {
   YAxis,
   YAxisProps,
 } from '../../../src';
-import { AxisDomain, CategoricalDomain, NumberDomain, StackOffsetType } from '../../../src/util/types';
-import { pageData, rangeData } from '../../../storybook/stories/data';
+import { useIsPanorama } from '../../../src/context/PanoramaContext';
+import { YAxisSettings } from '../../../src/state/cartesianAxisSlice';
 import { useAppSelector } from '../../../src/state/hooks';
 import {
   implicitYAxis,
@@ -28,14 +28,14 @@ import {
   selectNumericalDomain,
   selectRenderableAxisSettings,
 } from '../../../src/state/selectors/axisSelectors';
-import { YAxisSettings } from '../../../src/state/cartesianAxisSlice';
-import { expectYAxisTicks } from '../../helper/expectAxisTicks';
-import { useIsPanorama } from '../../../src/context/PanoramaContext';
-import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
+import { AxisDomain, CategoricalDomain, NumberDomain, StackOffsetType } from '../../../src/util/types';
 import { getCalculatedYAxisWidth } from '../../../src/util/YAxisUtils';
-import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
-import { createSelectorTestCase, rechartsTestRender } from '../../helper/createSelectorTestCase';
+import { pageData, rangeData } from '../../../storybook/stories/data';
 import { assertNotNull } from '../../helper/assertNotNull';
+import { createSelectorTestCase, rechartsTestRender } from '../../helper/createSelectorTestCase';
+import { expectYAxisTicks } from '../../helper/expectAxisTicks';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
+import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
 
 describe('<YAxis />', () => {
   const data = [
@@ -2255,6 +2255,41 @@ describe('<YAxis />', () => {
         <Bar dataKey="amt" />
       </BarChart>,
     );
+
+    // Get all tick elements from the rendered Y-axis
+    const tickElements = container.querySelectorAll('.recharts-cartesian-axis-tick-value');
+
+    const yAxis = container.querySelector('.yAxis');
+    assertNotNull(yAxis);
+    const yAxisLine = yAxis.querySelector('line');
+
+    const calculatedYAxisWidth = getCalculatedYAxisWidth({
+      ticks: Array.from(tickElements),
+      tickSize: 6,
+      tickMargin: 2,
+      label: undefined,
+      labelGapWithTick: 5,
+    });
+
+    expect(calculatedYAxisWidth).toBe(88); // 80 width + 6 tick size + 2 tick margin
+    expect(yAxisLine).toHaveAttribute('width', '88');
+  });
+
+  it('should render y-axis with dynamically calculated width even after starting from empty data', async () => {
+    mockGetBoundingClientRect({ width: 80, height: 30 });
+
+    const ticks = [0, 800, 1600, 2400];
+    const BarChartWrapper = ({ data: internalData }: Pick<ComponentProps<typeof BarChart>, 'data'>) => {
+      return (
+        <BarChart width={400} height={300} data={internalData}>
+          <YAxis width="auto" ticks={ticks} />
+          <Bar dataKey="amt" />
+        </BarChart>
+      );
+    };
+
+    const { container, rerender } = render(<BarChartWrapper data={[]} />);
+    rerender(<BarChartWrapper data={data} />);
 
     // Get all tick elements from the rendered Y-axis
     const tickElements = container.querySelectorAll('.recharts-cartesian-axis-tick-value');


### PR DESCRIPTION
## Description

Added effect in cartesian YAxis to update width to initial size on data change ( only the "emptyness")

## Related Issue
https://github.com/recharts/recharts/issues/7345

## Motivation and Context

If data is empty at some time in the graph lifetime, the Yaxis with width="auto" will be forever empty

## How Has This Been Tested?

ran tests in codebase
tested in npm run start -w www same code as in the issue

## Screenshots (if appropriate):

## Types of changes

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.(if the change is acceptable I'll consider writing them)
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Y-axis width now reliably resets from "auto" to the default value when a chart initially renders empty and later receives data, keeping axis and line sizing consistent.

* **Tests**
  * Added a test that verifies Y-axis auto-width behavior during the transition from empty to populated data to guard against regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recharts/recharts/pull/7347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->