### PR TITLE
Simplify spring code, fix animatinDuration

### DIFF
--- a/src/animation/JavascriptAnimate.tsx
+++ b/src/animation/JavascriptAnimate.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { noop } from '../util/DataUtils';
 import { resolveDefaultProps } from '../util/resolveDefaultProps';
 import configUpdate from './configUpdate';
-import { configEasing, EasingInput } from './easing';
+import { createEasingFunction, EasingInput } from './easing';
 import { AnimationManager } from './AnimationManager';
 import { useAnimationManager } from './useAnimationManager';
 import { Global } from '../util/Global';
@@ -75,7 +75,7 @@ export function JavascriptAnimate(outsideProps: JavascriptAnimateProps) {
     const startAnimation = configUpdate<AnimationElapsedTimeState>(
       from,
       to,
-      configEasing(easing),
+      createEasingFunction(easing),
       duration,
       setStyle,
       animationManager.getTimeoutController(),

--- a/src/animation/configUpdate.ts
+++ b/src/animation/configUpdate.ts
@@ -1,50 +1,8 @@
 import { getIntersectionKeys, mapObject } from './util';
-import { BezierEasingFunction, EasingFunction, SpringEasingFunction } from './easing';
+import { EasingFunction } from './easing';
 import { TimeoutController } from './timeoutController';
 
 export const alpha = (begin: number, end: number, k: number) => begin + (end - begin) * k;
-const needContinue = ({ from, to }: Val) => from !== to;
-
-type Val = {
-  from: number;
-  to: number;
-  velocity: number;
-};
-
-/*
- * @description: cal new from value and velocity in each stepper
- * @return: { [styleProperty]: { from, to, velocity } }
- */
-const calStepperVals = (easing: SpringEasingFunction, preVals: Record<string, Val>, steps: number) => {
-  const nextStepVals: Record<string, Val> = mapObject((key, val: Val): Val => {
-    if (needContinue(val)) {
-      const [newX, newV] = easing(val.from, val.to, val.velocity);
-      return {
-        ...val,
-        from: newX,
-        velocity: newV,
-      };
-    }
-
-    return val;
-  }, preVals);
-
-  if (steps < 1) {
-    return mapObject((key, val: Val): Val => {
-      if (needContinue(val) && nextStepVals[key] != null) {
-        return {
-          ...val,
-          velocity: alpha(val.velocity, nextStepVals[key].velocity, steps),
-          from: alpha(val.from, nextStepVals[key].from, steps),
-        };
-      }
-
-      return val;
-    }, preVals);
-  }
-
-  return calStepperVals(easing, nextStepVals, steps - 1);
-};
 
 export type FrameId = number;
 
@@ -58,70 +16,12 @@ export type CancelAnimationFunction = () => void;
 
 export type StartAnimationFunction = () => CancelAnimationFunction;
 
-function createStepperUpdate<T extends Record<string, unknown>>(
-  from: T,
-  to: T,
-  easing: SpringEasingFunction,
-  interKeys: ReadonlyArray<string>,
-  render: (currentStyle: T) => void,
-  timeoutController: TimeoutController,
-) {
-  let preTime: number;
-  let stepperStyle: Record<string, Val> = interKeys.reduce(
-    (res, key) => ({
-      ...res,
-      [key]: {
-        from: from[key],
-        velocity: 0,
-        to: to[key],
-      },
-    }),
-    {},
-  );
-  const getCurrStyle = () => mapObject((key, val: Val) => val.from, stepperStyle);
-  const shouldStopAnimation = () => !Object.values(stepperStyle).filter(needContinue).length;
-
-  let stopAnimation: CancelAnimationFunction | null = null;
-
-  const stepperUpdate = (now: number) => {
-    if (!preTime) {
-      preTime = now;
-    }
-    const deltaTime = now - preTime;
-    const steps = deltaTime / easing.dt;
-
-    stepperStyle = calStepperVals(easing, stepperStyle, steps);
-    // get union set and add compatible prefix
-    render({
-      ...from,
-      ...to,
-      ...getCurrStyle(),
-    });
-
-    preTime = now;
-
-    if (!shouldStopAnimation()) {
-      stopAnimation = timeoutController.setTimeout(stepperUpdate);
-    }
-  };
-
-  // return start animation method
-  return () => {
-    stopAnimation = timeoutController.setTimeout(stepperUpdate);
-
-    // return stop animation method
-    return () => {
-      stopAnimation?.();
-    };
-  };
-}
-
 type TimingStyle = Record<string, [number, number]>;
 
 function createTimingUpdate<T extends Record<string, number>>(
   from: T,
   to: T,
-  easing: BezierEasingFunction,
+  easing: EasingFunction,
   duration: number,
   interKeys: ReadonlyArray<string>,
   render: (currentStyle: T) => void,
@@ -205,7 +105,5 @@ export default <T extends Record<string, number>>(
     };
   }
 
-  return easing.isStepper === true
-    ? createStepperUpdate(from, to, easing, interKeys, render, timeoutController)
-    : createTimingUpdate(from, to, easing, duration, interKeys, render, timeoutController);
+  return createTimingUpdate(from, to, easing, duration, interKeys, render, timeoutController);
 };

--- a/src/animation/easing.ts
+++ b/src/animation/easing.ts
@@ -117,45 +117,85 @@ export const configBezier = (...args: BezierInput): BezierEasingFunction => {
 };
 
 type SpringInput = {
+  /**
+   * The stiffness coefficient of the spring.
+   * Higher values create a more forceful, faster pull towards the target.
+   */
   stiff?: number;
+  /**
+   * The damping coefficient (friction/resistance).
+   * Higher values reduce bounciness and stop oscillation sooner. Lower values create more bounce.
+   */
   damping?: number;
+  /**
+   * The physics simulation time step in milliseconds.
+   * Determines the granularity of the baked frames. 16.67ms roughly equals a 60fps frame delta.
+   */
   dt?: number;
 };
 
-export type SpringEasingFunction = {
-  isStepper: true;
-  dt: number;
-  (currX: number, destX: number, currV: number): [number, number];
-};
+/**
+ * Creates a performance-optimized, progress-based spring easing function.
+ * It pre-calculates ("bakes") spring physics frames upfront based on a fixed duration,
+ * then returns a pure, lightweight function mapping progress (0 to 1) to the animated position.
+ * This approach is ideal for low-power devices because it removes heavy physics math from the frame loop.
+ */
+export const createSpringEasing = (config: SpringInput = {}): EasingFunction => {
+  const { stiff = 100, damping = 8, dt = 16.67 } = config;
+  const destX = 1;
 
-export const configSpring = (config: SpringInput = {}): SpringEasingFunction => {
-  const { stiff = 100, damping = 8, dt = 17 } = config;
-  const stepper = (currX: number, destX: number, currV: number): ReturnType<SpringEasingFunction> => {
+  const positions: number[] = [0];
+  let currX = 0;
+  let currV = 0;
+
+  // Safety valve to prevent accidental infinite loops if physics config is extreme
+  const maxIterations = 10000;
+  let iterations = 0;
+
+  // 1. Run the simulation until the spring completely stops moving
+  while (iterations < maxIterations) {
     const FSpring = -(currX - destX) * stiff;
     const FDamping = currV * damping;
-    const newV = currV + ((FSpring - FDamping) * dt) / 1000;
-    const newX = (currV * dt) / 1000 + currX;
 
-    if (Math.abs(newX - destX) < ACCURACY && Math.abs(newV) < ACCURACY) {
-      return [destX, 0];
+    currV += ((FSpring - FDamping) * dt) / 1000;
+    currX += (currV * dt) / 1000;
+
+    positions.push(currX);
+
+    // Stop only when position is essentially at 1.0 AND bounce velocity has died down
+    if (Math.abs(currX - destX) < ACCURACY && Math.abs(currV) < ACCURACY) {
+      break;
     }
-    return [newX, newV];
+    iterations++;
+  }
+
+  // Force the absolute final element to be exactly 1.0 for a perfect finish
+  positions[positions.length - 1] = destX;
+  const maxIndex = positions.length - 1;
+
+  // 2. The ultra-smooth runtime function mapping your 0..1 progress
+  return (t: number): number => {
+    if (t <= 0) return 0;
+    if (t >= 1) return destX;
+
+    // Scale t (0..1) proportionally across our entire pre-calculated array
+    const exactFrame = t * maxIndex;
+    const index = Math.floor(exactFrame);
+    const fraction = exactFrame - index;
+
+    // Blend between the two closest frames
+    return (positions[index] ?? 0) + ((positions[index + 1] ?? 0) - (positions[index] ?? 0)) * fraction;
   };
-
-  stepper.isStepper = true as const;
-  stepper.dt = dt;
-
-  return stepper;
 };
 
-export type EasingFunction = BezierEasingFunction | SpringEasingFunction;
+export type EasingFunction = (t: number) => number;
 
 /**
  * @inline
  */
 export type EasingInput = NamedBezier | 'spring' | EasingFunction;
 
-export const configEasing = (easing: EasingInput): EasingFunction | null => {
+export const createEasingFunction = (easing: EasingInput): EasingFunction | null => {
   if (typeof easing === 'string') {
     switch (easing) {
       case 'ease':
@@ -165,7 +205,7 @@ export const configEasing = (easing: EasingInput): EasingFunction | null => {
       case 'linear':
         return configBezier(easing);
       case 'spring':
-        return configSpring();
+        return createSpringEasing();
       default:
         if (easing.split('(')[0] === 'cubic-bezier') {
           return configBezier(easing);

--- a/test/animation/configUpdate.spec.ts
+++ b/test/animation/configUpdate.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach, expect, vi, MockInstance } from 'vitest';
-import { configEasing } from '../../src/animation/easing';
+import { createEasingFunction } from '../../src/animation/easing';
 import animationFunction, {
   CancelAnimationFrameDi,
   CancelAnimationFunction,
@@ -13,7 +13,7 @@ describe('animationFunction', () => {
   describe('with linear easing', () => {
     const mockAnimationFrame = new MockTimeoutController();
     // this static property addition to a function is wild
-    const linearEasing = configEasing('linear');
+    const linearEasing = createEasingFunction('linear');
     let startAnimation: StartAnimationFunction;
     const render = vi.fn();
 
@@ -113,7 +113,7 @@ describe('animationFunction', () => {
 
   describe('with spring easing', () => {
     const mockAnimationFrame = new MockTimeoutController();
-    const springEasing = configEasing('spring');
+    const springEasing = createEasingFunction('spring');
     let startAnimation: StartAnimationFunction;
     const render = vi.fn();
 
@@ -169,60 +169,27 @@ describe('animationFunction', () => {
 
       // numbers are not exactly halfway through because the animation did not start at time 0, it started at time 4
       expect(render).toHaveBeenLastCalledWith({
-        x: 106.01478200678056,
-        y: 106.01478200678056,
+        x: 100.36052986528156,
+        y: 100.36052986528156,
       });
       expect(render).toHaveBeenCalledTimes(2);
       expect(mockAnimationFrame.getCallbacksCount()).toBe(1);
       // exact end of the animation - we got lucky but this is not guaranteed
       await mockAnimationFrame.triggerNextTimeout(1004);
       expect(render).toHaveBeenLastCalledWith({
-        x: 103.8629546018778,
-        y: 103.8629546018778,
-      });
-      expect(render).toHaveBeenCalledTimes(3);
-      // okay the animation continues beyond the duration?
-      expect(mockAnimationFrame.getCallbacksCount()).toBe(1);
-
-      await mockAnimationFrame.triggerNextTimeout(2000);
-      expect(render).toHaveBeenLastCalledWith({
-        x: 99.86220182838869,
-        y: 99.86220182838869,
+        x: 100,
+        y: 100,
       });
       expect(render).toHaveBeenCalledTimes(4);
-      expect(mockAnimationFrame.getCallbacksCount()).toBe(1);
+      expect(mockAnimationFrame.getCallbacksCount()).toBe(0);
 
-      // and it continues even further
-
-      await mockAnimationFrame.triggerNextTimeout(3000);
-      expect(render).toHaveBeenLastCalledWith({
-        x: 100.00438658948147,
-        y: 100.00438658948147,
-      });
-      expect(render).toHaveBeenCalledTimes(5);
-      expect(mockAnimationFrame.getCallbacksCount()).toBe(1);
-
-      // on and on
-
-      await mockAnimationFrame.triggerNextTimeout(4000);
-      expect(render).toHaveBeenLastCalledWith({
-        x: 99.9998780350853,
-        y: 99.9998780350853,
-      });
-      expect(render).toHaveBeenCalledTimes(6);
-      expect(mockAnimationFrame.getCallbacksCount()).toBe(1);
-
-      // when does this end?
-
-      await mockAnimationFrame.triggerNextTimeout(5000);
-
+      // animation is now complete.
+      await mockAnimationFrame.triggerNextTimeout(2000);
       expect(render).toHaveBeenLastCalledWith({
         x: 100,
         y: 100,
       });
-      expect(render).toHaveBeenCalledTimes(7);
-      // Done ... animation that had duration of 1000ms took 5000ms to complete, that doesn't sound right
-      // Actually. It looks like the duration is not respected at all, the animation is just always 5000ms long.
+      expect(render).toHaveBeenCalledTimes(4);
       expect(mockAnimationFrame.getCallbacksCount()).toBe(0);
     });
 
@@ -240,16 +207,6 @@ describe('animationFunction', () => {
       await mockAnimationFrame.triggerNextTimeout(2000);
 
       expect(render).toHaveBeenNthCalledWith(2, {
-        x: 99.86165969099825,
-        y: 99.86165969099825,
-      });
-      expect(render).toHaveBeenCalledTimes(2);
-      expect(mockAnimationFrame.getCallbacksCount()).toBe(1);
-
-      // okay, so the animation continues even after the duration
-      // this is the same 5000ms animation that we had before, so now let's overshoot it even more
-      await mockAnimationFrame.triggerNextTimeout(8000);
-      expect(render).toHaveBeenNthCalledWith(3, {
         x: 100,
         y: 100,
       });
@@ -274,7 +231,7 @@ describe('animationFunction', () => {
   describe('linear easing with mocked requestAnimationFrame', () => {
     const realAnimationFrame = new RequestAnimationFrameTimeoutController();
     // this static property addition to a function is wild
-    const linearEasing = configEasing('linear');
+    const linearEasing = createEasingFunction('linear');
     let startAnimation: StartAnimationFunction,
       requestAnimationFrameMock: MockInstance<RequestAnimationFrameDi>,
       cancelAnimationFrameMock: MockInstance<CancelAnimationFrameDi>;
@@ -311,7 +268,7 @@ describe('animationFunction', () => {
     });
 
     it('should use stepperUpdate if easing.isStepper is true', async () => {
-      const easing = configEasing('spring');
+      const easing = createEasingFunction('spring');
       const from = { val: '0' };
       const to = { val: '1' };
       const duration = 20;
@@ -329,7 +286,7 @@ describe('animationFunction', () => {
     });
 
     it('should use timingUpdate if easing.isStepper is false', () => {
-      const easing = configEasing('spring');
+      const easing = createEasingFunction('spring');
       const from = { x: 0, y: 0 };
       const to = { x: 100, y: 100 };
       const duration = 20;

--- a/test/animation/configUpdate.spec.ts
+++ b/test/animation/configUpdate.spec.ts
@@ -267,39 +267,6 @@ describe('animationFunction', () => {
       expect(typeof stopAnimation).toBe('function');
     });
 
-    it('should use stepperUpdate if easing.isStepper is true', async () => {
-      const easing = createEasingFunction('spring');
-      const from = { val: '0' };
-      const to = { val: '1' };
-      const duration = 20;
-
-      startAnimation = animationFunction(from, to, easing, duration, render, realAnimationFrame);
-
-      startAnimation();
-
-      expect(requestAnimationFrameMock).toHaveBeenCalledWith(expect.any(Function));
-
-      vi.advanceTimersToNextFrame();
-
-      // Check if render was called
-      expect(render).toHaveBeenCalled();
-    });
-
-    it('should use timingUpdate if easing.isStepper is false', () => {
-      const easing = createEasingFunction('spring');
-      const from = { x: 0, y: 0 };
-      const to = { x: 100, y: 100 };
-      const duration = 20;
-
-      startAnimation = animationFunction(from, to, easing, duration, render, realAnimationFrame);
-      startAnimation();
-      vi.advanceTimersToNextFrame();
-
-      expect(requestAnimationFrameMock).toHaveBeenCalled();
-
-      expect(render).toHaveBeenCalled();
-    });
-
     it('should stop animation when requested', () => {
       const from = { x: 0, y: 0 };
       const to = { x: 100, y: 100 };

--- a/test/animation/easing.spec.ts
+++ b/test/animation/easing.spec.ts
@@ -1,25 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import {
-  ACCURACY,
-  BezierEasingFunction,
-  configBezier,
-  configEasing,
-  configSpring,
-  EasingFunction,
-} from '../../src/animation/easing';
+import { configBezier, createEasingFunction, createSpringEasing } from '../../src/animation/easing';
 import { assertNotNull } from '../helper/assertNotNull';
-
-function assertIsBezierFunction(easing: EasingFunction): asserts easing is BezierEasingFunction {
-  if (typeof easing !== 'function' || easing.isStepper) {
-    throw new Error('Expected a Bezier easing function');
-  }
-}
-
-function assertIsSpringFunction(easing: EasingFunction): asserts easing is EasingFunction & { isStepper: true } {
-  if (typeof easing !== 'function' || !easing.isStepper) {
-    throw new Error('Expected a Spring easing function');
-  }
-}
 
 describe('configBezier', () => {
   it('should return a cubic-bezier function when given four numbers', () => {
@@ -152,100 +133,86 @@ describe('configBezier', () => {
   });
 });
 
-describe('configSpring', () => {
-  it('should return a stepper function with default config', () => {
-    const spring = configSpring();
-    expect(typeof spring).toBe('function');
-    expect(spring.isStepper).toBe(true);
-    expect(spring.dt).toBe(17);
+describe('createSpringEasing', () => {
+  it('should return a spring function with default config', () => {
+    const spring = createSpringEasing();
+    expect(spring).toBeInstanceOf(Function);
 
     // Test stepper with some inputs
-    const [newX, newV] = spring(0, 1, 0);
-    expect(newX).toBeCloseTo(0, 3);
-    expect(newV).toBeCloseTo(1.7, 3);
+    const t0 = spring(0);
+    expect(t0).toBeCloseTo(0, 3);
 
-    const [midX, midV] = spring(0.1, 1, 0);
-    expect(midX).toBeCloseTo(0.1, 3);
-    expect(midV).toBeCloseTo(1.53, 3);
+    const t1 = spring(0.1);
+    expect(t1).toBeCloseTo(1.1044, 3);
 
-    const [finalX, finalV] = spring(0.5, 1, 0);
-    expect(finalX).toBeCloseTo(0.5, 3);
-    expect(finalV).toBeCloseTo(0.85, 3);
+    // spring with basic settings settles quite fast
+    const t2 = spring(0.5);
+    expect(t2).toBeCloseTo(1.0028, 3);
+
+    const t3 = spring(0.8);
+    expect(t3).toBeCloseTo(1, 3);
+
+    const t4 = spring(0.9);
+    expect(t4).toBeCloseTo(1, 3);
+
+    const tFinal = spring(1);
+    expect(tFinal).toBe(1);
   });
 
   it('should handle custom config', () => {
-    const customSpring = configSpring({ stiff: 200, damping: 10, dt: 20 });
-    expect(customSpring.dt).toBe(20);
+    const customSpring = createSpringEasing({ stiff: 200, damping: 2 });
 
-    // Test stepper with some inputs
-    const [newX, newV] = customSpring(0, 1, 0);
-    expect(newX).toBeCloseTo(0, 3);
-    expect(newV).toBeCloseTo(4, 3);
+    const t0 = customSpring(0);
+    expect(t0).toBeCloseTo(0, 3);
 
-    const [midX, midV] = customSpring(0.1, 1, 0);
-    expect(midX).toBeCloseTo(0.1, 3);
-    expect(midV).toBeCloseTo(3.6, 3);
+    // This custom config creates a much bouncier spring, so we expect it to overshoot significantly at the start
+    const t1 = customSpring(0.1);
+    expect(t1).toBeCloseTo(0.6967, 3);
 
-    const [finalX, finalV] = customSpring(0.5, 1, 0);
-    expect(finalX).toBeCloseTo(0.5, 3);
-    expect(finalV).toBeCloseTo(2, 3);
-  });
+    const t2 = customSpring(0.3);
+    expect(t2).toBeCloseTo(1.0205, 3);
 
-  it('should settle at destination with zero velocity', () => {
-    const spring = configSpring();
-    let x = 0;
-    let v = 0;
-    const destX = 1;
+    // by the half of the animation done, even the more dynamic spring begins to settle
+    const t3 = customSpring(0.5);
+    expect(t3).toBeCloseTo(1.0089, 3);
 
-    // Run the spring simulation until it settles
-    for (let i = 0; i < 100; i++) {
-      [x, v] = spring(x, destX, v);
-      // If settled, we should break early
-      if (Math.abs(x - destX) < ACCURACY && Math.abs(v) < ACCURACY) {
-        break;
-      }
-    }
+    const t4 = customSpring(0.9);
+    expect(t4).toBeCloseTo(0.9998, 3);
 
-    // The spring should have settled
-    expect(x).toBeCloseTo(destX, 2);
-    expect(v).toBeCloseTo(0, 1);
+    const tFinal = customSpring(1);
+    expect(tFinal).toBe(1);
   });
 });
 
 describe('configEasing', () => {
   it('should return the correct bezier function for named easing', () => {
-    const easing = configEasing('ease');
+    const easing = createEasingFunction('ease');
     expect(easing).toBeInstanceOf(Function);
   });
 
-  it('should return stepper function', () => {
-    const spring = configEasing('spring');
+  it('should return spring function', () => {
+    const spring = createEasingFunction('spring');
     assertNotNull(spring);
     expect(spring).toBeInstanceOf(Function);
-    expect(spring.isStepper).toBe(true);
-    assertIsSpringFunction(spring);
-    expect(spring(0, 1, 0)).toEqual([0, 1.7]);
+    expect(spring(0.5)).toBeCloseTo(1.00289, 3);
   });
 
   it('should handle cubic-bezier input', () => {
-    const bezier = configEasing('cubic-bezier(0.42,0,0.58,1)');
+    const bezier = createEasingFunction('cubic-bezier(0.42,0,0.58,1)');
     assertNotNull(bezier);
     expect(bezier).toBeInstanceOf(Function);
-    assertIsBezierFunction(bezier);
-    expect(bezier.isStepper).toBe(false);
     expect(bezier(0.5)).toEqual(0.5);
   });
 
   it('should return null for invalid inputs', () => {
     // @ts-expect-error typescript correctly highlights that the input is invalid
-    const result = configEasing('invalid');
+    const result = createEasingFunction('invalid');
     expect(result).toBeNull();
   });
 
   it('should handle function inputs', () => {
     const customFunc = () => 7;
-    customFunc.isStepper = false as const; // Simulate a bezier function
-    const result = configEasing(customFunc);
+    const result = createEasingFunction(customFunc);
     expect(result).toBe(customFunc);
   });
 });


### PR DESCRIPTION
## Description

I am on the quest to simplify animations code and spring is next. This is a refactor that also fixes the bug where spring easing would ignore animation duration. So now the duration makes spring slower or faster, compared to before where the animation always took 5 seconds and ignored the animationDuration prop.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Overhauled animation easing to use a progress-based spring easing model.
  * Simplified animation interpolation so timelines consistently use the easing function output.
  * Updated easing creation to provide a unified easing function interface.
* **Tests**
  * Updated easing and animation configuration tests to match the new easing behavior and timing expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->