### PR TITLE
fix: keep active dot index on accessibility focus

### DIFF
--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1511,6 +1511,12 @@ export const generateCategoricalChart = ({
       eventCenter.removeListener(SYNC_EVENT, this.handleReceiveSyncEvent);
     }
 
+    syncAccessibilityIndex(state: CategoricalChartState) {
+      if (typeof state.activeTooltipIndex === 'number' && state.activeTooltipIndex >= 0) {
+        this.accessibilityManager.setIndex(state.activeTooltipIndex);
+      }
+    }
+
     handleLegendBBoxUpdate = (box: DOMRect | null) => {
       if (box) {
         const { dataStartIndex, dataEndIndex, updateId } = this.state;
@@ -1576,6 +1582,7 @@ export const generateCategoricalChart = ({
 
       if (mouse) {
         const nextState: CategoricalChartState = { ...mouse, isTooltipActive: true };
+        this.syncAccessibilityIndex(nextState);
         this.setState(nextState);
         this.triggerSyncEvent(nextState);
 
@@ -1590,6 +1597,7 @@ export const generateCategoricalChart = ({
       const mouse = this.getMouseInfo(e);
       const nextState: CategoricalChartState = mouse ? { ...mouse, isTooltipActive: true } : { isTooltipActive: false };
 
+      this.syncAccessibilityIndex(nextState);
       this.setState(nextState);
       this.triggerSyncEvent(nextState);
 
@@ -1673,6 +1681,7 @@ export const generateCategoricalChart = ({
 
       if (mouse) {
         const nextState: CategoricalChartState = { ...mouse, isTooltipActive: true };
+        this.syncAccessibilityIndex(nextState);
         this.setState(nextState);
         this.triggerSyncEvent(nextState);
 

--- a/test/chart/LineChart.spec.tsx
+++ b/test/chart/LineChart.spec.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { act, render, fireEvent, screen } from '@testing-library/react';
 
 import { vi, describe, test, SpyInstance } from 'vitest';
 import { LineChart, Line, XAxis, YAxis, Tooltip, Brush, CartesianAxis, Legend } from '../../src';
@@ -273,6 +273,61 @@ describe('<LineChart />', () => {
     // expect(onMouseUp).tohaveBeenCalled();
     // expect(propsOfCallback).to.include.all.keys(['className', 'points', 'connectNulls', 'type']);
     // expect(eventOfCallback).to.include.all.keys(['currentTarget', 'target']);
+  });
+
+  test('focus should not move activeDot away from the hovered point with accessibilityLayer enabled', () => {
+    vi.useFakeTimers();
+    try {
+      const onClick = vi.fn();
+      const margin = { top: 20, right: 20, bottom: 20, left: 20 };
+      const width = 400;
+      const height = 400;
+      const { container } = render(
+        <LineChart width={width} height={height} data={data} margin={margin} accessibilityLayer>
+          <Line type="monotone" dataKey="uv" stroke="#ff7300" activeDot={{ onClick }} isAnimationActive={false} />
+          <Tooltip />
+          <XAxis dataKey="name" />
+          <YAxis />
+        </LineChart>,
+      );
+
+      const wrapper = container.querySelector('.recharts-wrapper');
+      const svg = container.querySelector('svg');
+      assertNotNull(wrapper);
+      assertNotNull(svg);
+      const dots = container.querySelectorAll('.recharts-line-dot');
+      expect(dots).toHaveLength(data.length);
+      const secondDot = dots[1];
+      const secondPointX = Number(secondDot.getAttribute('cx'));
+      const secondPointY = Number(secondDot.getAttribute('cy'));
+
+      fireEvent.mouseOver(wrapper, {
+        bubbles: true,
+        cancelable: true,
+        clientX: secondPointX,
+        clientY: secondPointY,
+        pageX: secondPointX,
+        pageY: secondPointY,
+      });
+      vi.advanceTimersByTime(100);
+
+      const activeDot = container.querySelector('.recharts-active-dot circle');
+      assertNotNull(activeDot);
+      expect(activeDot).toHaveAttribute('cx', `${secondPointX}`);
+
+      act(() => {
+        svg.focus();
+      });
+
+      const focusedActiveDot = container.querySelector('.recharts-active-dot circle');
+      assertNotNull(focusedActiveDot);
+      expect(focusedActiveDot).toHaveAttribute('cx', `${secondPointX}`);
+      fireEvent.click(focusedActiveDot);
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   /*


### PR DESCRIPTION
Fixes #5589.

When `accessibilityLayer` is enabled, focusing the chart calls `AccessibilityManager.focus()`, which spoofs mouse movement from its internal index. Mouse hover/click already updates the chart's `activeTooltipIndex`, but the accessibility manager can still hold an older index, so the first pointer click can move the active dot back to the first point before the `activeDot` click handler runs.

This syncs the accessibility manager index from mouse-derived tooltip state, keeping focus from moving the active dot away from the hovered point.

Verification:

- `npm run test -- test/chart/LineChart.spec.tsx -t "focus should not move activeDot away from the hovered point with accessibilityLayer enabled"`
- `npm run test -- test/chart/LineChart.spec.tsx`

Note: I could not run local eslint/typecheck cleanly in this worktree because the 2.x checkout is using a temporary shared `node_modules` from the main branch; that resolves to newer ESLint/TypeScript versions than 2.x expects.