### PR TITLE
Add test for Pie and Legend animation

### DIFF
--- a/test/helper/expectAnimatedPieAngles.tsx
+++ b/test/helper/expectAnimatedPieAngles.tsx
@@ -1,0 +1,99 @@
+import { expect } from 'vitest';
+import { MockAnimationManager } from '../animation/MockProgressAnimationManager';
+import { assertNotNull } from './assertNotNull';
+import { getPieSectorAngles, selectPieSectors } from './expectPieSectors';
+
+export async function expectAnimatedPieAngles(
+  container: Element,
+  animationManager: MockAnimationManager,
+  steps: number = 5,
+): Promise<ReadonlyArray<ReadonlyArray<{ startAngle: number; endAngle: number }>>> {
+  assertNotNull(container);
+  /*
+   * Pie sectors at 0% progress do not render at all, so we
+   * start from 0.1 so that the sectors have rendered a little bit.
+   */
+  let animationProgress = 0.1;
+  await animationManager.setAnimationProgress(animationProgress);
+  const stepSize = (1 - animationProgress) / steps;
+  const initialPieSectors = selectPieSectors(container);
+  const initialAngles = getPieSectorAngles(initialPieSectors);
+  const initialAttributes = Array.from(initialPieSectors).map(sector => ({
+    fill: sector.getAttribute('fill'),
+    stroke: sector.getAttribute('stroke'),
+  }));
+
+  const anglesDuringAnimation: { startAngle: number; endAngle: number }[][] = [];
+  for (animationProgress += stepSize; animationProgress < 1; animationProgress += stepSize) {
+    // eslint-disable-next-line no-await-in-loop
+    await animationManager.setAnimationProgress(animationProgress);
+    const currentPieSectors = selectPieSectors(container);
+    const currentAngles = getPieSectorAngles(currentPieSectors);
+    anglesDuringAnimation.push(currentAngles);
+
+    // Assert that all angles change
+    initialAngles.forEach((initial, index) => {
+      const current = currentAngles[index];
+      const currentSector = currentPieSectors[index];
+      expect(currentSector.getAttribute('fill')).toBe(initialAttributes[index].fill);
+      expect(currentSector.getAttribute('stroke')).toBe(initialAttributes[index].stroke);
+      if (index === 0) {
+        // Because the pie grows from the same position, the start angle should remain the same for the first sector
+        expect(current.startAngle).toBe(initial.startAngle);
+      } else {
+        // For all other sectors, the start angle should change
+        expect(current.startAngle).not.toBe(initial.startAngle);
+      }
+      if (index !== currentAngles.length - 1) {
+        /*
+         * This is true for all sectors except the last one because the Pie is always a full circle.
+         * During the initial animation the Pie "grows" from the center, so the end angle of the last sector
+         * will indeed be different from the initial end angle,
+         * but during the "rearrange angles" animation the end angle of the last sector
+         * will always be 360 degrees, same as the initial end angle.
+         */
+        expect(current.endAngle).not.toBe(initial.endAngle);
+      }
+    });
+  }
+
+  await animationManager.completeAnimation();
+  // Final check to ensure the animation completed
+  const finalPieSectors = selectPieSectors(container);
+  expect(finalPieSectors).toHaveLength(initialPieSectors.length);
+  const finalAngles = getPieSectorAngles(finalPieSectors);
+  finalAngles.forEach((final, index) => {
+    const initial = initialAngles[index];
+    const finalSector = finalPieSectors[index];
+    expect(finalSector.getAttribute('fill')).toBe(initialAttributes[index].fill);
+    expect(finalSector.getAttribute('stroke')).toBe(initialAttributes[index].stroke);
+    if (index === 0) {
+      // Because the pie grows from the same position, the start angle should remain the same for the first sector
+      expect(final.startAngle).toBe(initial.startAngle);
+    } else {
+      // For all other sectors, the start angle should change
+      expect(final.startAngle).not.toBe(initial.startAngle);
+    }
+    if (index !== finalAngles.length - 1) {
+      /*
+       * This is true for all sectors except the last one because the Pie is always a full circle.
+       * During the initial animation the Pie "grows" from the center, so the end angle of the last sector
+       * will indeed be different from the initial end angle,
+       * but during the "rearrange angles" animation the end angle of the last sector
+       * will always be 360 degrees, same as the initial end angle.
+       */
+      expect(final.endAngle).not.toBe(initial.endAngle);
+    }
+  });
+
+  // Also, because the Pie is always a full circle, the end angle of the last sector should be 360 degrees
+  expect(finalAngles[finalAngles.length - 1].endAngle).toBe(0);
+
+  // collect the angles one last time, at the end of the animation
+  anglesDuringAnimation.push(finalAngles);
+
+  // Return the collected angles
+  expect(anglesDuringAnimation).toHaveLength(steps);
+
+  return anglesDuringAnimation;
+}

--- a/test/helper/expectAnimatedPiePaths.ts
+++ b/test/helper/expectAnimatedPiePaths.ts
@@ -1,0 +1,68 @@
+import { expect } from 'vitest';
+import { MockAnimationManager } from '../animation/MockProgressAnimationManager';
+import { assertNotNull } from './assertNotNull';
+import { selectPieSectors } from './expectPieSectors';
+import { trim } from './trim';
+
+export async function expectAnimatedPiePaths(
+  container: Element,
+  animationManager: MockAnimationManager,
+  steps: number = 5,
+): Promise<ReadonlyArray<ReadonlyArray<string>>> {
+  assertNotNull(container);
+  /*
+   * Pie sectors at 0% progress do not render at all, so we
+   * start from 0.1 so that the sectors have rendered a little bit.
+   */
+  let animationProgress = 0.1;
+  await animationManager.setAnimationProgress(animationProgress);
+  const stepSize = (1 - animationProgress) / steps;
+  const initialPieSectors = selectPieSectors(container);
+  expect(initialPieSectors.length).toBeGreaterThan(0);
+  const getD = (sector: Element) => {
+    const trimmed = trim(sector.getAttribute('d'));
+    assertNotNull(trimmed);
+    return trimmed;
+  };
+  const initialPathDs = Array.from(initialPieSectors).map(getD);
+  const initialAttributes = Array.from(initialPieSectors).map(sector => ({
+    fill: sector.getAttribute('fill'),
+    stroke: sector.getAttribute('stroke'),
+  }));
+
+  const pathDsDuringAnimation: string[][] = [];
+  for (animationProgress += stepSize; animationProgress < 1; animationProgress += stepSize) {
+    // eslint-disable-next-line no-await-in-loop
+    await animationManager.setAnimationProgress(animationProgress);
+    const currentPieSectors = selectPieSectors(container);
+    const currentPathDs = Array.from(currentPieSectors).map(getD);
+    pathDsDuringAnimation.push(currentPathDs);
+
+    // Assert that all d attributes change
+    initialPathDs.forEach((initial, index) => {
+      const currentSector = currentPieSectors[index];
+      expect(trim(currentSector.getAttribute('d'))).not.toBe(initial);
+      expect(currentSector.getAttribute('fill')).toBe(initialAttributes[index].fill);
+      expect(currentSector.getAttribute('stroke')).toBe(initialAttributes[index].stroke);
+    });
+  }
+
+  await animationManager.completeAnimation();
+  // Final check to ensure the animation completed
+  const finalPieSectors = selectPieSectors(container);
+  expect(finalPieSectors).toHaveLength(initialPieSectors.length);
+  finalPieSectors.forEach((sector, index) => {
+    expect(trim(sector.getAttribute('d'))).not.toBe(initialPathDs[index]);
+    expect(sector.getAttribute('fill')).toBe(initialAttributes[index].fill);
+    expect(sector.getAttribute('stroke')).toBe(initialAttributes[index].stroke);
+  });
+
+  // collect the path.d-s one last time, at the end of the animation
+  const finalPathDs = Array.from(finalPieSectors).map(getD);
+  pathDsDuringAnimation.push(finalPathDs);
+
+  // Return the collected path.d-s
+  expect(pathDsDuringAnimation).toHaveLength(steps);
+
+  return pathDsDuringAnimation;
+}

--- a/test/polar/Pie/Pie.animation.spec.tsx
+++ b/test/polar/Pie/Pie.animation.spec.tsx
@@ -4,15 +4,11 @@ import { act } from '@testing-library/react';
 import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
 import { PageData } from '../../_data';
 import { Pie, PieChart } from '../../../src';
-import {
-  expectPieSectors,
-  selectPieSectors,
-  getPieSectorAngles,
-  expectPieSectorAngles,
-} from '../../helper/expectPieSectors';
+import { expectPieSectorAngles, expectPieSectors } from '../../helper/expectPieSectors';
 import { assertNotNull } from '../../helper/assertNotNull';
-import { trim } from '../../helper/trim';
 import { MockAnimationManager } from '../../animation/MockProgressAnimationManager';
+import { expectAnimatedPiePaths } from '../../helper/expectAnimatedPiePaths';
+import { expectAnimatedPieAngles } from '../../helper/expectAnimatedPieAngles';
 
 const smallerData = PageData.slice(0, 3);
 
@@ -24,164 +20,6 @@ const finalSectorPaths = [
   { d: 'M 32,18.8231 A 36,36,0, 0,0, 32,81.1769 L 50,50 Z' },
   { d: 'M 32,81.1769 A 36,36,0, 0,0, 86,50 L 50,50 Z' },
 ];
-
-async function expectAnimatedPiePaths(
-  container: Element,
-  animationManager: MockAnimationManager,
-  steps: number = 5,
-): Promise<ReadonlyArray<ReadonlyArray<string>>> {
-  assertNotNull(container);
-  /*
-   * Pie sectors at 0% progress do not render at all, so we
-   * start from 0.1 so that the sectors have rendered a little bit.
-   */
-  let animationProgress = 0.1;
-  await animationManager.setAnimationProgress(animationProgress);
-  const stepSize = (1 - animationProgress) / steps;
-  const initialPieSectors = selectPieSectors(container);
-  expect(initialPieSectors.length).toBeGreaterThan(0);
-  const getD = (sector: Element) => {
-    const trimmed = trim(sector.getAttribute('d'));
-    assertNotNull(trimmed);
-    return trimmed;
-  };
-  const initialPathDs = Array.from(initialPieSectors).map(getD);
-  const initialAttributes = Array.from(initialPieSectors).map(sector => ({
-    fill: sector.getAttribute('fill'),
-    stroke: sector.getAttribute('stroke'),
-  }));
-
-  const pathDsDuringAnimation: string[][] = [];
-  for (animationProgress += stepSize; animationProgress < 1; animationProgress += stepSize) {
-    // eslint-disable-next-line no-await-in-loop
-    await animationManager.setAnimationProgress(animationProgress);
-    const currentPieSectors = selectPieSectors(container);
-    const currentPathDs = Array.from(currentPieSectors).map(getD);
-    pathDsDuringAnimation.push(currentPathDs);
-
-    // Assert that all d attributes change
-    initialPathDs.forEach((initial, index) => {
-      const currentSector = currentPieSectors[index];
-      expect(trim(currentSector.getAttribute('d'))).not.toBe(initial);
-      expect(currentSector.getAttribute('fill')).toBe(initialAttributes[index].fill);
-      expect(currentSector.getAttribute('stroke')).toBe(initialAttributes[index].stroke);
-    });
-  }
-
-  await animationManager.completeAnimation();
-  // Final check to ensure the animation completed
-  const finalPieSectors = selectPieSectors(container);
-  expect(finalPieSectors).toHaveLength(initialPieSectors.length);
-  finalPieSectors.forEach((sector, index) => {
-    expect(trim(sector.getAttribute('d'))).not.toBe(initialPathDs[index]);
-    expect(sector.getAttribute('fill')).toBe(initialAttributes[index].fill);
-    expect(sector.getAttribute('stroke')).toBe(initialAttributes[index].stroke);
-  });
-
-  // collect the path.d-s one last time, at the end of the animation
-  const finalPathDs = Array.from(finalPieSectors).map(getD);
-  pathDsDuringAnimation.push(finalPathDs);
-
-  // Return the collected path.d-s
-  expect(pathDsDuringAnimation).toHaveLength(steps);
-
-  return pathDsDuringAnimation;
-}
-
-async function expectAnimatedPieAngles(
-  container: Element,
-  animationManager: MockAnimationManager,
-  steps: number = 5,
-): Promise<ReadonlyArray<ReadonlyArray<{ startAngle: number; endAngle: number }>>> {
-  assertNotNull(container);
-  /*
-   * Pie sectors at 0% progress do not render at all, so we
-   * start from 0.1 so that the sectors have rendered a little bit.
-   */
-  let animationProgress = 0.1;
-  await animationManager.setAnimationProgress(animationProgress);
-  const stepSize = (1 - animationProgress) / steps;
-  const initialPieSectors = selectPieSectors(container);
-  const initialAngles = getPieSectorAngles(initialPieSectors);
-  const initialAttributes = Array.from(initialPieSectors).map(sector => ({
-    fill: sector.getAttribute('fill'),
-    stroke: sector.getAttribute('stroke'),
-  }));
-
-  const anglesDuringAnimation: { startAngle: number; endAngle: number }[][] = [];
-  for (animationProgress += stepSize; animationProgress < 1; animationProgress += stepSize) {
-    // eslint-disable-next-line no-await-in-loop
-    await animationManager.setAnimationProgress(animationProgress);
-    const currentPieSectors = selectPieSectors(container);
-    const currentAngles = getPieSectorAngles(currentPieSectors);
-    anglesDuringAnimation.push(currentAngles);
-
-    // Assert that all angles change
-    initialAngles.forEach((initial, index) => {
-      const current = currentAngles[index];
-      const currentSector = currentPieSectors[index];
-      expect(currentSector.getAttribute('fill')).toBe(initialAttributes[index].fill);
-      expect(currentSector.getAttribute('stroke')).toBe(initialAttributes[index].stroke);
-      if (index === 0) {
-        // Because the pie grows from the same position, the start angle should remain the same for the first sector
-        expect(current.startAngle).toBe(initial.startAngle);
-      } else {
-        // For all other sectors, the start angle should change
-        expect(current.startAngle).not.toBe(initial.startAngle);
-      }
-      if (index !== currentAngles.length - 1) {
-        /*
-         * This is true for all sectors except the last one because the Pie is always a full circle.
-         * During the initial animation the Pie "grows" from the center, so the end angle of the last sector
-         * will indeed be different from the initial end angle,
-         * but during the "rearrange angles" animation the end angle of the last sector
-         * will always be 360 degrees, same as the initial end angle.
-         */
-        expect(current.endAngle).not.toBe(initial.endAngle);
-      }
-    });
-  }
-
-  await animationManager.completeAnimation();
-  // Final check to ensure the animation completed
-  const finalPieSectors = selectPieSectors(container);
-  expect(finalPieSectors).toHaveLength(initialPieSectors.length);
-  const finalAngles = getPieSectorAngles(finalPieSectors);
-  finalAngles.forEach((final, index) => {
-    const initial = initialAngles[index];
-    const finalSector = finalPieSectors[index];
-    expect(finalSector.getAttribute('fill')).toBe(initialAttributes[index].fill);
-    expect(finalSector.getAttribute('stroke')).toBe(initialAttributes[index].stroke);
-    if (index === 0) {
-      // Because the pie grows from the same position, the start angle should remain the same for the first sector
-      expect(final.startAngle).toBe(initial.startAngle);
-    } else {
-      // For all other sectors, the start angle should change
-      expect(final.startAngle).not.toBe(initial.startAngle);
-    }
-    if (index !== finalAngles.length - 1) {
-      /*
-       * This is true for all sectors except the last one because the Pie is always a full circle.
-       * During the initial animation the Pie "grows" from the center, so the end angle of the last sector
-       * will indeed be different from the initial end angle,
-       * but during the "rearrange angles" animation the end angle of the last sector
-       * will always be 360 degrees, same as the initial end angle.
-       */
-      expect(final.endAngle).not.toBe(initial.endAngle);
-    }
-  });
-
-  // Also, because the Pie is always a full circle, the end angle of the last sector should be 360 degrees
-  expect(finalAngles[finalAngles.length - 1].endAngle).toBe(0);
-
-  // collect the angles one last time, at the end of the animation
-  anglesDuringAnimation.push(finalAngles);
-
-  // Return the collected angles
-  expect(anglesDuringAnimation).toHaveLength(steps);
-
-  return anglesDuringAnimation;
-}
 
 describe('Pie animation', () => {
   const onAnimationStart = vi.fn();

--- a/test/polar/Pie/PieWithLegend.animation.spec.tsx
+++ b/test/polar/Pie/PieWithLegend.animation.spec.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
+import { Legend, Pie, PieChart } from '../../../src';
+import { expectPieSectors } from '../../helper/expectPieSectors';
+import { PageData } from '../../_data';
+import { expectAnimatedPiePaths } from '../../helper/expectAnimatedPiePaths';
+import { expectAnimatedPieAngles } from '../../helper/expectAnimatedPieAngles';
+
+const smallerData = PageData.slice(0, 3);
+
+describe('initial animation when the chart has Legend in it (https://github.com/recharts/recharts/issues/7254)', () => {
+  const onAnimationStart = vi.fn();
+  const onAnimationEnd = vi.fn();
+
+  beforeEach(() => {
+    onAnimationStart.mockClear();
+    onAnimationEnd.mockClear();
+  });
+
+  const renderTestCase = createSelectorTestCase(({ children }) => (
+    <PieChart width={100} height={100}>
+      <Pie
+        data={smallerData}
+        dataKey="amt"
+        isAnimationActive
+        onAnimationStart={onAnimationStart}
+        onAnimationEnd={onAnimationEnd}
+      />
+      <Legend />
+      {children}
+    </PieChart>
+  ));
+
+  it('should first render nothing', () => {
+    const { container } = renderTestCase();
+
+    // Initially, no sectors should be rendered
+    expectPieSectors(container, []);
+  });
+
+  it('should call onAnimationStart callback when the animation begins', async () => {
+    const { animationManager } = renderTestCase();
+    expect(onAnimationStart).toHaveBeenCalledTimes(1);
+
+    await animationManager.setAnimationProgress(0.1);
+    expect(onAnimationStart).toHaveBeenCalledTimes(1);
+    expect(onAnimationStart).toHaveBeenCalledWith();
+
+    await animationManager.completeAnimation();
+    expect(onAnimationStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onAnimationEnd callback when the animation ends', async () => {
+    const { animationManager } = renderTestCase();
+
+    expect(onAnimationEnd).not.toHaveBeenCalled();
+    await animationManager.setAnimationProgress(0.9);
+    expect(onAnimationEnd).not.toHaveBeenCalled();
+
+    await animationManager.completeAnimation();
+    expect(onAnimationEnd).toHaveBeenCalledTimes(1);
+    expect(onAnimationEnd).toHaveBeenCalledWith();
+  });
+
+  it('should render sectors with animation', async () => {
+    const { container, animationManager } = renderTestCase();
+
+    const pathDs = await expectAnimatedPiePaths(container, animationManager, 5);
+
+    expect(pathDs).toEqual([
+      [
+        'M 86,50 A 36,36,0, 0,0, 69.7423,19.8961 L 50,50 Z',
+        'M 69.7423,19.8961 A 36,36,0, 0,0, 35.6532,16.9823 L 50,50 Z',
+        'M 35.6532,16.9823 A 36,36,0, 0,0, 14.5223,43.8902 L 50,50 Z',
+      ],
+      [
+        'M 86,50 A 36,36,0, 0,0, 49.2784,14.0072 L 50,50 Z',
+        'M 49.2784,14.0072 A 36,36,0, 0,0, 14.0289,51.443 L 50,50 Z',
+        'M 14.0289,51.443 A 36,36,0, 0,0, 52.1638,85.9349 L 50,50 Z',
+      ],
+      [
+        'M 86,50 A 36,36,0, 0,0, 38.1402,16.0096 L 50,50 Z',
+        'M 38.1402,16.0096 A 36,36,0, 0,0, 21.8141,72.3955 L 50,50 Z',
+        'M 21.8141,72.3955 A 36,36,0, 0,0, 80.4308,69.2345 L 50,50 Z',
+      ],
+      [
+        'M 86,50 A 36,36,0, 0,0, 33.2853,18.1156 L 50,50 Z',
+        'M 33.2853,18.1156 A 36,36,0, 0,0, 29.5212,79.6078 L 50,50 Z',
+        'M 29.5212,79.6078 A 36,36,0, 0,0, 85.7312,54.3908 L 50,50 Z',
+      ],
+      [
+        'M 86,50 A 36,36,0, 0,0, 32,18.8231 L 50,50 Z',
+        'M 32,18.8231 A 36,36,0, 0,0, 32,81.1769 L 50,50 Z',
+        'M 32,81.1769 A 36,36,0, 0,0, 86,50 L 50,50 Z',
+      ],
+    ]);
+  });
+
+  it('should render sectors with animated angles', async () => {
+    const { container, animationManager } = renderTestCase();
+
+    const angles = await expectAnimatedPieAngles(container, animationManager, 4);
+
+    expect(angles).toEqual([
+      [
+        { endAngle: 67.2973, startAngle: 0 },
+        { endAngle: 134.5946, startAngle: 67.2973 },
+        { endAngle: 201.8918, startAngle: 134.5946 },
+      ],
+      [
+        { endAngle: 101.7302, startAngle: 0 },
+        { endAngle: 203.4603, startAngle: 101.7302 },
+        { endAngle: 305.1906, startAngle: 203.4603 },
+      ],
+      [
+        { endAngle: 116.2289, startAngle: 0 },
+        { endAngle: 232.4579, startAngle: 116.2289 },
+        { endAngle: 348.6866, startAngle: 232.4579 },
+      ],
+      [
+        { endAngle: 120, startAngle: 0 },
+        { endAngle: 240, startAngle: 120 },
+        { endAngle: 0, startAngle: 240 },
+      ],
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

So I tried to reproduce the Pie + Legend animation problem and turns out that I accidentally fixed it in https://github.com/recharts/recharts/pull/7457. So here is at least a test to prevent regressions. I confirmed I can reproduce in browser and in the unit test before that commit, and cannot reproduce after the commit.

## Related Issue

Closes https://github.com/recharts/recharts/issues/7254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for pie chart animations with new helper functions for validating sector paths and angles during animation.
  * Added comprehensive test coverage for pie chart animations when a legend is present, including animation lifecycle callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->