### PR TITLE
fix(CartesianAxis): skip renderedTicks dispatch when tick values are unchanged

### DIFF
--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { SVGProps, useState, useRef, useCallback, forwardRef, useImperativeHandle, useEffect } from 'react';
 
 import get from 'es-toolkit/compat/get';
+import isEqual from 'es-toolkit/compat/isEqual';
 import { clsx } from 'clsx';
 import { Layer } from '../container/Layer';
 import { Text, Props as TextProps, TextAnchor, TextVerticalAnchor, isValidTextAnchor } from '../component/Text';
@@ -311,9 +312,17 @@ function RenderedTicksReporter({
   axisId: AxisId | undefined;
 }) {
   const dispatch = useAppDispatch();
+  /*
+   * The ticks array gets a new identity on every render even when its contents are unchanged.
+   * If we dispatched on every identity change, then every parent re-render would trigger
+   * a store update from a passive effect. Under rapid external updates (e.g. a slider
+   * driving chart data), those nested dispatches can trip React's update depth limit.
+   * https://github.com/recharts/recharts/issues/7563
+   */
+  const lastDispatchedTicksRef = useRef<ReadonlyArray<TickItemType> | null>(null);
   useEffect(() => {
     if (axisId == null || axisType == null) {
-      return noop;
+      return;
     }
     // Filter out irrelevant internal properties before exposing externally
     const tickItems = ticks.map(tick => ({
@@ -322,7 +331,17 @@ function RenderedTicksReporter({
       offset: tick.offset,
       index: tick.index,
     }));
+    if (isEqual(lastDispatchedTicksRef.current, tickItems)) {
+      return;
+    }
+    lastDispatchedTicksRef.current = tickItems;
     dispatch(setRenderedTicks({ ticks: tickItems, axisId, axisType }));
+  }, [dispatch, ticks, axisId, axisType]);
+
+  useEffect(() => {
+    if (axisId == null || axisType == null) {
+      return noop;
+    }
     return () => {
       dispatch(
         removeRenderedTicks({
@@ -331,7 +350,7 @@ function RenderedTicksReporter({
         }),
       );
     };
-  }, [dispatch, ticks, axisId, axisType]);
+  }, [dispatch, axisId, axisType]);
 
   return null;
 }

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -319,7 +319,11 @@ function RenderedTicksReporter({
    * driving chart data), those nested dispatches can trip React's update depth limit.
    * https://github.com/recharts/recharts/issues/7563
    */
-  const lastDispatchedTicksRef = useRef<ReadonlyArray<TickItemType> | null>(null);
+  const lastDispatchedTicksRef = useRef<{
+    ticks: ReadonlyArray<TickItemType>;
+    axisId: AxisId;
+    axisType: 'xAxis' | 'yAxis';
+  } | null>(null);
   useEffect(() => {
     if (axisId == null || axisType == null) {
       return;
@@ -331,10 +335,11 @@ function RenderedTicksReporter({
       offset: tick.offset,
       index: tick.index,
     }));
-    if (isEqual(lastDispatchedTicksRef.current, tickItems)) {
+    const last = lastDispatchedTicksRef.current;
+    if (last != null && last.axisId === axisId && last.axisType === axisType && isEqual(last.ticks, tickItems)) {
       return;
     }
-    lastDispatchedTicksRef.current = tickItems;
+    lastDispatchedTicksRef.current = { ticks: tickItems, axisId, axisType };
     dispatch(setRenderedTicks({ ticks: tickItems, axisId, axisType }));
   }, [dispatch, ticks, axisId, axisType]);
 

--- a/test/cartesian/ErrorBar.spec.tsx
+++ b/test/cartesian/ErrorBar.spec.tsx
@@ -1330,11 +1330,11 @@ describe('<ErrorBar />', () => {
           selectAxisDomainIncludingNiceTicks(state, 'yAxis', 0, useIsPanorama()),
         );
         expect(spy).toHaveBeenCalledWith([0, 3400]);
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
 
         rerender(secondRender);
         expect(spy).toHaveBeenLastCalledWith([0, 3600]);
-        expect(spy).toHaveBeenCalledTimes(8);
+        expect(spy).toHaveBeenCalledTimes(7);
       });
 
       test('YAxis ticks', () => {
@@ -1504,12 +1504,12 @@ describe('<ErrorBar />', () => {
           selectAxisDomainIncludingNiceTicks(state, 'yAxis', 0, useIsPanorama()),
         );
         expect(spy).toHaveBeenCalledWith([0, 3400]);
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
 
         rerender(secondRender);
 
         expect(spy).toHaveBeenLastCalledWith([0, 3600]);
-        expect(spy).toHaveBeenCalledTimes(8);
+        expect(spy).toHaveBeenCalledTimes(7);
       });
 
       test('YAxis ticks', () => {
@@ -1795,12 +1795,12 @@ describe('<ErrorBar />', () => {
           selectAxisDomainIncludingNiceTicks(state, 'xAxis', 0, useIsPanorama()),
         );
         expect(spy).toHaveBeenCalledWith([0, 3400]);
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
 
         rerender(secondRender);
 
         expect(spy).toHaveBeenLastCalledWith([0, 3600]);
-        expect(spy).toHaveBeenCalledTimes(8);
+        expect(spy).toHaveBeenCalledTimes(7);
       });
 
       test('XAxis ticks', () => {
@@ -2049,7 +2049,7 @@ describe('<ErrorBar />', () => {
           selectAxisDomainIncludingNiceTicks(state, 'xAxis', 0, useIsPanorama()),
         );
         expect(spy).toHaveBeenCalledWith([0, 3400]);
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
 
         rerender(secondRender);
 

--- a/test/cartesian/ReferenceDot.spec.tsx
+++ b/test/cartesian/ReferenceDot.spec.tsx
@@ -476,7 +476,7 @@ describe('<ReferenceDot />', () => {
       );
 
       expect(dotSpy).toHaveBeenLastCalledWith([]);
-      expect(dotSpy).toHaveBeenCalledTimes(6);
+      expect(dotSpy).toHaveBeenCalledTimes(5);
     });
   });
 });

--- a/test/cartesian/XAxis/XAxis.state.spec.tsx
+++ b/test/cartesian/XAxis/XAxis.state.spec.tsx
@@ -377,4 +377,24 @@ describe('state integration', () => {
     ];
     expectLastCalledWith(spy, expectedTicks);
   });
+
+  it('should keep rendered ticks referentially stable when re-rendering with unchanged tick values', () => {
+    // https://github.com/recharts/recharts/issues/7563
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <BarChart width={100} height={100} data={[{ x: 'x-1' }, { x: 'x-2' }, { x: 'x-3' }]}>
+        <XAxis xAxisId="foo" dataKey="x" />
+        {children}
+      </BarChart>
+    ));
+
+    const { spy, rerenderSameComponent } = renderTestCase(state => selectRenderedTicksOfAxis(state, 'xAxis', 'foo'));
+
+    const ticksBefore = spy.mock.calls[spy.mock.calls.length - 1][0];
+    assertNotNull(ticksBefore);
+
+    rerenderSameComponent();
+
+    const ticksAfter = spy.mock.calls[spy.mock.calls.length - 1][0];
+    expect(ticksAfter).toBe(ticksBefore);
+  });
 });

--- a/test/chart/ScatterChart.spec.tsx
+++ b/test/chart/ScatterChart.spec.tsx
@@ -1771,7 +1771,7 @@ describe('Tooltip integration', () => {
 
     it('should select tooltip payload configurations', () => {
       const { spy } = renderTestCase(state => selectTooltipPayloadConfigurations(state, 'axis', 'hover', '0'));
-      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenCalledTimes(2);
       expectLastCalledWith(spy, [
         {
           dataDefinedOnItem: [

--- a/test/component/Tooltip/Tooltip.sync.spec.tsx
+++ b/test/component/Tooltip/Tooltip.sync.spec.tsx
@@ -1018,7 +1018,7 @@ describe('Tooltip synchronization', () => {
         sourceViewBox: viewBox,
         graphicalItemId: undefined,
       });
-      expect(spyA).toHaveBeenCalledTimes(5);
+      expect(spyA).toHaveBeenCalledTimes(4);
       expect(spyB).toHaveBeenLastCalledWith({
         // Thanks to mouse events, synchronisation on this chart is now turned off so that it can start sending events to other charts
         // sourceViewBox is cleared by setMouseOverAxisIndex since Chart B is now doing its own interaction

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -1573,7 +1573,7 @@ describe('Tooltip visibility', () => {
           activeIndex: null,
           isActive: false,
         });
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
 
         showTooltip(container, composedChartMouseHoverTooltipSelector);
 
@@ -1581,7 +1581,7 @@ describe('Tooltip visibility', () => {
           activeIndex: '0',
           isActive: true,
         });
-        expect(spy).toHaveBeenCalledTimes(5);
+        expect(spy).toHaveBeenCalledTimes(4);
       });
 
       it('should render tooltip payload for hidden items', () => {

--- a/test/component/Tooltip/itemSorter.spec.tsx
+++ b/test/component/Tooltip/itemSorter.spec.tsx
@@ -444,7 +444,7 @@ describe('itemSorter in ComposedChart', () => {
             graphicalItemId: 'scatter-uv',
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
     });
 
@@ -749,7 +749,7 @@ describe('itemSorter in ComposedChart', () => {
             value: 2400,
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
     });
 

--- a/test/state/selectors/areaSelectors.spec.tsx
+++ b/test/state/selectors/areaSelectors.spec.tsx
@@ -290,14 +290,13 @@ describe('selectArea', () => {
         ],
       };
 
-      expect(spy).toHaveBeenCalledTimes(5);
+      expect(spy).toHaveBeenCalledTimes(4);
       /*
        * Fourth render has the new updated data with consistent dataKey.
        * Area will resume the animation from the most recent previous data
        * to the new points.
        */
       expect(spy).toHaveBeenNthCalledWith(4, expectedResultAfterRerender);
-      expect(spy).toHaveBeenNthCalledWith(5, expectedResultAfterRerender);
     });
   });
 });

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -1798,7 +1798,7 @@ describe('selectErrorBarsSettings', () => {
             direction: 'x',
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should return YAxis error bars', () => {
@@ -1809,7 +1809,7 @@ describe('selectErrorBarsSettings', () => {
             direction: 'y',
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
     });
 
@@ -1909,7 +1909,7 @@ describe('selectErrorBarsSettings', () => {
             direction: 'x',
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should return YAxis error bars', () => {
@@ -1920,7 +1920,7 @@ describe('selectErrorBarsSettings', () => {
             direction: 'y',
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
     });
 
@@ -1972,7 +1972,7 @@ describe('selectErrorBarsSettings', () => {
          * recomputes due to selectDisplayedData reference change, (4) auto-batched axes+items registered.
          * This is consistent with the horizontal LineChart baseline which also expects 4 renders.
          */
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should return YAxis error bars', () => {
@@ -1983,7 +1983,7 @@ describe('selectErrorBarsSettings', () => {
             direction: 'y',
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
     });
 
@@ -2066,7 +2066,7 @@ describe('selectErrorBarsSettings', () => {
          * recomputes due to selectDisplayedData reference change, (4) auto-batched axes+items registered.
          * This is consistent with the horizontal LineChart baseline which also expects 4 renders.
          */
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
 
       it('should return YAxis error bars', () => {
@@ -2085,7 +2085,7 @@ describe('selectErrorBarsSettings', () => {
             direction: 'y',
           },
         ]);
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(spy).toHaveBeenCalledTimes(3);
       });
     });
   });

--- a/test/state/selectors/lineSelectors.spec.tsx
+++ b/test/state/selectors/lineSelectors.spec.tsx
@@ -191,7 +191,7 @@ describe('selectLinePoints', () => {
         },
       ];
 
-      expect(spy).toHaveBeenCalledTimes(5);
+      expect(spy).toHaveBeenCalledTimes(4);
       /*
        * Last render has the new updated data with consistent dataKey.
        * Line will resume animation from the most recent previous data

--- a/test/state/selectors/selectIsTooltipActive.spec.tsx
+++ b/test/state/selectors/selectIsTooltipActive.spec.tsx
@@ -124,21 +124,21 @@ describe('selectIsTooltipActive', () => {
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(4);
+      expect(spy).toHaveBeenCalledTimes(3);
 
       showTooltip(container, scatterChartMouseHoverTooltipSelector);
       expectLastCalledWith(spy, {
         activeIndex: '0',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(5);
+      expect(spy).toHaveBeenCalledTimes(4);
 
       hideTooltip(container, scatterChartMouseHoverTooltipSelector);
       expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(6);
+      expect(spy).toHaveBeenCalledTimes(5);
     });
   });
 
@@ -167,21 +167,21 @@ describe('selectIsTooltipActive', () => {
         activeIndex: '3',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(4);
+      expect(spy).toHaveBeenCalledTimes(3);
 
       showTooltip(container, scatterChartMouseHoverTooltipSelector);
       expectLastCalledWith(spy, {
         activeIndex: '0',
         isActive: true,
       });
-      expect(spy).toHaveBeenCalledTimes(5);
+      expect(spy).toHaveBeenCalledTimes(4);
 
       hideTooltip(container, scatterChartMouseHoverTooltipSelector);
       expectLastCalledWith(spy, {
         activeIndex: null,
         isActive: false,
       });
-      expect(spy).toHaveBeenCalledTimes(6);
+      expect(spy).toHaveBeenCalledTimes(5);
     });
   });
 


### PR DESCRIPTION
## Description

`RenderedTicksReporter` dispatched `setRenderedTicks` from its passive effect on every render, because the `ticks` array it receives is rebuilt by a bare `getTicks()` call in render and so gets a new identity each time even when its contents are unchanged. On top of that, since `ticks` is in the effect's dependency array, every re-render also ran the effect cleanup, dispatching `removeRenderedTicks` — two store dispatches per axis per render.

This PR makes the reporter value-compare the outgoing tick items against the last dispatched ones (via a ref + `isEqual`) and skip the dispatch when nothing changed, and moves the `removeRenderedTicks` cleanup into its own effect so it only fires on actual unmount.

## Related Issue

Fixes #7563

## Motivation and Context

As described in #7563: when an app re-renders a chart rapidly (e.g. a range slider driving the chart's `data` each frame), every render triggered nested store dispatches from passive effects. Interleaved with the app's own `setState` calls, this trips React's maximum update depth limit (`RenderedTicksReporter.useEffect → dispatch → notifyNestedSubs → forceStoreRerender` during `commitPassiveUnmountOnFiber`) — a hard crash at real human drag speed in dev, and reproducible in production builds under higher-rate bursts. Even fully identity-stabilized apps still hit the dev-only warning floor because every legitimate data change was followed by a nested store dispatch.

With this change, data-driven re-renders with unchanged tick output complete without any nested store dispatch.

## How Has This Been Tested?

- New regression test in `test/cartesian/XAxis/XAxis.state.spec.tsx` asserting the rendered-ticks state stays referentially stable across a re-render with unchanged tick values. It fails against the previous implementation and passes with the fix.
- Full unit suite: 311 files, 16,228 tests passing (Windows, Node 18+).
- 29 existing render-count assertions across 10 test files needed their expected counts reduced by one: each chart now mounts with one fewer store update. The asserted values are unchanged — only the counts decreased, which is the measurable effect of removing the redundant dispatch.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary state updates by only publishing rendered axis tick data when the tick contents actually change.
  * Improved cleanup behavior to remove rendered tick state when the axis changes or unmounts, without tying it to tick recalculation.

* **Tests**
  * Updated existing chart, axis, error bar, selector, and tooltip tests to match reduced redundant selector invocations.
  * Added an integration test asserting referentially stable rendered tick arrays when charts re-render without underlying tick value changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->