### PR TITLE
Refresh ScatterChartPerformance example

### DIFF
--- a/www/src/docs/exampleComponents/ScatterChart/ScatterChartPerformance.tsx
+++ b/www/src/docs/exampleComponents/ScatterChart/ScatterChartPerformance.tsx
@@ -1,18 +1,23 @@
-import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+import { CartesianGrid, Scatter, ScatterChart, Tooltip, XAxis, YAxis, ZAxis } from 'recharts';
 import { between, random, RechartsDevtools } from '@recharts/devtools';
 
 const gen = random(42);
 
-const chartData = {
-  points: Array.from({ length: 100 }, (_1, i) => ({
+const countOfScatterElements = 100;
+const pointsPerScatter = 10;
+
+const datasets = Array.from({ length: countOfScatterElements }, (_1, i) => {
+  const passed = between(gen, 0, 10) > 5;
+  return {
     name: `line-${i}`,
-    passed: between(gen, 0, 10) > 5,
-    points: Array.from({ length: 10 }, (_2, j) => ({
-      x: j * 0.1,
+    passed,
+    points: Array.from({ length: pointsPerScatter }, _2 => ({
+      x: between(gen, 0, 100),
       y: between(gen, 0, 100),
+      z: between(gen, 0, 100),
     })),
-  })),
-};
+  };
+});
 
 export default function ScatterChartPerformance() {
   return (
@@ -29,15 +34,15 @@ export default function ScatterChartPerformance() {
       <CartesianGrid />
       <XAxis dataKey="x" type="number" unit="m" domain={[0, 1]} />
       <YAxis dataKey="y" type="number" unit="m" domain={[0, 100]} />
+      <ZAxis dataKey="z" range={[0, 100]} />
       <Tooltip />
 
-      {chartData.points.map(line => (
+      {datasets.map(line => (
         <Scatter
           key={line.name}
           data={line.points}
           fill={line.passed ? '#22c55e' : '#ef4444'}
           isAnimationActive={false}
-          line
           name={line.name}
           strokeWidth={4}
         />

--- a/www/src/docs/exampleComponents/ScatterChart/index.tsx
+++ b/www/src/docs/exampleComponents/ScatterChart/index.tsx
@@ -77,5 +77,11 @@ export const scatterChartExamples = {
     Component: ScatterChartPerformance,
     sourceCode: scatterChartPerformanceSource,
     name: 'Scatter Chart with many points (performance test)',
+    description: (
+      <p>
+        Renders multiple Scatter elements with multiple points in them. Edit this example to add or remove data points
+        and observe performance.
+      </p>
+    ),
   },
 } satisfies Record<string, ChartExample>;


### PR DESCRIPTION
## Description

Example only, so that we have some baseline for Scatter perf optimizations.

Here are some baseline observations on my laptop and 1k data points:

Initial render:
<img width="1440" height="655" alt="image" src="https://github.com/user-attachments/assets/16a4cdec-fb2d-4cb2-bae7-0bdb5cd1ee0e" />

<img width="1337" height="1263" alt="image" src="https://github.com/user-attachments/assets/7d4cf0b8-c72e-4e4c-b977-2d005fc841b2" />


Mouse over
<img width="1593" height="604" alt="image" src="https://github.com/user-attachments/assets/da0be06d-16e7-48e9-974b-b295487f4973" />

<img width="1333" height="1235" alt="image" src="https://github.com/user-attachments/assets/f87f4299-eea1-40f2-a702-c5f6b3e820d8" />


## Related Issue

https://github.com/recharts/recharts/issues/2862


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced scatter chart performance example to demonstrate 3D-scatter visualization with Z-axis support and parameterized dataset generation.

* **Documentation**
  * Added descriptive guidance to the scatter chart performance example with instructions for editing data points and observing performance impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->