### PR TITLE
Improve bundle tracing and tree-shaking for Shape defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint": "eslint .",
     "autofix": "eslint . --fix",
     "analyse": "cross-env NODE_ENV=analyse webpack -o umd/Recharts.js",
-    "trace-bundle": "npx tsx scripts/trace-bundle.ts",
+    "trace-bundle": "node scripts/trace-bundle.ts",
     "generate-bundle-data": "npx tsx scripts/generate-bundle-data.ts",
     "prettier": "prettier . --write",
     "tsc": "tsc",

--- a/scripts/trace-bundle.ts
+++ b/scripts/trace-bundle.ts
@@ -8,35 +8,78 @@
  *   npm run build-es6
  *
  * Usage:
- *   npx tsx scripts/trace-bundle.ts --from <ComponentA> --to <ComponentB>
+ *   node scripts/trace-bundle.ts --from <ComponentA> --to <ComponentB>
  *
  * Examples:
- *   npx tsx scripts/trace-bundle.ts --from Area --to Pie
- *   npx tsx scripts/trace-bundle.ts --from Line --to RadialBar
+ *   node scripts/trace-bundle.ts --from Area --to Pie
+ *   node scripts/trace-bundle.ts --from Line --to RadialBar
  *
  * The --to value is matched against file paths, so a partial name works too:
- *   npx tsx scripts/trace-bundle.ts --from Area --to polar
+ *   node scripts/trace-bundle.ts --from Area --to polar
  */
 import path from 'node:path';
 import fs from 'node:fs';
-import { getModuleGraph, type ModuleGraphNode } from './treeshaking';
+import { fileURLToPath } from 'node:url';
+import { getModuleGraph, type ModuleGraphNode } from './treeshaking.ts';
 
-const packageRoot = path.resolve(__dirname, '..');
+const currentFile = fileURLToPath(import.meta.url);
+const packageRoot = path.resolve(path.dirname(currentFile), '..');
 const es6Entry = path.join(packageRoot, 'es6', 'index.js');
+
+function isExecutedAsScript(): boolean {
+  const scriptPath = process.argv[1];
+  return scriptPath != null && currentFile === path.resolve(scriptPath);
+}
 
 function relativePath(id: string): string {
   if (id.startsWith(packageRoot)) return id.slice(packageRoot.length + 1);
   return id;
 }
 
+function stripExtension(filePath: string): string {
+  const extension = path.extname(filePath);
+  return extension.length === 0 ? filePath : filePath.slice(0, -extension.length);
+}
+
+function matchesPattern(id: string, pattern: string): boolean {
+  const normalizedPattern = pattern.toLowerCase();
+  const relativeId = relativePath(id);
+  const relativeIdWithoutExtension = stripExtension(relativeId);
+  const baseName = path.basename(relativeIdWithoutExtension);
+
+  return (
+    relativeId.toLowerCase().includes(normalizedPattern) ||
+    relativeIdWithoutExtension.toLowerCase() === normalizedPattern ||
+    baseName.toLowerCase() === normalizedPattern
+  );
+}
+
+export function findMatchingModules(graph: ReadonlyArray<ModuleGraphNode>, pattern: string): ModuleGraphNode[] {
+  const exactMatches = graph.filter(node => {
+    const relativeIdWithoutExtension = stripExtension(relativePath(node.id));
+    const baseName = path.basename(relativeIdWithoutExtension);
+    const normalizedPattern = pattern.toLowerCase();
+
+    return (
+      relativeIdWithoutExtension.toLowerCase() === normalizedPattern || baseName.toLowerCase() === normalizedPattern
+    );
+  });
+
+  if (exactMatches.length > 0) {
+    return exactMatches;
+  }
+
+  return graph.filter(node => matchesPattern(node.id, pattern));
+}
+
 function printUsage(): void {
   console.log('Usage:');
-  console.log('  npx tsx scripts/trace-bundle.ts --from <ComponentA> --to <ComponentB>');
+  console.log('  node scripts/trace-bundle.ts --from <ComponentA> --to <ComponentB>');
   console.log('');
   console.log('Examples:');
-  console.log('  npx tsx scripts/trace-bundle.ts --from Area --to Pie');
-  console.log('  npx tsx scripts/trace-bundle.ts --from Line --to RadialBar');
-  console.log('  npx tsx scripts/trace-bundle.ts --from Area --to polar');
+  console.log('  node scripts/trace-bundle.ts --from Area --to Pie');
+  console.log('  node scripts/trace-bundle.ts --from Line --to RadialBar');
+  console.log('  node scripts/trace-bundle.ts --from Area --to polar');
   console.log('');
   console.log('The --to value is matched against file paths (partial match is fine).');
   console.log('Run npm run build-es6 first if es6/index.js does not exist.');
@@ -45,9 +88,9 @@ function printUsage(): void {
 /**
  * BFS on the forward import graph from start to end.
  * Returns up to maxResults shortest paths, each expressed as an array of module IDs
- * from the entry to the target.
+ * from the source to the target.
  */
-function findShortestPaths(
+export function findShortestPaths(
   startId: string,
   endId: string,
   nodeById: Map<string, ModuleGraphNode>,
@@ -56,12 +99,19 @@ function findShortestPaths(
   const MAX_DEPTH = 25;
   const results: string[][] = [];
   const queue: string[][] = [[startId]];
+  const shortestPathLengthById = new Map<string, number>([[startId, 1]]);
+  let shortestResultLength: number | null = null;
 
   while (queue.length > 0 && results.length < maxResults) {
     const currentPath = queue.shift()!;
     const current = currentPath[currentPath.length - 1];
 
+    if (shortestResultLength != null && currentPath.length > shortestResultLength) {
+      continue;
+    }
+
     if (current === endId) {
+      shortestResultLength = currentPath.length;
       results.push(currentPath);
       continue;
     }
@@ -72,9 +122,14 @@ function findShortestPaths(
     if (!node) continue;
 
     for (const next of node.importedIds) {
-      if (!currentPath.includes(next)) {
-        queue.push([...currentPath, next]);
-      }
+      if (currentPath.includes(next)) continue;
+
+      const nextDepth = currentPath.length + 1;
+      const shortestKnownPath = shortestPathLengthById.get(next);
+      if (shortestKnownPath != null && shortestKnownPath < nextDepth) continue;
+
+      shortestPathLengthById.set(next, nextDepth);
+      queue.push([...currentPath, next]);
     }
   }
 
@@ -82,16 +137,16 @@ function findShortestPaths(
 }
 
 async function main(): Promise<void> {
-  if (!fs.existsSync(es6Entry)) {
-    console.error('Error: es6/index.js not found. Build the es6 output first:\n  npm run build-es6');
-    process.exit(1);
-  }
-
   const args = process.argv.slice(2);
 
   if (args.includes('--help') || args.includes('-h')) {
     printUsage();
     process.exit(0);
+  }
+
+  if (!fs.existsSync(es6Entry)) {
+    console.error('Error: es6/index.js not found. Build the es6 output first:\n  npm run build-es6');
+    process.exit(1);
   }
 
   const fromIdx = args.indexOf('--from');
@@ -109,20 +164,15 @@ async function main(): Promise<void> {
 
   const graph = await getModuleGraph(fromComponent);
   const nodeById = new Map(graph.map(n => [n.id, n]));
+  const sourceNodes = findMatchingModules(graph, fromComponent);
 
-  // Identify the entry node: the node with no importers (the temp file we created)
-  const entryNode = graph.find(n => n.importers.length === 0 && n.importedIds.length > 0);
-  if (!entryNode) {
-    console.error('Could not identify bundle entry node.');
+  if (sourceNodes.length === 0) {
+    console.error(`No modules matching "${fromComponent}" were found in the bundle graph.`);
     process.exit(1);
   }
 
   // Find target modules that match the --to pattern
-  const toPatternLower = toPattern.toLowerCase();
-  const targetNodes = graph.filter(n => {
-    const rel = relativePath(n.id);
-    return rel.toLowerCase().includes(toPatternLower) || path.basename(n.id, '.js').toLowerCase() === toPatternLower;
-  });
+  const targetNodes = findMatchingModules(graph, toPattern);
 
   if (targetNodes.length === 0) {
     console.log(`No modules matching "${toPattern}" were found in the bundle.`);
@@ -137,41 +187,45 @@ async function main(): Promise<void> {
   }
 
   let foundAny = false;
-  for (const target of targetNodes) {
-    const relTarget = relativePath(target.id);
-    const sizeKb = (target.renderedLength / 1024).toFixed(2);
+  for (const source of sourceNodes) {
+    const relSource = relativePath(source.id);
 
-    console.log(`──────────────────────────────────────────────────────`);
-    console.log(`Target: ${relTarget}  (${sizeKb} kB rendered)`);
-    console.log(`──────────────────────────────────────────────────────`);
+    for (const target of targetNodes) {
+      const relTarget = relativePath(target.id);
+      const sizeKb = (target.renderedLength / 1024).toFixed(2);
 
-    if (target.renderedLength === 0) {
-      console.log(`✓  This module is fully tree-shaken away (renderedLength = 0).`);
-      console.log(`   It is imported somewhere in the dependency graph but contributes no output code.\n`);
-      continue;
-    }
+      console.log(`──────────────────────────────────────────────────────`);
+      console.log(`From:   ${relSource}`);
+      console.log(`Target: ${relTarget}  (${sizeKb} kB rendered)`);
+      console.log(`──────────────────────────────────────────────────────`);
 
-    const paths = findShortestPaths(entryNode.id, target.id, nodeById, 8);
+      if (target.renderedLength === 0) {
+        console.log(`✓  This module is fully tree-shaken away (renderedLength = 0).`);
+        console.log(`   The path below shows why it is still imported before tree-shaking.\n`);
+      }
 
-    if (paths.length === 0) {
-      console.log(`No import path found from "${fromComponent}" to this module.\n`);
-    } else {
-      foundAny = true;
-      console.log(`Found ${paths.length} shortest import path(s):\n`);
-      paths.forEach((p, i) => {
-        console.log(`  Path ${i + 1}:`);
-        p.forEach((id, depth) => {
-          let prefix: string;
-          if (depth === 0) prefix = '┌';
-          else if (depth === p.length - 1) prefix = '└';
-          else prefix = '│';
-          const arrow = depth === 0 ? '' : '──';
-          const nodeSize = nodeById.get(id)?.renderedLength ?? 0;
-          const sizeStr = nodeSize > 0 ? `  (${(nodeSize / 1024).toFixed(2)} kB)` : '  (tree-shaken)';
-          console.log(`    ${prefix}${arrow} ${relativePath(id)}${sizeStr}`);
+      const paths = findShortestPaths(source.id, target.id, nodeById, 8);
+
+      if (paths.length === 0) {
+        console.log(`No import path found from "${relSource}" to this module.\n`);
+      } else {
+        foundAny = true;
+        console.log(`Found ${paths.length} shortest import path(s):\n`);
+        paths.forEach((p, i) => {
+          console.log(`  Path ${i + 1}:`);
+          p.forEach((id, depth) => {
+            let prefix: string;
+            if (depth === 0) prefix = '┌';
+            else if (depth === p.length - 1) prefix = '└';
+            else prefix = '│';
+            const arrow = depth === 0 ? '' : '──';
+            const nodeSize = nodeById.get(id)?.renderedLength ?? 0;
+            const sizeStr = nodeSize > 0 ? `  (${(nodeSize / 1024).toFixed(2)} kB)` : '  (tree-shaken)';
+            console.log(`    ${prefix}${arrow} ${relativePath(id)}${sizeStr}`);
+          });
+          console.log();
         });
-        console.log();
-      });
+      }
     }
   }
 
@@ -181,7 +235,9 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch(err => {
-  console.error('Error:', (err as Error).message ?? err);
-  process.exit(1);
-});
+if (isExecutedAsScript()) {
+  main().catch(err => {
+    console.error('Error:', (err as Error).message ?? err);
+    process.exit(1);
+  });
+}

--- a/scripts/treeshaking.test.ts
+++ b/scripts/treeshaking.test.ts
@@ -175,15 +175,22 @@ describe.skipIf(!es6EntryExists)('trace-bundle integration', () => {
   it('finds the path from the requested component module instead of the package entry', async () => {
     const graph = await getModuleGraph('Area');
     const area = findMatchingModules(graph, 'Area');
-    const rectangle = findMatchingModules(graph, 'Rectangle');
+    const dot = findMatchingModules(graph, 'Dot');
     const nodeById = new Map(graph.map(node => [node.id, node]));
 
     expect(area).toHaveLength(1);
-    expect(rectangle).toHaveLength(1);
-    expect(findShortestPaths(area[0].id, rectangle[0].id, nodeById, 8)).toContainEqual([
-      path.resolve(__dirname, '..', 'src', 'cartesian', 'Area.tsx'),
-      path.resolve(__dirname, '..', 'src', 'util', 'ActiveShapeUtils.tsx'),
-      path.resolve(__dirname, '..', 'src', 'shape', 'Rectangle.tsx'),
+    expect(dot).toHaveLength(1);
+    expect(findShortestPaths(area[0].id, dot[0].id, nodeById, 8)).toEqual([
+      [
+        path.resolve(__dirname, '..', 'src', 'cartesian', 'Area.tsx'),
+        path.resolve(__dirname, '..', 'src', 'component', 'Dots.tsx'),
+        path.resolve(__dirname, '..', 'src', 'shape', 'Dot.tsx'),
+      ],
+      [
+        path.resolve(__dirname, '..', 'src', 'cartesian', 'Area.tsx'),
+        path.resolve(__dirname, '..', 'src', 'component', 'ActivePoints.tsx'),
+        path.resolve(__dirname, '..', 'src', 'shape', 'Dot.tsx'),
+      ],
     ]);
   }, 30_000);
 });

--- a/scripts/treeshaking.test.ts
+++ b/scripts/treeshaking.test.ts
@@ -5,6 +5,7 @@ import {
   treeshake,
   getBundleSize,
   getBundleSizeReport,
+  getModuleGraph,
   findComponentsInBundle,
   CHART_COMPONENT_NAMES,
   CARTESIAN_COMPONENT_NAMES,
@@ -12,8 +13,10 @@ import {
   formatBundleSize,
   getReductionPercent,
   matchComponentNamesInBundle,
+  type ModuleGraphNode,
 } from './treeshaking';
 import { treeshakingGroups } from './treeshaking-groups';
+import { findMatchingModules, findShortestPaths } from './trace-bundle.ts';
 import { ProjectDocReader } from '../omnidoc/readProject';
 
 const es6EntryPath = path.resolve(__dirname, '..', 'es6', 'index.js');
@@ -140,4 +143,47 @@ describe('matchComponentNamesInBundle', () => {
     const foundComponents = matchComponentNamesInBundle(code, ['LineChart', 'Foo', 'Bar', 'Baz', 'Zoo', 'NotInCode']);
     expect(foundComponents).toEqual(new Set(['Foo', 'Bar', 'Baz', 'Zoo']));
   });
+});
+
+describe('trace-bundle helpers', () => {
+  it('prefers exact component module matches over broader path matches', () => {
+    const graph: ReadonlyArray<ModuleGraphNode> = [
+      { id: '/repo/src/index.ts', importedIds: [], importers: [], renderedLength: 0 },
+      { id: '/repo/src/cartesian/Area.tsx', importedIds: [], importers: [], renderedLength: 10 },
+      { id: '/repo/src/cartesian/ReferenceArea.tsx', importedIds: [], importers: [], renderedLength: 10 },
+    ];
+
+    expect(findMatchingModules(graph, 'Area').map(node => node.id)).toEqual(['/repo/src/cartesian/Area.tsx']);
+  });
+
+  it('returns only shortest import paths', () => {
+    const graph: ReadonlyArray<ModuleGraphNode> = [
+      { id: 'Area', importedIds: ['ActiveShapeUtils', 'LongHop'], importers: [], renderedLength: 1 },
+      { id: 'ActiveShapeUtils', importedIds: ['Rectangle'], importers: ['Area'], renderedLength: 1 },
+      { id: 'LongHop', importedIds: ['AnotherHop'], importers: ['Area'], renderedLength: 1 },
+      { id: 'AnotherHop', importedIds: ['Rectangle'], importers: ['LongHop'], renderedLength: 1 },
+      { id: 'Rectangle', importedIds: [], importers: ['ActiveShapeUtils', 'AnotherHop'], renderedLength: 1 },
+    ];
+
+    const nodeById = new Map(graph.map(node => [node.id, node]));
+
+    expect(findShortestPaths('Area', 'Rectangle', nodeById, 8)).toEqual([['Area', 'ActiveShapeUtils', 'Rectangle']]);
+  });
+});
+
+describe.skipIf(!es6EntryExists)('trace-bundle integration', () => {
+  it('finds the path from the requested component module instead of the package entry', async () => {
+    const graph = await getModuleGraph('Area');
+    const area = findMatchingModules(graph, 'Area');
+    const rectangle = findMatchingModules(graph, 'Rectangle');
+    const nodeById = new Map(graph.map(node => [node.id, node]));
+
+    expect(area).toHaveLength(1);
+    expect(rectangle).toHaveLength(1);
+    expect(findShortestPaths(area[0].id, rectangle[0].id, nodeById, 8)).toContainEqual([
+      path.resolve(__dirname, '..', 'src', 'cartesian', 'Area.tsx'),
+      path.resolve(__dirname, '..', 'src', 'util', 'ActiveShapeUtils.tsx'),
+      path.resolve(__dirname, '..', 'src', 'shape', 'Rectangle.tsx'),
+    ]);
+  }, 30_000);
 });

--- a/scripts/treeshaking.ts
+++ b/scripts/treeshaking.ts
@@ -8,9 +8,15 @@ import { minify } from 'terser';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { babel } from '@rollup/plugin-babel';
 
-const packageRoot = path.resolve(__dirname, '..');
+const currentFile = fileURLToPath(import.meta.url);
+const packageRoot = path.resolve(path.dirname(currentFile), '..');
 const srcEntry = path.join(packageRoot, 'src', 'index.ts');
 const es6Directory = path.join(packageRoot, 'es6');
+
+function isExecutedAsScript(): boolean {
+  const scriptPath = process.argv[1];
+  return scriptPath != null && currentFile === path.resolve(scriptPath);
+}
 
 function getExternals(): Array<string | RegExp> {
   const packageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf-8'));
@@ -428,7 +434,7 @@ export const ALL_TRACKED_COMPONENT_NAMES: string[] = [
 ];
 
 // when called as the first argument of node, we read the array of component names or file paths from the command line
-if (require.main === module) {
+if (isExecutedAsScript()) {
   const args = process.argv.slice(2);
   // If the first argument is a file path, pass it directly. Otherwise, pass the array of components.
   const input = args.length === 1 && /\.(tsx?|jsx?)$/.test(args[0]) ? args[0] : args;


### PR DESCRIPTION
## Summary
- run the bundle tracing script through native Node instead of `tsx` and keep the trace-bundle tests aligned with that flow
- remove the shared `shapeType` selector from `Shape` so each chart component provides its own default renderer
- update tree-shaking expectations for the affected chart bundles and assert that `Area` no longer reaches `Rectangle` through `ActiveShapeUtils`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized build scripts for improved Node.js ESM compatibility.
  * Enhanced bundle tracing performance with optimized pathfinding algorithm to handle multiple source and target modules efficiently.

* **Tests**
  * Added comprehensive test coverage for bundle tracing helper functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recharts/recharts/pull/7348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->