### PR TITLE
Omnidoc: group props into collapsible sections and add @since support

### DIFF
--- a/omnidoc/generateApiDoc.spec.ts
+++ b/omnidoc/generateApiDoc.spec.ts
@@ -185,6 +185,19 @@ describe('generateApiDoc', () => {
     expect(apiDoc.deprecated).not.toEqual(expect.stringContaining('{@link'));
   });
 
+  it('should render Markdown in deprecated prop text and include prop @since tags', async () => {
+    const apiDoc = await generateApiDoc('Legend', reader, exampleReader, contextMap);
+    const verticalAlign = apiDoc.props.find(prop => prop.name === 'verticalAlign');
+    const position = apiDoc.props.find(prop => prop.name === 'position');
+
+    expect(verticalAlign?.deprecated).toEqual(
+      expect.objectContaining({
+        'en-US': expect.stringContaining('<code>position</code>'),
+      }),
+    );
+    expect(position?.since).toBe('3.10');
+  });
+
   it('should include return value in API doc for hooks', async () => {
     const apiDoc = await generateApiDoc('useChartHeight', reader, exampleReader, contextMap);
     expect(apiDoc.returnValue).toBeDefined();

--- a/omnidoc/generateApiDoc.spec.ts
+++ b/omnidoc/generateApiDoc.spec.ts
@@ -185,7 +185,7 @@ describe('generateApiDoc', () => {
     expect(apiDoc.deprecated).not.toEqual(expect.stringContaining('{@link'));
   });
 
-  it('should render Markdown in deprecated prop text and include prop @since tags', async () => {
+  it('should render Markdown in deprecated prop text and include prop @since tags', { timeout: 10000 }, async () => {
     const apiDoc = await generateApiDoc('Legend', reader, exampleReader, contextMap);
     const verticalAlign = apiDoc.props.find(prop => prop.name === 'verticalAlign');
     const position = apiDoc.props.find(prop => prop.name === 'position');

--- a/omnidoc/generateApiDoc.ts
+++ b/omnidoc/generateApiDoc.ts
@@ -178,14 +178,23 @@ async function renderJsDocRichText(
 async function renderDeprecatedTagText(
   text: string,
   componentNames?: ReadonlyArray<string>,
-): Promise<string | { [locale: string]: string }> {
+): Promise<{ [locale: string]: string }> {
   const textWithLinks = processInlineLinks(text, componentNames);
-  if (textWithLinks === text) {
-    return text;
-  }
   return {
     'en-US': await marked.parse(textWithLinks),
   };
+}
+
+function getPropTag(
+  propMetaList: ReturnType<ProjectDocReader['getPropMeta']>,
+  tagName: string,
+): { text: string | undefined } | undefined {
+  const rechartsProp = propMetaList.find(prop => prop.origin === 'recharts' && getTagText(prop.jsDoc, tagName));
+  if (rechartsProp) {
+    return getTagText(rechartsProp.jsDoc, tagName);
+  }
+
+  return propMetaList.map(prop => getTagText(prop.jsDoc, tagName)).find(tag => tag !== undefined);
 }
 
 async function generateComponentDescription(
@@ -359,35 +368,19 @@ async function generateApiDoc(
     const isOptional = projectReader.isOptionalProp(componentName, propName);
 
     const propMetaList = projectReader.getPropMeta(componentName, propName);
-    let deprecated: string | boolean | undefined;
-
-    // Prefer recharts origin
-    const rechartsProp = propMetaList.find(p => p.origin === 'recharts');
-    if (rechartsProp && rechartsProp.jsDoc) {
-      const tag = getTagText(rechartsProp.jsDoc, 'deprecated');
-      if (tag) {
-        deprecated = tag.text ? await renderDeprecatedTagText(tag.text, allExports) : true;
-      }
+    const deprecatedTag = getPropTag(propMetaList, 'deprecated');
+    let deprecated: string | boolean | { [locale: string]: string } | undefined;
+    if (deprecatedTag) {
+      deprecated = deprecatedTag.text ? await renderDeprecatedTagText(deprecatedTag.text, allExports) : true;
     }
-
-    // Fallback
-    if (deprecated === undefined) {
-      for (const p of propMetaList) {
-        if (p.jsDoc) {
-          const tag = getTagText(p.jsDoc, 'deprecated');
-          if (tag) {
-            deprecated = tag.text ? await renderDeprecatedTagText(tag.text, allExports) : true;
-            break;
-          }
-        }
-      }
-    }
+    const since = getPropTag(propMetaList, 'since')?.text;
 
     const prop: ApiProps = {
       name: propName,
       type: typeString,
       isOptional,
       deprecated,
+      since,
     };
 
     // Add description if available
@@ -568,6 +561,10 @@ function stringifyApiDoc(apiDoc: ApiDoc): string {
           ? stringifyLocalizedRichText(prop.deprecated)
           : JSON.stringify(prop.deprecated)
       },`;
+    }
+
+    if (prop.since !== undefined) {
+      result += `"since": ${JSON.stringify(prop.since)},`;
     }
 
     result += `},`;

--- a/src/cartesian/getCartesianPosition.tsx
+++ b/src/cartesian/getCartesianPosition.tsx
@@ -36,6 +36,9 @@ export type CartesianLabelPosition =
       y?: number | string;
     };
 
+/**
+ * @inline
+ */
 export type CartesianPosition =
   | 'top'
   | 'left'

--- a/www/src/docs/api/types.ts
+++ b/www/src/docs/api/types.ts
@@ -16,6 +16,7 @@ export type ApiProps = {
   format?: ReadonlyArray<string>;
   examples?: ReadonlyArray<PropExample>;
   deprecated?: boolean | string | Partial<Record<SupportedLocale, ReactNode>>;
+  since?: string;
 };
 
 export type ApiDoc = {

--- a/www/src/locale/en-US.ts
+++ b/www/src/locale/en-US.ts
@@ -107,6 +107,10 @@ export const map = {
     showData: 'Show data format',
     hideData: 'Hide data format',
     animation: 'Animation',
+    current: 'Props',
+    deprecated: 'Deprecated Props',
+    events: 'Events',
+    since: 'Available since Recharts',
   },
   'design-disciplines': {
     'design-disciplines': 'Design Disciplines',

--- a/www/src/locale/zh-CN.ts
+++ b/www/src/locale/zh-CN.ts
@@ -103,6 +103,10 @@ export const map = {
     showData: '显示数据格式',
     hideData: '隐藏数据格式',
     animation: '动画',
+    current: '属性',
+    deprecated: '已弃用的属性',
+    events: '事件',
+    since: 'Recharts 自',
   },
   'design-disciplines': {
     'design-disciplines': '设计原则',

--- a/www/src/views/APIView.css
+++ b/www/src/views/APIView.css
@@ -2,6 +2,7 @@
   .deprecated-message {
     display: flex;
     flex-direction: row;
+
     section,
     p {
       display: inline;
@@ -15,6 +16,7 @@
 
         .code {
           position: relative;
+
           .view-data-button {
             position: absolute;
             right: 0;
@@ -33,6 +35,7 @@
       }
     }
   }
+
   .api-component-item {
     display: inline-block;
     margin: 8px 20px 8px 0;
@@ -43,6 +46,19 @@
     height: 30px;
     line-height: 30px;
   }
+
+  .props-section {
+    .sub-title button {
+      appearance: none;
+      background: none;
+      border: 0;
+      color: inherit;
+      cursor: pointer;
+      font: inherit;
+      padding: 0;
+    }
+  }
+
   .props-list {
     .props-item {
       border-bottom: 1px solid #f5f5f5;
@@ -67,20 +83,9 @@
             color: #999;
             text-decoration: line-through;
           }
+
           .deprecated-label {
             margin-left: 10px;
-          }
-
-          .props-section {
-            .sub-title button {
-              appearance: none;
-              background: none;
-              border: 0;
-              color: inherit;
-              cursor: pointer;
-              font: inherit;
-              padding: 0;
-            }
           }
         }
 
@@ -88,6 +93,7 @@
           padding-left: 20px;
           color: #bf2a5c;
         }
+
         .optional {
           margin-left: 10px;
         }
@@ -105,19 +111,23 @@
           margin-right: 10px;
         }
       }
+
       .examples {
         .title {
           margin: 0;
           font-weight: 700;
         }
+
         .list {
           a {
             color: #1281ca;
           }
         }
       }
+
       .format {
         margin-bottom: 10px;
+
         .title {
           margin: 0;
           font-weight: 700;

--- a/www/src/views/APIView.css
+++ b/www/src/views/APIView.css
@@ -56,6 +56,9 @@
       cursor: pointer;
       font: inherit;
       padding: 0;
+      .expander {
+        font-size: 1ex;
+      }
     }
   }
 

--- a/www/src/views/APIView.css
+++ b/www/src/views/APIView.css
@@ -70,6 +70,18 @@
           .deprecated-label {
             margin-left: 10px;
           }
+
+          .props-section {
+            .sub-title button {
+              appearance: none;
+              background: none;
+              border: 0;
+              color: inherit;
+              cursor: pointer;
+              font: inherit;
+              padding: 0;
+            }
+          }
         }
 
         .type {

--- a/www/src/views/APIViewNew.tsx
+++ b/www/src/views/APIViewNew.tsx
@@ -1,5 +1,6 @@
 import Helmet from 'react-helmet';
 import { Link } from 'react-router';
+import { useState } from 'react';
 import { allApiDocs as API } from '../docs/api';
 import { localeGet, parseLocalObj, useLocale } from '../utils/LocaleUtils.ts';
 import './APIView.css';
@@ -40,59 +41,156 @@ type PropsListProps = {
   locale: SupportedLocale;
 };
 
-function PropsList({ props, locale }: PropsListProps) {
-  if (!props || !props.length) {
+type PropsSection = 'current' | 'deprecated' | 'events';
+
+const PROPS_SECTION_STORAGE_KEY = 'recharts-api-props-sections';
+
+function getInitialExpandedSections(): Record<PropsSection, boolean> {
+  if (typeof window === 'undefined') {
+    return { current: true, deprecated: false, events: false };
+  }
+
+  try {
+    const storedValue = window.localStorage.getItem(PROPS_SECTION_STORAGE_KEY);
+    if (storedValue === null) {
+      return { current: true, deprecated: false, events: false };
+    }
+    const parsedValue: unknown = JSON.parse(storedValue);
+    if (typeof parsedValue !== 'object' || parsedValue === null) {
+      return { current: true, deprecated: false, events: false };
+    }
+    return {
+      current: !('current' in parsedValue) || parsedValue.current === true,
+      deprecated: 'deprecated' in parsedValue && parsedValue.deprecated === true,
+      events: 'events' in parsedValue && parsedValue.events === true,
+    };
+  } catch {
+    return { current: true, deprecated: false, events: false };
+  }
+}
+
+type PropsSectionProps = {
+  entries: ReadonlyArray<ApiProps>;
+  locale: SupportedLocale;
+  section: PropsSection;
+  isExpanded: boolean;
+  onToggle: (section: PropsSection) => void;
+};
+
+function PropsSection({ entries, locale, section, isExpanded, onToggle }: PropsSectionProps) {
+  if (entries.length === 0) {
     return null;
   }
 
+  const sectionId = `props-${section}`;
+  return (
+    <section className="props-section">
+      <h4 className="sub-title">
+        <button type="button" aria-expanded={isExpanded} aria-controls={sectionId} onClick={() => onToggle(section)}>
+          {localeGet(locale, 'api', section)}
+        </button>
+      </h4>
+      {isExpanded ? (
+        <ul className="props-list" id={sectionId}>
+          {entries.map((entry: ApiProps) => (
+            <li className="props-item" key={entry.name} id={entry.name}>
+              <p className={`header ${entry.deprecated ? 'deprecated' : ''}`}>
+                <span className="title">
+                  <a href={`#${entry.name}`}>{entry.name}</a>
+                </span>
+                <span className="type">{entry.type}</span>
+                {entry.isOptional ? <em className="optional">optional</em> : null}
+                {entry.deprecated ? <em className="deprecated-label">@deprecated</em> : null}
+              </p>
+              {entry.deprecated && entry.deprecated !== true ? (
+                <div className="deprecated-message">
+                  <strong>Deprecated:</strong> {parseLocalObj(locale, entry.deprecated)}
+                </div>
+              ) : null}
+              <p className="desc">{parseLocalObj(locale, entry.desc)}</p>
+              {entry.since ? (
+                <p className="since">
+                  {localeGet(locale, 'api', 'since')} {entry.since}
+                </p>
+              ) : null}
+              {entry.defaultVal !== null &&
+              entry.defaultVal !== undefined &&
+              entry.defaultVal !== 'null' &&
+              entry.defaultVal !== 'undefined' ? (
+                <p className="default">
+                  <span className="title">{localeGet(locale, 'api', 'default')}</span>
+                  <code>{JSON.stringify(entry.defaultVal)}</code>
+                </p>
+              ) : null}
+              {entry.format && entry.format.length ? (
+                <div className="format">
+                  <p className="title">{localeGet(locale, 'api', 'format')}</p>
+                  <pre className="format-code">
+                    <code>{entry.format.join('\n')}</code>
+                  </pre>
+                </div>
+              ) : null}
+              {entry.examples && entry.examples.length ? (
+                <div className="examples">
+                  <p className="title">{localeGet(locale, 'api', 'examples')}</p>
+                  <ul className="list">
+                    <PropsExamples examples={entry.examples} locale={locale} />
+                  </ul>
+                </div>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
+function PropsList({ props, locale }: PropsListProps) {
+  const [expandedSections, setExpandedSections] = useState(getInitialExpandedSections);
+  const toggleSection = (section: PropsSection) => {
+    setExpandedSections(previousSections => {
+      const nextSections = { ...previousSections, [section]: !previousSections[section] };
+      try {
+        window.localStorage.setItem(PROPS_SECTION_STORAGE_KEY, JSON.stringify(nextSections));
+      } catch {
+        // Storage may be unavailable, so preserve the state for this page only.
+      }
+      return nextSections;
+    });
+  };
+
+  if (!props.length) {
+    return null;
+  }
+
+  const currentProps = props.filter(prop => !prop.deprecated && !prop.name.startsWith('on'));
+  const deprecatedProps = props.filter(prop => prop.deprecated);
+  const events = props.filter(prop => !prop.deprecated && prop.name.startsWith('on'));
+
   return (
     <>
-      <h4 className="sub-title">Props</h4>
-      <ul className="props-list">
-        {props.map((entry: ApiProps) => (
-          <li className="props-item" key={entry.name} id={entry.name}>
-            <p className={`header ${entry.deprecated ? 'deprecated' : ''}`}>
-              <span className="title">
-                <a href={`#${entry.name}`}>{entry.name}</a>
-              </span>
-              <span className="type">{entry.type}</span>
-              {entry.isOptional ? <em className="optional">optional</em> : null}
-              {entry.deprecated ? <em className="deprecated-label">@deprecated</em> : null}
-            </p>
-            {entry.deprecated && entry.deprecated !== true ? (
-              <div className="deprecated-message">
-                <strong>Deprecated:</strong> {parseLocalObj(locale, entry.deprecated)}
-              </div>
-            ) : null}
-            <p className="desc">{parseLocalObj(locale, entry.desc)}</p>
-            {entry.defaultVal !== null &&
-            entry.defaultVal !== undefined &&
-            entry.defaultVal !== 'null' &&
-            entry.defaultVal !== 'undefined' ? (
-              <p className="default">
-                <span className="title">{localeGet(locale, 'api', 'default')}</span>
-                <code>{JSON.stringify(entry.defaultVal)}</code>
-              </p>
-            ) : null}
-            {entry.format && entry.format.length ? (
-              <div className="format">
-                <p className="title">{localeGet(locale, 'api', 'format')}</p>
-                <pre className="format-code">
-                  <code>{entry.format.join('\n')}</code>
-                </pre>
-              </div>
-            ) : null}
-            {entry.examples && entry.examples.length ? (
-              <div className="examples">
-                <p className="title">{localeGet(locale, 'api', 'examples')}</p>
-                <ul className="list">
-                  <PropsExamples examples={entry.examples} locale={locale} />
-                </ul>
-              </div>
-            ) : null}
-          </li>
-        ))}
-      </ul>
+      <PropsSection
+        entries={currentProps}
+        locale={locale}
+        section="current"
+        isExpanded={expandedSections.current}
+        onToggle={toggleSection}
+      />
+      <PropsSection
+        entries={deprecatedProps}
+        locale={locale}
+        section="deprecated"
+        isExpanded={expandedSections.deprecated}
+        onToggle={toggleSection}
+      />
+      <PropsSection
+        entries={events}
+        locale={locale}
+        section="events"
+        isExpanded={expandedSections.events}
+        onToggle={toggleSection}
+      />
     </>
   );
 }

--- a/www/src/views/APIViewNew.tsx
+++ b/www/src/views/APIViewNew.tsx
@@ -87,7 +87,8 @@ function PropsSection({ entries, locale, section, isExpanded, onToggle }: PropsS
     <section className="props-section">
       <h4 className="sub-title">
         <button type="button" aria-expanded={isExpanded} aria-controls={sectionId} onClick={() => onToggle(section)}>
-          {localeGet(locale, 'api', section)}
+          {localeGet(locale, 'api', section)}{' '}
+          <i className="expander">{isExpanded ? 'Click to collapse' : 'Click to expand'}</i>
         </button>
       </h4>
       {isExpanded ? (


### PR DESCRIPTION
Website only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API documentation now shows “Available since” metadata for supported properties.
  * API props are organized into collapsible **Current**, **Deprecated**, and **Events** sections.
  * Expansion state is remembered between visits.
* **Improvements**
  * Deprecated property descriptions now render from Markdown with proper formatting/localization.
  * Updated English/Chinese labels and improved accessible, consistent styling for section toggles.
* **Tests**
  * Added automated coverage for deprecated rendering and “since” metadata in generated API docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->