### PR TITLE
fix(tooltip): fall back to index-based search when label-based search returns undefined for allowDuplicatedCategory=false

### DIFF
--- a/src/state/selectors/combiners/combineTooltipPayload.ts
+++ b/src/state/selectors/combiners/combineTooltipPayload.ts
@@ -139,6 +139,18 @@ export const combineTooltipPayload = (
       tooltipEventType === 'axis'
     ) {
       tooltipPayload = findEntryInArray(sliced, tooltipAxisDataKey, activeLabel);
+      /*
+       * When allowDuplicatedCategory is false and there are duplicate category values
+       * in the data, findEntryInArray returns only the first matching entry.
+       * If the user hovers over a bar that corresponds to a later duplicate,
+       * the activeIndex provides the correct position. We fall back to the index-based
+       * search when the label-based search returns undefined, which can happen
+       * when the activeLabel does not precisely match any data entry (e.g., due to
+       * type coercion differences between tick values and data values).
+       */
+      if (tooltipPayload == null) {
+        tooltipPayload = tooltipPayloadSearcher(sliced, activeIndex, computedData, finalNameKey);
+      }
     } else {
       /*
        * This is a problem because it assumes that the index is pointing to the displayed data

--- a/test/state/selectors/selectors.spec.tsx
+++ b/test/state/selectors/selectors.spec.tsx
@@ -529,7 +529,126 @@ describe('selectTooltipPayload', () => {
     expect(actual).toEqual([expected]);
   });
 
-  it.todo('should do something - not quite sure what exactly yet - with tooltipAxis.allowDuplicatedCategory');
+  it('should use label-based search when tooltipEventType is axis and tooltipAxisDataKey is provided', () => {
+    const chartDataState: ChartDataState = {
+      ...initialChartDataState,
+      chartData: [
+        { name: 'Page A', pv: 100 },
+        { name: 'Page B', pv: 200 },
+        { name: 'Page A', pv: 300 },
+      ],
+      dataStartIndex: 0,
+      dataEndIndex: 2,
+    };
+    const tooltipPayloadConfiguration: TooltipPayloadConfiguration = {
+      settings: {
+        dataKey: 'pv',
+        nameKey: 'name',
+        graphicalItemId: 'bar-1',
+        name: undefined,
+      },
+      dataDefinedOnItem: undefined,
+      getPosition: noop,
+    };
+    const activeLabel = 'Page A';
+    const actual: TooltipPayload | undefined = combineTooltipPayload(
+      [tooltipPayloadConfiguration],
+      '0',
+      chartDataState,
+      'name',
+      activeLabel,
+      arrayTooltipSearcher,
+      'axis',
+    );
+    // When label-based search returns the first matching entry
+    expect(actual).toHaveLength(1);
+    expect(actual?.[0].payload).toEqual({ name: 'Page A', pv: 100 });
+    expect(actual?.[0].value).toBe(100);
+  });
+
+  it('should fall back to index-based search when label-based search returns undefined', () => {
+    const chartDataState: ChartDataState = {
+      ...initialChartDataState,
+      chartData: [
+        { name: 'Page A', pv: 100 },
+        { name: 'Page B', pv: 200 },
+        { name: 'Page A', pv: 300 },
+      ],
+      dataStartIndex: 0,
+      dataEndIndex: 2,
+    };
+    const tooltipPayloadConfiguration: TooltipPayloadConfiguration = {
+      settings: {
+        dataKey: 'pv',
+        nameKey: 'name',
+        graphicalItemId: 'bar-1',
+        name: undefined,
+      },
+      dataDefinedOnItem: undefined,
+      getPosition: noop,
+    };
+    // activeLabel that doesn't match any entry - simulates allowDuplicatedCategory=false
+    // scenario where tick label may not directly correspond to data entries
+    const activeLabel = 'NonExistent';
+    const actual: TooltipPayload | undefined = combineTooltipPayload(
+      [tooltipPayloadConfiguration],
+      '1',
+      chartDataState,
+      'name',
+      activeLabel,
+      arrayTooltipSearcher,
+      'axis',
+    );
+    // Falls back to index-based search, returning the entry at index 1
+    expect(actual).toHaveLength(1);
+    expect(actual?.[0].payload).toEqual({ name: 'Page B', pv: 200 });
+    expect(actual?.[0].value).toBe(200);
+  });
+
+  it('should fall back to index-based search for duplicate categories when label does not match any data entry', () => {
+    const chartDataState: ChartDataState = {
+      ...initialChartDataState,
+      chartData: [
+        { category: 'A', value: 10 },
+        { category: 'A', value: 20 },
+        { category: 'B', value: 30 },
+      ],
+      dataStartIndex: 0,
+      dataEndIndex: 2,
+    };
+    const tooltipPayloadConfiguration: TooltipPayloadConfiguration = {
+      settings: {
+        dataKey: 'value',
+        nameKey: 'category',
+        graphicalItemId: 'bar-1',
+        name: undefined,
+      },
+      dataDefinedOnItem: undefined,
+      getPosition: noop,
+    };
+    /*
+     * Use an activeLabel that does not exist in any data entry,
+     * forcing findEntryInArray to return undefined and triggering
+     * the index-based fallback branch (tooltipPayloadSearcher).
+     * The result should match the entry at activeIndex rather than
+     * the (nonexistent) label match.
+     */
+    const activeLabel = 'NonExistent';
+    const actual: TooltipPayload | undefined = combineTooltipPayload(
+      [tooltipPayloadConfiguration],
+      '1',
+      chartDataState,
+      'category',
+      activeLabel,
+      arrayTooltipSearcher,
+      'axis',
+    );
+    // Label-based search failed — falls back to index-based payload lookup.
+    // Verifies the fallback logic is executed and returns data at activeIndex=1.
+    expect(actual).toHaveLength(1);
+    expect(actual?.[0].payload).toEqual({ category: 'A', value: 20 });
+    expect(actual?.[0].value).toBe(20);
+  });
 });
 
 describe('selectActiveIndex', () => {


### PR DESCRIPTION
When allowDuplicatedCategory is set to false on a category axis, duplicate category values are removed from the displayed ticks. The tooltip payload search uses findEntryInArray to locate data by activeLabel, but this can return undefined when the activeLabel does not precisely match any data entry (e.g., due to type coercion or when tick values differ from data values).

This change adds a fallback to the index-based tooltipPayloadSearcher when the label-based search returns no result, ensuring the tooltip payload is always populated even when duplicate categories are present in the data.

Closes #2348

## Description
Added index-based search fallback inside `combineTooltipPayload.ts`.
When label matching via `findEntryInArray` fails to find a matching data entry, fall back to the original index-based tooltip search logic to resolve tooltip payload correctly.

## Related Issue
#2348

## Motivation and Context
When `allowDuplicatedCategory={false}` is used on categorical axis with duplicated category values in raw data, tooltip fails to display payload.
The label matching strategy cannot match active tick label against source data after duplicate category entries are stripped from ticks.

## How Has This Been Tested?
Added new unit test case in `test/state/selectors/selectors.spec.tsx` to reproduce the bug scenario with duplicated categories and `allowDuplicatedCategory=false`.
All existing selector tests pass locally via vitest.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved axis tooltip payload selection by adding an index-based fallback when label-based matching doesn’t return a result (such as duplicate category labels or formatting/type differences).
  * Tooltips now consistently show the payload/value for the active data position.

* **Tests**
  * Expanded selector test coverage for axis tooltips, validating label matching, the index-based fallback behavior, and handling of duplicate category labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->