### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ $ npm install recharts react-is
 
 `react-is` needs to match the version of your installed `react` package.
 
+### Deno
+
+Deno is a drop-in replacement for npm, so Recharts installs the same way:
+
+```sh
+$ deno add recharts react-is
+```
+
 ### umd
 
 The UMD build is also available on unpkg.com:


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The Installation section documents npm. Since Deno is a drop-in replacement for npm these days, this adds a short Deno subsection in parity:

```sh
deno add recharts react-is
```

Docs-only change (Recharts resolves and installs the same way under Deno). Totally fine to close this if you'd rather keep it npm-only. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide with Deno support, enabling users to install Recharts via Deno package manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->