### PR TITLE
docs(zoom): Zoom & Pan guide

### DIFF
--- a/www/src/components/GuideView/ZoomAndPan/AutoScaleFollowExample.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/AutoScaleFollowExample.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import {
+  AutoScaleAxis,
+  CartesianGrid,
+  FollowSeries,
+  Line,
+  LineChart,
+  MouseWheelZoom,
+  PanOnDrag,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZoomScrollbar,
+} from 'recharts';
+import { generateMockData } from '@recharts/devtools';
+
+const data = generateMockData(80, 13);
+
+type ControlsType = {
+  autoScale: boolean;
+  follow: boolean;
+};
+
+const defaultState: ControlsType = {
+  autoScale: true,
+  follow: false,
+};
+
+/*
+ * Zoom into a slice of x (wheel) then pan around (drag the plot or the scrollbar): the y axis keeps
+ * re-fitting to the data inside the visible window. Swap <AutoScaleAxis /> for
+ * <FollowSeries dataKey="x" autoScale /> to keep one series centred instead.
+ */
+export default function AutoScaleFollowExample(props: Partial<ControlsType>) {
+  const autoScale = props.autoScale ?? defaultState.autoScale;
+  const follow = props.follow ?? defaultState.follow;
+
+  return (
+    <LineChart width={700} height={300} data={data} responsive>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey="label" />
+      <YAxis />
+      <Tooltip />
+      <Line type="monotone" dataKey="x" stroke="#8884d8" dot={false} isAnimationActive={false} />
+      <MouseWheelZoom axis="x" />
+      <PanOnDrag axis="x" />
+      <ZoomScrollbar axis="x" />
+      {autoScale && !follow && <AutoScaleAxis />}
+      {follow && <FollowSeries dataKey="x" autoScale={autoScale} />}
+    </LineChart>
+  );
+}
+
+export function AutoScaleFollowExampleControls({
+  onChange,
+  sessionStoreValues,
+}: {
+  onChange: (values: ControlsType) => void;
+  sessionStoreValues: ControlsType | null;
+}) {
+  const [state, setState] = React.useState<ControlsType>(sessionStoreValues ?? defaultState);
+
+  const handleChange = (nextValues: Partial<ControlsType>) => {
+    const newState = { ...state, ...nextValues };
+    setState(newState);
+    onChange(newState);
+  };
+
+  React.useEffect(() => {
+    onChange(state);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <form>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <label htmlFor="autoscale">
+                <input
+                  id="autoscale"
+                  type="checkbox"
+                  checked={state.autoScale}
+                  onChange={e => handleChange({ autoScale: e.target.checked })}
+                />
+                {' AutoScaleAxis'}
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="follow">
+                <input
+                  id="follow"
+                  type="checkbox"
+                  checked={state.follow}
+                  onChange={e => handleChange({ follow: e.target.checked })}
+                />
+                {' FollowSeries'}
+              </label>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p style={{ marginTop: '1rem', fontSize: '0.9rem', color: '#666' }}>
+        {!state.autoScale && !state.follow && 'Y axis is free and does not react to X zoom or pan.'}
+        {state.autoScale && !state.follow && 'Y axis re-fits to the visible data. Zoom X and pan to see it react.'}
+        {state.follow && !state.autoScale && 'Y axis keeps the series centred while panning (fixed span).'}
+        {state.follow && state.autoScale && 'Y axis keeps the series centred and auto-scales the span around it.'}
+      </p>
+    </form>
+  );
+}

--- a/www/src/components/GuideView/ZoomAndPan/BrushZoomModeExample.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/BrushZoomModeExample.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { Brush, BrushZoomControls, CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis, ZoomAndPan } from 'recharts';
+import { generateMockData } from '@recharts/devtools';
+
+const data = generateMockData(80, 9);
+
+type ControlsType = {
+  autoScaleYDomain: boolean;
+  brushWheel: boolean;
+  brushPinch: boolean;
+  globalWheel: boolean;
+};
+
+const defaultState: ControlsType = {
+  autoScaleYDomain: true,
+  brushWheel: true,
+  brushPinch: true,
+  globalWheel: true,
+};
+
+/*
+ * The familiar Brush UI editing the zoom viewport instead of slicing data: drag the travellers or
+ * the window, wheel over the rail, or zoom the plot itself - everything stays in sync because they
+ * all edit the same viewport. autoScaleYDomain re-fits y to the visible window while you brush x.
+ */
+export default function BrushZoomModeExample(props: Partial<ControlsType>) {
+  const autoScaleYDomain = props.autoScaleYDomain ?? defaultState.autoScaleYDomain;
+  const brushWheel = props.brushWheel ?? defaultState.brushWheel;
+  const brushPinch = props.brushPinch ?? defaultState.brushPinch;
+  const globalWheel = props.globalWheel ?? defaultState.globalWheel;
+
+  return (
+    <LineChart width={700} height={340} data={data} responsive>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey="label" />
+      <YAxis />
+      <Tooltip />
+      <Line type="monotone" dataKey="x" stroke="#8884d8" dot={false} isAnimationActive={false} />
+      <ZoomAndPan axis="x" initialZoom={{ x: { start: 0.25, end: 0.6 } }} scrollbars={false} wheel={globalWheel} />
+      <Brush
+        mode="zoom"
+        autoScaleYDomain={autoScaleYDomain}
+        height={48}
+        stroke="#1d4ed8"
+        controls={<BrushZoomControls wheel={brushWheel} pinch={brushPinch} />}
+      >
+        <LineChart data={data}>
+          <Line type="monotone" dataKey="x" stroke="#8884d8" dot={false} isAnimationActive={false} />
+        </LineChart>
+      </Brush>
+    </LineChart>
+  );
+}
+
+export function BrushZoomModeExampleControls({
+  onChange,
+  sessionStoreValues,
+}: {
+  onChange: (values: ControlsType) => void;
+  sessionStoreValues: ControlsType | null;
+}) {
+  const [state, setState] = React.useState<ControlsType>(sessionStoreValues ?? defaultState);
+
+  const handleChange = (nextValues: Partial<ControlsType>) => {
+    const newState = { ...state, ...nextValues };
+    setState(newState);
+    onChange(newState);
+  };
+
+  React.useEffect(() => {
+    onChange(state);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <form>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <label htmlFor="brush-autoscale">
+                <input
+                  id="brush-autoscale"
+                  type="checkbox"
+                  checked={state.autoScaleYDomain}
+                  onChange={e => handleChange({ autoScaleYDomain: e.target.checked })}
+                />
+                {' autoScaleYDomain'}
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="global-wheel">
+                <input
+                  id="global-wheel"
+                  type="checkbox"
+                  checked={state.globalWheel}
+                  onChange={e => handleChange({ globalWheel: e.target.checked })}
+                />
+                {' wheel on chart'}
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="brush-wheel">
+                <input
+                  id="brush-wheel"
+                  type="checkbox"
+                  checked={state.brushWheel}
+                  onChange={e => handleChange({ brushWheel: e.target.checked })}
+                />
+                {' wheel on Brush'}
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="brush-pinch">
+                <input
+                  id="brush-pinch"
+                  type="checkbox"
+                  checked={state.brushPinch}
+                  onChange={e => handleChange({ brushPinch: e.target.checked })}
+                />
+                {' pinch on Brush'}
+              </label>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p style={{ marginTop: '1rem', fontSize: '0.9rem', color: '#666' }}>
+        Drag the travellers, wheel over the rail, or zoom the plot - they edit the same viewport. Try disabling
+        &quot;wheel on chart&quot; then test &quot;wheel on Brush&quot; to see the difference.
+      </p>
+    </form>
+  );
+}

--- a/www/src/components/GuideView/ZoomAndPan/ComposedInteractionsExample.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/ComposedInteractionsExample.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import {
+  AxisZoom,
+  CartesianGrid,
+  DoubleClickReset,
+  Line,
+  LineChart,
+  MouseWheelZoom,
+  PanOnDrag,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZoomScrollbar,
+  PinchZoom,
+  ZoomPanKeyboard,
+} from 'recharts';
+import { generateMockData } from '@recharts/devtools';
+
+const data = generateMockData(60, 5);
+
+type ControlsType = {
+  wheel: boolean;
+  pan: boolean;
+  axisZoom: boolean;
+  doubleClickReset: boolean;
+  keyboard: boolean;
+  pinch: boolean;
+  scrollbar: boolean;
+};
+
+const defaultState: ControlsType = {
+  wheel: true,
+  pan: true,
+  axisZoom: true,
+  doubleClickReset: true,
+  keyboard: false,
+  pinch: false,
+  scrollbar: true,
+};
+
+/*
+ * No bundle: exactly four interactions are mounted. Wheel zooms, drag pans, wheel over an axis
+ * zooms only that axis, double-click resets - and nothing else (no pinch, no keyboard).
+ */
+export default function ComposedInteractionsExample(props: Partial<ControlsType>) {
+  const wheel = props.wheel ?? defaultState.wheel;
+  const pan = props.pan ?? defaultState.pan;
+  const axisZoom = props.axisZoom ?? defaultState.axisZoom;
+  const doubleClickReset = props.doubleClickReset ?? defaultState.doubleClickReset;
+  const keyboard = props.keyboard ?? defaultState.keyboard;
+  const pinch = props.pinch ?? defaultState.pinch;
+  const scrollbar = props.scrollbar ?? defaultState.scrollbar;
+
+  return (
+    <LineChart width={700} height={300} data={data} responsive>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey="label" />
+      <YAxis />
+      <Tooltip />
+      <Line type="monotone" dataKey="x" stroke="#8884d8" dot={false} isAnimationActive={false} />
+      {wheel && <MouseWheelZoom />}
+      {pan && <PanOnDrag />}
+      {axisZoom && <AxisZoom />}
+      {doubleClickReset && <DoubleClickReset />}
+      {keyboard && <ZoomPanKeyboard />}
+      {pinch && <PinchZoom />}
+      {scrollbar && <ZoomScrollbar axis="x" />}
+    </LineChart>
+  );
+}
+
+export function ComposedInteractionsExampleControls({
+  onChange,
+  sessionStoreValues,
+}: {
+  onChange: (values: ControlsType) => void;
+  sessionStoreValues: ControlsType | null;
+}) {
+  const [state, setState] = React.useState<ControlsType>(sessionStoreValues ?? defaultState);
+
+  const handleChange = (nextValues: Partial<ControlsType>) => {
+    const newState = { ...state, ...nextValues };
+    setState(newState);
+    onChange(newState);
+  };
+
+  React.useEffect(() => {
+    onChange(state);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <form>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <label htmlFor="wheel">
+                <input
+                  id="wheel"
+                  type="checkbox"
+                  checked={state.wheel}
+                  onChange={e => handleChange({ wheel: e.target.checked })}
+                />
+                {' MouseWheelZoom'}
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="pan">
+                <input
+                  id="pan"
+                  type="checkbox"
+                  checked={state.pan}
+                  onChange={e => handleChange({ pan: e.target.checked })}
+                />
+                {' PanOnDrag'}
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="axisZoom">
+                <input
+                  id="axisZoom"
+                  type="checkbox"
+                  checked={state.axisZoom}
+                  onChange={e => handleChange({ axisZoom: e.target.checked })}
+                />
+                {' AxisZoom'}
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="doubleClickReset">
+                <input
+                  id="doubleClickReset"
+                  type="checkbox"
+                  checked={state.doubleClickReset}
+                  onChange={e => handleChange({ doubleClickReset: e.target.checked })}
+                />
+                {' DoubleClickReset'}
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="keyboard">
+                <input
+                  id="keyboard"
+                  type="checkbox"
+                  checked={state.keyboard}
+                  onChange={e => handleChange({ keyboard: e.target.checked })}
+                />
+                {' ZoomPanKeyboard'}
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="pinch">
+                <input
+                  id="pinch"
+                  type="checkbox"
+                  checked={state.pinch}
+                  onChange={e => handleChange({ pinch: e.target.checked })}
+                />
+                {' PinchZoom'}
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="scrollbar">
+                <input
+                  id="scrollbar"
+                  type="checkbox"
+                  checked={state.scrollbar}
+                  onChange={e => handleChange({ scrollbar: e.target.checked })}
+                />
+                {' ZoomScrollbar'}
+              </label>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p style={{ marginTop: '1rem', fontSize: '0.9rem', color: '#666' }}>
+        Toggle individual interactions to compose exactly the gestures you want.
+      </p>
+    </form>
+  );
+}

--- a/www/src/components/GuideView/ZoomAndPan/ControlledSyncExample.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/ControlledSyncExample.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis, ZoomAndPan } from 'recharts';
+import { generateMockData } from '@recharts/devtools';
+
+const data = generateMockData(60, 17);
+const fullViewport = { x: { start: 0, end: 1 }, y: { start: 0, end: 1 } };
+
+/*
+ * The viewport lives in React state and both charts receive it as a controlled prop: zoom or pan
+ * either chart and the other follows. The same pattern persists zoom across remounts, drives the
+ * chart from a router/URL, or feeds a server query with the visible window.
+ */
+export default function ControlledSyncExample() {
+  const [viewport, setViewport] = useState(fullViewport);
+  const zoom = { axis: 'x' as const, viewport, onZoomChange: setViewport, scrollbars: false };
+
+  return (
+    <div>
+      <LineChart width={700} height={200} data={data} responsive>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="label" />
+        <YAxis />
+        <Tooltip />
+        <Line type="monotone" dataKey="x" stroke="#8884d8" dot={false} isAnimationActive={false} />
+        <ZoomAndPan {...zoom} />
+      </LineChart>
+      <LineChart width={700} height={200} data={data} responsive>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="label" />
+        <YAxis />
+        <Tooltip />
+        <Line type="monotone" dataKey="y" stroke="#82ca9d" dot={false} isAnimationActive={false} />
+        <ZoomAndPan {...zoom} />
+      </LineChart>
+    </div>
+  );
+}

--- a/www/src/components/GuideView/ZoomAndPan/CustomControlsExample.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/CustomControlsExample.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis, useZoom, useZoomState } from 'recharts';
+import { generateMockData } from '@recharts/devtools';
+
+const data = generateMockData(60, 11);
+
+function ZoomButtons() {
+  // The full helper API: zoomIn/zoomOut/pan/reset over the shared viewport.
+  const { zoomIn, zoomOut, reset, isZoomed } = useZoom();
+  // Or the useState-shaped tuple, for custom controls or your own gesture library.
+  const [zoom, setZoom] = useZoomState();
+
+  return (
+    <div style={{ display: 'flex', gap: 6, marginBottom: 8, alignItems: 'center' }}>
+      <button type="button" onClick={() => zoomIn()}>
+        Zoom in
+      </button>
+      <button type="button" onClick={() => zoomOut()}>
+        Zoom out
+      </button>
+      <button type="button" onClick={() => setZoom({ x: { start: 0.75, end: 1 } })}>
+        Last quarter
+      </button>
+      <button type="button" onClick={reset} disabled={!isZoomed}>
+        Reset
+      </button>
+      <span style={{ fontFamily: 'monospace', fontSize: 12 }}>
+        x: [{zoom.x.start.toFixed(2)}, {zoom.x.end.toFixed(2)}]
+      </span>
+    </div>
+  );
+}
+
+export default function CustomControlsExample() {
+  return (
+    <LineChart width={700} height={300} data={data} responsive>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey="label" />
+      <YAxis />
+      <Tooltip />
+      <Line type="monotone" dataKey="x" stroke="#8884d8" dot={false} isAnimationActive={false} />
+      {/* No interaction components mounted: the buttons are the only way to zoom. */}
+      <ZoomButtons />
+    </LineChart>
+  );
+}

--- a/www/src/components/GuideView/ZoomAndPan/CustomControlsExample.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/CustomControlsExample.tsx
@@ -1,39 +1,38 @@
-import React from 'react';
 import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis, useZoom, useZoomState } from 'recharts';
 import { generateMockData } from '@recharts/devtools';
 
 const data = generateMockData(60, 11);
 
 function ZoomButtons() {
-  // The full helper API: zoomIn/zoomOut/pan/reset over the shared viewport.
   const { zoomIn, zoomOut, reset, isZoomed } = useZoom();
-  // Or the useState-shaped tuple, for custom controls or your own gesture library.
   const [zoom, setZoom] = useZoomState();
 
   return (
-    <div style={{ display: 'flex', gap: 6, marginBottom: 8, alignItems: 'center' }}>
-      <button type="button" onClick={() => zoomIn()}>
-        Zoom in
-      </button>
-      <button type="button" onClick={() => zoomOut()}>
-        Zoom out
-      </button>
-      <button type="button" onClick={() => setZoom({ x: { start: 0.75, end: 1 } })}>
-        Last quarter
-      </button>
-      <button type="button" onClick={reset} disabled={!isZoomed}>
-        Reset
-      </button>
-      <span style={{ fontFamily: 'monospace', fontSize: 12 }}>
-        x: [{zoom.x.start.toFixed(2)}, {zoom.x.end.toFixed(2)}]
-      </span>
-    </div>
+    <foreignObject x={8} y={308} width={684} height={46}>
+      <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+        <button type="button" onClick={() => zoomIn()}>
+          Zoom in
+        </button>
+        <button type="button" onClick={() => zoomOut()}>
+          Zoom out
+        </button>
+        <button type="button" onClick={() => setZoom({ x: { start: 0.75, end: 1 } })}>
+          Last quarter
+        </button>
+        <button type="button" onClick={reset} disabled={!isZoomed}>
+          Reset
+        </button>
+        <span style={{ fontFamily: 'monospace', fontSize: 12 }}>
+          x: [{zoom.x.start.toFixed(2)}, {zoom.x.end.toFixed(2)}]
+        </span>
+      </div>
+    </foreignObject>
   );
 }
 
 export default function CustomControlsExample() {
   return (
-    <LineChart width={700} height={300} data={data} responsive>
+    <LineChart width={700} height={360} data={data} margin={{ bottom: 64 }} responsive>
       <CartesianGrid strokeDasharray="3 3" />
       <XAxis dataKey="label" />
       <YAxis />

--- a/www/src/components/GuideView/ZoomAndPan/MinimapExample.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/MinimapExample.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  Minimap,
+  MinimapDrag,
+  MinimapKeyboard,
+  MinimapPinch,
+  MinimapWheel,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZoomAndPan,
+} from 'recharts';
+import { generateMockData } from '@recharts/devtools';
+
+const data = generateMockData(80, 3);
+
+type MinimapPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+type ControlsType = {
+  minimapPosition: MinimapPosition;
+  minimapWheel: boolean;
+  minimapPinch: boolean;
+  globalWheel: boolean;
+};
+
+const defaultState: ControlsType = {
+  minimapPosition: 'bottom-right',
+  minimapWheel: true,
+  minimapPinch: true,
+  globalWheel: true,
+};
+
+export default function MinimapExample(props: Partial<ControlsType>) {
+  const minimapPosition = props.minimapPosition ?? defaultState.minimapPosition;
+  const minimapWheel = props.minimapWheel ?? defaultState.minimapWheel;
+  const minimapPinch = props.minimapPinch ?? defaultState.minimapPinch;
+  const globalWheel = props.globalWheel ?? defaultState.globalWheel;
+
+  return (
+    <LineChart width={700} height={320} data={data} responsive>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey="label" />
+      <YAxis />
+      <Tooltip />
+      <Line type="monotone" dataKey="x" stroke="#8884d8" dot={false} isAnimationActive={false} />
+      <Line type="monotone" dataKey="y" stroke="#82ca9d" dot={false} isAnimationActive={false} />
+      <ZoomAndPan axis="x" initialZoom={{ x: { start: 0.2, end: 0.5 } }} scrollbars={false} wheel={globalWheel} />
+      {/* Drag the rectangle to pan, resize its edges to zoom, click outside it to jump. */}
+      <Minimap
+        axis="x"
+        position={minimapPosition}
+        width={200}
+        height={70}
+        viewportStroke="#1d4ed8"
+        controls={
+          <>
+            <MinimapDrag />
+            <MinimapWheel enabled={minimapWheel} />
+            {minimapPinch && <MinimapPinch />}
+            <MinimapKeyboard />
+          </>
+        }
+      >
+        <LineChart data={data}>
+          <Line type="monotone" dataKey="x" stroke="#8884d8" dot={false} isAnimationActive={false} />
+        </LineChart>
+      </Minimap>
+    </LineChart>
+  );
+}
+
+export function MinimapExampleControls({
+  onChange,
+  sessionStoreValues,
+}: {
+  onChange: (values: ControlsType) => void;
+  sessionStoreValues: ControlsType | null;
+}) {
+  const [state, setState] = React.useState<ControlsType>(sessionStoreValues ?? defaultState);
+
+  const handleChange = (nextValues: Partial<ControlsType>) => {
+    const newState = { ...state, ...nextValues };
+    setState(newState);
+    onChange(newState);
+  };
+
+  React.useEffect(() => {
+    onChange(state);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <form>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <label htmlFor="minimap-position">Minimap position</label>
+            </td>
+            <td style={{ padding: '0 1ex' }}>
+              <select
+                id="minimap-position"
+                value={state.minimapPosition}
+                onChange={e => handleChange({ minimapPosition: e.target.value as MinimapPosition })}
+              >
+                <option value="top-left">Top left</option>
+                <option value="top-right">Top right</option>
+                <option value="bottom-left">Bottom left</option>
+                <option value="bottom-right">Bottom right</option>
+              </select>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="global-wheel">
+                <input
+                  id="global-wheel"
+                  type="checkbox"
+                  checked={state.globalWheel}
+                  onChange={e => handleChange({ globalWheel: e.target.checked })}
+                />
+                {' wheel on chart'}
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="minimap-wheel">
+                <input
+                  id="minimap-wheel"
+                  type="checkbox"
+                  checked={state.minimapWheel}
+                  onChange={e => handleChange({ minimapWheel: e.target.checked })}
+                />
+                {' wheel on minimap'}
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <label htmlFor="minimap-pinch">
+                <input
+                  id="minimap-pinch"
+                  type="checkbox"
+                  checked={state.minimapPinch}
+                  onChange={e => handleChange({ minimapPinch: e.target.checked })}
+                />
+                {' pinch on minimap'}
+              </label>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p style={{ marginTop: '1rem', fontSize: '0.9rem', color: '#666' }}>
+        Drag the rectangle to pan, resize its edges to zoom, click outside to jump. Try disabling &quot;wheel on
+        chart&quot; then test &quot;wheel on minimap&quot; to see the difference.
+      </p>
+    </form>
+  );
+}

--- a/www/src/components/GuideView/ZoomAndPan/QuickStartExample.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/QuickStartExample.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis, ZoomAndPan } from 'recharts';
 import { generateMockData } from '@recharts/devtools';
 

--- a/www/src/components/GuideView/ZoomAndPan/QuickStartExample.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/QuickStartExample.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis, ZoomAndPan } from 'recharts';
+import { generateMockData } from '@recharts/devtools';
+
+const data = generateMockData(60, 7);
+
+export default function QuickStartExample() {
+  return (
+    <LineChart width={700} height={300} data={data} responsive>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey="label" />
+      <YAxis />
+      <Tooltip />
+      <Line type="monotone" dataKey="x" stroke="#8884d8" dot={false} isAnimationActive={false} />
+      <Line type="monotone" dataKey="y" stroke="#82ca9d" dot={false} isAnimationActive={false} />
+      {/* Wheel to zoom, drag to pan, Shift + drag to select, double-click to reset. */}
+      <ZoomAndPan />
+    </LineChart>
+  );
+}

--- a/www/src/components/GuideView/ZoomAndPan/SpecialChartsExample.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/SpecialChartsExample.tsx
@@ -1,0 +1,37 @@
+import { Pie, PieChart, Sankey, Tooltip, ZoomAndPan } from 'recharts';
+
+const pieData = [
+  { name: 'Group A', value: 400 },
+  { name: 'Group B', value: 300 },
+  { name: 'Group C', value: 300 },
+  { name: 'Group D', value: 200 },
+];
+
+const sankeyData = {
+  nodes: [{ name: 'Visit' }, { name: 'Direct' }, { name: 'Referral' }, { name: 'Converted' }],
+  links: [
+    { source: 0, target: 1, value: 60 },
+    { source: 0, target: 2, value: 40 },
+    { source: 1, target: 3, value: 25 },
+    { source: 2, target: 3, value: 22 },
+  ],
+};
+
+/*
+ * Charts without cartesian axes zoom as a camera: wheel over them, drag to pan, double-click to
+ * reset. Centric charts (the pie) zoom uniformly so they keep their aspect ratio.
+ */
+export default function SpecialChartsExample() {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+      <PieChart width={340} height={260} responsive>
+        <Tooltip />
+        <Pie data={pieData} dataKey="value" nameKey="name" outerRadius={90} fill="#8884d8" />
+        <ZoomAndPan scrollbars={false} />
+      </PieChart>
+      <Sankey width={340} height={260} data={sankeyData} zoom={{ scrollbars: false }}>
+        <Tooltip />
+      </Sankey>
+    </div>
+  );
+}

--- a/www/src/components/GuideView/ZoomAndPan/index.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/index.tsx
@@ -1,0 +1,246 @@
+import styles from '../guideTable.module.css';
+import { LinkToApi } from '../../Shared/LinkToApi.tsx';
+
+/**
+ * Guide for the cartesian Zoom & Pan feature.
+ *
+ * Written in the final state (the API as it will be once the whole feature lands), as a spec to work
+ * backwards from. The feature is composable: zoom is off until you opt in, by adding the interaction
+ * components or hooks you want. They all share one normalized per-axis viewport.
+ */
+export function ZoomAndPanGuide() {
+  return (
+    <article>
+      <h1>Zoom &amp; Pan</h1>
+      <p>
+        Recharts can zoom and pan a cartesian chart (<LinkToApi>LineChart</LinkToApi>, <LinkToApi>AreaChart</LinkToApi>,{' '}
+        <LinkToApi>BarChart</LinkToApi>, <LinkToApi>ScatterChart</LinkToApi>, <LinkToApi>ComposedChart</LinkToApi>). It
+        is <strong>off by default</strong> and fully composable: you opt in by adding the interaction components (or
+        hooks) you want, and they all drive one shared, normalized viewport.
+      </p>
+
+      <h2>The viewport</h2>
+      <p>
+        Zoom is described by a <strong>viewport</strong>: how much of each axis is currently visible, as a fraction in{' '}
+        <code>[0, 1]</code> of the axis itself.
+      </p>
+      <pre>{`type AxisWindow = { start: number; end: number }; // 0..1 along the axis
+type Viewport = { x?: AxisWindow; y?: AxisWindow };
+
+// the default (un-zoomed) viewport: the whole chart
+{ x: { start: 0, end: 1 }, y: { start: 0, end: 1 } }
+
+// the right third of the x axis, fully zoomed out on y
+{ x: { start: 0.66, end: 1 } }`}</pre>
+      <p>
+        It is expressed as <strong>fractions of the axis</strong>, not pixels and not data values, on purpose: it stays
+        correct across container resizes, and it applies the same way to linear, time and band (categorical) scales. A
+        fraction can express &quot;show 2&frac12; categories&quot;, which a data-value window cannot, and it allows
+        smooth sub-pixel panning even on a categorical axis. Note that <code>window</code> here is the visible slice of
+        an axis, it has nothing to do with the browser window, and resizing the browser never zooms the chart.
+      </p>
+
+      <h2>Turning it on: interaction components</h2>
+      <p>
+        Add the interactions you want as children of the chart. Each one registers its own handlers and is independently
+        tree-shakeable, so you only ship what you use. Nothing here changes the <LinkToApi>Brush</LinkToApi> or any
+        existing behavior.
+      </p>
+      <pre>{`import {
+  LineChart, XAxis, YAxis, Line,
+  MouseWheelZoom, PanOnDrag, DragToZoom, ZoomPanKeyboard, PinchZoom, ZoomScrollbar,
+} from 'recharts';
+
+<LineChart data={data} width={600} height={300}>
+  <XAxis dataKey="date" />
+  <YAxis />
+  <Line dataKey="value" />
+
+  {/* opt into exactly the interactions you want */}
+  <MouseWheelZoom />
+  <PanOnDrag />
+  <DragToZoom />
+  <ZoomPanKeyboard />
+  <PinchZoom />
+  <ZoomScrollbar axis="x" />
+</LineChart>`}</pre>
+
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Component</th>
+            <th>What it does</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>&lt;MouseWheelZoom /&gt;</code>
+            </td>
+            <td>
+              Wheel / trackpad to zoom around the pointer. <code>Shift</code> pans horizontally,{' '}
+              <code>Ctrl/Cmd + Shift</code> pans vertically.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>&lt;PanOnDrag /&gt;</code>
+            </td>
+            <td>Drag the plot to pan.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>&lt;DragToZoom /&gt;</code>
+            </td>
+            <td>Drag a rectangle to zoom into it (hold a modifier, or use it without panning).</td>
+          </tr>
+          <tr>
+            <td>
+              <code>&lt;ZoomPanKeyboard /&gt;</code>
+            </td>
+            <td>
+              When the chart is focused: <code>+</code>/<code>-</code> zoom, arrow keys pan, <code>Shift</code>+arrows
+              pan faster, <code>0</code>/<code>Esc</code> reset.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>&lt;PinchZoom /&gt;</code>
+            </td>
+            <td>Touch: two-finger pinch to zoom and two-finger drag to pan.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>&lt;AxisZoom axis=&quot;x&quot; /&gt;</code>
+            </td>
+            <td>Wheel or drag directly on an axis band to zoom / pan only that axis.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>&lt;ZoomScrollbar axis=&quot;x&quot; /&gt;</code>
+            </td>
+            <td>An on-canvas scrollbar for a zoomed axis: drag the band to pan.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>&lt;DoubleClickReset /&gt;</code>
+            </td>
+            <td>Double-click (or double-tap) to reset to the full view.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>Common options live on the components, per interaction or shared via context:</p>
+      <pre>{`<MouseWheelZoom axis="x" step={1.15} />   // x only, custom zoom step per notch
+<DragToZoom axis="xy" minZoom={1} maxZoom={25} />
+<ZoomScrollbar axis="y" />`}</pre>
+
+      <h2>Controlled &amp; uncontrolled state</h2>
+      <p>
+        The chart owns the viewport. Leave it alone for an uncontrolled chart, set an initial value, or control it
+        fully.
+      </p>
+      <pre>{`// uncontrolled, with an initial zoom
+<LineChart data={data} defaultZoomViewport={{ x: { start: 0.2, end: 0.6 } }}>
+  <MouseWheelZoom />
+</LineChart>
+
+// controlled: you hold the viewport and update it
+const [viewport, setViewport] = useState({ x: { start: 0.2, end: 0.6 } });
+
+<LineChart data={data} zoomViewport={viewport} onZoomViewportChange={setViewport}>
+  <MouseWheelZoom />
+</LineChart>`}</pre>
+      <p>
+        <code>onZoomViewportChange</code> fires on every change with the new viewport. Because it is the same shape you
+        pass back in, a controlled chart settles without a feedback loop, and you can sync several charts by sharing one
+        viewport.
+      </p>
+
+      <h2>Custom UI &amp; your own gestures</h2>
+      <p>
+        For buttons, sliders, a minimap of your own, or a different gesture library entirely, drop down to the hooks.
+        They read and write the same viewport as the components.
+      </p>
+      <pre>{`import { useZoom } from 'recharts';
+
+function ZoomButtons() {
+  const { zoomIn, zoomOut, reset, isZoomed } = useZoom();
+  return (
+    <div>
+      <button onClick={() => zoomIn()}>+</button>
+      <button onClick={() => zoomOut()}>-</button>
+      <button onClick={reset} disabled={!isZoomed}>Reset</button>
+    </div>
+  );
+}`}</pre>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Hook</th>
+            <th>For</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>useZoom()</code>
+            </td>
+            <td>
+              Read / control the viewport from your own UI:{' '}
+              <code>{`{ viewport, setViewport, zoomIn, zoomOut, pan, reset, isZoomed }`}</code>.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>useMouseWheelZoom()</code>, <code>usePinchZoom()</code>, &hellip;
+            </td>
+            <td>The low-level hooks the components are built on. Use them to wire a gesture onto your own element.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        To bring your own gesture library completely: add none of the built-in interaction components, and drive the
+        chart through controlled <code>zoomViewport</code> + <code>onZoomViewportChange</code> from your library&apos;s
+        handlers. The built-ins are then just a convenient default you can opt out of.
+      </p>
+
+      <h2>Touch</h2>
+      <p>
+        <code>&lt;PinchZoom /&gt;</code> uses two fingers (pinch to zoom, two-finger drag to pan), plus double-tap to
+        reset and double-tap-then-drag to zoom (the &quot;maps&quot; gesture). A single finger is left entirely to the{' '}
+        <LinkToApi>Tooltip</LinkToApi>, so one finger never zooms and there is no conflict. While you interact with the
+        chart it takes over touch handling (<code>touch-action: none</code>) so the page does not scroll and the browser
+        does not pinch-zoom; everything is opt-in, so leave <code>&lt;PinchZoom /&gt;</code> out and touch is untouched.
+      </p>
+
+      <h2>Accessibility</h2>
+      <p>
+        <code>&lt;ZoomPanKeyboard /&gt;</code> makes the chart focusable and pannable from the keyboard. When zoomed,
+        data-point navigation is scoped to the visible window, so you never tab to a point that is off screen.
+        Everything is reachable without a pointer.
+      </p>
+
+      <h2>How it renders</h2>
+      <p>
+        Recharts already maps every datum to a pixel through one per-axis scale (<code>domain → range</code>). Zoom
+        hooks into that single spot: when a window is not full, the axis <strong>range</strong> (the pixel interval the
+        scale maps into) is stretched by <code>1 / windowWidth</code> and shifted so the visible slice fills the plot
+        area. The <strong>domain is left untouched</strong>.
+      </p>
+      <p>
+        Every renderer (line, bar, area, scatter, grid, ticks, reference lines) asks that same scale for positions, so
+        they all zoom automatically, and anything outside the plot area is hidden by the clip path Recharts already
+        applies. Tooltip, cursor and keyboard use the scale&apos;s inverse, derived from the same stretched range, so
+        hit-testing stays consistent. No graphical component needs to know about zoom.
+      </p>
+
+      <h2>Defaults</h2>
+      <p>
+        Zoom and every gesture are <strong>off until you opt in</strong> with a component, hook or prop, and the
+        existing <LinkToApi>Brush</LinkToApi> is unchanged. Enabling anything by default would be a breaking change, so
+        it never happens implicitly.
+      </p>
+    </article>
+  );
+}

--- a/www/src/components/GuideView/ZoomAndPan/index.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/index.tsx
@@ -5,6 +5,18 @@ import QuickStartExample from './QuickStartExample';
 import quickStartExampleSource from './QuickStartExample?raw';
 import CustomControlsExample from './CustomControlsExample';
 import customControlsExampleSource from './CustomControlsExample?raw';
+import MinimapExample, { MinimapExampleControls } from './MinimapExample';
+import minimapExampleSource from './MinimapExample?raw';
+import ComposedInteractionsExample, { ComposedInteractionsExampleControls } from './ComposedInteractionsExample';
+import composedInteractionsExampleSource from './ComposedInteractionsExample?raw';
+import ControlledSyncExample from './ControlledSyncExample';
+import controlledSyncExampleSource from './ControlledSyncExample?raw';
+import AutoScaleFollowExample, { AutoScaleFollowExampleControls } from './AutoScaleFollowExample';
+import autoScaleFollowExampleSource from './AutoScaleFollowExample?raw';
+import SpecialChartsExample from './SpecialChartsExample';
+import specialChartsExampleSource from './SpecialChartsExample?raw';
+import BrushZoomModeExample, { BrushZoomModeExampleControls } from './BrushZoomModeExample';
+import brushZoomModeExampleSource from './BrushZoomModeExample?raw';
 
 /**
  * Guide for the cartesian Zoom & Pan feature.
@@ -60,67 +72,38 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
         sourceCode={quickStartExampleSource}
         stackBlitzTitle="Recharts zoom and pan quick start"
       />
-      <pre>{`import { LineChart, XAxis, YAxis, Line, ZoomAndPan } from 'recharts';
-
-<LineChart data={data} width={600} height={300}>
-  <XAxis dataKey="date" />
-  <YAxis />
-  <Line dataKey="value" />
-  <ZoomAndPan />
-</LineChart>`}</pre>
       <p>
         It takes the same options as the individual interactions, so you can tune it or switch parts off without
         dropping to the granular components:
       </p>
       <pre>{`<ZoomAndPan axis="x" minZoom={1} maxZoom={20} pinch={false} scrollbars={false} />`}</pre>
       <p>
-        As a shorthand, every chart root also accepts a <code>zoom</code> prop that mounts{' '}
-        <code>&lt;ZoomAndPan /&gt;</code> for you. It takes <code>true</code> for the defaults, an axis (
-        <code>&quot;x&quot;</code>, <code>&quot;y&quot;</code>, <code>&quot;xy&quot;</code>) or a full options object:
+        Add <code>&lt;Minimap /&gt;</code> when the chart needs a persistent overview of the full data. Drag the
+        rectangle to pan, resize its edges to zoom, click outside it to jump:
       </p>
-      <pre>{`<LineChart data={data} zoom="x">...</LineChart>
-<BarChart data={data} zoom={{ axis: 'x', maxZoom: 10, scrollbars: false }}>...</BarChart>`}</pre>
-      <p>
-        Add <code>&lt;Minimap /&gt;</code> when the chart needs a persistent overview of the full data:
-      </p>
-      <pre>{`<LineChart data={data} width={600} height={300}>
-  <XAxis dataKey="date" />
-  <YAxis />
-  <Line dataKey="value" />
-  <ZoomAndPan axis="x" />
-  <Minimap axis="x">
-    <LineChart data={data}>
-      <Line dataKey="value" />
-    </LineChart>
-  </Minimap>
-</LineChart>`}</pre>
+      <CodeEditorWithPreview
+        Component={MinimapExample}
+        Controls={MinimapExampleControls}
+        sourceCode={minimapExampleSource}
+        stackBlitzTitle="Recharts zoomed chart with a Minimap"
+        defaultTool="controls"
+      />
 
       <h2>Composing individual interactions</h2>
       <p>
         For exact control over which interactions exist (or to wire your own), drop the bundle and add just the pieces
         you want as children of the chart. Each one registers its own handlers and is independently tree-shakeable, so
         you only ship what you use. The <LinkToApi>Brush</LinkToApi> keeps its existing index-slicing behavior unless
-        you explicitly switch it to <code>mode=&quot;zoom&quot;</code>.
+        you explicitly switch it to <code>mode=&quot;zoom&quot;</code>. Here exactly four interactions are mounted -
+        wheel, drag-to-pan, axis bands and double-click reset - and nothing else (no pinch, no keyboard):
       </p>
-      <pre>{`import {
-  LineChart, XAxis, YAxis, Line,
-  MouseWheelZoom, PanOnDrag, DragToZoom, DragToSelect, ZoomPanKeyboard, PinchZoom, ZoomScrollbar,
-} from 'recharts';
-
-<LineChart data={data} width={600} height={300}>
-  <XAxis dataKey="date" />
-  <YAxis />
-  <Line dataKey="value" />
-
-  {/* opt into exactly the interactions you want */}
-  <MouseWheelZoom />
-  <PanOnDrag />
-  <DragToZoom />
-  <DragToSelect onSelect={selection => setSelectedWindow(selection)} />
-  <ZoomPanKeyboard />
-  <PinchZoom />
-  <ZoomScrollbar axis="x" />
-</LineChart>`}</pre>
+      <CodeEditorWithPreview
+        Component={ComposedInteractionsExample}
+        Controls={ComposedInteractionsExampleControls}
+        sourceCode={composedInteractionsExampleSource}
+        stackBlitzTitle="Recharts composed zoom interactions"
+        defaultTool="controls"
+      />
 
       <table className={styles.table}>
         <thead>
@@ -190,13 +173,23 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
             <td>
               <code>&lt;Minimap /&gt;</code>
             </td>
-            <td>A panorama plus an editable viewport rectangle: drag to pan, resize to zoom, click to jump.</td>
+            <td>
+              A panorama plus an editable viewport rectangle. Its default <code>&lt;MinimapControls /&gt;</code> bundle
+              can be replaced with <code>&lt;MinimapWheel /&gt;</code>, <code>&lt;MinimapDrag /&gt;</code>,{' '}
+              <code>&lt;MinimapPinch /&gt;</code>, <code>&lt;MinimapKeyboard /&gt;</code>, or your own controls. The
+              rectangle always shows the complete viewport; <code>axis</code> only limits what the Minimap controls
+              update.
+            </td>
           </tr>
           <tr>
             <td>
               <code>&lt;Brush mode=&quot;zoom&quot; /&gt;</code>
             </td>
-            <td>Uses the Brush panorama and travellers to edit the zoom viewport instead of slicing data.</td>
+            <td>
+              Uses the Brush panorama and travellers to edit the zoom viewport instead of slicing data. Its default{' '}
+              <code>&lt;BrushZoomControls /&gt;</code> can be replaced with <code>&lt;BrushWheelZoom /&gt;</code>,{' '}
+              <code>&lt;BrushPinchZoom /&gt;</code>, or your own controls.
+            </td>
           </tr>
           <tr>
             <td>
@@ -208,29 +201,21 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
       </table>
 
       <p>Common options live on the components, per interaction or shared via context:</p>
-      <pre>{`<MouseWheelZoom axis="x" step={1.15} panStep={0.0015} />
-<DragToZoom axis="xy" minZoom={1} maxZoom={25} modifier="shift" />
-<DragToSelect onSelect={selection => setSelectedWindow(selection)} />
-<PinchZoom threshold={12} touchDrag="pan" doubleTapDrag="select" onSelect={selection => setSelectedWindow(selection)} />
-<ZoomPanKeyboard panStep={0.1} panFastMultiplier={2.5} />
-<ZoomScrollbar axis="y" thickness={12} thumbClassName="zoom-thumb" />
-<Minimap axis="x" position="bottom-right" width={180} height={80} />
-<Brush mode="zoom" axis="x" autoScaleYDomain />`}</pre>
+      <pre>{`<MouseWheelZoom axis="x" step={1.15} />
+<DragToZoom modifier="shift" minZoom={1} maxZoom={25} />
+<PinchZoom threshold={12} touchDrag="pan" />
+<ZoomScrollbar axis="y" thumbClassName="zoom-thumb" />
+<Minimap axis="x" position="bottom-right" width={180} />
+<Minimap axis="x" controls={<><MinimapDrag /><MinimapWheel /></>} />
+<Brush mode="zoom" axis="x" autoScaleYDomain />
+<Brush mode="zoom" controls={<BrushZoomControls wheel={false} />} />`}</pre>
       <p>
-        <code>step</code> controls zoom speed. <code>panStep</code> controls keyboard or wheel pan distance depending on
-        the component. <code>threshold</code> controls how far fingers must spread before a pinch starts zooming.
-        Scrollbars can be styled with <code>className</code>/<code>style</code> for the track and{' '}
+        <code>step</code> controls zoom speed. <code>threshold</code> controls how far fingers must spread before a
+        pinch starts zooming. Scrollbars can be styled with <code>className</code>/<code>style</code> for the track and{' '}
         <code>thumbClassName</code>/<code>thumbStyle</code> for the thumb. The drag rectangle of{' '}
         <code>&lt;DragToZoom /&gt;</code> / <code>&lt;DragToSelect /&gt;</code> (and <code>&lt;ZoomAndPan /&gt;</code>)
         is styled the same way with <code>selectionClassName</code>/<code>selectionStyle</code>. Both keep stable{' '}
         <code>.recharts-zoom-scrollbar</code> / <code>.recharts-zoom-selection</code> classes for plain CSS or Tailwind.
-      </p>
-      <p>
-        <code>&lt;DragToSelect /&gt;</code> is the single selection component: mouse / pen uses rectangle drag, and
-        touch uses double-tap-then-drag, with both paths calling the same <code>onSelect</code>. If you use the bundled{' '}
-        <code>&lt;ZoomAndPan /&gt;</code> instead, <code>touchDoubleTapDrag=&quot;zoom&quot;</code> keeps the maps-style
-        mobile zoom, while <code>touchDoubleTapDrag=&quot;select&quot;</code> emits the mobile selection through{' '}
-        <code>onTouchSelect</code>.
       </p>
 
       <h2>Controlled &amp; uncontrolled state</h2>
@@ -239,42 +224,36 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
         <code>&lt;ZoomAndPan /&gt;</code> (and any individual interaction component).
       </p>
       <pre>{`// uncontrolled, with an initial zoom
-<LineChart data={data}>
-  <ZoomAndPan initialZoom={{ x: { start: 0.2, end: 0.6 } }} />
-</LineChart>
+<ZoomAndPan initialZoom={{ x: { start: 0.2, end: 0.6 } }} />
 
 // controlled: you hold the viewport and update it
-const [viewport, setViewport] = useState({ x: { start: 0.2, end: 0.6 } });
-
-<LineChart data={data}>
-  <ZoomAndPan viewport={viewport} onZoomChange={setViewport} />
-</LineChart>`}</pre>
+<ZoomAndPan viewport={viewport} onZoomChange={setViewport} />`}</pre>
       <p>
         <code>onZoomChange</code> fires on every change with the new viewport. Because it is the same shape you pass
         back in, a controlled chart settles without a feedback loop, and you can sync several charts by sharing one
-        viewport.
+        viewport - zoom or pan either chart below and the other follows:
       </p>
+      <CodeEditorWithPreview
+        Component={ControlledSyncExample}
+        sourceCode={controlledSyncExampleSource}
+        stackBlitzTitle="Recharts synced zoom across two charts"
+      />
 
       <h2>Auto-scaling, follow &amp; level of detail</h2>
       <p>
         A few headless helpers react to the viewport. <code>&lt;AutoScaleAxis /&gt;</code> re-fits the value axis to the
-        data visible in the current window as you pan or zoom; <code>&lt;FollowSeries /&gt;</code> keeps one series
-        vertically centred while panning (optionally auto-scaling the span around it); and <code>useScatterLOD</code>{' '}
-        decimates dense scatter data against the zoomed scales, so you draw fewer points when zoomed out and reveal more
-        detail as you zoom in.
+        data visible in the current window as you pan or zoom - zoom into a slice of x below, then pan, and watch the y
+        axis re-fit; <code>&lt;FollowSeries /&gt;</code> keeps one series vertically centred while panning (optionally
+        auto-scaling the span around it); and <code>useScatterLOD</code> decimates dense scatter data against the zoomed
+        scales, so you draw fewer points when zoomed out and reveal more detail as you zoom in.
       </p>
-      <pre>{`<LineChart data={data}>
-  <Line dataKey="value" />
-  <MouseWheelZoom axis="x" />
-  <AutoScaleAxis />                     {/* fit the value axis to the visible window */}
-  {/* or keep one series centred: <FollowSeries dataKey="value" autoScale /> */}
-</LineChart>
-
-// dense scatter: roughly one point per cell, more as you zoom in
-function Points() {
-  const lod = useScatterLOD(bigData, { x: 'x', y: 'y' });
-  return <Scatter data={lod} />;
-}`}</pre>
+      <CodeEditorWithPreview
+        Component={AutoScaleFollowExample}
+        Controls={AutoScaleFollowExampleControls}
+        sourceCode={autoScaleFollowExampleSource}
+        stackBlitzTitle="Recharts auto-scaling y while zooming x"
+        defaultTool="controls"
+      />
       <p>
         Both helpers are layout-aware: they fit / re-centre the <em>value</em> axis, which is y in a horizontal layout
         and x in a vertical one (where the categories run along y). Pass an explicit <code>axis</code> to{' '}
@@ -290,15 +269,11 @@ function Points() {
         and radial charts zoom uniformly so they keep their aspect ratio. The exact same gestures, options, controlled
         state and <code>useZoom()</code> hook apply.
       </p>
-      <pre>{`<PieChart width={400} height={300}>
-  <Pie data={data} dataKey="value" />
-  <ZoomAndPan />
-</PieChart>
-
-<Sankey width={600} height={300} data={sankeyData}>
-  {/* one-finger drag pans on touch - handy for maps-like exploration */}
-  <ZoomAndPan touchDrag="pan" />
-</Sankey>`}</pre>
+      <CodeEditorWithPreview
+        Component={SpecialChartsExample}
+        sourceCode={specialChartsExampleSource}
+        stackBlitzTitle="Recharts camera zoom on polar and standalone charts"
+      />
       <p>
         Tooltips stay attached to their items while zoomed (active coordinates are mapped through the same transform),
         and content outside the plot area is clipped only while actually zoomed. Axis-band gestures and scrollbars that
@@ -323,8 +298,17 @@ function Points() {
         They meet in <code>&lt;Brush mode=&quot;zoom&quot;&gt;</code>: the familiar Brush UI (travellers, panorama)
         editing the range-driven viewport instead of slicing, in sync with every other zoom control. Use classic Brush
         when stepping through whole data windows is the point; use the zoom viewport when you want smooth, gesture-led
-        exploration; use Brush zoom mode when you want both.
+        exploration; use Brush zoom mode when you want both. Drag the travellers below, wheel over the rail, or zoom the
+        plot itself - they edit the same viewport. To customize the Brush gestures, replace its default{' '}
+        <code>&lt;BrushZoomControls /&gt;</code> bundle through the <code>controls</code> prop:
       </p>
+      <CodeEditorWithPreview
+        Component={BrushZoomModeExample}
+        Controls={BrushZoomModeExampleControls}
+        sourceCode={brushZoomModeExampleSource}
+        stackBlitzTitle="Recharts Brush in zoom mode"
+        defaultTool="controls"
+      />
 
       <h2>Custom UI &amp; your own gestures</h2>
       <p>
@@ -341,18 +325,6 @@ function Points() {
         sourceCode={customControlsExampleSource}
         stackBlitzTitle="Recharts custom zoom controls"
       />
-      <pre>{`import { useZoom } from 'recharts';
-
-function ZoomButtons() {
-  const { zoomIn, zoomOut, reset, isZoomed } = useZoom();
-  return (
-    <div>
-      <button onClick={() => zoomIn()}>+</button>
-      <button onClick={() => zoomOut()}>-</button>
-      <button onClick={reset} disabled={!isZoomed}>Reset</button>
-    </div>
-  );
-}`}</pre>
       <table className={styles.table}>
         <thead>
           <tr>
@@ -372,16 +344,25 @@ function ZoomButtons() {
           </tr>
           <tr>
             <td>
-              <code>useMouseWheelZoom()</code>, <code>usePinchZoom()</code>, &hellip;
+              <code>useMinimapControls()</code>
             </td>
-            <td>The low-level hooks the components are built on. Use them to wire a gesture onto your own element.</td>
+            <td>
+              Build custom Minimap controls against the same viewport rectangle, hit testing, and overlay node used by
+              the built-in Minimap controls.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>useBrushZoomControls()</code>
+            </td>
+            <td>Build custom Brush zoom-mode gestures on top of the Brush rail geometry and shared zoom state.</td>
           </tr>
         </tbody>
       </table>
       <p>
         To bring your own gesture library completely: add none of the built-in interaction components, and drive the
         viewport from your library&apos;s handlers through <code>useZoom()</code> (or a controlled{' '}
-        <code>&lt;ZoomAndPan /&gt;</code>). The built-ins are then just a convenient default you can opt out of.
+        <code>&lt;ZoomAndPan /&gt;</code>).
       </p>
 
       <h2>Touch</h2>
@@ -394,16 +375,9 @@ function ZoomButtons() {
         By default a single finger is left to the <LinkToApi>Tooltip</LinkToApi> / cursor: dragging moves the active
         data point, and a tap sets it. Set <code>touchDrag=&quot;pan&quot;</code> (on <code>&lt;PinchZoom /&gt;</code>{' '}
         or <code>&lt;ZoomAndPan /&gt;</code>) to make a one-finger drag pan the chart instead; a plain tap still updates
-        the tooltip/cursor at that position, so you never lose the ability to inspect a data point. This is useful on
-        dashboards where scrolling is handled by the page and the chart needs to feel &ldquo;grabbable&rdquo;.
+        the tooltip/cursor at that position, so you never lose the ability to inspect a data point.
       </p>
-      <pre>{`// default: one-finger drag moves the tooltip cursor
-<PinchZoom />
-
-// one-finger drag pans instead; tap still sets the tooltip
-<PinchZoom touchDrag="pan" />
-
-// same option on the bundle component
+      <pre>{`<PinchZoom touchDrag="pan" />
 <ZoomAndPan touchDrag="pan" />`}</pre>
       <p>
         While you interact with the chart it takes over touch handling (<code>touch-action: none</code>) so the page

--- a/www/src/components/GuideView/ZoomAndPan/index.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/index.tsx
@@ -1,5 +1,10 @@
 import styles from '../guideTable.module.css';
 import { LinkToApi } from '../../Shared/LinkToApi.tsx';
+import { CodeEditorWithPreview } from '../../CodeEditorWithPreview';
+import QuickStartExample from './QuickStartExample';
+import quickStartExampleSource from './QuickStartExample?raw';
+import CustomControlsExample from './CustomControlsExample';
+import customControlsExampleSource from './CustomControlsExample?raw';
 
 /**
  * Guide for the cartesian Zoom & Pan feature.
@@ -47,8 +52,14 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
       <h2>Quick start</h2>
       <p>
         For the usual experience in one line, add <code>&lt;ZoomAndPan /&gt;</code>. It bundles the sensible defaults:
-        wheel zoom, drag to pan, pinch, keyboard, double-click reset and scrollbars.
+        wheel zoom, drag to pan, pinch, keyboard, double-click reset and scrollbars. Try it: wheel over the chart, drag
+        to pan, double-click to reset.
       </p>
+      <CodeEditorWithPreview
+        Component={QuickStartExample}
+        sourceCode={quickStartExampleSource}
+        stackBlitzTitle="Recharts zoom and pan quick start"
+      />
       <pre>{`import { LineChart, XAxis, YAxis, Line, ZoomAndPan } from 'recharts';
 
 <LineChart data={data} width={600} height={300}>
@@ -294,11 +305,42 @@ function Points() {
         require a cartesian axis are automatically disabled on these charts; everything else works unchanged.
       </p>
 
+      <h2>Brush or ZoomAndPan?</h2>
+      <p>Recharts now has two ways to show a slice of the data, and both are valid:</p>
+      <ul>
+        <li>
+          <LinkToApi>Brush</LinkToApi> in its classic mode is <strong>domain-driven</strong>: it slices the data to an
+          index window (<code>startIndex</code>/<code>endIndex</code>), the axes re-fit to the visible slice, and the
+          rest of the data is simply not rendered. Whole categories enter and leave the view.
+        </li>
+        <li>
+          <code>ZoomAndPan</code> is <strong>range-driven</strong>: the data and domain stay untouched and the axis
+          range is stretched instead, so panning is continuous (including sub-category positions) and every gesture maps
+          to the same normalized viewport.
+        </li>
+      </ul>
+      <p>
+        They meet in <code>&lt;Brush mode=&quot;zoom&quot;&gt;</code>: the familiar Brush UI (travellers, panorama)
+        editing the range-driven viewport instead of slicing, in sync with every other zoom control. Use classic Brush
+        when stepping through whole data windows is the point; use the zoom viewport when you want smooth, gesture-led
+        exploration; use Brush zoom mode when you want both.
+      </p>
+
       <h2>Custom UI &amp; your own gestures</h2>
       <p>
         For buttons, sliders, a minimap of your own, or a different gesture library entirely, drop down to the hooks.
-        They read and write the same viewport as the components.
+        They read and write the same viewport as the components: <code>useZoom()</code> gives you the viewport plus
+        zoomIn/zoomOut/pan/reset helpers, and <code>useZoomState()</code> is the same state as a <code>useState</code>
+        -shaped tuple (<code>const [zoom, setZoom] = useZoomState()</code>). Every built-in consumer (
+        <code>ZoomAndPan</code>, the granular components, <code>Minimap</code>, <code>Brush mode=&quot;zoom&quot;</code>
+        ) reads and writes that same state, so custom controls stay in sync with all of them. In this example no
+        interaction component is mounted; the buttons are the only way to zoom:
       </p>
+      <CodeEditorWithPreview
+        Component={CustomControlsExample}
+        sourceCode={customControlsExampleSource}
+        stackBlitzTitle="Recharts custom zoom controls"
+      />
       <pre>{`import { useZoom } from 'recharts';
 
 function ZoomButtons() {

--- a/www/src/components/GuideView/ZoomAndPan/index.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/index.tsx
@@ -156,23 +156,23 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
 
       <h2>Controlled &amp; uncontrolled state</h2>
       <p>
-        The chart owns the viewport. Leave it alone for an uncontrolled chart, set an initial value, or control it
-        fully.
+        Leave it alone for an uncontrolled chart, set an initial value, or control it fully. These live on{' '}
+        <code>&lt;ZoomAndPan /&gt;</code> (and any individual interaction component).
       </p>
       <pre>{`// uncontrolled, with an initial zoom
-<LineChart data={data} defaultZoomViewport={{ x: { start: 0.2, end: 0.6 } }}>
-  <MouseWheelZoom />
+<LineChart data={data}>
+  <ZoomAndPan initialZoom={{ x: { start: 0.2, end: 0.6 } }} />
 </LineChart>
 
 // controlled: you hold the viewport and update it
 const [viewport, setViewport] = useState({ x: { start: 0.2, end: 0.6 } });
 
-<LineChart data={data} zoomViewport={viewport} onZoomViewportChange={setViewport}>
-  <MouseWheelZoom />
+<LineChart data={data}>
+  <ZoomAndPan viewport={viewport} onZoomChange={setViewport} />
 </LineChart>`}</pre>
       <p>
-        <code>onZoomViewportChange</code> fires on every change with the new viewport. Because it is the same shape you
-        pass back in, a controlled chart settles without a feedback loop, and you can sync several charts by sharing one
+        <code>onZoomChange</code> fires on every change with the new viewport. Because it is the same shape you pass
+        back in, a controlled chart settles without a feedback loop, and you can sync several charts by sharing one
         viewport.
       </p>
 
@@ -220,8 +220,8 @@ function ZoomButtons() {
       </table>
       <p>
         To bring your own gesture library completely: add none of the built-in interaction components, and drive the
-        chart through controlled <code>zoomViewport</code> + <code>onZoomViewportChange</code> from your library&apos;s
-        handlers. The built-ins are then just a convenient default you can opt out of.
+        viewport from your library&apos;s handlers through <code>useZoom()</code> (or a controlled{' '}
+        <code>&lt;ZoomAndPan /&gt;</code>). The built-ins are then just a convenient default you can opt out of.
       </p>
 
       <h2>Touch</h2>

--- a/www/src/components/GuideView/ZoomAndPan/index.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/index.tsx
@@ -14,9 +14,13 @@ export function ZoomAndPanGuide() {
       <h1>Zoom &amp; Pan</h1>
       <p>
         Recharts can zoom and pan a cartesian chart (<LinkToApi>LineChart</LinkToApi>, <LinkToApi>AreaChart</LinkToApi>,{' '}
-        <LinkToApi>BarChart</LinkToApi>, <LinkToApi>ScatterChart</LinkToApi>, <LinkToApi>ComposedChart</LinkToApi>). It
-        is <strong>off by default</strong> and fully composable: you opt in by adding the interaction components (or
-        hooks) you want, and they all drive one shared, normalized viewport.
+        <LinkToApi>BarChart</LinkToApi>, <LinkToApi>ScatterChart</LinkToApi>, <LinkToApi>ComposedChart</LinkToApi>) in
+        both horizontal and vertical layouts, and non-cartesian charts too (<LinkToApi>PieChart</LinkToApi>,{' '}
+        <LinkToApi>RadarChart</LinkToApi>, <LinkToApi>RadialBarChart</LinkToApi>, <LinkToApi>FunnelChart</LinkToApi>,{' '}
+        <LinkToApi>Sankey</LinkToApi>, <LinkToApi>SunburstChart</LinkToApi>, <LinkToApi>Treemap</LinkToApi> — see{' '}
+        <a href="#special-charts">Polar &amp; standalone charts</a>). It is <strong>off by default</strong> and fully
+        composable: you opt in by adding the interaction components (or hooks) you want, and they all drive one shared,
+        normalized viewport.
       </p>
 
       <h2>The viewport</h2>
@@ -58,16 +62,38 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
         dropping to the granular components:
       </p>
       <pre>{`<ZoomAndPan axis="x" minZoom={1} maxZoom={20} pinch={false} scrollbars={false} />`}</pre>
+      <p>
+        As a shorthand, every chart root also accepts a <code>zoom</code> prop that mounts{' '}
+        <code>&lt;ZoomAndPan /&gt;</code> for you. It takes <code>true</code> for the defaults, an axis (
+        <code>&quot;x&quot;</code>, <code>&quot;y&quot;</code>, <code>&quot;xy&quot;</code>) or a full options object:
+      </p>
+      <pre>{`<LineChart data={data} zoom="x">...</LineChart>
+<BarChart data={data} zoom={{ axis: 'x', maxZoom: 10, scrollbars: false }}>...</BarChart>`}</pre>
+      <p>
+        Add <code>&lt;Minimap /&gt;</code> when the chart needs a persistent overview of the full data:
+      </p>
+      <pre>{`<LineChart data={data} width={600} height={300}>
+  <XAxis dataKey="date" />
+  <YAxis />
+  <Line dataKey="value" />
+  <ZoomAndPan axis="x" />
+  <Minimap axis="x">
+    <LineChart data={data}>
+      <Line dataKey="value" />
+    </LineChart>
+  </Minimap>
+</LineChart>`}</pre>
 
       <h2>Composing individual interactions</h2>
       <p>
         For exact control over which interactions exist (or to wire your own), drop the bundle and add just the pieces
         you want as children of the chart. Each one registers its own handlers and is independently tree-shakeable, so
-        you only ship what you use. Nothing here changes the <LinkToApi>Brush</LinkToApi> or any existing behavior.
+        you only ship what you use. The <LinkToApi>Brush</LinkToApi> keeps its existing index-slicing behavior unless
+        you explicitly switch it to <code>mode=&quot;zoom&quot;</code>.
       </p>
       <pre>{`import {
   LineChart, XAxis, YAxis, Line,
-  MouseWheelZoom, PanOnDrag, DragToZoom, ZoomPanKeyboard, PinchZoom, ZoomScrollbar,
+  MouseWheelZoom, PanOnDrag, DragToZoom, DragToSelect, ZoomPanKeyboard, PinchZoom, ZoomScrollbar,
 } from 'recharts';
 
 <LineChart data={data} width={600} height={300}>
@@ -79,6 +105,7 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
   <MouseWheelZoom />
   <PanOnDrag />
   <DragToZoom />
+  <DragToSelect onSelect={selection => setSelectedWindow(selection)} />
   <ZoomPanKeyboard />
   <PinchZoom />
   <ZoomScrollbar axis="x" />
@@ -115,6 +142,14 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
           </tr>
           <tr>
             <td>
+              <code>&lt;DragToSelect /&gt;</code>
+            </td>
+            <td>
+              Drag a rectangle and receive the selected viewport window in <code>onSelect</code> without changing zoom.
+            </td>
+          </tr>
+          <tr>
+            <td>
               <code>&lt;ZoomPanKeyboard /&gt;</code>
             </td>
             <td>
@@ -142,6 +177,18 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
           </tr>
           <tr>
             <td>
+              <code>&lt;Minimap /&gt;</code>
+            </td>
+            <td>A panorama plus an editable viewport rectangle: drag to pan, resize to zoom, click to jump.</td>
+          </tr>
+          <tr>
+            <td>
+              <code>&lt;Brush mode=&quot;zoom&quot; /&gt;</code>
+            </td>
+            <td>Uses the Brush panorama and travellers to edit the zoom viewport instead of slicing data.</td>
+          </tr>
+          <tr>
+            <td>
               <code>&lt;DoubleClickReset /&gt;</code>
             </td>
             <td>Double-click (or double-tap) to reset to the full view.</td>
@@ -150,9 +197,30 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
       </table>
 
       <p>Common options live on the components, per interaction or shared via context:</p>
-      <pre>{`<MouseWheelZoom axis="x" step={1.15} />   // x only, custom zoom step per notch
-<DragToZoom axis="xy" minZoom={1} maxZoom={25} />
-<ZoomScrollbar axis="y" />`}</pre>
+      <pre>{`<MouseWheelZoom axis="x" step={1.15} panStep={0.0015} />
+<DragToZoom axis="xy" minZoom={1} maxZoom={25} modifier="shift" />
+<DragToSelect onSelect={selection => setSelectedWindow(selection)} />
+<PinchZoom threshold={12} touchDrag="pan" doubleTapDrag="select" onSelect={selection => setSelectedWindow(selection)} />
+<ZoomPanKeyboard panStep={0.1} panFastMultiplier={2.5} />
+<ZoomScrollbar axis="y" thickness={12} thumbClassName="zoom-thumb" />
+<Minimap axis="x" position="bottom-right" width={180} height={80} />
+<Brush mode="zoom" axis="x" autoScaleYDomain />`}</pre>
+      <p>
+        <code>step</code> controls zoom speed. <code>panStep</code> controls keyboard or wheel pan distance depending on
+        the component. <code>threshold</code> controls how far fingers must spread before a pinch starts zooming.
+        Scrollbars can be styled with <code>className</code>/<code>style</code> for the track and{' '}
+        <code>thumbClassName</code>/<code>thumbStyle</code> for the thumb. The drag rectangle of{' '}
+        <code>&lt;DragToZoom /&gt;</code> / <code>&lt;DragToSelect /&gt;</code> (and <code>&lt;ZoomAndPan /&gt;</code>)
+        is styled the same way with <code>selectionClassName</code>/<code>selectionStyle</code>. Both keep stable{' '}
+        <code>.recharts-zoom-scrollbar</code> / <code>.recharts-zoom-selection</code> classes for plain CSS or Tailwind.
+      </p>
+      <p>
+        <code>&lt;DragToSelect /&gt;</code> is the single selection component: mouse / pen uses rectangle drag, and
+        touch uses double-tap-then-drag, with both paths calling the same <code>onSelect</code>. If you use the bundled{' '}
+        <code>&lt;ZoomAndPan /&gt;</code> instead, <code>touchDoubleTapDrag=&quot;zoom&quot;</code> keeps the maps-style
+        mobile zoom, while <code>touchDoubleTapDrag=&quot;select&quot;</code> emits the mobile selection through{' '}
+        <code>onTouchSelect</code>.
+      </p>
 
       <h2>Controlled &amp; uncontrolled state</h2>
       <p>
@@ -174,6 +242,56 @@ const [viewport, setViewport] = useState({ x: { start: 0.2, end: 0.6 } });
         <code>onZoomChange</code> fires on every change with the new viewport. Because it is the same shape you pass
         back in, a controlled chart settles without a feedback loop, and you can sync several charts by sharing one
         viewport.
+      </p>
+
+      <h2>Auto-scaling, follow &amp; level of detail</h2>
+      <p>
+        A few headless helpers react to the viewport. <code>&lt;AutoScaleAxis /&gt;</code> re-fits the value axis to the
+        data visible in the current window as you pan or zoom; <code>&lt;FollowSeries /&gt;</code> keeps one series
+        vertically centred while panning (optionally auto-scaling the span around it); and <code>useScatterLOD</code>{' '}
+        decimates dense scatter data against the zoomed scales, so you draw fewer points when zoomed out and reveal more
+        detail as you zoom in.
+      </p>
+      <pre>{`<LineChart data={data}>
+  <Line dataKey="value" />
+  <MouseWheelZoom axis="x" />
+  <AutoScaleAxis />                     {/* fit the value axis to the visible window */}
+  {/* or keep one series centred: <FollowSeries dataKey="value" autoScale /> */}
+</LineChart>
+
+// dense scatter: roughly one point per cell, more as you zoom in
+function Points() {
+  const lod = useScatterLOD(bigData, { x: 'x', y: 'y' });
+  return <Scatter data={lod} />;
+}`}</pre>
+      <p>
+        Both helpers are layout-aware: they fit / re-centre the <em>value</em> axis, which is y in a horizontal layout
+        and x in a vertical one (where the categories run along y). Pass an explicit <code>axis</code> to{' '}
+        <code>&lt;AutoScaleAxis /&gt;</code> to override.
+      </p>
+
+      <h2 id="special-charts">Polar &amp; standalone charts</h2>
+      <p>
+        Charts without cartesian axes — <LinkToApi>PieChart</LinkToApi>, <LinkToApi>RadarChart</LinkToApi>,{' '}
+        <LinkToApi>RadialBarChart</LinkToApi>, <LinkToApi>FunnelChart</LinkToApi>, <LinkToApi>Sankey</LinkToApi>,{' '}
+        <LinkToApi>SunburstChart</LinkToApi> and <LinkToApi>Treemap</LinkToApi> — zoom as a <strong>camera</strong>:
+        instead of stretching axis ranges, the plot content is scaled and translated under the same viewport. Centric
+        and radial charts zoom uniformly so they keep their aspect ratio. The exact same gestures, options, controlled
+        state and <code>useZoom()</code> hook apply.
+      </p>
+      <pre>{`<PieChart width={400} height={300}>
+  <Pie data={data} dataKey="value" />
+  <ZoomAndPan />
+</PieChart>
+
+<Sankey width={600} height={300} data={sankeyData}>
+  {/* one-finger drag pans on touch - handy for maps-like exploration */}
+  <ZoomAndPan touchDrag="pan" />
+</Sankey>`}</pre>
+      <p>
+        Tooltips stay attached to their items while zoomed (active coordinates are mapped through the same transform),
+        and content outside the plot area is clipped only while actually zoomed. Axis-band gestures and scrollbars that
+        require a cartesian axis are automatically disabled on these charts; everything else works unchanged.
       </p>
 
       <h2>Custom UI &amp; your own gestures</h2>
@@ -227,10 +345,28 @@ function ZoomButtons() {
       <h2>Touch</h2>
       <p>
         <code>&lt;PinchZoom /&gt;</code> uses two fingers (pinch to zoom, two-finger drag to pan), plus double-tap to
-        reset and double-tap-then-drag to zoom (the &quot;maps&quot; gesture). A single finger is left entirely to the{' '}
-        <LinkToApi>Tooltip</LinkToApi>, so one finger never zooms and there is no conflict. While you interact with the
-        chart it takes over touch handling (<code>touch-action: none</code>) so the page does not scroll and the browser
-        does not pinch-zoom; everything is opt-in, so leave <code>&lt;PinchZoom /&gt;</code> out and touch is untouched.
+        reset. Double-tap-then-drag defaults to zooming (the &quot;maps&quot; gesture), and can instead select a window
+        when configured with <code>doubleTapDrag=&quot;select&quot;</code>.
+      </p>
+      <p>
+        By default a single finger is left to the <LinkToApi>Tooltip</LinkToApi> / cursor: dragging moves the active
+        data point, and a tap sets it. Set <code>touchDrag=&quot;pan&quot;</code> (on <code>&lt;PinchZoom /&gt;</code>{' '}
+        or <code>&lt;ZoomAndPan /&gt;</code>) to make a one-finger drag pan the chart instead; a plain tap still updates
+        the tooltip/cursor at that position, so you never lose the ability to inspect a data point. This is useful on
+        dashboards where scrolling is handled by the page and the chart needs to feel &ldquo;grabbable&rdquo;.
+      </p>
+      <pre>{`// default: one-finger drag moves the tooltip cursor
+<PinchZoom />
+
+// one-finger drag pans instead; tap still sets the tooltip
+<PinchZoom touchDrag="pan" />
+
+// same option on the bundle component
+<ZoomAndPan touchDrag="pan" />`}</pre>
+      <p>
+        While you interact with the chart it takes over touch handling (<code>touch-action: none</code>) so the page
+        does not scroll and the browser does not pinch-zoom; everything is opt-in, so leave{' '}
+        <code>&lt;PinchZoom /&gt;</code> out and touch is untouched.
       </p>
 
       <h2>Accessibility</h2>
@@ -256,9 +392,10 @@ function ZoomButtons() {
 
       <h2>Defaults</h2>
       <p>
-        Zoom and every gesture are <strong>off until you opt in</strong> with a component, hook or prop, and the
-        existing <LinkToApi>Brush</LinkToApi> is unchanged. Enabling anything by default would be a breaking change, so
-        it never happens implicitly.
+        Zoom and every gesture are <strong>off until you opt in</strong> with a component, hook or prop. The existing{' '}
+        <LinkToApi>Brush</LinkToApi> remains <code>mode=&quot;slice&quot;</code> by default, and zoom coupling is only
+        enabled with <code>mode=&quot;zoom&quot;</code>. Enabling anything by default would be a breaking change, so it
+        never happens implicitly.
       </p>
     </article>
   );

--- a/www/src/components/GuideView/ZoomAndPan/index.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/index.tsx
@@ -195,7 +195,7 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
             <td>
               <code>&lt;DoubleClickReset /&gt;</code>
             </td>
-            <td>Double-click (or double-tap) to reset to the full view.</td>
+            <td>Double-click to reset to the configured zoom floor.</td>
           </tr>
         </tbody>
       </table>
@@ -221,7 +221,8 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
       <h2>Controlled &amp; uncontrolled state</h2>
       <p>
         Leave it alone for an uncontrolled chart, set an initial value, or control it fully. These live on{' '}
-        <code>&lt;ZoomAndPan /&gt;</code> (and any individual interaction component).
+        <code>&lt;ZoomAndPan /&gt;</code>. Individual interaction components expose gesture, axis, and limit props; use{' '}
+        <code>&lt;ZoomAndPan /&gt;</code> when you need controlled viewport props.
       </p>
       <pre>{`// uncontrolled, with an initial zoom
 <ZoomAndPan initialZoom={{ x: { start: 0.2, end: 0.6 } }} />
@@ -380,9 +381,9 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
       <pre>{`<PinchZoom touchDrag="pan" />
 <ZoomAndPan touchDrag="pan" />`}</pre>
       <p>
-        While you interact with the chart it takes over touch handling (<code>touch-action: none</code>) so the page
-        does not scroll and the browser does not pinch-zoom; everything is opt-in, so leave{' '}
-        <code>&lt;PinchZoom /&gt;</code> out and touch is untouched.
+        Pinch, axis, and scrollbar gestures prevent the browser from claiming the active gesture; one-finger plot
+        scrolling is preserved unless you opt into <code>touchDrag=&quot;pan&quot;</code>. Everything is opt-in, so
+        leave <code>&lt;PinchZoom /&gt;</code> out and touch is untouched.
       </p>
 
       <h2>Accessibility</h2>

--- a/www/src/components/GuideView/ZoomAndPan/index.tsx
+++ b/www/src/components/GuideView/ZoomAndPan/index.tsx
@@ -40,11 +40,30 @@ type Viewport = { x?: AxisWindow; y?: AxisWindow };
         an axis, it has nothing to do with the browser window, and resizing the browser never zooms the chart.
       </p>
 
-      <h2>Turning it on: interaction components</h2>
+      <h2>Quick start</h2>
       <p>
-        Add the interactions you want as children of the chart. Each one registers its own handlers and is independently
-        tree-shakeable, so you only ship what you use. Nothing here changes the <LinkToApi>Brush</LinkToApi> or any
-        existing behavior.
+        For the usual experience in one line, add <code>&lt;ZoomAndPan /&gt;</code>. It bundles the sensible defaults:
+        wheel zoom, drag to pan, pinch, keyboard, double-click reset and scrollbars.
+      </p>
+      <pre>{`import { LineChart, XAxis, YAxis, Line, ZoomAndPan } from 'recharts';
+
+<LineChart data={data} width={600} height={300}>
+  <XAxis dataKey="date" />
+  <YAxis />
+  <Line dataKey="value" />
+  <ZoomAndPan />
+</LineChart>`}</pre>
+      <p>
+        It takes the same options as the individual interactions, so you can tune it or switch parts off without
+        dropping to the granular components:
+      </p>
+      <pre>{`<ZoomAndPan axis="x" minZoom={1} maxZoom={20} pinch={false} scrollbars={false} />`}</pre>
+
+      <h2>Composing individual interactions</h2>
+      <p>
+        For exact control over which interactions exist (or to wire your own), drop the bundle and add just the pieces
+        you want as children of the chart. Each one registers its own handlers and is independently tree-shakeable, so
+        you only ship what you use. Nothing here changes the <LinkToApi>Brush</LinkToApi> or any existing behavior.
       </p>
       <pre>{`import {
   LineChart, XAxis, YAxis, Line,

--- a/www/src/locale/en-US.ts
+++ b/www/src/locale/en-US.ts
@@ -50,6 +50,7 @@ export const map = {
     cell: 'Migrate from Cell component to shape prop',
     coordinateSystems: 'Coordinate and dimension systems',
     animations: 'Animation',
+    zoomAndPan: 'Zoom & Pan',
   },
   installation: {
     installation: 'Installation',

--- a/www/src/locale/zh-CN.ts
+++ b/www/src/locale/zh-CN.ts
@@ -50,6 +50,7 @@ export const map = {
     cell: '从 Cell 组件迁移到 shape 属性',
     coordinateSystems: '坐标系与维度系统',
     animations: '动画',
+    zoomAndPan: '缩放和平移',
   },
   installation: {
     installation: '安装',

--- a/www/src/navigation.data.ts
+++ b/www/src/navigation.data.ts
@@ -24,6 +24,7 @@ const guidePages = [
   'barAlignment',
   'cell',
   'animations',
+  'zoomAndPan',
 ];
 
 export function getSiteRoutes(): string[] {

--- a/www/src/views/GuideView.tsx
+++ b/www/src/views/GuideView.tsx
@@ -20,6 +20,7 @@ import { RoundedBars } from '../components/GuideView/RoundedBars';
 import { BarAlign } from '../components/GuideView/BarAlign';
 import { CellDeprecationNotice } from '../components/GuideView/CellDeprecationNotice';
 import { AnimationsGuide } from '../components/GuideView/Animations';
+import { ZoomAndPanGuide } from '../components/GuideView/ZoomAndPan';
 
 const guideMap: Record<string, ComponentType<{ locale: SupportedLocale }>> = {
   installation: Installation,
@@ -37,6 +38,7 @@ const guideMap: Record<string, ComponentType<{ locale: SupportedLocale }>> = {
   cell: CellDeprecationNotice,
   typescript: TypeScript,
   animations: AnimationsGuide,
+  zoomAndPan: ZoomAndPanGuide,
 };
 
 export const allGuides = Object.keys(guideMap);


### PR DESCRIPTION
Per the discussion on #7410, this ports the zoom/pan documentation from the Storybook story into a proper **website guide** (following `.github/skills/guide/SKILL.md`), as its own PR so the API can be discussed in parallel with the small state-change PRs.

It is written in the **final state** (the API as it will be once the whole feature lands), to work backwards from, as you suggested.

### What it covers
- The normalized per-axis **viewport** (`{ x?, y? }`, each a `[0, 1]` window of the axis), and why fractions rather than pixels or data values (resize-stable, and works the same for linear / time / band scales).
- A **composable, opt-in API**: interaction components you add as children, each tree-shakeable: `<MouseWheelZoom/>`, `<PanOnDrag/>`, `<DragToZoom/>`, `<ZoomPanKeyboard/>`, `<PinchZoom/>`, `<AxisZoom/>`, `<ZoomScrollbar/>`, `<DoubleClickReset/>`.
- **Controlled & uncontrolled** state (`zoomViewport` / `onZoomViewportChange` / `defaultZoomViewport`).
- **Custom UI / bring-your-own gestures** via a `useZoom()` hook and the low-level per-gesture hooks the components are built on.
- Touch, accessibility (keyboard navigation scoped to the visible window when zoomed), and the **off-by-default** guarantee (nothing zooms until you opt in; the existing Brush is unchanged).
- How it renders: stretch the axis **range** (not the domain) at one selector, so every renderer zooms automatically and nothing needs to learn about zoom.

This is a **proposal for the public API**; naming and granularity are open for discussion, which is exactly what this PR is for. The "Roadmap" section from the old story is intentionally dropped.

Refs #7410.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full Zoom & Pan guide covering overview, quick-start, composing interactions, controlled vs uncontrolled modes, auto-scaling/LOD helpers, custom UI/gesture hooks, touch and keyboard behavior, and rendering semantics.
* **Documentation**
  * Guide page added to site navigation and guide listings; includes runnable Quick Start and Custom Controls examples demonstrating zoom/pan controls and presets.
* **Localization**
  * Added English and Chinese strings for the new guide title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->