### PR TITLE
Fix verifyExamples.spec.ts to check if the excluded symbol is actually exported at all

### DIFF
--- a/omnidoc/DocReader.ts
+++ b/omnidoc/DocReader.ts
@@ -3,7 +3,7 @@ export type DefaultValue = { type: 'known'; value: unknown | undefined } | { typ
 export interface DocReader {
   /**
    * Returns all exported public symbol names from the project.
-   * Excludes hooks and functions, and types.
+   * Includes everything - Components, hooks, functions, types, all of it
    */
   getPublicSymbolNames(): ReadonlyArray<string>;
 
@@ -14,6 +14,7 @@ export interface DocReader {
 
   /**
    * Returns all runtime exports: components, hooks, and utilities.
+   * Excludes types
    */
   getAllRuntimeExportedNames(): ReadonlyArray<string>;
 

--- a/omnidoc/readProject.ts
+++ b/omnidoc/readProject.ts
@@ -138,6 +138,10 @@ export class ProjectDocReader implements DocReader {
     return this.getPublicSymbolNames(SymbolFlags.Variable | SymbolFlags.Function);
   }
 
+  getAllExportedNames(): ReadonlyArray<string> {
+    return this.getPublicSymbolNames();
+  }
+
   private getComponentDeclaration(component: string): ExportedDeclarations {
     const sourceFile = this.project.getSourceFileOrThrow('src/index.ts');
     const exportedDeclarations = sourceFile.getExportedDeclarations();

--- a/omnidoc/verifyExamples.spec.ts
+++ b/omnidoc/verifyExamples.spec.ts
@@ -111,7 +111,6 @@ describe('Documentation Examples Coverage', () => {
     'YAxisOrientation',
     'XAxisPadding',
     'YAxisPadding',
-    'NiceTicks',
     'CartesianTickItem',
     'TextAnchor',
     'TooltipItemSorter',
@@ -150,7 +149,6 @@ describe('Documentation Examples Coverage', () => {
     'useYAxisInverseTickSnapScale',
     'ZIndexLayer',
     'AnimationMatchByProp',
-    'AnimationStatus',
     'LineDrawShape',
     'LinePointItem',
     'matchAppend',
@@ -205,6 +203,10 @@ describe('Documentation Examples Coverage', () => {
   ]);
 
   describe.each(exportsThatNeedExamples)('Excluded export: %s', exportName => {
+    test('is actually exported from the library', () => {
+      expect(projectReader.getPublicSymbolNames()).toContain(exportName);
+    });
+
     test('still has no example usage', () => {
       const examples = exampleReader.getExamples(exportName);
       expect(examples.length, `${exportName} is excluded but already has examples`).toBe(0);
@@ -212,6 +214,10 @@ describe('Documentation Examples Coverage', () => {
   });
 
   describe.each(Array.from(exportsThatNeedPropExamples))('Excluded prop example: %s', exportName => {
+    test('is actually exported from the library', () => {
+      expect(projectReader.getPublicSymbolNames()).toContain(exportName);
+    });
+
     test('has a component example', () => {
       const examples = exampleReader.getExamples(exportName);
       expect(examples.length, `No examples found for ${exportName}`).toBeGreaterThan(0);


### PR DESCRIPTION
Docs test only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new method to retrieve all exported symbol names from the project, providing comprehensive access to the library's complete public exports without filtering.

* **Tests**
  * Updated example coverage verification rules to strengthen documentation standards across library exports with enhanced validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->