### PR TITLE
fix(YAxis): render explicit ticks when a non-literal domain can't resolve on empty data (#7362)

### DIFF
--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -1094,6 +1094,7 @@ export const combineNumericalDomain = (
   referenceElementsDomain: NumberDomain | undefined,
   layout: LayoutType,
   axisType: AllAxisTypes,
+  numericTicksDomain?: NumberDomain | undefined,
 ): NumberDomain | undefined => {
   if (domainFromUserPreference != null) {
     // We're done! No need to compute anything else.
@@ -1107,8 +1108,61 @@ export const combineNumericalDomain = (
     ? mergeDomains(domainOfStackGroups, referenceElementsDomain, dataAndErrorBarsDomain)
     : mergeDomains(referenceElementsDomain, dataAndErrorBarsDomain);
 
-  return parseNumericalUserDomain(domainDefinition, mergedDomains, axisSettings.allowDataOverflow);
+  const parsedDomain = parseNumericalUserDomain(domainDefinition, mergedDomains, axisSettings.allowDataOverflow);
+  if (parsedDomain != null) {
+    return parsedDomain;
+  }
+
+  /*
+   * https://github.com/recharts/recharts/issues/7362
+   * The user-provided domain could not be resolved without data - it's a function
+   * bound or one of 'auto'/'dataMin'/'dataMax' - and there is no data domain to
+   * resolve it from: empty or all-null data, and no domain-extending reference
+   * elements (only reference dots/lines/areas with ifOverflow="extendDomain"
+   * contribute to mergedDomains). If the
+   * axis opted into data overflow and supplied an explicit numeric `ticks` array,
+   * fall back to the ticks' [min, max] extent so the explicit tick ladder still
+   * renders, mirroring what a literal numeric domain already does.
+   */
+  if (axisSettings.allowDataOverflow && mergedDomains == null && numericTicksDomain != null) {
+    return numericTicksDomain;
+  }
+
+  return parsedDomain;
 };
+
+/**
+ * https://github.com/recharts/recharts/issues/7362
+ * Derives the [min, max] extent of an axis's explicit numeric `ticks`. Used by
+ * {@link combineNumericalDomain} as a last-resort domain when a non-literal domain
+ * cannot be resolved without data. Returns undefined for non-number axes, or when
+ * no numeric ticks were supplied.
+ */
+export const combineNumericTicksDomain = (axisSettings: AllAxisSettings): NumberDomain | undefined => {
+  if (
+    axisSettings == null ||
+    axisSettings.type !== 'number' ||
+    !('ticks' in axisSettings) ||
+    axisSettings.ticks == null
+  ) {
+    return undefined;
+  }
+  const numericTicks = onlyAllowNumbers(axisSettings.ticks);
+  if (numericTicks.length === 0) {
+    return undefined;
+  }
+  return [Math.min(...numericTicks), Math.max(...numericTicks)];
+};
+
+export const selectNumericTicksDomain: (
+  state: RechartsRootState,
+  axisType: AllAxisTypes,
+  axisId: AxisId,
+) => NumberDomain | undefined = createSelector([selectBaseAxis], combineNumericTicksDomain, {
+  memoizeOptions: {
+    resultEqualityCheck: numberDomainEqualityCheck,
+  },
+});
 
 export const selectNumericalDomain: (
   state: RechartsRootState,
@@ -1125,6 +1179,7 @@ export const selectNumericalDomain: (
     selectReferenceElementsDomain,
     selectChartLayout,
     pickAxisType,
+    selectNumericTicksDomain,
   ],
   combineNumericalDomain,
   {

--- a/test/cartesian/YAxis/YAxis.7362.derivedDomain.spec.tsx
+++ b/test/cartesian/YAxis/YAxis.7362.derivedDomain.spec.tsx
@@ -1,43 +1,33 @@
 /**
  * @fileOverview https://github.com/recharts/recharts/issues/7362
  *
- * TDD red test for the *function-domain* half of #7362.
+ * Ticks-fallback for the derived/function-`domain` half of #7362.
  *
  * PR #7379 (YAxis.7362.spec.tsx) covers the LITERAL case: `type="number"` +
- * `domain={[0, 100]}` + `ticks` + `allowDataOverflow` already renders the
- * 0/25/50/75/100 ladder when every series value is null (or `data=[]`).
+ * `domain={[0, 100]}` + `ticks` + `allowDataOverflow` already renders the ladder
+ * on all-null/empty data, because a literal domain resolves without data.
  *
- * This spec covers the case that does NOT work yet: a **function** `domain`.
- * A function bound already gets to decide its own value — e.g.
- * `[0, (dataMax) => (Number.isFinite(dataMax) && dataMax > 0 ? dataMax : 100)]`
- * returns a finite `100` when there is no data. The DESIRED behavior is that
- * recharts invokes that function even when the data domain is empty, so the
- * returned finite bounds resolve the scale and the explicit `ticks` render —
- * exactly like the literal case.
+ * A NON-literal `domain` (a function bound, or 'auto'/'dataMin'/'dataMax') cannot
+ * resolve without data, so today the scale never builds and the axis renders zero
+ * ticks even when explicit `ticks` are supplied. The fix: when the domain cannot
+ * be resolved without data, there is no data domain, `allowDataOverflow` is set,
+ * and explicit numeric `ticks` are present, fall back to
+ * `[min(ticks), max(ticks)]` so the explicit ladder still renders. See
+ * `combineNumericalDomain` in src/state/selectors/axisSelectors.ts.
  *
- * Today recharts SKIPS function domains when there is no data domain
- * (`numericalDomainSpecifiedWithoutRequiringData` returns undefined for any
- * function; `parseNumericalUserDomain` only calls the function when
- * `dataDomain != null`), so these render zero ticks. See
- * src/util/isDomainSpecifiedByUser.ts.
- *
- * These cases use `it.fails` on purpose: each test asserts the DESIRED behavior
- * (the ladder renders), which currently throws — so `it.fails` passes and keeps
- * the suite green while documenting the gap. When recharts is changed to invoke
- * a function domain without data, the assertions will start passing and `it.fails`
- * will flip to FAILING — the signal to drop `.fails` and lock in the behavior.
+ * Negative guards below pin the boundaries: a resolvable literal domain still
+ * wins, data-present behavior is unchanged, and the fallback requires
+ * `allowDataOverflow`.
  */
 import React from 'react';
-import { describe, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { Line, LineChart, XAxis, YAxis } from '../../../src';
 import { AxisDomain } from '../../../src/util/types';
-import { expectYAxisTicks } from '../../helper/expectAxisTicks';
+import { ExpectAxisDomain, expectYAxisTicks } from '../../helper/expectAxisTicks';
+import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 
-type Datum = {
-  name: string;
-  value: number | null;
-};
+type Datum = { name: string; value: number | null };
 
 const explicitTicks = [0, 25, 50, 75, 100];
 const ladder = [
@@ -49,43 +39,159 @@ const ladder = [
 ];
 
 const allNullData: ReadonlyArray<Datum> = [
-  { name: 'Page A', value: null },
-  { name: 'Page B', value: null },
-  { name: 'Page C', value: null },
-  { name: 'Page D', value: null },
+  { name: 'A', value: null },
+  { name: 'B', value: null },
+  { name: 'C', value: null },
+  { name: 'D', value: null },
 ];
 
-function renderChart({ data, domain }: { data: ReadonlyArray<Datum>; domain: AxisDomain }) {
-  return render(
+function renderChart({
+  data,
+  domain,
+  ticks = explicitTicks,
+  allowDataOverflow = true,
+}: {
+  data: ReadonlyArray<Datum>;
+  domain: AxisDomain;
+  ticks?: ReadonlyArray<number>;
+  allowDataOverflow?: boolean;
+}) {
+  const axisDomainSpy = vi.fn();
+  const renderResult = render(
     <LineChart width={500} height={300} data={data}>
       <XAxis dataKey="name" />
-      <YAxis type="number" domain={domain} allowDataOverflow ticks={explicitTicks} />
+      <YAxis type="number" domain={domain} allowDataOverflow={allowDataOverflow} ticks={[...ticks]} />
       <Line type="monotone" dataKey="value" stroke="#8884d8" isAnimationActive={false} connectNulls />
+      <ExpectAxisDomain assert={axisDomainSpy} axisType="yAxis" />
     </LineChart>,
   );
+  return { ...renderResult, axisDomainSpy };
 }
 
-// A function upper bound that resolves to a finite ceiling when there is no data.
+function yTickCount(container: Element): number {
+  return container.querySelectorAll('.recharts-yAxis .recharts-cartesian-axis-tick').length;
+}
+
+// Flexible variant for edge cases: optional/non-numeric ticks, tickCount-only, and extra chart children.
+function renderChartEx({
+  data = allNullData,
+  domain,
+  ticks,
+  tickCount,
+  allowDataOverflow = true,
+}: {
+  data?: ReadonlyArray<Datum>;
+  domain: AxisDomain;
+  ticks?: ReadonlyArray<number | string>;
+  tickCount?: number;
+  allowDataOverflow?: boolean;
+}) {
+  const axisDomainSpy = vi.fn();
+  const renderResult = render(
+    <LineChart width={500} height={300} data={data}>
+      <XAxis dataKey="name" />
+      <YAxis
+        type="number"
+        domain={domain}
+        allowDataOverflow={allowDataOverflow}
+        {...(ticks != null ? { ticks: [...ticks] as number[] } : {})}
+        {...(tickCount != null ? { tickCount } : {})}
+      />
+      <Line type="monotone" dataKey="value" stroke="#8884d8" isAnimationActive={false} connectNulls />
+      <ExpectAxisDomain assert={axisDomainSpy} axisType="yAxis" />
+    </LineChart>,
+  );
+  return { ...renderResult, axisDomainSpy };
+}
+
 const functionUpperBound: AxisDomain = [
   0,
   (dataMax: number) => (Number.isFinite(dataMax) && dataMax > 0 ? dataMax : 100),
 ];
-// A whole-domain function that ignores the (absent) data extent entirely.
 const wholeDomainFunction: AxisDomain = () => [0, 100];
 
-describe('YAxis issue 7362 — function domain should render ticks when data is empty/all-null', () => {
-  it.fails('renders the ladder for all-null data with a function upper-bound domain', () => {
-    const { container } = renderChart({ data: allNullData, domain: functionUpperBound });
+describe('YAxis issue 7362 — ticks fallback for non-literal domains on empty/all-null data', () => {
+  it('function upper-bound domain + all-null data renders the ladder from ticks', () => {
+    const { container, axisDomainSpy } = renderChart({ data: allNullData, domain: functionUpperBound });
+    expectLastCalledWith(axisDomainSpy, [0, 100]);
     expectYAxisTicks(container, ladder);
   });
 
-  it.fails('renders the ladder for empty data with a function upper-bound domain', () => {
-    const { container } = renderChart({ data: [], domain: functionUpperBound });
+  it('function upper-bound domain + empty data renders the ladder from ticks', () => {
+    const { container, axisDomainSpy } = renderChart({ data: [], domain: functionUpperBound });
+    expectLastCalledWith(axisDomainSpy, [0, 100]);
     expectYAxisTicks(container, ladder);
   });
 
-  it.fails('renders the ladder for all-null data with a whole-domain function', () => {
-    const { container } = renderChart({ data: allNullData, domain: wholeDomainFunction });
+  it('whole-domain function + all-null data renders the ladder from ticks', () => {
+    const { container, axisDomainSpy } = renderChart({ data: allNullData, domain: wholeDomainFunction });
+    expectLastCalledWith(axisDomainSpy, [0, 100]);
     expectYAxisTicks(container, ladder);
+  });
+
+  it("['auto','auto'] domain + all-null data renders the ladder from ticks", () => {
+    const { container, axisDomainSpy } = renderChart({ data: allNullData, domain: ['auto', 'auto'] });
+    expectLastCalledWith(axisDomainSpy, [0, 100]);
+    expectYAxisTicks(container, ladder);
+  });
+
+  it("['dataMin','dataMax'] domain + all-null data renders the ladder from ticks", () => {
+    const { container, axisDomainSpy } = renderChart({ data: allNullData, domain: ['dataMin', 'dataMax'] });
+    expectLastCalledWith(axisDomainSpy, [0, 100]);
+    expectYAxisTicks(container, ladder);
+  });
+
+  it('derives the domain from min/max of unsorted ticks', () => {
+    const { axisDomainSpy } = renderChart({ data: allNullData, domain: ['auto', 'auto'], ticks: [100, 0, 50, 25, 75] });
+    expectLastCalledWith(axisDomainSpy, [0, 100]);
+  });
+
+  // ---- Negative guards: the fallback must not engage here ----
+
+  it('does NOT override a resolvable literal domain (literal wins over ticks extent)', () => {
+    const { container, axisDomainSpy } = renderChart({ data: allNullData, domain: [0, 200] });
+    expectLastCalledWith(axisDomainSpy, [0, 200]);
+    expect(yTickCount(container)).toBe(5);
+  });
+
+  it('does NOT engage without allowDataOverflow', () => {
+    const { container, axisDomainSpy } = renderChart({
+      data: allNullData,
+      domain: functionUpperBound,
+      allowDataOverflow: false,
+    });
+    expectLastCalledWith(axisDomainSpy, undefined);
+    expect(yTickCount(container)).toBe(0);
+  });
+
+  it('does NOT engage when data is present (function resolves from data)', () => {
+    const data: ReadonlyArray<Datum> = [
+      { name: 'A', value: 10 },
+      { name: 'B', value: 40 },
+    ];
+    const { axisDomainSpy } = renderChart({ data, domain: [0, (dataMax: number) => dataMax] });
+    expectLastCalledWith(axisDomainSpy, [0, 40]);
+  });
+
+  it('does NOT engage from tickCount alone (no explicit ticks array)', () => {
+    const { container, axisDomainSpy } = renderChartEx({ domain: ['auto', 'auto'], tickCount: 5 });
+    expectLastCalledWith(axisDomainSpy, undefined);
+    expect(yTickCount(container)).toBe(0);
+  });
+
+  it('drops non-numeric ticks and derives the domain from the numeric ones', () => {
+    const { axisDomainSpy } = renderChartEx({ domain: ['auto', 'auto'], ticks: [0, 'foo', NaN, 100] });
+    expectLastCalledWith(axisDomainSpy, [0, 100]);
+  });
+
+  it('does NOT engage when no ticks are numeric', () => {
+    const { container, axisDomainSpy } = renderChartEx({ domain: ['auto', 'auto'], ticks: ['foo', NaN] });
+    expectLastCalledWith(axisDomainSpy, undefined);
+    expect(yTickCount(container)).toBe(0);
+  });
+
+  it('handles a single tick without crashing', () => {
+    const { container } = renderChartEx({ domain: ['auto', 'auto'], ticks: [50] });
+    expect(yTickCount(container)).toBe(1);
   });
 });


### PR DESCRIPTION
> Draft — proposes the approach @PavelVanecek suggested on #7362 (derive the domain from explicit `ticks` when data is absent). Opening as a draft for a steer on the approach before polishing.

## What

Follow-up to #7384 (the failing repro). When a numeric axis supplies an explicit `ticks` array but its `domain` cannot be resolved without data — a **function** bound, or `'auto'`/`'dataMin'`/`'dataMax'` — the scale never builds on empty/all-null data, so the axis renders **zero ticks**. A literal numeric domain already works; this extends that to derived domains.

This avoids the typing problem raised on the issue (the `AxisDomain` function form is typed `(NumberDomain, boolean) => NumberDomain`, so feeding it `undefined`/`NaN` would be a breaking change): instead of calling the user's function without data, we fall back to the explicit ticks' extent.

## How

`combineNumericalDomain` falls back to `[Math.min(...ticks), Math.max(...ticks)]` of the explicit numeric ticks **only when all of**:
- the user domain could not be resolved without data (`numericalDomainSpecifiedWithoutRequiringData` → `undefined`), and
- `parseNumericalUserDomain` also returned `undefined` (no data domain — empty/all-null data and no domain-extending reference elements), and
- `allowDataOverflow` is set, and
- the axis is `type="number"` with ≥1 numeric tick.

So it **never** overrides a resolvable literal domain, **never** engages when data is present, and leaves category / polar / tooltip paths untouched.

- adds `combineNumericTicksDomain` + `selectNumericTicksDomain` (the ticks `[min,max]` extent)
- threads it as an optional input to `combineNumericalDomain` (polar/tooltip pass nothing → unchanged)
- **does not** touch `parseNumericalUserDomain` / `numericalDomainSpecifiedWithoutRequiringData` — their "undefined without data" contract is preserved
- converts the #7384 `it.fails` repro into passing tests + adds edge-case coverage (unsorted/non-numeric/single ticks, tickCount-only, literal-wins, no-overflow, data-present guards)

## Test plan

- [x] `YAxis.7362.derivedDomain.spec.tsx` — 13 cases (positive + negative guards) pass
- [x] Affected selectors/axis/scatter/polar inventory + full `unit:lib` suite green locally (vitest 4)
- [x] format / lint / typecheck clean
- [ ] Maintainer steer on the approach
- [ ] Open question: should the fallback also apply without `allowDataOverflow`? (kept it required, for parity with the literal-domain path)

Refs #7362. Follows #7384.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where axis ticks would not render properly when no data is available but explicit numeric ticks are specified. The axis domain now intelligently falls back to the explicit tick range when `allowDataOverflow` is enabled.

* **Tests**
  * Expanded test coverage to verify axis behavior with explicit ticks on empty or null data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->