### PR TITLE
fix(Tooltip): find the active sector in the angle-axis wrap-around gap

### DIFF
--- a/src/util/getActiveCoordinate.ts
+++ b/src/util/getActiveCoordinate.ts
@@ -120,6 +120,19 @@ export const calculateActiveTickIndex = (
 
   if (axisType === 'angleAxis' && range != null && Math.abs(Math.abs(range[1] - range[0]) - 360) <= 1e-6) {
     // ticks are distributed in a circle
+    const span = range[1] - range[0];
+    /*
+     * Tick coordinates can be shifted outside of the range (e.g. by the band offset
+     * that tooltip ticks receive), so both the coordinate and the intervals live
+     * modulo the full circle. Testing the coordinate shifted by a whole turn in both
+     * directions closes the wrap-around gap where no interval matched
+     * and the active index came back as -1.
+     * https://github.com/recharts/recharts/issues/5099
+     */
+    const isInside = (lowerLimit: number, upperLimit: number, inclusiveLower: boolean): boolean =>
+      [coordinate, coordinate + span, coordinate - span].some(
+        c => (inclusiveLower ? c >= lowerLimit : c > lowerLimit) && c <= upperLimit,
+      );
     for (let i = 0; i < len; i++) {
       const before = i > 0 ? unsortedTicks[i - 1]?.coordinate : unsortedTicks[len - 1]?.coordinate;
       const cur = unsortedTicks[i]?.coordinate;
@@ -150,17 +163,14 @@ export const calculateActiveTickIndex = (
           Math.max(cur, (sameDirectionCoord + cur) / 2),
         ];
 
-        if (
-          (coordinate > sameInterval[0] && coordinate <= sameInterval[1]) ||
-          (coordinate >= diffInterval[0] && coordinate <= diffInterval[1])
-        ) {
+        if (isInside(sameInterval[0], sameInterval[1], false) || isInside(diffInterval[0], diffInterval[1], true)) {
           return unsortedTicks[i]?.index;
         }
       } else {
         const minValue = Math.min(before, after);
         const maxValue = Math.max(before, after);
 
-        if (coordinate > (minValue + cur) / 2 && coordinate <= (maxValue + cur) / 2) {
+        if (isInside((minValue + cur) / 2, (maxValue + cur) / 2, false)) {
           return unsortedTicks[i]?.index;
         }
       }

--- a/test/util/ChartUtils.spec.tsx
+++ b/test/util/ChartUtils.spec.tsx
@@ -262,6 +262,37 @@ describe('calculateActiveTickIndex', () => {
   it('calculateActiveTickIndex(16, ticks) should return 3', () => {
     expect(calculateActiveTickIndex(16, ticks, [], 'radiusAxis', [0, 100])).toBe(3);
   });
+
+  describe('on a full-circle angle axis with offset-shifted ticks', () => {
+    /*
+     * The tick coordinates the tooltip selector produces for a 4-sector PieChart:
+     * band starts (0, 90, 180, 270) shifted by the band offset of -4.
+     * https://github.com/recharts/recharts/issues/5099
+     */
+    const angleTicks: ReadonlyArray<TickItem> = [
+      { coordinate: -4, index: 0, value: 'a', offset: -4 },
+      { coordinate: 86, index: 1, value: 'b', offset: -4 },
+      { coordinate: 176, index: 2, value: 'c', offset: -4 },
+      { coordinate: 266, index: 3, value: 'd', offset: -4 },
+    ];
+
+    it.each([{ coordinate: 357 }, { coordinate: 358 }, { coordinate: 359.9 }])(
+      'should return the first sector for pointer angle $coordinate inside the wrap-around gap',
+      ({ coordinate }) => {
+        expect(calculateActiveTickIndex(coordinate, angleTicks, angleTicks, 'angleAxis', [0, 360])).toBe(0);
+      },
+    );
+
+    it.each([
+      { coordinate: 20, expected: 0 },
+      { coordinate: 100, expected: 1 },
+      { coordinate: 200, expected: 2 },
+      { coordinate: 300, expected: 3 },
+      { coordinate: 330, expected: 0 },
+    ])('should return sector $expected for pointer angle $coordinate', ({ coordinate, expected }) => {
+      expect(calculateActiveTickIndex(coordinate, angleTicks, angleTicks, 'angleAxis', [0, 360])).toBe(expected);
+    });
+  });
 });
 
 describe('getDomainOfStackGroups', () => {


### PR DESCRIPTION
## Description

On a full-circle angle axis, `calculateActiveTickIndex` can return -1 for pointer angles near the range wrap, so hovering that part of a PieChart produces no active sector — `onMouseMove` gets no coordinates and the tooltip doesn't show. This is the calculation ckifer pinned down in the issue: tooltip ticks get shifted by the band offset (±4° for a 4-sector pie), which moves the first/last tick intervals partially out of the [0, 360] window. The pointer angle is always normalized into that window, so the slice between the last covered boundary and 360° (356°–360° in the 4-sector case, the "bottom right" from the reports) matches no interval and falls through to -1.

Zeroing the offset fixes pie but breaks RadarChart (as noted in the thread), so this fix leaves the offset alone and instead makes the interval matching wrap-aware: the coordinate is also tested shifted by a full turn in both directions. It's strictly widening — every coordinate that matched before still matches the same sector (the intervals partition the circle, so the shifted candidates can't produce a conflicting match), and only the previously-dead gap gains coverage.

## Related Issue

Fixes #5099

## Motivation and Context

Hovering near the wrap of a full-circle pie silently loses the tooltip/mouse coordinates even though the pointer is inside a sector.

## How Has This Been Tested?

Unit tests in `test/util/ChartUtils.spec.tsx` using the exact tick shape the tooltip selector produces for a 4-sector pie (band starts shifted by -4, range [0, 360]): three pointer angles inside the wrap gap (357, 358, 359.9) return -1 on current main and sector 0 with this change, and five control angles across all sectors return the same index before and after the change. Also ran the full polar surface as a guard for the RadarChart concern from the thread: `test/polar/`, `PieChart`, `RadarChart`, `RadialBarChart` (19 files, 522 tests), plus `test/state/` and the Tooltip component suites (64 files, 1236 tests), `tsc`, and eslint — all green.

## Screenshots (if appropriate):

n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved active sector detection for full-circle charts when angle coordinates wrap around or fall outside the standard range.
  * Ensured pointer interactions select the correct sector across wrap-around boundaries.

* **Tests**
  * Added coverage for full-circle angle-axis interactions, including wrapped and offset coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->