### PR TITLE
fix: avoid es-toolkit compat subpath imports

### DIFF
--- a/scripts/buildOutput.test.ts
+++ b/scripts/buildOutput.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { describe, it, expect } from 'vitest';
 import { globSync } from 'glob';
 
@@ -63,6 +63,14 @@ describe('expected folder structure', () => {
   describe('es6 folder output', () => {
     it('should have expected files and no more', async () => {
       await checkFolderOutput('es6/**/*', 'es6Files');
+    });
+
+    it('should avoid es-toolkit compat subpath imports', () => {
+      const es6Output = globSync('es6/**/*.js')
+        .map(file => readFileSync(file, 'utf8'))
+        .join('\n');
+
+      expect(es6Output).not.toContain('es-toolkit/compat/');
     });
   });
 

--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react';
 import { clsx } from 'clsx';
 import { scalePoint, ScalePoint } from 'victory-vendor/d3-scale';
-import range from 'es-toolkit/compat/range';
+import { range } from 'es-toolkit/compat';
 import { Layer } from '../container/Layer';
 import { Text } from '../component/Text';
 import { getValueByDataKey } from '../util/ChartUtils';

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { SVGProps, useState, useRef, useCallback, forwardRef, useImperativeHandle, useEffect } from 'react';
 
-import get from 'es-toolkit/compat/get';
+import { get } from 'es-toolkit/compat';
 import { clsx } from 'clsx';
 import { Layer } from '../container/Layer';
 import { Text, Props as TextProps, TextAnchor, TextVerticalAnchor, isValidTextAnchor } from '../component/Text';

--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { MutableRefObject, ReactElement, ReactNode, useMemo, useRef } from 'react';
-import omit from 'es-toolkit/compat/omit';
+import { omit } from 'es-toolkit/compat';
 
 import { clsx } from 'clsx';
 import { selectActiveIndex } from '../state/selectors/selectors';

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 import { MouseEvent, ReactElement, ReactNode, SVGProps, useCallback, useMemo, useState } from 'react';
-import maxBy from 'es-toolkit/compat/maxBy';
-import sumBy from 'es-toolkit/compat/sumBy';
-import get from 'es-toolkit/compat/get';
+import { get, maxBy, sumBy } from 'es-toolkit/compat';
 import { Surface } from '../container/Surface';
 import { Layer } from '../container/Layer';
 import { Props as RectangleProps, Rectangle } from '../shape/Rectangle';

--- a/src/chart/SunburstChart.tsx
+++ b/src/chart/SunburstChart.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { CSSProperties, useState } from 'react';
 import { scaleLinear } from 'victory-vendor/d3-scale';
 import { clsx } from 'clsx';
-import get from 'es-toolkit/compat/get';
+import { get } from 'es-toolkit/compat';
 import { Surface } from '../container/Surface';
 import { Layer } from '../container/Layer';
 import { Sector } from '../shape/Sector';

--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { PureComponent, ReactNode, useCallback, useState } from 'react';
-import omit from 'es-toolkit/compat/omit';
-import get from 'es-toolkit/compat/get';
+import { get, omit } from 'es-toolkit/compat';
 
 import { Layer } from '../container/Layer';
 import { Surface } from '../container/Surface';

--- a/src/component/DefaultTooltipContent.tsx
+++ b/src/component/DefaultTooltipContent.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 import { CSSProperties, HTMLAttributes, ReactNode, SVGProps } from 'react';
-import sortBy from 'es-toolkit/compat/sortBy';
+import { sortBy } from 'es-toolkit/compat';
 import { clsx } from 'clsx';
 import { isNullish, isNumOrStr } from '../util/DataUtils';
 import { DataKey } from '../util/types';

--- a/src/component/ResponsiveContainer.tsx
+++ b/src/component/ResponsiveContainer.tsx
@@ -13,7 +13,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import throttle from 'es-toolkit/compat/throttle';
+import { throttle } from 'es-toolkit/compat';
 import { isNumber, noop } from '../util/DataUtils';
 import { warn } from '../util/LogUtils';
 import {

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { MutableRefObject, ReactElement, ReactNode, SVGProps, useMemo, useRef } from 'react';
-import get from 'es-toolkit/compat/get';
+import { get } from 'es-toolkit/compat';
 
 import { clsx } from 'clsx';
 import { selectPieLegend, selectPieSectors } from '../state/selectors/pieSelectors';

--- a/src/polar/PolarRadiusAxis.tsx
+++ b/src/polar/PolarRadiusAxis.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { FunctionComponent, ReactElement, ReactNode, SVGProps, useEffect, useMemo } from 'react';
-import maxBy from 'es-toolkit/compat/maxBy';
-import minBy from 'es-toolkit/compat/minBy';
+import { maxBy, minBy } from 'es-toolkit/compat';
 
 import { clsx } from 'clsx';
 import { Text } from '../component/Text';

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { MouseEvent, MutableRefObject, ReactElement, ReactNode, SVGProps, useRef } from 'react';
-import last from 'es-toolkit/compat/last';
+import { last } from 'es-toolkit/compat';
 
 import { clsx } from 'clsx';
 import { interpolate, isNullish, noop } from '../util/DataUtils';

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import range from 'es-toolkit/compat/range';
+import { range } from 'es-toolkit/compat';
 import { selectChartLayout } from '../../context/chartLayoutContext';
 import {
   getDomainOfStackGroups,

--- a/src/state/selectors/legendSelectors.ts
+++ b/src/state/selectors/legendSelectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import sortBy from 'es-toolkit/compat/sortBy';
+import { sortBy } from 'es-toolkit/compat';
 import { RechartsRootState } from '../store';
 import { LegendSettings } from '../legendSlice';
 import { LegendPayload } from '../../component/DefaultLegendContent';

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import sortBy from 'es-toolkit/compat/sortBy';
+import { sortBy } from 'es-toolkit/compat';
 import { useAppSelector } from '../hooks';
 import { RechartsRootState } from '../store';
 import {

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -1,5 +1,4 @@
-import sortBy from 'es-toolkit/compat/sortBy';
-import get from 'es-toolkit/compat/get';
+import { get, sortBy } from 'es-toolkit/compat';
 
 import {
   Series,

--- a/src/util/DataUtils.ts
+++ b/src/util/DataUtils.ts
@@ -1,4 +1,4 @@
-import get from 'es-toolkit/compat/get';
+import { get } from 'es-toolkit/compat';
 import { NonEmptyArray, Percent } from './types';
 import { round } from './round';
 

--- a/src/util/ReactUtils.ts
+++ b/src/util/ReactUtils.ts
@@ -1,4 +1,4 @@
-import get from 'es-toolkit/compat/get';
+import { get } from 'es-toolkit/compat';
 
 import * as React from 'react';
 import { Children, ReactNode } from 'react';

--- a/src/util/payload/getUniqPayload.ts
+++ b/src/util/payload/getUniqPayload.ts
@@ -1,4 +1,4 @@
-import uniqBy from 'es-toolkit/compat/uniqBy';
+import { uniqBy } from 'es-toolkit/compat';
 
 type UniqueFunc<T> = (entry: T) => unknown;
 


### PR DESCRIPTION
## Description

Replace default imports from `es-toolkit/compat/*` subpaths with named imports from the public `es-toolkit/compat` entrypoint.

This prevents Vite 8/Rolldown from applying incompatible CommonJS interop to the compat subpath wrappers, which can make Recharts fail during module initialization. A build-output regression test ensures published ESM files do not reintroduce compat subpath imports.

## Related Issue

Fixes #7454

## Motivation and Context

With `es-toolkit@1.47.0`, the reproduction from #7454 renders a blank page in Vite development mode and throws `TypeError: require_isUnsafeProperty is not a function`. The compat entrypoint exposes proper named ESM exports, so importing from it avoids the broken wrapper interop while preserving the same lodash-compatible functions.

## How Has This Been Tested?

- Reproduced the runtime failure with the issue's Vite 8 reproduction and `es-toolkit@1.47.0`.
- Replaced the installed Recharts ESM output with this branch's build, cleared Vite's dependency cache, and verified the chart renders with no console errors.
- `npm run build`
- `npm run test` (16,210 passing tests; expected failures/skips unchanged)
- `npm run check-types`
- `npm run lint` (no errors; existing warnings only)

## Screenshots (if appropriate):

Not applicable; this fixes module initialization rather than a visual behavior.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build compatibility by consolidating utility imports.
  - Prevented generated ES6 output from retaining compatibility subpath imports.

- **Tests**
  - Added validation to ensure compiled output uses supported utility import paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->