### PR TITLE
docs: clarify custom labels and ticks need SVG elements

### DIFF
--- a/omnidoc/commentSimilarityExceptions.ts
+++ b/omnidoc/commentSimilarityExceptions.ts
@@ -124,6 +124,11 @@ export const commentSimilarityExceptions: ReadonlyArray<CommentSimilarityGroup> 
     reason: 'LabelList dataKey has special complications compared to other components',
   },
   {
+    components: ['LabelList'],
+    props: ['content'],
+    reason: 'LabelList content renders labels for data items, unlike Treemap content which renders tree nodes',
+  },
+  {
     components: ['Text'],
     props: ['width'],
     reason: 'has extra details on automated wrapping',

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -271,7 +271,8 @@ interface AreaProps<DataPointType = any, DataValueType = any>
    * - `true`: renders default labels
    * - `false`: no labels are rendered
    * - `object`: the props of LabelList component
-   * - `ReactElement`: a custom label element
+   * - `ReactElement`: a custom SVG label element, such as `<text>` or `<g>`.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: a render function of custom label
    *
    * @defaultValue false

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -329,7 +329,8 @@ interface BarProps<DataPointType, ValueAxisType> extends DataConsumer<DataPointT
    * - `true`: renders default labels;
    * - `false`: no labels are rendered;
    * - `object`: the props of LabelList component;
-   * - `ReactElement`: a custom label element;
+   * - `ReactElement`: a custom SVG label element, such as `<text>` or `<g>`.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: a render function of custom label.
    *
    * @defaultValue false

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -248,7 +248,8 @@ interface LineProps<DataPointType = any, DataValueType = any>
    * - `true`: renders default labels;
    * - `false`: no labels are rendered;
    * - `object`: the props of LabelList component;
-   * - `ReactElement`: a custom label element;
+   * - `ReactElement`: a custom SVG label element, such as `<text>` or `<g>`.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: a render function of custom label.
    *
    * @defaultValue false

--- a/src/cartesian/ReferenceArea.tsx
+++ b/src/cartesian/ReferenceArea.tsx
@@ -100,7 +100,8 @@ interface ReferenceAreaProps<
    * - `false`: no labels are rendered
    * - `string` | `number`: the content of the label
    * - `object`: the props of LabelList component
-   * - `ReactElement`: a custom label element
+   * - `ReactElement`: a custom SVG label element, such as `<text>` or `<g>`.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: a render function of custom label
    *
    * @defaultValue false

--- a/src/cartesian/ReferenceDot.tsx
+++ b/src/cartesian/ReferenceDot.tsx
@@ -78,7 +78,8 @@ interface ReferenceDotProps<
    * - `false`: no labels are rendered
    * - `string` | `number`: the content of the label
    * - `object`: the props of LabelList component
-   * - `ReactElement`: a custom label element
+   * - `ReactElement`: a custom SVG label element, such as `<text>` or `<g>`.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: a render function of custom label
    *
    * @defaultValue false

--- a/src/cartesian/ReferenceLine.tsx
+++ b/src/cartesian/ReferenceLine.tsx
@@ -117,7 +117,8 @@ interface ReferenceLineProps<
    * - `false`: no labels are rendered
    * - `string` | `number`: the content of the label
    * - `object`: the props of LabelList component
-   * - `ReactElement`: a custom label element
+   * - `ReactElement`: a custom SVG label element, such as `<text>` or `<g>`.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: a render function of custom label
    *
    * @defaultValue false

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -298,7 +298,8 @@ interface ScatterProps<DataPointType = any, DataValueType = any>
    * - `true`: renders default labels;
    * - `false`: no labels are rendered;
    * - `object`: the props of LabelList component;
-   * - `ReactElement`: a custom label element;
+   * - `ReactElement`: a custom SVG label element, such as `<text>` or `<g>`.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: a render function of custom label.
    *
    * @defaultValue false

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -138,7 +138,8 @@ interface XAxisProps<DataPointType = any, DataValueType = any> extends Omit<
    * - `false`: Do not render any tick labels.
    * - `true`: Render tick labels with default settings.
    * - `object`: An object of props to be merged into the internally calculated tick props.
-   * - `ReactElement`: A custom React element to be used as the tick label.
+   * - `ReactElement`: A custom SVG React element to be used as the tick label.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: A function that returns a React element for custom rendering of tick labels.
    *
    * @defaultValue true

--- a/src/cartesian/YAxis.tsx
+++ b/src/cartesian/YAxis.tsx
@@ -134,7 +134,8 @@ interface YAxisProps<DataPointType = any, DataValueType = any> extends Omit<
    * - `false`: Do not render any tick labels.
    * - `true`: Render tick labels with default settings.
    * - `object`: An object of props to be merged into the internally calculated tick props.
-   * - `ReactElement`: A custom React element to be used as the tick label.
+   * - `ReactElement`: A custom SVG React element to be used as the tick label.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: A function that returns a React element for custom rendering of tick labels.
    *
    * @defaultValue true

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -477,6 +477,8 @@ export interface Props<DataPointType extends TreemapDataType = TreemapDataType, 
 
   /**
    * If set to a React element, the option is the customized React element of rendering the content.
+   * Use an SVG element or component, such as `<text>` or `<g>`.
+   * HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * If set to a function, the function will be called to render the content.
    */
   content?: TreemapContentType;

--- a/src/component/Label.tsx
+++ b/src/component/Label.tsx
@@ -83,7 +83,9 @@ interface LabelProps extends ZIndexable {
   children?: RenderableText;
   className?: string;
   /**
-   * If set a React element, the option is the custom react element of rendering label.
+   * If set a React element, the option is the custom React element of rendering label.
+   * Use an SVG element or component, such as `<text>` or `<g>`.
+   * HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * If set a function, the function will be called to render label content.
    *
    * @example <Label content={CustomizedLabel} />

--- a/src/component/LabelList.tsx
+++ b/src/component/LabelList.tsx
@@ -79,6 +79,8 @@ interface LabelListProps extends ZIndexable {
   dataKey?: DataKey<any>;
   /**
    * If set a React element, the option is the customized React element of rendering each label.
+   * Use an SVG element or component, such as `<text>` or `<g>`.
+   * HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * If set to a function, the function is called once for each item
    *
    * @example <LabelList content={CustomizedLabel} />

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -332,7 +332,8 @@ interface PieProps<DataPointType = any, DataValueType = any>
    * - `false`: no labels are rendered;
    * - `object` that has `position` prop: the props of LabelList component;
    * - `object` that does not have `position` prop: the props of a custom Pie label (similar to Label with position "outside"); this variant supports `labelLine`
-   * - `ReactElement`: a custom label element;
+   * - `ReactElement`: a custom SVG label element, such as `<text>` or `<g>`.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: a render function of custom label.
    *
    * Also see the `labelLine` prop that draws a line connecting each label to the corresponding sector.

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -146,7 +146,8 @@ interface RadarProps<DataPointType = any, DataValueType = any>
    * - `true`: renders default labels;
    * - `false`: no labels are rendered;
    * - `object`: the props of LabelList component;
-   * - `ReactElement`: a custom label element;
+   * - `ReactElement`: a custom SVG label element, such as `<text>` or `<g>`.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: a render function of custom label.
    *
    * @defaultValue false

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -393,7 +393,8 @@ interface InternalRadialBarProps<DataPointType = any, DataValueType = any>
    * - `true`: renders default labels;
    * - `false`: no labels are rendered;
    * - `object`: the props of LabelList component;
-   * - `ReactElement`: a custom label element;
+   * - `ReactElement`: a custom SVG label element, such as `<text>` or `<g>`.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: a render function of custom label.
    *
    * @defaultValue false

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1001,7 +1001,8 @@ export interface RenderableAxisProps<DataPointType, DataValueType> extends BaseA
    * - `false`: no label is rendered
    * - `string` | `number`: the content of the label
    * - `object`: the props of LabelList component
-   * - `ReactElement`: a custom label element
+   * - `ReactElement`: a custom SVG label element, such as `<text>` or `<g>`.
+   *   HTML elements such as `<div>` are not valid inside the chart SVG and may trigger React DOM warnings.
    * - `function`: a render function of custom label
    *
    * @defaultValue false


### PR DESCRIPTION
## Description

Clarifies that custom `label`, `Label`, `LabelList`, `XAxis tick`, and `YAxis tick` React elements need to be SVG elements/components, not HTML elements such as `<div>`.

## Related Issue

Refs #3177

## Motivation and Context

Issue #3177 includes a request to document React DOM warnings when an HTML element is used as chart label/tick content. These prop comments feed the generated API documentation, so this makes the supported custom-rendering surface explicit near the affected props.

## How Has This Been Tested?

- `git diff --check HEAD~1 HEAD`
- Verified the new guidance appears in the affected source comments with `grep`

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance across chart components for `label`, `tick`, and label `content` to use SVG-based React elements (e.g., `<text>`/`<g>`).
  * Added explicit warnings in prop docs that HTML elements like `<div>` are invalid inside SVG-rendered charts and may trigger React DOM warnings.
  * Updated label-related documentation consistently, including Treemap and axis label typings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
