### PR TITLE
Manual animations on website

### DIFF
--- a/www/src/components/CodeEditorWithPreview.tsx
+++ b/www/src/components/CodeEditorWithPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ComponentType, ReactNode } from 'react';
+import React, { ComponentType, ReactNode, useEffect, useState } from 'react';
 import * as RechartsScope from 'recharts';
 import * as D3ShapeScope from 'd3-shape';
 import * as RechartsDevtoolsScope from '@recharts/devtools';
@@ -8,11 +8,12 @@ import type { Lever } from './Shared/levers/Levers.tsx';
 import { Levers } from './Shared/levers/Levers.tsx';
 import { StackBlitzLink } from './Shared/StackBlitzLink';
 import { sendEvent } from './analytics';
-import { ToolFrame, ToolType, ToolItem } from './Playground/ToolFrame';
+import { ToolFrame, ToolItem, ToolType } from './Playground/ToolFrame';
 import { SourceCodeEditor } from './Playground/SourceCodeEditor';
 import { DevToolsPanel } from './Playground/DevToolsPanel';
 import { AnnotationsPanel } from './Playground/AnnotationsPanel';
 import { CopyButton } from '../utils/CopyButton';
+import { ManualAnimationControls, ManualAnimationContext } from './ManualAnimationContext.tsx';
 
 /**
  * Props passed to the previewed component.
@@ -165,6 +166,8 @@ export function CodeEditorWithPreview<T>({
   // Refactor for DevTools Copy State
   const [devToolsValue, setDevToolsValue] = useState<unknown>(undefined);
 
+  const [isManualAnimations, setIsManualAnimations] = useState<boolean>(false);
+
   // Update tools definition
   const actualTools: ToolItem[] = [
     {
@@ -191,36 +194,38 @@ export function CodeEditorWithPreview<T>({
       label: 'Annotations',
       component: <AnnotationsPanel />,
     },
-  ];
-
-  if (defaultControlsState != null && levers != null) {
-    actualTools.push({
+    {
       name: 'controls',
       label: 'Controls',
       component: (
         <div style={{ padding: '10px', height: '100%', overflow: 'auto' }}>
-          <Levers
-            defaultState={defaultControlsState}
-            levers={levers}
-            onChange={setControlsState}
-            state={controlsState}
-          />
+          {defaultControlsState != null && levers != null && (
+            <Levers
+              defaultState={defaultControlsState}
+              levers={levers}
+              onChange={setControlsState}
+              state={controlsState}
+            />
+          )}
+          <ManualAnimationControls isManualAnimationEnabled={isManualAnimations} onToggle={setIsManualAnimations} />
         </div>
       ),
-    });
-  }
+    },
+  ];
 
   return (
     <RechartsDevtoolsContext>
-      <PreviewResult
-        Component={Component}
-        isEditMode={isEditMode}
-        codeToRun={codeToRun}
-        Runner={Runner}
-        componentProps={controlsState ?? defaultControlsState}
-      />
+      <ManualAnimationContext enabled={isManualAnimations}>
+        <PreviewResult
+          Component={Component}
+          isEditMode={isEditMode}
+          codeToRun={codeToRun}
+          Runner={Runner}
+          componentProps={controlsState ?? defaultControlsState}
+        />
 
-      <ToolFrame activeTool={activeTool} onToolChange={setActiveTool} tools={actualTools} />
+        <ToolFrame activeTool={activeTool} onToolChange={setActiveTool} tools={actualTools} />
+      </ManualAnimationContext>
     </RechartsDevtoolsContext>
   );
 }

--- a/www/src/components/ManualAnimationContext.tsx
+++ b/www/src/components/ManualAnimationContext.tsx
@@ -1,4 +1,14 @@
-import React, { createContext, ReactNode, useCallback, useContext, useEffect, useId, useRef, useState } from 'react';
+import React, {
+  createContext,
+  CSSProperties,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 import {
   AnimationController,
   AnimationControllerProvider,
@@ -137,6 +147,30 @@ function TimeSetter() {
   );
 }
 
+/* Container: Stack items vertically with a clean gap between rows */
+const radioGroupStyle: CSSProperties = {
+  display: 'flex',
+  gap: '12px',
+};
+
+/* Label: Vertically centers the default circle with the text */
+const radioLabelStyle = {
+  display: 'flex',
+  alignItems: 'center' /* Forces perfect vertical alignment */,
+  gap: '8px' /* Adjust this to change space between circle and text */,
+  cursor: 'pointer',
+  fontSize: '16px',
+  color: '#333',
+};
+
+/* Optional: Make the default radio slightly larger if it feels tiny */
+const radioInputStyle = {
+  margin: 0 /* Removes default browser margins that mess up alignment */,
+  width: '16px',
+  height: '16px',
+  cursor: 'pointer',
+};
+
 export function ManualAnimationControls({
   isManualAnimationEnabled,
   onToggle,
@@ -148,14 +182,28 @@ export function ManualAnimationControls({
   const id = useId();
   return (
     <>
-      <label>
-        <input type="radio" name={id} defaultChecked={!isManualAnimationEnabled} onChange={() => onToggle(false)} />
-        Autoplay Animations (default)
-      </label>
-      <label>
-        <input type="radio" name={id} defaultChecked={isManualAnimationEnabled} onChange={() => onToggle(true)} />
-        Manual Animations
-      </label>
+      <div style={radioGroupStyle}>
+        <label style={radioLabelStyle}>
+          <input
+            style={radioInputStyle}
+            type="radio"
+            name={id}
+            defaultChecked={!isManualAnimationEnabled}
+            onChange={() => onToggle(false)}
+          />
+          Autoplay Animations (default)
+        </label>
+        <label style={radioLabelStyle}>
+          <input
+            style={radioInputStyle}
+            type="radio"
+            name={id}
+            defaultChecked={isManualAnimationEnabled}
+            onChange={() => onToggle(true)}
+          />
+          Manual Animations
+        </label>
+      </div>
       {isManualAnimationEnabled && (
         <>
           <p>Time is paused. Control the animation progress by dragging the red line below.</p>

--- a/www/src/components/ManualAnimationContext.tsx
+++ b/www/src/components/ManualAnimationContext.tsx
@@ -1,0 +1,201 @@
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useId, useRef, useState } from 'react';
+import {
+  AnimationController,
+  AnimationControllerProvider,
+  AnimationHandle,
+  Bar,
+  BarStack,
+  createVerticalChart,
+  DefaultZIndexes,
+  getRelativeCoordinate,
+  ReferenceLine,
+  useXAxisInverseScale,
+  XAxis,
+  YAxis,
+  ZIndexLayer,
+} from 'recharts';
+import { Blanket } from '@recharts/devtools/dist/annotations';
+
+export const MockTimeContext = createContext<MockClock>([0, () => {}]);
+
+export const RunningAnimationsContext = createContext<ReadonlyArray<AnimationHandle>>([]);
+
+type MockClock = [currentTime: number, setCurrentTime: (currentTime: number) => void];
+
+export const ManualAnimationManager = ({ children }: { children: ReactNode }) => {
+  const [animations, setAnimations] = useState<ReadonlyArray<AnimationHandle>>([]);
+  const mockClock = useState<number>(0);
+  const [timeListeners, setTimeListeners] = useState<ReadonlyArray<(now: number) => void>>([]);
+  const currentTime = useRef<number>(0);
+  // eslint-disable-next-line prefer-destructuring
+  currentTime.current = mockClock[0];
+
+  const manualAnimationController: AnimationController = useCallback<AnimationController>(
+    (_timeoutController, animationHandle, listener) => {
+      setAnimations(prev => [...prev, animationHandle]);
+      // tick once to lock the animation in
+      animationHandle.tick(currentTime.current);
+      const timeListener = (now: number) => {
+        animationHandle.tick(now);
+        if (animationHandle.getState() === 'active') {
+          listener(animationHandle.getInterpolated());
+        }
+      };
+      setTimeListeners(prev => [...prev, timeListener]);
+      return () => {
+        setAnimations(prev => prev.filter(handle => handle !== animationHandle));
+        setTimeListeners(prev => prev.filter(handle => handle !== timeListener));
+      };
+    },
+    [setAnimations],
+  );
+
+  useEffect(() => {
+    timeListeners.forEach(listener => listener(mockClock[0]));
+  }, [timeListeners, mockClock]);
+
+  return (
+    <MockTimeContext.Provider value={mockClock}>
+      <RunningAnimationsContext.Provider value={animations}>
+        <AnimationControllerProvider value={manualAnimationController}>{children}</AnimationControllerProvider>
+      </RunningAnimationsContext.Provider>
+    </MockTimeContext.Provider>
+  );
+};
+export const ManualAnimationContext = ({ children, enabled }: { children: ReactNode; enabled: boolean }) => {
+  if (!enabled) {
+    return children;
+  }
+  return <ManualAnimationManager>{children}</ManualAnimationManager>;
+};
+const TypedChart = createVerticalChart<AnimationHandle, string, [number, number]>()({
+  Bar,
+  XAxis,
+  YAxis,
+});
+
+/**
+ * This component is responsible for displaying and modifying the current animation time;
+ * it's like a fake clock. Instead of actual wall clock time, it shows a line
+ * that you can drag left and right and that updates the fake animation time.
+ */
+function TimeSetter() {
+  const [currentTime, setCurrentTime] = useContext(MockTimeContext);
+  const isDraggingRef = React.useRef(false);
+
+  /*
+   * We use the scale to calculate XAxis value from mouse coordinates
+   */
+  const scale = useXAxisInverseScale();
+  if (scale == null) {
+    // called outside the chart context
+    return null;
+  }
+
+  const mouseHandler = (e: React.MouseEvent<SVGGraphicsElement>) => {
+    const chartCoordinates = getRelativeCoordinate(e);
+    // converts from coordinates to XAxis domain value
+    const newTime = scale(chartCoordinates.relativeX);
+    setCurrentTime(Number(newTime));
+  };
+
+  const onMouseDown = () => {
+    isDraggingRef.current = true;
+  };
+
+  const onMouseUp = () => {
+    isDraggingRef.current = false;
+  };
+
+  const onMouseMove = (e: React.MouseEvent<SVGGraphicsElement>) => {
+    if (isDraggingRef.current) {
+      mouseHandler(e);
+    }
+  };
+
+  return (
+    <>
+      {/* Put the indicator line on top of most things */}
+      <ZIndexLayer zIndex={DefaultZIndexes.cursorLine}>
+        <ReferenceLine
+          x={currentTime}
+          stroke="red"
+          label={{ value: 'Current Time', position: 'insideTop', fill: 'red' }}
+        />
+      </ZIndexLayer>
+      {/* The Blanket is invisible overlay for capturing mouse events, that goes on the very top */}
+      <ZIndexLayer zIndex={DefaultZIndexes.label + 1}>
+        <Blanket
+          onClick={mouseHandler}
+          onMouseDown={onMouseDown}
+          onMouseUp={onMouseUp}
+          onMouseMove={onMouseMove}
+          pointerEvents="auto"
+        />
+      </ZIndexLayer>
+    </>
+  );
+}
+
+export function ManualAnimationControls({
+  isManualAnimationEnabled,
+  onToggle,
+}: {
+  isManualAnimationEnabled: boolean;
+  onToggle: (isManualAnimationEnabled: boolean) => void;
+}) {
+  const animations = useContext(RunningAnimationsContext);
+  const id = useId();
+  return (
+    <>
+      <label>
+        <input type="radio" name={id} defaultChecked={!isManualAnimationEnabled} onChange={() => onToggle(false)} />
+        Autoplay Animations (default)
+      </label>
+      <label>
+        <input type="radio" name={id} defaultChecked={isManualAnimationEnabled} onChange={() => onToggle(true)} />
+        Manual Animations
+      </label>
+      {isManualAnimationEnabled && (
+        <>
+          <p>Time is paused. Control the animation progress by dragging the red line below.</p>
+          <TypedChart.BarChart
+            responsive
+            style={{ width: '100%', height: '200px', cursor: 'ew-resize' }}
+            data={animations}
+            maxBarSize={30}
+          >
+            <TimeSetter />
+            <TypedChart.YAxis type="category" width="auto" dataKey={handle => handle.getAnimationId()} />
+            <BarStack radius={8}>
+              <TypedChart.Bar
+                dataKey={handle => [handle.getBeginStartedTime() ?? 0, handle.getAnimationBegin()]}
+                /*
+                 * All graphical items inside here must have animations disabled,
+                 * otherwise they trigger their own rerender in an infinite loop.
+                 * We could have it split in different contexts, but it's simpler this way.
+                 */
+                isAnimationActive={false}
+                fill="yellow"
+              />
+              <TypedChart.Bar
+                dataKey={handle => [
+                  (handle.getBeginStartedTime() ?? 0) + handle.getAnimationBegin(),
+                  (handle.getBeginStartedTime() ?? 0) + handle.getAnimationBegin() + handle.getAnimationDuration(),
+                ]}
+                isAnimationActive={false}
+                fill="blue"
+                label={{
+                  position: 'insideRight',
+                  fill: 'white',
+                  dataKey: handle => `duration: ${handle.getAnimationDuration()} ms`,
+                }}
+              />
+            </BarStack>
+            <TypedChart.XAxis type="number" />
+          </TypedChart.BarChart>
+        </>
+      )}
+    </>
+  );
+}

--- a/www/src/components/ManualAnimationContext.tsx
+++ b/www/src/components/ManualAnimationContext.tsx
@@ -188,7 +188,7 @@ export function ManualAnimationControls({
             style={radioInputStyle}
             type="radio"
             name={id}
-            defaultChecked={!isManualAnimationEnabled}
+            checked={!isManualAnimationEnabled}
             onChange={() => onToggle(false)}
           />
           Autoplay Animations (default)
@@ -198,7 +198,7 @@ export function ManualAnimationControls({
             style={radioInputStyle}
             type="radio"
             name={id}
-            defaultChecked={isManualAnimationEnabled}
+            checked={isManualAnimationEnabled}
             onChange={() => onToggle(true)}
           />
           Manual Animations

--- a/www/src/docs/exampleComponents/AreaChart/AreaChartExample.tsx
+++ b/www/src/docs/exampleComponents/AreaChart/AreaChartExample.tsx
@@ -76,6 +76,8 @@ const AreaChartExample = ({ isAnimationActive = true }) => (
       fillOpacity={1}
       fill="url(#colorUv)"
       isAnimationActive={isAnimationActive}
+      animationBegin={200}
+      animationDuration={1300}
     />
     <Area
       type="monotone"


### PR DESCRIPTION
Uses the new 3.9 animation controls to implement manual animation overrides on the website. Should work on all charts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual animation control for charts, allowing users to toggle between autoplay and manual modes.
  * In manual mode, users can drag to scrub the animation timeline with a visible indicator of active animation segments.

* **New Features**
  * Updated the code editor preview tooling to support manual animation toggles within the controls UI.

* **Bug Fixes**
  * Set explicit animation timing for the first area series in the AreaChart example to improve consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->