### PR TITLE
fix(Rectangle): allow zero-dimension rendering for animation t=0 frames

### DIFF
--- a/src/shape/Rectangle.tsx
+++ b/src/shape/Rectangle.tsx
@@ -220,7 +220,7 @@ export const Rectangle: React.FC<Props> = rectangleProps => {
   const animationIdInput = useMemo(() => ({ x, y, width, height, radius }), [x, y, width, height, radius]);
   const animationId = useAnimationId(animationIdInput, 'rectangle-');
 
-  if (x !== +x || y !== +y || width !== +width || height !== +height || width === 0 || height === 0) {
+  if (x !== +x || y !== +y || width !== +width || height !== +height) {
     return null;
   }
 

--- a/test/shape/Rectangle.spec.tsx
+++ b/test/shape/Rectangle.spec.tsx
@@ -34,7 +34,7 @@ describe('<Rectangle />', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it("Shouldn't render anything when height === 0 || width === 0", () => {
+  it('Should render zero-size path when height === 0 || width === 0', () => {
     const { container } = render(
       <Surface width={400} height={400}>
         <Rectangle x={50} y={200} width={80} height={0} radius={5} fill="#ff7300" />
@@ -42,8 +42,7 @@ describe('<Rectangle />', () => {
       </Surface>,
     );
 
-    expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(0);
-    expect(container).toMatchSnapshot();
+    expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(2);
   });
 
   it("Shouldn't render any path when x, y, width or height is not a number", () => {

--- a/test/shape/__snapshots__/Rectangle.spec.tsx.snap
+++ b/test/shape/__snapshots__/Rectangle.spec.tsx.snap
@@ -101,17 +101,3 @@ exports[`<Rectangle /> > Shouldn't render any path when x, y, width or height is
   </svg>
 </div>
 `;
-
-exports[`<Rectangle /> > Shouldn't render anything when height === 0 || width === 0 1`] = `
-<div>
-  <svg
-    class="recharts-surface"
-    height="400"
-    viewBox="0 0 400 400"
-    width="400"
-  >
-    <title />
-    <desc />
-  </svg>
-</div>
-`;


### PR DESCRIPTION
Fixes #7377

The `Rectangle` component returns null when width or height is zero, which breaks Bar mount-animations. Bar.renderRectanglesWithAnimation interpolates from zero dimensions at t=0 to final values at t=1 — when Rectangle returns null at t=0, no path element is emitted and if the animation stalls, bars stay permanently invisible.

The zero-dimension guard in Rectangle is redundant — Bar already filters zero-dimension rectangles at the selector level in computeBarRectangles (for sparse stacked chart performance), so by the time a Rectangle renders with real data, the dimensions are non-zero. The only case where zero dimensions reach Rectangle is during animation interpolation, where they should produce a harmless zero-size path.

Removed the `|| width === 0 || height === 0` clause from the early return. The existing NaN/non-numeric guards remain. Updated the corresponding test and removed stale snapshot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rectangles with zero width or height are now rendered instead of being skipped.
* **Tests**
  * Updated rectangle tests to assert rendering for zero-dimension cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->