### PR TITLE
feat(XAxis): support height="auto" to size the axis to its tick labels

### DIFF
--- a/omnidoc/commentSimilarityExceptions.ts
+++ b/omnidoc/commentSimilarityExceptions.ts
@@ -55,6 +55,11 @@ export const commentSimilarityExceptions: ReadonlyArray<CommentSimilarityGroup> 
     reason: 'YAxis width allows "auto" value, unlike other components',
   },
   {
+    components: ['XAxis'],
+    props: ['height'],
+    reason: 'XAxis height allows "auto" value, unlike other components',
+  },
+  {
     components: ['Brush'],
     props: ['width'],
     reason: 'Brush width defaults to chart width, unlike other components',

--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -239,6 +239,7 @@
   "es6/util/ReduceCSSCalc.js",
   "es6/util/ScatterUtils.js",
   "es6/util/TickUtils.js",
+  "es6/util/XAxisUtils.js",
   "es6/util/YAxisUtils.js",
   "es6/util/axisPropsAreEqual.js",
   "es6/util/createCartesianCharts.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -239,6 +239,7 @@
   "lib/util/ReduceCSSCalc.js",
   "lib/util/ScatterUtils.js",
   "lib/util/TickUtils.js",
+  "lib/util/XAxisUtils.js",
   "lib/util/YAxisUtils.js",
   "lib/util/axisPropsAreEqual.js",
   "lib/util/createCartesianCharts.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -239,6 +239,7 @@
   "types/util/ReduceCSSCalc.d.ts",
   "types/util/ScatterUtils.d.ts",
   "types/util/TickUtils.d.ts",
+  "types/util/XAxisUtils.d.ts",
   "types/util/YAxisUtils.d.ts",
   "types/util/axisPropsAreEqual.d.ts",
   "types/util/createCartesianCharts.d.ts",

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -28,6 +28,7 @@ import { getTicks } from './getTicks';
 import { svgPropertiesNoEvents, svgPropertiesNoEventsFromUnknown } from '../util/svgPropertiesNoEvents';
 import { AxisId, XAxisOrientation, XAxisPadding, YAxisOrientation, YAxisPadding } from '../state/cartesianAxisSlice';
 import { getCalculatedYAxisWidth } from '../util/YAxisUtils';
+import { getCalculatedXAxisHeight } from '../util/XAxisUtils';
 import { RequiresDefaultProps, resolveDefaultProps } from '../util/resolveDefaultProps';
 import { ZIndexable, ZIndexLayer } from '../zIndex/ZIndexLayer';
 import { DefaultZIndexes } from '../zIndex/DefaultZIndexes';
@@ -91,6 +92,7 @@ export interface CartesianAxisProps extends ZIndexable {
 
 export interface CartesianAxisRef {
   getCalculatedWidth(): number;
+  getCalculatedHeight(): number;
 }
 
 export const defaultCartesianAxisProps = {
@@ -493,6 +495,15 @@ const CartesianAxisComponent = forwardRef<CartesianAxisRef, InternalProps>((prop
   useImperativeHandle(ref, (): CartesianAxisRef => ({
     getCalculatedWidth: (): number => {
       return getCalculatedYAxisWidth({
+        ticks: tickRefs.current,
+        label: props.labelRef?.current,
+        labelGapWithTick: 5,
+        tickSize: props.tickSize,
+        tickMargin: props.tickMargin,
+      });
+    },
+    getCalculatedHeight: (): number => {
+      return getCalculatedXAxisHeight({
         ticks: tickRefs.current,
         label: props.labelRef?.current,
         labelGapWithTick: 5,

--- a/src/cartesian/XAxis.tsx
+++ b/src/cartesian/XAxis.tsx
@@ -2,9 +2,9 @@
  * @fileOverview X Axis
  */
 import * as React from 'react';
-import { ReactElement, ReactNode, useLayoutEffect, useMemo, useRef } from 'react';
+import { ReactElement, ReactNode, isValidElement, useLayoutEffect, useMemo, useRef } from 'react';
 import { clsx } from 'clsx';
-import { CartesianAxis, defaultCartesianAxisProps } from './CartesianAxis';
+import { CartesianAxis, CartesianAxisRef, defaultCartesianAxisProps } from './CartesianAxis';
 import {
   AxisInterval,
   AxisTick,
@@ -23,6 +23,7 @@ import {
   addXAxis,
   replaceXAxis,
   removeXAxis,
+  updateXAxisHeight,
   XAxisOrientation,
   XAxisPadding,
   XAxisSettings,
@@ -37,6 +38,7 @@ import {
 } from '../state/selectors/axisSelectors';
 import { selectAxisViewBox } from '../state/selectors/selectChartOffsetInternal';
 import { useIsPanorama } from '../context/PanoramaContext';
+import { isLabelContentAFunction } from '../component/Label';
 import { RequiresDefaultProps, resolveDefaultProps } from '../util/resolveDefaultProps';
 import { axisPropsAreEqual } from '../util/axisPropsAreEqual';
 import { CustomScaleDefinition } from '../util/scale/CustomScaleDefinition';
@@ -71,9 +73,12 @@ interface XAxisProps<DataPointType = any, DataValueType = any> extends Omit<
   /**
    * Height of the axis in pixels.
    *
+   * When set to `'auto'`, the height is calculated dynamically based on the tick labels and the axis label,
+   * mirroring the `YAxis` `width="auto"` behavior. Useful when tick labels are rotated or span multiple lines.
+   *
    * @defaultValue 30
    */
-  height?: number;
+  height?: number | 'auto';
   /**
    * If set true, flips ticks around the axis line, displaying the labels inside the chart instead of outside.
    * @defaultValue false
@@ -248,9 +253,14 @@ function SetXAxisSettings(props: Omit<XAxisSettings, 'type'> & { type: AxisDomai
 }
 
 const XAxisImpl = (props: PropsWithDefaults) => {
-  const { xAxisId, className } = props;
+  const { xAxisId, className, height, label } = props;
+
+  const cartesianAxisRef = useRef<CartesianAxisRef>(null);
+  const labelRef = useRef(null);
+
   const viewBox = useAppSelector(selectAxisViewBox);
   const isPanorama = useIsPanorama();
+  const dispatch = useAppDispatch();
   const axisType = 'xAxis';
   const cartesianTickItems = useAppSelector(state => selectTicksOfAxis(state, axisType, xAxisId, isPanorama));
   const axisSize = useAppSelector(state => selectXAxisSize(state, xAxisId));
@@ -263,6 +273,43 @@ const XAxisImpl = (props: PropsWithDefaults) => {
    */
   const synchronizedSettings = useAppSelector(state => selectXAxisSettingsNoDefaults(state, xAxisId));
 
+  useLayoutEffect(() => {
+    // No dynamic height calculation is done when height !== 'auto'
+    // or when a function/react element is used for label
+    if (
+      height !== 'auto' ||
+      !axisSize ||
+      isLabelContentAFunction(label) ||
+      isValidElement(label) ||
+      synchronizedSettings == null
+    ) {
+      return;
+    }
+
+    const axisComponent = cartesianAxisRef.current;
+    if (!axisComponent) {
+      return;
+    }
+
+    const updatedXAxisHeight = axisComponent.getCalculatedHeight();
+
+    // if the height has changed, dispatch an action to update the height
+    if (Math.round(axisSize.height) !== Math.round(updatedXAxisHeight)) {
+      dispatch(updateXAxisHeight({ id: xAxisId, height: updatedXAxisHeight }));
+    }
+  }, [
+    // The dependency on cartesianAxisRef.current is not needed because useLayoutEffect will run after every render.
+    // The ref will be populated by then.
+    // To re-run this effect when ticks change, we can depend on the ticks array from the store.
+    cartesianTickItems,
+    axisSize,
+    dispatch,
+    label,
+    xAxisId,
+    height,
+    synchronizedSettings,
+  ]);
+
   if (axisSize == null || position == null || synchronizedSettings == null) {
     return null;
   }
@@ -274,6 +321,8 @@ const XAxisImpl = (props: PropsWithDefaults) => {
     <CartesianAxis
       {...allOtherProps}
       {...restSynchronizedSettings}
+      ref={cartesianAxisRef}
+      labelRef={labelRef}
       x={position.x}
       y={position.y}
       width={axisSize.width}

--- a/src/state/cartesianAxisSlice.ts
+++ b/src/state/cartesianAxisSlice.ts
@@ -128,10 +128,13 @@ export type CartesianAxisSettings = BaseCartesianAxis &
     tickFormatter: TickFormatter | undefined;
   };
 
+export type XAxisHeight = number | 'auto';
+
 export type XAxisSettings = CartesianAxisSettings & {
   padding: XAxisPadding;
-  height: number;
+  height: XAxisHeight;
   orientation: XAxisOrientation;
+  heightHistory?: number[];
 };
 
 export type YAxisWidth = number | 'auto';
@@ -267,6 +270,30 @@ const cartesianAxisSlice = createSlice({
         };
       }
     },
+    updateXAxisHeight(state, action: PayloadAction<{ id: AxisId; height: number }>) {
+      const { id, height } = action.payload;
+      const axis = state.xAxis[id];
+      if (axis) {
+        const history = axis.heightHistory || [];
+        // An oscillation is detected when the new height is the same as the height before the last one.
+        // This is a simple A -> B -> A pattern. If the next height is B, and the difference is less than 1 pixel, we ignore it.
+        if (
+          history.length === 3 &&
+          history[0] === history[2] &&
+          height === history[1] &&
+          height !== axis.height &&
+          Math.abs(height - (history[0] ?? 0)) <= 1
+        ) {
+          return;
+        }
+        const newHistory = [...history, height].slice(-3);
+        state.xAxis[id] = {
+          ...axis,
+          height,
+          heightHistory: newHistory,
+        };
+      }
+    },
   },
 });
 
@@ -281,6 +308,7 @@ export const {
   replaceZAxis,
   removeZAxis,
   updateYAxisWidth,
+  updateXAxisHeight,
 } = cartesianAxisSlice.actions;
 
 export const cartesianAxisReducer = cartesianAxisSlice.reducer;

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -78,7 +78,7 @@ import { AngleAxisSettings, RadiusAxisSettings } from '../polarAxisSlice';
 import { pickAxisType } from './pickAxisType';
 import { pickAxisId } from './pickAxisId';
 import { combineAxisRangeWithReverse } from './combiners/combineAxisRangeWithReverse';
-import { DEFAULT_Y_AXIS_WIDTH } from '../../util/Constants';
+import { DEFAULT_X_AXIS_HEIGHT, DEFAULT_Y_AXIS_WIDTH } from '../../util/Constants';
 import { getStackSeriesIdentifier } from '../../util/stacks/getStackSeriesIdentifier';
 import { AllStackGroups, StackGroup } from '../../util/stacks/stackTypes';
 import { combineDisplayedStackedData, DisplayedStackedData } from './combiners/combineDisplayedStackedData';
@@ -1717,9 +1717,10 @@ const selectAllYAxesWithOffsetType: (
 );
 
 const getXAxisSize = (offset: ChartOffsetInternal, axisSettings: XAxisSettings): Size => {
+  const height = typeof axisSettings.height === 'number' ? axisSettings.height : DEFAULT_X_AXIS_HEIGHT;
   return {
     width: offset.width,
-    height: axisSettings.height,
+    height,
   };
 };
 

--- a/src/state/selectors/selectChartOffsetInternal.ts
+++ b/src/state/selectors/selectChartOffsetInternal.ts
@@ -14,7 +14,7 @@ import { LegendSettings } from '../legendSlice';
 import { appendOffsetOfLegend } from '../../util/ChartUtils';
 import { selectChartHeight, selectChartWidth, selectMargin } from './containerSelectors';
 import { selectAllXAxes, selectAllYAxes } from './selectAllAxes';
-import { DEFAULT_Y_AXIS_WIDTH } from '../../util/Constants';
+import { DEFAULT_X_AXIS_HEIGHT, DEFAULT_Y_AXIS_WIDTH } from '../../util/Constants';
 import { RechartsRootState } from '../store';
 
 export const selectBrushHeight = (state: RechartsRootState) => state.brush.height;
@@ -45,7 +45,8 @@ function selectTopAxesOffset(state: RechartsRootState): number {
   const xAxes = selectAllXAxes(state);
   return xAxes.reduce((result: number, entry: XAxisSettings): number => {
     if (entry.orientation === 'top' && !entry.mirror && !entry.hide) {
-      return result + entry.height;
+      const height = typeof entry.height === 'number' ? entry.height : DEFAULT_X_AXIS_HEIGHT;
+      return result + height;
     }
     return result;
   }, 0);
@@ -55,7 +56,8 @@ function selectBottomAxesOffset(state: RechartsRootState): number {
   const xAxes = selectAllXAxes(state);
   return xAxes.reduce((result: number, entry: XAxisSettings): number => {
     if (entry.orientation === 'bottom' && !entry.mirror && !entry.hide) {
-      return result + entry.height;
+      const height = typeof entry.height === 'number' ? entry.height : DEFAULT_X_AXIS_HEIGHT;
+      return result + height;
     }
     return result;
   }, 0);

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -39,3 +39,5 @@ export const DATA_ITEM_INDEX_ATTRIBUTE_NAME = 'data-recharts-item-index';
 export const DATA_ITEM_GRAPHICAL_ITEM_ID_ATTRIBUTE_NAME = 'data-recharts-item-id';
 
 export const DEFAULT_Y_AXIS_WIDTH = 60;
+
+export const DEFAULT_X_AXIS_HEIGHT = 30;

--- a/src/util/XAxisUtils.tsx
+++ b/src/util/XAxisUtils.tsx
@@ -1,0 +1,51 @@
+type IGetBoundingClient = Pick<Element, 'getBoundingClientRect'>;
+
+/**
+ * Calculates the height of the X-axis based on the tick labels and the axis label.
+ * @param params - The parameters object.
+ * @param [params.ticks] - An array-like object of tick elements, each with a `getBoundingClientRect` method.
+ * @param [params.label] - The axis label element, with a `getBoundingClientRect` method.
+ * @param [params.labelGapWithTick=5] - The gap between the label and the tick.
+ * @param [params.tickSize=0] - The length of the tick line.
+ * @param [params.tickMargin=0] - The margin between the tick line and the tick text.
+ * @returns The calculated height of the X-axis.
+ */
+export const getCalculatedXAxisHeight = ({
+  ticks,
+  label,
+  labelGapWithTick = 5, // Default gap between label and tick
+  tickSize = 0,
+  tickMargin = 0,
+}: {
+  ticks: ArrayLike<IGetBoundingClient> | null;
+  label: IGetBoundingClient | null | undefined;
+  labelGapWithTick: number | undefined;
+  tickSize: number | undefined;
+  tickMargin: number | undefined;
+}): number => {
+  // find the max height of the tick labels
+  let maxTickHeight = 0;
+  if (ticks) {
+    Array.from(ticks).forEach((tickNode: IGetBoundingClient) => {
+      if (tickNode) {
+        const bbox = tickNode.getBoundingClientRect();
+
+        if (bbox.height > maxTickHeight) {
+          maxTickHeight = bbox.height;
+        }
+      }
+    });
+
+    // calculate height of the axis label
+    const labelHeight = label ? label.getBoundingClientRect().height : 0;
+
+    const tickHeight = tickSize + tickMargin;
+
+    // calculate the updated height of the x-axis
+    const updatedXAxisHeight = maxTickHeight + tickHeight + labelHeight + (label ? labelGapWithTick : 0);
+
+    return Math.round(updatedXAxisHeight);
+  }
+
+  return 0;
+};

--- a/test/cartesian/XAxis/XAxis.autoHeight.spec.tsx
+++ b/test/cartesian/XAxis/XAxis.autoHeight.spec.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Bar, BarChart, XAxis } from '../../../src';
+import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
+import { assertNotNull } from '../../helper/assertNotNull';
+import { getCalculatedXAxisHeight } from '../../../src/util/XAxisUtils';
+
+const data = [
+  { name: 'Page A', amt: 2400 },
+  { name: 'Page B', amt: 1398 },
+  { name: 'Page C', amt: 9800 },
+];
+
+describe('<XAxis height="auto" />', () => {
+  it('should render the x-axis with the given numeric height', () => {
+    const xAxisHeight = 40;
+
+    const { container } = render(
+      <BarChart width={100} height={100} data={data}>
+        <XAxis height={xAxisHeight} />
+        <Bar dataKey="amt" />
+      </BarChart>,
+    );
+
+    const xAxis = container.querySelector('.xAxis');
+    assertNotNull(xAxis);
+    const xAxisLine = xAxis.querySelector('line');
+
+    expect(xAxis).toBeVisible();
+    expect(xAxisLine).toHaveAttribute('height', String(xAxisHeight));
+  });
+
+  it('should render x-axis with dynamically calculated height when height="auto"', () => {
+    // getBoundingClientRect returns 0 in jsdom, so mock a tick label height of 80px
+    mockGetBoundingClientRect({ width: 30, height: 80 });
+
+    const { container } = render(
+      <BarChart width={400} height={300} data={data}>
+        <XAxis dataKey="name" height="auto" />
+        <Bar dataKey="amt" />
+      </BarChart>,
+    );
+
+    // Get all tick elements from the rendered X-axis
+    const tickElements = container.querySelectorAll('.recharts-cartesian-axis-tick-value');
+
+    const xAxis = container.querySelector('.xAxis');
+    assertNotNull(xAxis);
+    const xAxisLine = xAxis.querySelector('line');
+
+    const calculatedXAxisHeight = getCalculatedXAxisHeight({
+      ticks: Array.from(tickElements),
+      tickSize: 6,
+      tickMargin: 2,
+      label: undefined,
+      labelGapWithTick: 5,
+    });
+
+    expect(calculatedXAxisHeight).toBe(88); // 80 height + 6 tick size + 2 tick margin
+    expect(xAxisLine).toHaveAttribute('height', '88');
+  });
+});


### PR DESCRIPTION
Fixes #7301.

Adds `height="auto"` to `XAxis`, mirroring the existing `YAxis` `width="auto"` (#5880). When set, the axis height is measured from the rendered tick labels and axis label after layout, then dispatched back into the axis state, so rotated or multi-line tick labels are no longer clipped and don't need manual `margin.bottom` tuning.

The implementation mirrors the Y-axis path end to end:

- `getCalculatedXAxisHeight` measures the tallest tick label plus tick size/margin and the axis label (analog of `getCalculatedYAxisWidth`).
- `CartesianAxis` exposes `getCalculatedHeight()` on its ref.
- `XAxisImpl` runs a `useLayoutEffect` that dispatches `updateXAxisHeight` when `height === 'auto'`, with the same oscillation guard, and the same skips when `label` is a function or a React element.
- `height` is typed `number | 'auto'`; the size and offset selectors fall back to `DEFAULT_X_AXIS_HEIGHT` (30) until measured, so the default behavior is unchanged.

## Tests

New `test/cartesian/XAxis/XAxis.autoHeight.spec.tsx` covers the fixed-height control case and the dynamic `"auto"` case (calculated height 88 = 80 tick + 6 tick size + 2 tick margin).

Local checks: `tsc --noEmit` clean, eslint clean, existing XAxis/YAxis/state suites (848 tests) still green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic X-axis height calculation based on rendered tick labels and axis labels.
  * X-axis height now accepts `"auto"` in addition to numeric values.
  * Added a default X-axis height of 30 when no numeric height is available.

* **Bug Fixes**
  * Improved chart layout offsets when X-axis height is calculated dynamically.
  * Prevented minor height oscillations during automatic sizing.

* **Tests**
  * Added coverage for numeric and automatic X-axis height behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->