### PR TITLE
fix: prevent getBandSizeOfAxis from collapsing band size due to floating-point tick gaps

### DIFF
--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -680,9 +680,9 @@ export const getBandSizeOfAxis = (
     // value cannot dictate the spacing.
     const minMeaningfulGap = maxGap * 1e-4;
     let bandSize = Infinity;
-    for (let i = 0; i < gaps.length; i++) {
-      if (gaps[i] > minMeaningfulGap) {
-        bandSize = Math.min(gaps[i], bandSize);
+    for (const gap of gaps) {
+      if (gap > minMeaningfulGap) {
+        bandSize = Math.min(gap, bandSize);
       }
     }
 

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -661,13 +661,29 @@ export const getBandSizeOfAxis = (
 
   if (axis && ticks && ticks.length >= 2) {
     const orderedTicks: ReadonlyArray<TickItem> = sortBy(ticks, (o: TickItem) => o.coordinate);
-    let bandSize = Infinity;
 
+    // Collect the pixel gaps between adjacent category positions and track the
+    // widest one.
+    const gaps: number[] = [];
+    let maxGap = 0;
     for (let i = 1, len = orderedTicks.length; i < len; i++) {
-      const cur = orderedTicks[i];
-      const prev = orderedTicks[i - 1];
+      const gap = (orderedTicks[i]?.coordinate || 0) - (orderedTicks[i - 1]?.coordinate || 0);
+      gaps.push(gap);
+      maxGap = Math.max(gap, maxGap);
+    }
 
-      bandSize = Math.min((cur?.coordinate || 0) - (prev?.coordinate || 0), bandSize);
+    // High-precision float values can place two ticks at (almost) the same pixel,
+    // producing a spurious sub-pixel gap. Such near-coincident positions are the
+    // same category slot for rendering purposes and must not define the band
+    // size, otherwise every bar collapses to ~0px wide (issue #4043). Ignore gaps
+    // that are a negligible fraction of the widest gap so a single near-duplicate
+    // value cannot dictate the spacing.
+    const minMeaningfulGap = maxGap * 1e-4;
+    let bandSize = Infinity;
+    for (let i = 0; i < gaps.length; i++) {
+      if (gaps[i] > minMeaningfulGap) {
+        bandSize = Math.min(gaps[i], bandSize);
+      }
     }
 
     return bandSize === Infinity ? 0 : bandSize;

--- a/test/util/ChartUtils.spec.tsx
+++ b/test/util/ChartUtils.spec.tsx
@@ -150,6 +150,34 @@ describe('getBandSizeOfAxis', () => {
     ];
     expect(getBandSizeOfAxis(axis, ticks)).toBe(2);
   });
+
+  it('should not collapse band size when high-precision values place two ticks at nearly the same pixel (#4043)', () => {
+    const axis: BaseAxisWithScale = {
+      allowDataOverflow: false,
+      allowDuplicatedCategory: false,
+      dataKey: undefined,
+      domain: undefined,
+      id: defaultAxisId,
+      includeHidden: false,
+      name: undefined,
+      reversed: false,
+      unit: undefined,
+      type: 'number',
+      scale: rechartsScaleFactory<number>(scaleLinear()),
+    };
+    // Categories are evenly spaced 10px apart, but a high-precision float value
+    // produces an extra tick that is a sub-pixel distance from an existing one.
+    // That spurious tiny gap must not become the band size (it used to collapse
+    // every bar to ~0.00008px wide).
+    const ticks: ReadonlyArray<TickItem> = [
+      { coordinate: 0, index: 0, value: 'a' },
+      { coordinate: 10, index: 1, value: 'b' },
+      { coordinate: 20, index: 2, value: 'c' },
+      { coordinate: 30, index: 3, value: 'd' },
+      { coordinate: 30.00008318614652580436, index: 4, value: 'e' },
+    ];
+    expect(getBandSizeOfAxis(axis, ticks)).toBe(10);
+  });
 });
 
 describe('getValueByDataKey', () => {


### PR DESCRIPTION
## Description

`getBandSizeOfAxis` derives the band size from the smallest pixel gap between adjacent (sorted) axis ticks. On a numeric axis, two high-precision float values can map to nearly the same pixel, producing a spurious sub-pixel gap (e.g. `0.00008318614652580436` in the issue reproduction). That tiny gap becomes the band size, which collapses every bar in the chart to ~0px wide.

This change ignores adjacent-tick gaps smaller than `1e-4 × maxGap` when computing the minimum spacing. A relative threshold (rather than an absolute pixel value) is used so the fix scales with chart size: near-coincident ticks represent the same rendering slot regardless of how large the chart is, while legitimately uneven category spacing (which is on the same order of magnitude as the widest gap) is unaffected. If every gap is below the threshold, the function returns `0`, matching the previous behavior for all-coincident ticks.

Fixes #4043

## Related Issue

#4043 (open, labeled bug): bars collapse to ~0 width when data contains high-precision values that place two ticks sub-pixel apart.

## Motivation and Context

Charts with high-precision numeric data currently render invisible bars because a single near-duplicate tick position dictates the band size. See the issue for a reproduction.

## How Has This Been Tested?

- Added a unit test in `test/util/ChartUtils.spec.tsx` reproducing the issue: ticks evenly spaced 10px apart plus one tick a sub-pixel distance from another; the band size is now `10` instead of `~0.00008`.
- Ran `npx vitest run --config vitest.config.mts test/util/ChartUtils.spec.tsx` — 68/68 tests pass.
- `npm run check-types-lib` and `eslint` pass on the changed files.
- No storybook story or VR test was added.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart category-band sizing when tick positions are nearly identical.
  * Prevented tiny floating-point gaps from collapsing calculated band sizes.

* **Tests**
  * Added regression coverage for high-precision tick coordinates to ensure expected band sizes are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->