### PR TITLE
feat(Sankey): support accessibilityLayer, title and desc props

### DIFF
--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -852,6 +852,14 @@ interface SankeyProps extends EventThrottlingProps {
   className?: string;
   children?: ReactNode;
   /**
+   * Turn on accessibility support for keyboard-only and screen reader users.
+   *
+   * @defaultValue true
+   */
+  accessibilityLayer?: boolean;
+  title?: string;
+  desc?: string;
+  /**
    * Empty space around the container.
    *
    * @defaultValue {"top":5,"right":5,"bottom":5,"left":5}
@@ -1203,6 +1211,7 @@ function AllNodeElements({
 }
 
 export const sankeyDefaultProps = {
+  accessibilityLayer: true,
   align: 'justify',
   dataKey: 'value',
   iterations: 32,
@@ -1238,9 +1247,26 @@ function SankeyImpl(props: InternalSankeyProps) {
     margin,
     verticalAlign,
     align,
+    accessibilityLayer,
+    title,
+    desc,
   } = props;
 
   const attrs = svgPropertiesNoEvents(others);
+
+  let tabIndex: number | undefined, role: string | undefined;
+
+  if (typeof attrs.tabIndex === 'number') {
+    tabIndex = attrs.tabIndex;
+  } else {
+    tabIndex = accessibilityLayer ? 0 : undefined;
+  }
+
+  if (typeof attrs.role === 'string') {
+    role = attrs.role;
+  } else {
+    role = accessibilityLayer ? 'application' : undefined;
+  }
 
   const width = useChartWidth();
   const height = useChartHeight();
@@ -1337,7 +1363,7 @@ function SankeyImpl(props: InternalSankeyProps) {
   return (
     <>
       <SetComputedData computedData={{ links: modifiedLinks, nodes: modifiedNodes }} />
-      <Surface {...attrs} width={width} height={height}>
+      <Surface {...attrs} title={title} desc={desc} role={role} tabIndex={tabIndex} width={width} height={height}>
         {children}
         <AllSankeyLinkElements
           graphicalItemId={id}

--- a/test/chart/Sankey.spec.tsx
+++ b/test/chart/Sankey.spec.tsx
@@ -72,6 +72,48 @@ describe('<Sankey />', () => {
     expect(container.querySelectorAll('.recharts-sankey-link')).toHaveLength(68);
   });
 
+  describe('accessibility', () => {
+    it('should add tabindex and role to the svg element by default', () => {
+      const { container } = render(<Sankey width={1000} height={500} data={exampleSankeyData} />);
+
+      const svg = container.querySelector('svg');
+      assertNotNull(svg);
+      expect(svg).toHaveAttribute('role', 'application');
+      expect(svg).toHaveAttribute('tabindex', '0');
+    });
+
+    it('should not add tabindex and role to the svg element when accessibilityLayer=false', () => {
+      const { container } = render(
+        <Sankey width={1000} height={500} data={exampleSankeyData} accessibilityLayer={false} />,
+      );
+
+      const svg = container.querySelector('svg');
+      assertNotNull(svg);
+      expect(svg).not.toHaveAttribute('role');
+      expect(svg).not.toHaveAttribute('tabindex');
+    });
+
+    it('should prefer explicit role and tabIndex over the accessibilityLayer defaults', () => {
+      const { container } = render(
+        <Sankey width={1000} height={500} data={exampleSankeyData} role="img" tabIndex={-1} />,
+      );
+
+      const svg = container.querySelector('svg');
+      assertNotNull(svg);
+      expect(svg).toHaveAttribute('role', 'img');
+      expect(svg).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('should set title and description correctly', () => {
+      const { container } = render(
+        <Sankey width={1000} height={500} data={exampleSankeyData} title="Sankey title" desc="Sankey description" />,
+      );
+
+      expect(container.querySelector('title')).toHaveTextContent('Sankey title');
+      expect(container.querySelector('desc')).toHaveTextContent('Sankey description');
+    });
+  });
+
   it('re-renders links and nodes when data changes', () => {
     const { container, rerender } = render(<Sankey width={1000} height={500} data={exampleSankeyData} />);
 


### PR DESCRIPTION
## Description

Sankey currently rejects the `accessibilityLayer`, `title` and `desc` props at the type level, and even at runtime `title`/`desc` get stripped by `svgPropertiesNoEvents` before they reach `Surface`, so there's no way to give the chart an accessible name or description.

This adds the three props to `SankeyProps` and handles them locally in `SankeyImpl`: `title`/`desc` are passed explicitly to the existing `Surface` (which already knows how to render them), and `role`/`tabIndex` default to `application`/`0` when `accessibilityLayer` is on (the default, same as every other chart), while explicit `role`/`tabIndex` props still win. Same precedence logic as `MainChartSurface`.

I deliberately did not move Sankey onto `RootSurface` — that was the approach in #7153 and the concern there was that it drags in ZIndex portal support as a side effect. No changes to `Surface` either. Keyboard navigation wiring for Sankey nodes/links is out of scope here; this covers the props and the SVG attributes.

## Related Issue

Fixes #7151

## Motivation and Context

Users migrating from 2.x lost the ability to set `accessibilityLayer`/`title`/`desc` on Sankey (TS errors, and silently dropped at runtime). Every other chart supports them.

## How Has This Been Tested?

Added an `accessibility` describe block to `test/chart/Sankey.spec.tsx`: default role/tabindex, `accessibilityLayer={false}` omitting them, explicit `role`/`tabIndex` overriding the defaults, and `title`/`desc` rendering. The default-attributes and title/desc tests fail on current main and pass with this change; the full Sankey spec (33 tests), `AccessibilityLayer.spec.tsx` and `Sankey.typed.spec.tsx` all pass locally, plus `tsc` and eslint on the changed files.

## Screenshots (if appropriate):

n/a — attribute-only change, no visual difference.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessibility support to Sankey charts by default.
  * Charts now include appropriate keyboard navigation and application semantics.
  * Added support for custom titles and descriptions for screen readers.
  * Added options to disable the accessibility layer or override accessibility attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->