### PR TITLE
Add stacked bar chart with horizontal threshold line example and test

### DIFF
--- a/test-vr/tests/www/BarChartApiExamples.spec-vr.tsx
+++ b/test-vr/tests/www/BarChartApiExamples.spec-vr.tsx
@@ -21,6 +21,7 @@ import TimelineExample from '../../../www/src/docs/exampleComponents/BarChart/Ti
 import CandlestickExample from '../../../www/src/docs/exampleComponents/BarChart/CandlestickExample';
 import BoxPlotExample from '../../../www/src/docs/exampleComponents/BarChart/BoxPlotExample';
 import AnimatedBarWidthExample from '../../../www/src/docs/exampleComponents/BarChart/AnimatedBarWidthExample';
+import StackedBarChartWithHorizontalLine from '../../../www/src/docs/exampleComponents/BarChart/StackedBarChartWithHorizontalLine';
 
 test('CandlestickExample', async ({ mount }) => {
   const component = await mount(<CandlestickExample defaultIndex="50" />);
@@ -128,5 +129,10 @@ test('RangedStackedBarChart', async ({ mount }) => {
 
 test('AnimatedBarWidthExample', async ({ mount }) => {
   const component = await mount(<AnimatedBarWidthExample isAnimationActive={false} defaultIndex="2" />);
+  await expect(component).toHaveScreenshot();
+});
+
+test('StackedBarChartWithHorizontalLine', async ({ mount }) => {
+  const component = await mount(<StackedBarChartWithHorizontalLine />);
   await expect(component).toHaveScreenshot();
 });

--- a/www/src/docs/exampleComponents/BarChart/StackedBarChartWithHorizontalLine.tsx
+++ b/www/src/docs/exampleComponents/BarChart/StackedBarChartWithHorizontalLine.tsx
@@ -1,0 +1,149 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ReferenceLine,
+  LabelList,
+  LabelProps,
+} from 'recharts';
+import { RechartsDevtools } from '@recharts/devtools';
+
+// #region Sample data
+const data = [
+  {
+    name: 'Page A',
+    data1: 4000,
+    data2: 2400,
+    data3: 1500,
+    amt: 2400,
+  },
+  {
+    name: 'Page B',
+    data1: 9000,
+    data2: 1398,
+    data3: 2500,
+    amt: 2210,
+  },
+  {
+    name: 'Page C',
+    data1: 2000,
+    data2: 9800,
+    data3: 4200,
+    amt: 2290,
+  },
+  {
+    name: 'Page D',
+    data1: 2780,
+    data2: 3908,
+    data3: 1300,
+    amt: 2000,
+  },
+  {
+    name: 'Page E',
+    data1: 1890,
+    data2: 4800,
+    data3: 5400,
+    amt: 2181,
+  },
+  {
+    name: 'Page F',
+    data1: 2390,
+    data2: 8800,
+    data3: 1500,
+    amt: 3000,
+  },
+  {
+    name: 'Page G',
+    data1: 3490,
+    data2: 4300,
+    data3: 2600,
+    amt: 2100,
+  },
+];
+
+// #endregion
+const THRESHOLD = 18000;
+
+type DataPoint = (typeof data)[number];
+
+const StackTotalLabel = (props: LabelProps) => {
+  const { x, y, width, value } = props;
+  const total = Number(value);
+  if (x == null || y == null || width == null || Number.isNaN(total)) {
+    return null;
+  }
+
+  const label = total.toLocaleString();
+  const cx = Number(x) + Number(width) / 2;
+  const cy = Number(y) - 18;
+  const boxWidth = label.length * 8 + 16;
+  const boxHeight = 22;
+  const borderRadius = 6;
+
+  return (
+    <g>
+      <rect
+        x={cx - boxWidth / 2}
+        y={cy - boxHeight / 2}
+        width={boxWidth}
+        height={boxHeight}
+        rx={borderRadius}
+        ry={borderRadius}
+        fill="#fff"
+        stroke="#E2F0CB"
+        strokeWidth={1.5}
+      />
+      <text x={cx} y={cy} fill="#333" textAnchor="middle" dominantBaseline="middle" fontSize={12} fontWeight={400}>
+        {label}
+      </text>
+    </g>
+  );
+};
+
+const StackedBarChartWithHorizontalLine = () => {
+  return (
+    <BarChart
+      style={{ width: '100%', maxWidth: '700px', maxHeight: '70vh', aspectRatio: 1.618 }}
+      responsive
+      data={data}
+      margin={{
+        top: 40,
+        right: 0,
+        left: 30,
+        bottom: 5,
+      }}
+    >
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey="name" niceTicks="snap125" />
+      <YAxis width="auto" niceTicks="snap125" />
+      <Tooltip cursor={false} />
+      <Legend />
+      <ReferenceLine
+        y={THRESHOLD}
+        stroke="red"
+        strokeWidth={2}
+        label={{ value: 'Threshold', fill: 'red', position: 'left' }}
+      />
+      <Bar dataKey="data1" stackId="a" fill="#C7CEEA" />
+      <Bar dataKey="data2" stackId="a" fill="#B5EAD7" />
+      <Bar dataKey="data3" stackId="a" fill="#E2F0CB">
+        <LabelList
+          content={StackTotalLabel}
+          position="top"
+          offset={8}
+          valueAccessor={entry => {
+            const point = entry.payload as DataPoint;
+            return point.data1 + point.data2 + point.data3;
+          }}
+        />
+      </Bar>
+      <RechartsDevtools />
+    </BarChart>
+  );
+};
+
+export default StackedBarChartWithHorizontalLine;

--- a/www/src/docs/exampleComponents/BarChart/StackedBarChartWithHorizontalLine.tsx
+++ b/www/src/docs/exampleComponents/BarChart/StackedBarChartWithHorizontalLine.tsx
@@ -73,10 +73,6 @@ type DataPoint = (typeof data)[number];
 const StackTotalLabel = (props: LabelProps) => {
   const { x, y, width, value } = props;
   const total = Number(value);
-  if (x == null || y == null || width == null || Number.isNaN(total)) {
-    return null;
-  }
-
   const label = total.toLocaleString();
   const cx = Number(x) + Number(width) / 2;
   const cy = Number(y) - 18;

--- a/www/src/docs/exampleComponents/BarChart/index.tsx
+++ b/www/src/docs/exampleComponents/BarChart/index.tsx
@@ -50,6 +50,8 @@ import AnimatedBarTimeSeriesExample, {
 import AnimatedBarTimeSeriesExampleSource from './AnimatedBarTimeSeriesExample.tsx?raw';
 import ScrollAnimateBarChart from './ScrollAnimateBarChart.tsx';
 import ScrollAnimateBarChartSource from './ScrollAnimateBarChart.tsx?raw';
+import StackedBarChartWithHorizontalLine from './StackedBarChartWithHorizontalLine.tsx';
+import StackedBarChartWithHorizontalLineSource from './StackedBarChartWithHorizontalLine.tsx?raw';
 
 export { BarChartNavExample };
 
@@ -234,6 +236,21 @@ export const barChartExamples = {
         This example uses new components introduced in 3.9 to animate the chart based on the scroll position. The
         animation controller is provided by a custom function that listens to the window scroll event and updates the
         animation time.
+      </p>
+    ),
+  },
+  StackedBarChartWithHorizontalLine: {
+    Component: StackedBarChartWithHorizontalLine,
+    sourceCode: StackedBarChartWithHorizontalLineSource,
+    name: 'Stacked Bar Chart with Horizontal Line',
+    description: (
+      <p>
+        This example shows a stacked bar chart with a horizontal line indicating a threshold.
+        <br />
+        The chart uses the <strong>Bar</strong> component to create the bars, and the <strong>ReferenceLine</strong>
+        component to create the horizontal line.
+        <br />
+        The <strong>LabelList</strong> component is used to display the total value of the bars above the threshold.
       </p>
     ),
   },


### PR DESCRIPTION
## Description
Add stacked bar chart with horizontal threshold line example and test vr

## Screenshots (if appropriate):
<img width="770" height="593" alt="image" src="https://github.com/user-attachments/assets/02e25fa6-08ad-4b17-b7db-c8c4936c22d2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the stacked bar chart example so total labels are shown more consistently instead of being skipped in some cases.
* **Tests**
  * Added visual coverage for the stacked bar chart with horizontal line example to help catch display regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->