### PR TITLE
fix(Brush): slide snaps back to original position on mouseup when start/endIndex are controlled

### DIFF
--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -556,6 +556,8 @@ class BrushWithState extends PureComponent<BrushWithStateProps, State> {
         prevTravellerWidth: travellerWidth,
         prevX: x,
         prevWidth: width,
+        prevStartIndexControlledFromProps: startIndexControlledFromProps,
+        prevEndIndexControlledFromProps: endIndexControlledFromProps,
         ...(data && data.length
           ? createScale({ data, width, x, travellerWidth, startIndex, endIndex })
           : { scale: undefined, scaleValues: undefined }),

--- a/test/cartesian/Brush.spec.tsx
+++ b/test/cartesian/Brush.spec.tsx
@@ -580,6 +580,33 @@ describe('<Brush />', () => {
     });
   });
 
+  describe('dragging the slide when start/endIndex are controlled from props', () => {
+    test('should not snap the slide back to its original position on mouseup', () => {
+      // startIndex/endIndex are controlled from props but without an onChange handler,
+      // so they stay fixed for the duration of the drag - same as a drag that never crosses
+      // a data index boundary, which is the common case for small mouse movements.
+      const { container } = render(
+        <BarChart width={400} height={100} data={data}>
+          <Brush dataKey="value" x={100} y={50} width={400} height={40} startIndex={3} endIndex={6} />
+        </BarChart>,
+      );
+
+      const slide = container.querySelector('.recharts-brush-slide') as SVGRectElement;
+      const travellers = () => container.querySelectorAll('.recharts-brush-traveller');
+      const positionsOf = (elements: NodeListOf<Element>) =>
+        Array.from(elements).map(el => el.getAttribute('aria-valuenow'));
+
+      fireEvent.mouseDown(slide, { clientX: 200 });
+      fireEvent.mouseMove(slide, { clientX: 220 });
+      const positionsWhileDragging = positionsOf(travellers());
+
+      fireEvent.mouseUp(slide);
+      const positionsAfterMouseUp = positionsOf(travellers());
+
+      expect(positionsAfterMouseUp).toEqual(positionsWhileDragging);
+    });
+  });
+
   describe('panorama and state integration', () => {
     it('should select data from the parent chart', () => {
       const rootDataSpy = vi.fn();


### PR DESCRIPTION
## Summary

Fixes #6279.

The reported repro ("drag the brush handle past the start/end bound, drag it back in, the position ends up offset") turns out to be a symptom of a more general bug: **dragging the Brush's slide and releasing the mouse can snap `startX` back to its original, pre-drag position whenever `startIndex`/`endIndex` are controlled via props** - regardless of whether the drag went out of bounds. Any drag that ends without `onChange` having changed the controlled `startIndex`/`endIndex` prop (the common case for small mouse movements that don't cross a data-index boundary) triggers it.

### Root cause

`Brush.getDerivedStateFromProps` has a branch that re-syncs `startX`/`endX` from `startIndexControlledFromProps`/`endIndexControlledFromProps` whenever those controlled props change, but only while the user is *not* currently interacting with the brush (so it doesn't fight an active drag). The guard for "not interacting" is only false while `isSlideMoving`/`isTravellerMoving`/etc. are true, so this branch is skipped for the entire duration of a drag.

The `prevStartIndexControlledFromProps`/`prevEndIndexControlledFromProps` tracking fields used for the comparison were only ever initialized *inside that same skipped branch* - never on mount. Since the branch is always skipped while dragging, the first time it runs again is the render right after `mouseup`. At that point `prevStartIndexControlledFromProps` is still `undefined`, so `undefined !== startIndexControlledFromProps` is `true`even though the prop never actually changed - and the code incorrectly treats this as "the controlled prop changed", resetting `startX` back to `scale(startIndexControlledFromProps)` and discarding the user's drag.

### Fix

Initialize `prevStartIndexControlledFromProps`/`prevEndIndexControlledFromProps` in the same `getDerivedStateFromProps` branch that already computes the scale on mount / data change, so the trackers start in sync with the actual prop values instead of `undefined`. This closes the false-mismatch window without touching the (correct) re-sync behavior for when the controlled props genuinely change later.

## Test plan

- [x] Added a regression test in `test/cartesian/Brush.spec.tsx` (`dragging the slide when start/endIndex are controlled from props`) that drags the slide with controlled `startIndex`/`endIndex` and asserts the position right after `mouseup` matches the position while dragging.
- [x] Verified the new test fails without the fix (`startX` reverts to its pre-drag value) and passes with it.
- [x] `npm run test` - full suite passes (16199 passed, same pre-existing 6 expected-fail / unrelated website-build failures as on `main`).
- [x] `npm run check-types` - passes.
- [x] `npm run lint` - passes (0 errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved brush behavior when start and end positions are controlled from props, so dragged selections no longer snap back unexpectedly after release.
  * Kept traveller positions in sync during data updates for a smoother, more consistent interaction.

* **Tests**
  * Added coverage for controlled brush dragging to verify traveller positions remain stable after mouse release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->