### PR TITLE
Types: switch Shape from spread to separate prop object

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -121,7 +121,6 @@ export interface BarRectangleItem extends RectangleProps {
 export type BarShapeProps = BarRectangleItem & {
   isActive: boolean;
   index: number;
-  option?: ActiveShape<BarShapeProps, SVGPathElement> | undefined;
 };
 
 interface BarProps<DataPointType, ValueAxisType> extends DataConsumer<DataPointType, ValueAxisType>, ZIndexable {

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -551,12 +551,13 @@ function StaticCurve({
     layout,
     connectNulls,
     strokeDasharray: strokeDasharray ?? props.strokeDasharray,
+    pathRef,
   };
 
   return (
     <>
       {points?.length > 1 && (
-        <Shape option={shape} renderDefaultShape={defaultLineShape} {...curveProps} pathRef={pathRef} />
+        <Shape<CurveProps, SVGPathElement> option={shape} DefaultShape={defaultLineShape} shapeProps={curveProps} />
       )}
       <LineDotsWrapper points={points} clipPathId={clipPathId} props={props} />
     </>

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -537,6 +537,7 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
         const symbolProps: ScatterShapeProps = {
           ...baseProps,
           ...entry,
+          isActive,
           index: i,
           [DATA_ITEM_GRAPHICAL_ITEM_ID_ATTRIBUTE_NAME]: String(id),
         };
@@ -558,7 +559,7 @@ function ScatterSymbols(props: ScatterSymbolsProps) {
               onMouseLeave={onMouseLeaveFromContext(entry, i)}
               onClick={onClickFromContext(entry, i)}
             >
-              <ScatterSymbol option={option} isActive={isActive} {...symbolProps} />
+              <ScatterSymbol option={option} {...symbolProps} />
             </Layer>
           </ZIndexLayer>
         );

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -18,12 +18,12 @@ import {
   ActiveShape,
   adaptEventsOfChild,
   AnimationDuration,
-  EasingInput,
   ChartOffsetInternal,
   Coordinate,
   DataConsumer,
   DataKey,
   DataProvider,
+  EasingInput,
   GeometrySector,
   LegendType,
   PresentationAttributesAdaptChildEvent,
@@ -185,7 +185,12 @@ export type PieSectorDataItem = PiePresentationProps &
     cornerRadius: number | undefined;
   };
 
-export type PieSectorShapeProps = PieSectorDataItem & { isActive: boolean; index: number };
+export type PieSectorShapeProps = PieSectorDataItem & {
+  [DATA_ITEM_INDEX_ATTRIBUTE_NAME]: number;
+  [DATA_ITEM_GRAPHICAL_ITEM_ID_ATTRIBUTE_NAME]: GraphicalItemId;
+  isActive: boolean;
+  index: number;
+} & SVGProps<SVGPathElement>;
 export type PieShape = ActiveShape<PieSectorShapeProps, SVGPathElement>;
 
 interface PieEvents {
@@ -679,10 +684,12 @@ function PieSectors(props: PieSectorsProps) {
           graphicalItemMatches;
         const inactiveShape = activeIndex ? inactiveShapeProp : null;
         const sectorOptions = activeShape && isActive ? activeShape : inactiveShape;
-        const sectorProps = {
+        const sectorProps: PieSectorShapeProps = {
           ...entry,
           stroke: entry.stroke,
           tabIndex: -1,
+          index: i,
+          isActive,
           [DATA_ITEM_INDEX_ATTRIBUTE_NAME]: i,
           [DATA_ITEM_GRAPHICAL_ITEM_ID_ATTRIBUTE_NAME]: id,
         };
@@ -697,12 +704,10 @@ function PieSectors(props: PieSectorsProps) {
             onMouseLeave={onMouseLeaveFromContext(entry, i)}
             onClick={onClickFromContext(entry, i)}
           >
-            <Shape
+            <Shape<PieSectorShapeProps, SVGPathElement>
               option={sectorOptions ?? shape}
-              index={i}
-              isActive={isActive}
-              renderDefaultShape={defaultPieSectorShape}
-              {...sectorProps}
+              DefaultShape={defaultPieSectorShape}
+              shapeProps={sectorProps}
             />
           </Layer>
         );

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -150,7 +150,7 @@ function RadialBarSectors({ sectors, allOtherRadialBarProps, showLabels }: Radia
         const onMouseLeave = onMouseLeaveFromContext(entry, i);
         const onClick = onClickFromContext(entry, i);
 
-        const radialBarSectorProps: RadialBarSectorProps = {
+        const radialBarSectorProps: React.ComponentProps<typeof RadialBarSector> = {
           ...baseProps,
           cornerRadius: parseCornerRadius(cornerRadius),
           ...entry,
@@ -484,7 +484,7 @@ class RadialBarWithState extends PureComponent<InternalProps> {
             return null;
           }
 
-          const props: RadialBarSectorProps = {
+          const props: React.ComponentProps<typeof RadialBarSector> = {
             cornerRadius: parseCornerRadius(cornerRadius),
             ...rest,
             // @ts-expect-error backgroundProps is contributing unknown props

--- a/src/util/ActiveShapeUtils.tsx
+++ b/src/util/ActiveShapeUtils.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { cloneElement, isValidElement, ReactElement } from 'react';
-import isPlainObject from 'es-toolkit/compat/isPlainObject';
 
 import { Layer } from '../container/Layer';
+import { ActiveShape } from './types';
 
 /**
  * This is an abstraction for rendering a user defined prop for a customized shape in several forms.
@@ -16,38 +16,49 @@ import { Layer } from '../container/Layer';
  * The concrete default shape is supplied by the caller so this helper does not
  * import unrelated shapes and accidentally couple bundles together.
  */
-type ShapeRenderer<PropsType extends object> = React.ComponentType<PropsType>;
+type ShapeRenderer<PropsType> = (props: PropsType) => React.ReactNode;
 
-export type ShapeProps<OptionType, PropsType extends object> = {
-  option: OptionType;
-  renderDefaultShape: ShapeRenderer<PropsType>;
-  isActive?: boolean;
-  index?: string | number;
+type ShapeOptionProps<PropsType extends object> = Partial<PropsType>;
+
+type ShapeOptionElement<PropsType extends object> = ReactElement<ShapeOptionProps<PropsType>>;
+
+export type ShapeProps<PropsType extends object, ElementType extends SVGElement = SVGElement> = {
+  /**
+   * Multi-value prop, decides either which component renders, or which props it receives, based on the value type:
+   *
+   * - If a React element, then it gets cloned with new props injected (this works but is counter-intuitive and impossible to type properly, please don't prefer this path)
+   * - If a function, it gets called with props plus index (keep in mind: this will change in 4.0 where we will render it as JSX component instead)
+   * - If an object, then it gets passed to the default shape as props
+   * - Else it's ignored and the default shape is rendered with the props from this component
+   */
+  option: ActiveShape<PropsType, ElementType> | undefined;
+  /**
+   * This prop controls the default shape. If `option` is either a React element, or a function, then it's ignored.
+   * If `option` is an object, then this shape is rendered with the props from `option`.
+   * If `option` is anything else (e.g. boolean), then this shape is rendered with the props from this component.
+   */
+  DefaultShape: ShapeRenderer<PropsType>;
+  /**
+   * The props forwarded to the selected shape branch.
+   *
+   * Keeping these props grouped avoids generic object-rest widening. That lets this helper keep strong types
+   * without relying on casts or `@ts-expect-error`.
+   */
+  shapeProps: PropsType;
   activeClassName?: string;
   inActiveClassName?: string;
-} & PropsType;
+};
 
-function defaultPropTransformer<OptionType extends object, PropsType extends object>(
-  option: OptionType,
-  props: PropsType,
-): PropsType & OptionType {
+function mergeShapeProps<PropsType extends object>(option: ShapeOptionProps<PropsType>, props: PropsType): PropsType {
   return {
     ...props,
     ...option,
   };
 }
 
-function isShapeFunction<PropsType>(
-  option: unknown,
-): option is (props: PropsType, index?: string | number) => React.ReactNode {
-  return typeof option === 'function';
-}
-
-function isShapeOptionsObject(option: unknown): option is object {
-  return isPlainObject(option) && typeof option !== 'boolean';
-}
-
-export function getPropsFromShapeOption<T extends object>(option: ReactElement<T> | T): T {
+export function getPropsFromShapeOption<PropsType extends object>(
+  option: ShapeOptionElement<PropsType> | ShapeOptionProps<PropsType>,
+): ShapeOptionProps<PropsType> {
   if (isValidElement(option)) {
     return option.props;
   }
@@ -55,33 +66,55 @@ export function getPropsFromShapeOption<T extends object>(option: ReactElement<T
   return option;
 }
 
-export function Shape<OptionPropsType extends object, PropsType extends OptionPropsType, OptionType>({
+function renderWithShapeElement<PropsType extends object>(option: ShapeOptionElement<PropsType>, props: PropsType) {
+  return cloneElement(option, mergeShapeProps(getPropsFromShapeOption(option), props));
+}
+
+function getShapeIndex(shapeProps: object): string | number | undefined {
+  if (!('index' in shapeProps)) {
+    return undefined;
+  }
+
+  const { index } = shapeProps;
+  return typeof index === 'number' || typeof index === 'string' ? index : undefined;
+}
+
+function isActiveShape(shapeProps: object): boolean {
+  return 'isActive' in shapeProps && shapeProps.isActive === true;
+}
+
+/**
+ * Renders the user-provided active shape option while keeping each runtime branch aligned with its TypeScript type.
+ *
+ * The `option` prop supports four shapes:
+ * - React element: clone it and let its own props override the injected ones
+ * - function: call it with the forwarded props and optional index
+ * - plain object: merge it into the default shape props
+ * - boolean / undefined: ignore it and render the default shape with the forwarded props
+ */
+export function Shape<PropsType extends object, ElementType extends SVGElement = SVGElement>({
   option,
-  renderDefaultShape,
+  DefaultShape,
+  shapeProps,
   activeClassName = 'recharts-active-shape',
   inActiveClassName = 'recharts-shape',
-  ...props
-}: ShapeProps<OptionType, PropsType>) {
-  const { index, isActive } = props;
-  // TypeScript does not preserve the original generic object type through object rest destructuring.
-  // @ts-expect-error object rest widens generic props beyond PropsType
-  const shapeProps: PropsType = props;
-  const DefaultShape = renderDefaultShape;
+}: ShapeProps<PropsType, ElementType>) {
+  const index = getShapeIndex(shapeProps);
   let shape: React.ReactNode;
+
   if (isValidElement(option)) {
-    shape = cloneElement(option, { ...shapeProps, ...getPropsFromShapeOption(option) });
-  } else if (option === renderDefaultShape) {
-    const OptionShape = renderDefaultShape;
-    shape = <OptionShape {...shapeProps} />;
-  } else if (isShapeFunction<OptionPropsType>(option)) {
+    shape = renderWithShapeElement(option, shapeProps);
+  } else if (option === DefaultShape) {
+    shape = <DefaultShape {...shapeProps} />;
+  } else if (typeof option === 'function') {
     shape = option(shapeProps, index);
-  } else if (isShapeOptionsObject(option)) {
-    shape = <DefaultShape {...defaultPropTransformer(option, shapeProps)} />;
+  } else if (typeof option === 'object') {
+    shape = <DefaultShape {...mergeShapeProps(option, shapeProps)} />;
   } else {
     shape = <DefaultShape {...shapeProps} />;
   }
 
-  if (isActive) {
+  if (isActiveShape(shapeProps)) {
     return <Layer className={activeClassName}>{shape}</Layer>;
   }
 

--- a/src/util/BarUtils.tsx
+++ b/src/util/BarUtils.tsx
@@ -8,25 +8,24 @@ import { isNullish, isNumber } from './DataUtils';
 
 export const defaultBarShape = Rectangle;
 
-export type BarRectangleProps = {
+export type BarRectangleProps = BarShapeProps & {
   option: ActiveShape<BarShapeProps, SVGPathElement>;
-  isActive: boolean;
   onMouseEnter?: (e: React.MouseEvent<SVGPathElement, MouseEvent>) => void;
   onMouseLeave?: (e: React.MouseEvent<SVGPathElement, MouseEvent>) => void;
   onClick?: (e: React.MouseEvent<SVGPathElement, MouseEvent>) => void;
-  width?: number;
-  height?: number;
-  index: number;
   dataKey: DataKey<any> | undefined;
 } & Omit<RectangleProps, 'onAnimationStart' | 'onAnimationEnd'>;
 
-export function BarRectangle(props: BarRectangleProps) {
+type BarRectangleShapeProps = Omit<BarRectangleProps, 'option'>;
+
+export function BarRectangle({ option, ...shapeProps }: BarRectangleProps) {
   return (
-    <Shape
-      renderDefaultShape={defaultBarShape}
+    <Shape<BarRectangleShapeProps, SVGPathElement>
+      option={option}
+      DefaultShape={defaultBarShape}
+      shapeProps={shapeProps}
       activeClassName="recharts-active-bar"
       inActiveClassName="recharts-inactive-bar"
-      {...props}
     />
   );
 }

--- a/src/util/FunnelUtils.tsx
+++ b/src/util/FunnelUtils.tsx
@@ -10,6 +10,14 @@ export type FunnelTrapezoidProps = {
   isActive: boolean;
 } & FunnelTrapezoidItem;
 
-export function FunnelTrapezoid(props: FunnelTrapezoidProps) {
-  return <Shape renderDefaultShape={defaultFunnelShape} {...props} />;
+type FunnelTrapezoidShapeProps = Omit<FunnelTrapezoidProps, 'option'>;
+
+export function FunnelTrapezoid({ option, ...shapeProps }: FunnelTrapezoidProps) {
+  return (
+    <Shape<FunnelTrapezoidShapeProps, SVGPathElement>
+      option={option}
+      DefaultShape={defaultFunnelShape}
+      shapeProps={shapeProps}
+    />
+  );
 }

--- a/src/util/RadialBarUtils.tsx
+++ b/src/util/RadialBarUtils.tsx
@@ -15,10 +15,19 @@ export function parseCornerRadius(cornerRadius: string | number | undefined): nu
 
 export interface RadialBarSectorProps extends RadialBarDataItem {
   index: number;
-  option: Exclude<RadialBarProps['shape'], undefined> | RadialBarProps['activeShape'];
   isActive: boolean;
 }
 
-export function RadialBarSector(props: RadialBarSectorProps) {
-  return <Shape renderDefaultShape={defaultRadialBarShape} {...props} />;
+type RadialBarSectorComponentProps = RadialBarSectorProps & {
+  option: Exclude<RadialBarProps['shape'], undefined> | RadialBarProps['activeShape'];
+};
+
+export function RadialBarSector({ option, ...shapeProps }: RadialBarSectorComponentProps) {
+  return (
+    <Shape<RadialBarSectorProps, SVGPathElement>
+      option={option}
+      DefaultShape={defaultRadialBarShape}
+      shapeProps={shapeProps}
+    />
+  );
 }

--- a/src/util/ScatterUtils.tsx
+++ b/src/util/ScatterUtils.tsx
@@ -7,32 +7,34 @@ import { DATA_ITEM_GRAPHICAL_ITEM_ID_ATTRIBUTE_NAME } from './Constants';
 import { GraphicalItemId } from '../state/graphicalItemsSlice';
 
 export type ScatterShapeProps = ScatterPointItem & {
+  isActive: boolean;
   index: number;
   [DATA_ITEM_GRAPHICAL_ITEM_ID_ATTRIBUTE_NAME]: GraphicalItemId;
 };
 
-function renderSymbols(props: ScatterShapeProps) {
+type ScatterSymbolShapeProps = ScatterShapeProps & InnerSymbolsProp;
+
+function renderSymbols(props: ScatterSymbolShapeProps) {
   return <Symbols {...props} />;
 }
 
 export function ScatterSymbol({
   option,
-  isActive,
   ...props
 }: {
   option: ActiveShape<ScatterShapeProps & InnerSymbolsProp, SVGPathElement> | SymbolType;
-  isActive: boolean;
 } & ScatterShapeProps) {
   if (typeof option === 'string') {
     return (
-      <Shape
+      <Shape<ScatterSymbolShapeProps, SVGPathElement>
         option={<Symbols type={option} {...props} />}
-        isActive={isActive}
-        renderDefaultShape={renderSymbols}
-        {...props}
+        DefaultShape={renderSymbols}
+        shapeProps={props}
       />
     );
   }
 
-  return <Shape option={option} isActive={isActive} renderDefaultShape={renderSymbols} {...props} />;
+  return (
+    <Shape<ScatterSymbolShapeProps, SVGPathElement> option={option} DefaultShape={renderSymbols} shapeProps={props} />
+  );
 }


### PR DESCRIPTION
Further simplify the Shape type so that it's easier to add the new animation props in the other PR.

Isolated change, no public API difference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated shape rendering prop structures across bar, line, scatter, pie, and radial bar chart components.
  * Refactored shape utilities to consolidate how props are passed to shape components.
  * Modified type definitions for shape component props and signatures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/recharts/recharts/pull/7351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->