### PR TITLE
fix(YAxis): show the first tick on a reversed axis

### DIFF
--- a/src/cartesian/getTicks.ts
+++ b/src/cartesian/getTicks.ts
@@ -42,6 +42,15 @@ function getTicksEnd(
         ...entry,
         tickCoord: gap > 0 ? entry.coordinate - gap * sign : entry.coordinate,
       };
+    } else if (i === 0) {
+      // Nudge the first tick inwards when it would overflow the start edge,
+      // mirroring what getTicksStart does for the last tick. Without this the
+      // tick fails the visibility check and is dropped instead of rendered.
+      const gap = sign * (entry.coordinate - (sign * getSize()) / 2 - start);
+      result[i] = entry = {
+        ...entry,
+        tickCoord: gap < 0 ? entry.coordinate - gap * sign : entry.coordinate,
+      };
     } else {
       result[i] = entry = { ...entry, tickCoord: entry.coordinate };
     }

--- a/test/cartesian/getTicks.spec.ts
+++ b/test/cartesian/getTicks.spec.ts
@@ -239,4 +239,37 @@ describe('getTicks', () => {
       },
     );
   });
+
+  describe('reversed axis', () => {
+    // A reversed YAxis puts the smallest value at the top of the chart, so the
+    // first tick sits right against the start edge of the axis.
+    // See https://github.com/recharts/recharts/issues/2882
+    const reversedYAxisTicks: ReadonlyArray<TickItem> = [
+      { value: '0', coordinate: 5, index: 0, offset: 0 },
+      { value: '25', coordinate: 70, index: 1, offset: 0 },
+      { value: '50', coordinate: 135, index: 2, offset: 0 },
+      { value: '75', coordinate: 200, index: 3, offset: 0 },
+      { value: '100', coordinate: 265, index: 4, offset: 0 },
+    ];
+    const reversedYAxisInput: GetTicksInput = {
+      ...EXAMPLE_INPUT,
+      orientation: 'left' as const,
+      ticks: reversedYAxisTicks,
+    };
+
+    test.each(['preserveEnd', 'preserveStart', 'preserveStartEnd'] as const)(
+      'shows the tick at the start edge with interval=%s',
+      interval => {
+        const result = getTicks({ ...reversedYAxisInput, interval }) as CartesianTickItem[];
+
+        expect(result.map(tick => tick.value)).toEqual(['0', '25', '50', '75', '100']);
+      },
+    );
+
+    test('nudges the tick at the start edge inwards to keep it visible', () => {
+      const result = getTicks({ ...reversedYAxisInput, interval: 'preserveEnd' as const }) as CartesianTickItem[];
+
+      expect(result[0]).toEqual({ value: '0', coordinate: 5, tickCoord: 6, isShow: true, index: 0, offset: 0 });
+    });
+  });
 });


### PR DESCRIPTION
## Description

`getTicksEnd` clamps the last tick inwards when it would overflow the `end` edge, but nothing does the same for the first tick against the `start` edge — every tick other than the last just takes `tickCoord: entry.coordinate`. So when tick 0 sits within half its own size of `start`, it fails the visibility check in `isVisible` and gets filtered out instead of being nudged into view.

`getTicksStart` already has exactly this clamp for its index 0 (about 70 lines further down the same file), which is why `interval="preserveStart"` shows the tick and `preserveEnd` doesn't. This adds the mirror-image branch to `getTicksEnd`, reusing the same formula.

It shows up on a reversed YAxis because `reversed` flips the range so the minimum domain value lands right against the start edge, and YAxis defaults to `interval="preserveEnd"` — hence "the minimum value is not displayed". A normal YAxis puts the minimum far from that edge, so it never triggers.

Worth noting for review: `getTicks` is shared with XAxis, so this isn't YAxis-local. The clamp only fires when `gap < 0`, i.e. only for a tick that is being dropped today, so any tick that currently renders keeps its exact `tickCoord`. The full `test/cartesian` suite (68 files) passes unchanged, no snapshot churn.

## Related Issue

Fixes #2882

## Motivation and Context

`<YAxis reversed />` silently drops its minimum tick label.

## How Has This Been Tested?

Added a `reversed axis` block to the existing `test/cartesian/getTicks.spec.ts` using the reversed-YAxis tick layout (ascending coordinates hugging the top edge). One test asserts all five ticks show across `preserveEnd`/`preserveStart`/`preserveStartEnd` — only `preserveEnd` fails on main, which isolates the defect to `getTicksEnd`; another pins the clamped `tickCoord`. Both fail on main and pass here. Also ran the whole `test/cartesian` directory (1659 tests), `tsc`, and eslint.

## Screenshots (if appropriate):

n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reversed-axis charts so the first tick remains visible at the start edge.
  * Improved tick positioning to prevent valid labels from being incorrectly omitted.

* **Tests**
  * Added coverage for reversed-axis tick behavior across preserved interval settings.
  * Verified that start-edge ticks are correctly nudged inward when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->