### PR TITLE
fix(Brush): keep controlled startIndex/endIndex on data updates

### DIFF
--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -990,9 +990,14 @@ function BrushInternal(props: InternalProps) {
   const { startIndex: startIndexFromProps, endIndex: endIndexFromProps } = props;
 
   useEffect(() => {
-    // start and end index can be controlled from props, and we need them to stay up-to-date in the Redux state too
+    /*
+     * start and end index can be controlled from props, and we need them to stay up-to-date in the Redux state too.
+     * `chartData` is also a dependency here: whenever the chart data changes, `chartDataSlice` may reset
+     * `dataStartIndex` / `dataEndIndex` back to the full range. If the indices are controlled from props,
+     * this effect re-applies them so a controlled Brush selection is never silently clobbered by a data update.
+     */
     dispatch(setDataStartEndIndexes({ startIndex: startIndexFromProps, endIndex: endIndexFromProps }));
-  }, [dispatch, endIndexFromProps, startIndexFromProps]);
+  }, [dispatch, endIndexFromProps, startIndexFromProps, chartData]);
 
   useBrushChartSynchronisation();
 

--- a/test/cartesian/Brush.spec.tsx
+++ b/test/cartesian/Brush.spec.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { describe, expect, test, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BarChart, Brush, BrushProps, ComposedChart, Customized, Line, LineChart, ReferenceLine } from '../../src';
 import { assertNotNull } from '../helper/assertNotNull';
 import { useAppSelector } from '../../src/state/hooks';
@@ -707,7 +707,10 @@ describe('<Brush />', () => {
       // Simulate a parent re-render that creates a brand new array instance
       // (e.g. a fresh fetch or a non-memoized map) with the same length.
       const button = container.querySelector('button') as HTMLButtonElement;
-      fireEvent.click(button);
+      act(() => {
+        fireEvent.click(button);
+        vi.runOnlyPendingTimers();
+      });
 
       const lastCall = spy.mock.calls[spy.mock.calls.length - 1][0];
       expect(lastCall.chartData).not.toBe(data);

--- a/test/cartesian/Brush.spec.tsx
+++ b/test/cartesian/Brush.spec.tsx
@@ -673,6 +673,49 @@ describe('<Brush />', () => {
     });
   });
 
+  describe('controlled startIndex and endIndex across data updates', () => {
+    // Keeping this as a stable component reference (not re-created per render) matters:
+    // if the component type identity changed between renders, React would unmount and
+    // remount the whole chart instead of re-rendering it, which would defeat the purpose
+    // of this test (a genuine parent re-render with a new `data` array, not a remount).
+    function ControlledBrushWithChangingData({ children }: { children: React.ReactNode }) {
+      const [chartData, setChartData] = useState(data);
+      return (
+        <>
+          <BarChart width={400} height={100} data={chartData}>
+            {children}
+            <Brush dataKey="value" startIndex={2} endIndex={5} x={100} y={50} width={400} height={40} />
+          </BarChart>
+          <button type="button" onClick={() => setChartData(data.map(entry => ({ ...entry })))}>
+            change data
+          </button>
+        </>
+      );
+    }
+
+    it('should preserve the controlled startIndex and endIndex when the data array identity changes but the length stays the same', () => {
+      const renderTestCase = createSelectorTestCase(ControlledBrushWithChangingData);
+      const { spy, container } = renderTestCase(selectChartDataWithIndexes);
+
+      expectLastCalledWith(spy, {
+        chartData: data,
+        dataStartIndex: 2,
+        dataEndIndex: 5,
+        computedData: undefined,
+      });
+
+      // Simulate a parent re-render that creates a brand new array instance
+      // (e.g. a fresh fetch or a non-memoized map) with the same length.
+      const button = container.querySelector('button') as HTMLButtonElement;
+      fireEvent.click(button);
+
+      const lastCall = spy.mock.calls[spy.mock.calls.length - 1][0];
+      expect(lastCall.chartData).not.toBe(data);
+      expect(lastCall.dataStartIndex).toBe(2);
+      expect(lastCall.dataEndIndex).toBe(5);
+    });
+  });
+
   describe('dy props', () => {
     it('should added its given y value', () => {
       const { container } = render(


### PR DESCRIPTION
## Description

Controlled `startIndex`/`endIndex` on `<Brush>` get silently overwritten when the chart `data` array changes. The sync effect that copies the props into Redux only depended on the index props themselves, so once `chartDataSlice` reset `dataStartIndex`/`dataEndIndex` on a data update, nothing re-applied the controlled values. Adding `chartData` to that effect's dependency array makes it re-assert the controlled indices any time the data changes, not just when the index props change.

This does not touch `chartDataSlice.ts` or the reducer's reset behavior at all, and does not affect uncontrolled Brush usage in any way (`setDataStartEndIndexes` is a no-op when both indices are undefined). It's unrelated to the referential-equality discussion in #7021 - that was about whether Brush should treat a same-length new array reference as "unchanged" for internally-managed selection state, which is a separate question from what a controlled component does with props it was explicitly given. This PR doesn't reopen that; it just makes controlled props actually win, the same way a controlled `<input value>` would.

## Related Issue

Fixes #7462

## Motivation and Context

Bug fix. Controlled Brush is a documented pattern and currently doesn't work reliably across data updates.

## How Has This Been Tested?

Added a unit test in test/cartesian/Brush.spec.tsx that renders a controlled Brush, changes the data array to a new reference of the same length, and asserts the controlled indices are preserved. Ran the full unit suite locally, all green.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Brush start/end range controls now remain consistent when the chart updates its underlying data, avoiding unintended resets of the selected brush positions.
  * Controlled brush indices are preserved across data re-renders, even when the chart receives a new data array instance.
* **Tests**
  * Added coverage to verify controlled Brush indices stay stable after parent chart re-renders with updated data identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->