### PR TITLE
fix(DefaultLegendContent): omit empty value from legend icon aria-label

### DIFF
--- a/src/component/DefaultLegendContent.tsx
+++ b/src/component/DefaultLegendContent.tsx
@@ -238,7 +238,7 @@ function Items(props: InternalProps) {
           height={iconSize}
           viewBox={viewBox}
           style={svgStyle}
-          aria-label={`${entry.value} legend icon`}
+          aria-label={entry.value == null ? 'legend icon' : `${entry.value} legend icon`}
         >
           <Icon data={entry} iconType={iconType} inactiveColor={inactiveColor} />
         </Surface>

--- a/test/component/Legend.spec.tsx
+++ b/test/component/Legend.spec.tsx
@@ -618,6 +618,19 @@ describe('<Legend />', () => {
       expect(surface.getAttribute('aria-label')).toBe('UV legend icon');
     });
 
+    test('aria-label drops the value when the legend entry has no name or string dataKey', () => {
+      const { container } = rechartsTestRender(
+        <LineChart width={500} height={500} data={numericalData}>
+          <Legend />
+          <Line dataKey={row => row.value} />
+        </LineChart>,
+      );
+
+      const legendItem = container.getElementsByClassName('legend-item-0')[0];
+      const surface = legendItem.getElementsByClassName('recharts-surface')[0];
+      expect(surface.getAttribute('aria-label')).toBe('legend icon');
+    });
+
     it('should render one line legend item for each Line, with default class and style attributes', () => {
       const { container, getByText } = rechartsTestRender(
         <LineChart width={500} height={500} data={numericalData}>


### PR DESCRIPTION
The legend icon's `aria-label` is built as `${entry.value} legend icon`. When a series has no `name` and a function `dataKey`, `getTooltipNameProp` returns `undefined`, so the label becomes the literal string "undefined legend icon" and a screen reader reads out "undefined". The legend item renders no visible text in that case, so the accessible name no longer matches what is shown.

The fix guards the value: when it is missing the label is just "legend icon", otherwise it is unchanged. Small follow-up to #5414 (which added the label) and #7109 (which kept it on the raw value).

I added a test that renders `<Line dataKey={row => row.value} />` with no name. Before the change the icon's aria-label was "undefined legend icon"; after it is "legend icon". The full `Legend.spec` suite still passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legend accessibility labels so icon descriptions now fall back to a generic label when no entry value is available.
  * Prevented empty or confusing labels for legend items when a name is missing.

* **Tests**
  * Added coverage for legend behavior when entries lack a name and use a non-string data key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->