### PR TITLE
Add custom fillOpacity on hover website example

### DIFF
--- a/www/src/docs/exampleComponents/PieChart/PieChartWithCustomizedLabel.tsx
+++ b/www/src/docs/exampleComponents/PieChart/PieChartWithCustomizedLabel.tsx
@@ -1,4 +1,12 @@
-import { Pie, PieChart, PieLabelRenderProps, PieSectorShapeProps, Sector } from 'recharts';
+import {
+  Pie,
+  PieChart,
+  PieLabelRenderProps,
+  PieSectorShapeProps,
+  Sector,
+  useActiveTooltipDataPoints,
+  useIsTooltipActive,
+} from 'recharts';
 import { RechartsDevtools } from '@recharts/devtools';
 
 // #region Sample data
@@ -31,7 +39,23 @@ const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, per
 };
 
 const MyCustomPie = (props: PieSectorShapeProps) => {
-  return <Sector {...props} fill={COLORS[props.index % COLORS.length]} />;
+  const p = useActiveTooltipDataPoints();
+  const isAnyPieActive = useIsTooltipActive();
+  const isThisPieActive = isAnyPieActive && props.payload === p?.[0];
+  let fillOpacity: number;
+  if (isAnyPieActive && !isThisPieActive) {
+    fillOpacity = 0.5;
+  } else {
+    fillOpacity = 1;
+  }
+  return (
+    <Sector
+      {...props}
+      fill={COLORS[props.index % COLORS.length]}
+      fillOpacity={fillOpacity}
+      style={{ transition: 'fill-opacity 0.3s ease' }}
+    />
+  );
 };
 
 export default function PieChartWithCustomizedLabel({ isAnimationActive = true }: { isAnimationActive?: boolean }) {


### PR DESCRIPTION
## Description

Cell is deprecated and will be removed in 4.0, please don't use Cell. This example shows setting opacity using hooks instead.

## Related Issue

Closes https://github.com/recharts/recharts/issues/5045
Closes https://github.com/recharts/recharts/issues/4216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced pie chart interactivity with improved visual feedback. Chart segments now display opacity changes with smooth transitions when hovering, providing a more intuitive and responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->