### PR TITLE
fix: preserve single-value line dash gaps during animation

### DIFF
--- a/src/cartesian/LineDrawShape.tsx
+++ b/src/cartesian/LineDrawShape.tsx
@@ -33,21 +33,27 @@ function generateSimpleStrokeDasharray(totalLength: number, length: number): str
 }
 
 /**
- * Repeats a dash pattern array a given number of times.
+ * Normalizes a dash pattern to the even-length sequence used by SVG renderers.
+ * Odd-length stroke-dasharray values repeat once, so "5" behaves like "5 5".
  *
- * If the input array has an odd length, a trailing `0` is appended to make it even
- * before repeating, because SVG stroke-dasharray patterns must have an even number
- * of values to cycle correctly between dash and gap segments.
+ * @param lines Array of dash/gap lengths to repeat
+ * @returns An even-length dash pattern
+ */
+function normalizeDashPattern(lines: number[]): number[] {
+  return lines.length % 2 !== 0 ? [...lines, ...lines] : lines;
+}
+
+/**
+ * Repeats a dash pattern array a given number of times.
  *
  * @param lines Array of dash/gap lengths to repeat
  * @param count Number of times to repeat the pattern
  * @returns A new array with the pattern repeated `count` times
  */
 function repeat(lines: number[], count: number): number[] {
-  const linesUnit = lines.length % 2 !== 0 ? [...lines, 0] : lines;
   const result: number[] = [];
   for (let i = 0; i < count; ++i) {
-    result.push(...linesUnit);
+    result.push(...lines);
   }
   return result;
 }
@@ -68,7 +74,8 @@ function repeat(lines: number[], count: number): number[] {
  * @returns A stroke-dasharray string incorporating the custom dash pattern
  */
 function getStrokeDasharray(length: number, totalLength: number, lines: number[]): string {
-  const lineLength = lines.reduce((pre, next) => pre + next, 0);
+  const normalizedLines = normalizeDashPattern(lines);
+  const lineLength = normalizedLines.reduce((pre, next) => pre + next, 0);
 
   // if lineLength is 0 return the default when no strokeDasharray is provided
   if (!lineLength) {
@@ -78,17 +85,17 @@ function getStrokeDasharray(length: number, totalLength: number, lines: number[]
   const count = Math.floor(length / lineLength);
   const remainLength = length % lineLength;
   let remainLines: number[] = [];
-  for (let i = 0, sum = 0; i < lines.length; sum += lines[i] ?? 0, ++i) {
-    const lineValue = lines[i];
+  for (let i = 0, sum = 0; i < normalizedLines.length; sum += normalizedLines[i] ?? 0, ++i) {
+    const lineValue = normalizedLines[i];
     if (lineValue != null && sum + lineValue > remainLength) {
-      remainLines = [...lines.slice(0, i), remainLength - sum];
+      remainLines = [...normalizedLines.slice(0, i), remainLength - sum];
       break;
     }
   }
 
   const emptyLines = remainLines.length % 2 === 0 ? [0, totalLength] : [totalLength];
 
-  return [...repeat(lines, count), ...remainLines, ...emptyLines].map(line => `${line}px`).join(', ');
+  return [...repeat(normalizedLines, count), ...remainLines, ...emptyLines].map(line => `${line}px`).join(', ');
 }
 
 /**

--- a/test/cartesian/Line.animation.spec.tsx
+++ b/test/cartesian/Line.animation.spec.tsx
@@ -433,6 +433,21 @@ describe('Line animation', () => {
         // After the animation is completed, stroke-dasharray is the user-provided value.
         expect(line).toHaveAttribute('stroke-dasharray', '7 3');
       });
+
+      it('should preserve single-value dash gaps during animation', async () => {
+        const renderSingleDash = createSelectorTestCase(({ children }) => (
+          <LineChart data={PageData} width={100} height={100}>
+            <Line dataKey="uv" animationEasing="linear" strokeDasharray="5" />
+            {children}
+          </LineChart>
+        ));
+        const { container, animationManager } = renderSingleDash();
+
+        await animationManager.setAnimationProgress(0.1);
+
+        const line = getLine(container);
+        expect(line).toHaveAttribute('stroke-dasharray', '5px, 5px, 0px, 100px');
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Single-value SVG `strokeDasharray` patterns repeat themselves, so `strokeDasharray="5"` should behave like `5 5`. During the animated line reveal, Recharts currently normalizes odd dash arrays by appending `0`, which turns `5` into `5 0` and removes the visible gap.

This normalizes odd dash patterns by repeating the pattern before calculating the animated dash reveal.

## Related Issue

Fixes #3588

## Motivation and Context

This keeps the entrance animation consistent with SVG stroke-dasharray semantics and prevents a single-value dashed line from rendering as a solid line while it animates.

## How Has This Been Tested?

- Red before fix: `npm run test -- test/cartesian/Line.animation.spec.tsx -t "single-value dash gaps"` failed with `5px, 0px, 5px, 0px, 0px, 100px`
- `npm run test -- test/cartesian/Line.animation.spec.tsx -t "single-value dash gaps"`
- `npm run test -- test/cartesian/Line.animation.spec.tsx`
- `npm run test -- test/cartesian/Line.spec.tsx -t strokeDasharray`
- `npm run test -- test/cartesian/Line.animation.spec.tsx test/cartesian/Line.spec.tsx`
- `npx eslint src/cartesian/LineDrawShape.tsx test/cartesian/Line.animation.spec.tsx`
- `npm run check-types-lib`
- `npm run check-types-test`
- `npm run omnidoc`
- `npm run lint` (passes with existing warning-level docs example messages)
- `git diff --check`

I also ran full `npm run test`; it fails locally in unrelated Treemap/Tooltip timer-loop tests and omnidoc timeout tests, while the affected Line test files pass.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dashed line rendering to properly interpret custom dash patterns, ensuring consistent SVG stroke-dasharray behavior across all pattern configurations.

* **Tests**
  * Added test case to verify correct animation progression of stroke dash arrays with single-value patterns, ensuring proper dash-gap behavior during animation cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->