### PR TITLE
Install deno

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,11 @@ jobs:
         with:
           version: 10
 
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
       - name: Download Packed Library Artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
For integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the integration test workflow by ensuring Deno is available before test steps run, which helps keep CI checks reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->