### PR TITLE
Add ?isolated mode to website

### DIFF
--- a/www/src/components/Playground/ToolFrame.tsx
+++ b/www/src/components/Playground/ToolFrame.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { useIsIsolatedView } from '../../routes/useIsIsolatedView.ts';
 
 /**
  * The allowed types of tools in the playground.
@@ -55,6 +56,11 @@ type ToolFrameProps = {
  */
 export function ToolFrame({ activeTool, onToolChange, tools, className = '' }: ToolFrameProps) {
   const activeToolItem = tools.find(t => t.name === activeTool);
+  const isIsolated = useIsIsolatedView();
+
+  if (isIsolated) {
+    return null;
+  }
 
   return (
     <div className={`codemirror-wrapper ${className}`}>

--- a/www/src/layouts/Frame.tsx
+++ b/www/src/layouts/Frame.tsx
@@ -9,6 +9,7 @@ import { useLocale } from '../utils/LocaleUtils.ts';
 import { Navigation } from '../components/Navigation.tsx';
 import { SidebarNav } from '../components/Shared/SidebarNav';
 import { RechartsLogo } from './RechartsLogo.tsx';
+import { useIsIsolatedView } from '../routes/useIsIsolatedView.ts';
 
 type FrameProps = {
   children: ReactNode;
@@ -25,10 +26,15 @@ export function getShortCommitHash(commitHash: string | undefined): string | und
 }
 
 export function Frame(props: FrameProps) {
+  const isIsolated = useIsIsolatedView();
   const { children } = props;
   const locale = useLocale();
   const fullCommitHash = import.meta.env.VITE_RECHARTS_COMMIT_HASH;
   const shortCommitHash = getShortCommitHash(fullCommitHash);
+
+  if (isIsolated) {
+    return <main>{children}</main>;
+  }
 
   return (
     <div className="container">

--- a/www/src/routes/useIsIsolatedView.ts
+++ b/www/src/routes/useIsIsolatedView.ts
@@ -1,0 +1,13 @@
+import { useSearchParams } from 'react-router';
+
+const queryParamName = 'isolated';
+
+/**
+ * Reads ?isolated query param. If true (or empty) returns true.
+ * This is useful if you want to only render the one chart and don't want the dozens of others rendered on the page.
+ * This turns off the navigation, devtools, menus, footer.
+ */
+export function useIsIsolatedView(): boolean {
+  const [params] = useSearchParams();
+  return params.has(queryParamName) && params.get(queryParamName) !== 'false';
+}


### PR DESCRIPTION
Website only. I want to observe some performance changes but the other charts get in the way so I hide all the others when this query param is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an isolated-view mode that shows only the main content area.
  * Toolbars, navigation, sidebar, and footer are hidden in this mode for a cleaner focused view.
  * The app now recognizes an `isolated` URL parameter to toggle this behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->