### PR TITLE
Add id-token: write to npm-publish.yml

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -56,5 +56,3 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm publish --tag "${{ steps.release-info.outputs.npm_tag }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -55,4 +55,5 @@ jobs:
           echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
       - run: npm ci
       - run: npm run build
+      - run: npm install -g npm@latest
       - run: npm publish --tag "${{ steps.release-info.outputs.npm_tag }}"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,8 @@
 name: npm publish
 
 permissions:
+  # https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
+  id-token: write  # Required for OIDC
   contents: read
 
 on:
@@ -19,6 +21,7 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
+          package-manager-cache: false  # never use caching in release builds
       - name: Determine release version and npm dist-tag
         id: release-info
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,9 +3,6 @@
 
 name: npm publish
 
-permissions:
-  contents: read
-
 on:
   release:
     types: [published]
@@ -16,9 +13,13 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Recharts Repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v6
@@ -45,13 +46,16 @@ jobs:
           retention-days: 1
 
   publish-npm:
-    permissions:
-      # https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
-      id-token: write # Required for OIDC
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
+      id-token: write # Required for OIDC
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 26
           registry-url: https://registry.npmjs.org/
           package-manager-cache: false  # never use caching in release builds
       - name: Determine release version and npm dist-tag
@@ -55,5 +55,4 @@ jobs:
           echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
       - run: npm ci
       - run: npm run build
-      - run: npm install -g npm@latest
       - run: npm publish --tag "${{ steps.release-info.outputs.npm_tag }}"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,24 +4,65 @@
 name: npm publish
 
 permissions:
-  # https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
-  id-token: write  # Required for OIDC
   contents: read
 
 on:
   release:
     types: [published]
+env:
+  NODE_VERSION: 26.x
 
 jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Recharts Repository
+        uses: actions/checkout@v7
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org/
+          package-manager-cache: false  # never use caching in release builds
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build main lib
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: |
+            es6/
+            lib/
+            umd/
+            types/
+          retention-days: 1
+
   publish-npm:
+    permissions:
+      # https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
+      id-token: write # Required for OIDC
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 26
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org/
           package-manager-cache: false  # never use caching in release builds
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+
       - name: Determine release version and npm dist-tag
         id: release-info
         env:
@@ -53,6 +94,4 @@ jobs:
           fi
 
           echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
-      - run: npm ci
-      - run: npm run build
       - run: npm publish --tag "${{ steps.release-info.outputs.npm_tag }}"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,8 +16,8 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
Following https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the npm publishing workflow to use GitHub OIDC “trusted publishing” for improved release authentication.
  * Refreshed the release build steps and adjusted publish behavior to remove token-based npm authentication.
  * Updated release build configuration, including package-manager caching behavior.

* **Security**
  * Improved publish credentials handling by eliminating the need for an npm auth token.

*No user-facing changes in this release.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->