### PR TITLE
fix: clear stale active bar layer state

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -635,6 +635,9 @@ function BarRectangleWithActiveState(
     activeBar &&
     String(entry.originalDataIndex) === activeIndex &&
     (activeDataKey == null || dataKey === activeDataKey);
+  const isAnotherBarActive =
+    activeIndex != null &&
+    (String(entry.originalDataIndex) !== activeIndex || (activeDataKey != null && dataKey !== activeDataKey));
 
   const [stayInLayer, setStayInLayer] = useState(false);
   const [hasMountedActive, setHasMountedActive] = useState(false);
@@ -652,12 +655,15 @@ function BarRectangleWithActiveState(
       });
     } else {
       setHasMountedActive(false);
+      if (isAnotherBarActive) {
+        setStayInLayer(false);
+      }
     }
 
     return () => {
       cancelAnimationFrame(rafId);
     };
-  }, [isActive]);
+  }, [isActive, isAnotherBarActive]);
 
   const handleTransitionEnd = useCallback(() => {
     // 4. Leave the layer only when the exit transition finishes

--- a/test/cartesian/Bar/Bar.csstransition.spec.tsx
+++ b/test/cartesian/Bar/Bar.csstransition.spec.tsx
@@ -5,7 +5,7 @@ import { generateMockData } from '@recharts/devtools';
 import { Bar, BarChart, BarShapeProps, DefaultZIndexes, Tooltip, XAxis } from '../../../src';
 import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
 import { expectActiveBars, expectBars, ExpectedBar } from '../../helper/expectBars';
-import { hideTooltip, showTooltip } from '../../component/Tooltip/tooltipTestHelpers';
+import { hideTooltip, showTooltip, showTooltipOnCoordinate } from '../../component/Tooltip/tooltipTestHelpers';
 import { barChartMouseHoverTooltipSelector } from '../../component/Tooltip/tooltipMouseHoverSelectors';
 import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
 import { expectNthCalledWith } from '../../helper/expectLastCalledWith';
@@ -301,6 +301,43 @@ describe('Bar CSS transitions', () => {
        * React appears to optimize away the final render, so no extra calls are made.
        */
       expect(shapeSpy).toHaveBeenCalledTimes(7);
+    });
+
+    it('should remove the old active layer bar when another bar becomes active', () => {
+      const renderTestCase = createSelectorTestCase(({ children }) => (
+        <BarChart width={400} height={400} data={generateMockData(2, 10)}>
+          <Bar dataKey="y" isAnimationActive={false} activeBar />
+          <XAxis dataKey="x" />
+          {children}
+          <Tooltip />
+        </BarChart>
+      ));
+
+      const { container } = renderTestCase();
+
+      showTooltip(container, barChartMouseHoverTooltipSelector);
+      act(() => {
+        vi.runOnlyPendingTimers();
+      });
+
+      expect(
+        container.querySelectorAll(`.recharts-zIndex-layer_${DefaultZIndexes.activeBar} .recharts-active-bar`),
+      ).toHaveLength(1);
+      expect(
+        container.querySelectorAll(`.recharts-zIndex-layer_${DefaultZIndexes.activeBar} .recharts-inactive-bar`),
+      ).toHaveLength(0);
+
+      showTooltipOnCoordinate(container, barChartMouseHoverTooltipSelector, { clientX: 300, clientY: 150 });
+      act(() => {
+        vi.runOnlyPendingTimers();
+      });
+
+      expect(
+        container.querySelectorAll(`.recharts-zIndex-layer_${DefaultZIndexes.activeBar} .recharts-active-bar`),
+      ).toHaveLength(1);
+      expect(
+        container.querySelectorAll(`.recharts-zIndex-layer_${DefaultZIndexes.activeBar} .recharts-inactive-bar`),
+      ).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
Fixes #6953.

When an active Bar moves into the active z-index layer, it waits for transitionend before returning to the normal bar layer. If another bar becomes active before that event fires, the previous bar can stay in the active layer as an inactive shape.

This clears that stale layer state when the active index/dataKey points to another bar, while preserving the existing transitionend path when the chart simply becomes inactive.

Verification:

- npm run test -- test/cartesian/Bar/Bar.csstransition.spec.tsx -t "should remove the old active layer bar when another bar becomes active"
- npm run test -- test/cartesian/Bar/Bar.csstransition.spec.tsx
- npx eslint src/cartesian/Bar.tsx test/cartesian/Bar/Bar.csstransition.spec.tsx
- npx prettier --check src/cartesian/Bar.tsx test/cartesian/Bar/Bar.csstransition.spec.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bar hover transitions so the previously active bar is removed from the active layer when another bar is selected.
  * Ensured only the newly selected bar remains highlighted during repeated hover interactions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->