### PR TITLE
Do not fail npm publish if husky is not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-component"
   ],
   "scripts": {
-    "prepare": "husky",
+    "prepare": "husky || true",
     "prebuild": "npm run omnidoc",
     "build": "npm run build-types && npm run build-cjs && npm run build-es6 && npm run build-umd && npm run test-build-output",
     "build-cjs": "rimraf lib && cross-env NODE_ENV=commonjs babel ./src -d lib --extensions '.js,.ts,.tsx'",


### PR DESCRIPTION
This should fix the publishing workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved install/setup reliability by allowing the prepare step to complete even if optional Husky setup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->