### PR TITLE
fix(Pie): make maxRadius actually constrain percentage-based radii

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -555,7 +555,7 @@ const getOuterRadius = (
 
 const parseCoordinateOfPie = (pieSettings: PieSettings, offset: ChartOffsetInternal, dataPoint: any): PieCoordinate => {
   const { top, left, width, height } = offset;
-  const maxPieRadius = getMaxRadius(width, height);
+  const maxPieRadius = pieSettings.maxRadius || getMaxRadius(width, height);
   const cx = left + getPercentValue(pieSettings.cx, width, width / 2);
   const cy = top + getPercentValue(pieSettings.cy, height, height / 2);
   const innerRadius = getPercentValue(pieSettings.innerRadius, maxPieRadius, 0);

--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -555,14 +555,14 @@ const getOuterRadius = (
 
 const parseCoordinateOfPie = (pieSettings: PieSettings, offset: ChartOffsetInternal, dataPoint: any): PieCoordinate => {
   const { top, left, width, height } = offset;
-  const maxPieRadius = pieSettings.maxRadius || getMaxRadius(width, height);
+  const maxPieRadius = pieSettings.maxRadius ?? getMaxRadius(width, height);
   const cx = left + getPercentValue(pieSettings.cx, width, width / 2);
   const cy = top + getPercentValue(pieSettings.cy, height, height / 2);
   const innerRadius = getPercentValue(pieSettings.innerRadius, maxPieRadius, 0);
 
   const outerRadius = getOuterRadius(dataPoint, pieSettings.outerRadius, maxPieRadius);
 
-  const maxRadius = pieSettings.maxRadius || Math.sqrt(width * width + height * height) / 2;
+  const maxRadius = pieSettings.maxRadius ?? Math.sqrt(width * width + height * height) / 2;
 
   return { cx, cy, innerRadius, outerRadius, maxRadius };
 };

--- a/test/state/selectors/pieSelectors.spec.tsx
+++ b/test/state/selectors/pieSelectors.spec.tsx
@@ -965,5 +965,13 @@ describe('PieSectorData and PieSectorDataItem type should include data propertie
       assertNotNull(sectors);
       expect(sectors[0].outerRadius).toBe(316);
     });
+
+    it('should preserve a zero maxRadius when resolving percentage radii', () => {
+      const { spy } = renderMaxRadiusTestCase(0)(state => selectPieSectors(state, 'pie-id', []));
+      const sectors = spy.mock.lastCall?.[0];
+      assertNotNull(sectors);
+      expect(sectors[0].outerRadius).toBe(0);
+      expect(sectors[0].maxRadius).toBe(0);
+    });
   });
 });

--- a/test/state/selectors/pieSelectors.spec.tsx
+++ b/test/state/selectors/pieSelectors.spec.tsx
@@ -931,4 +931,39 @@ describe('PieSectorData and PieSectorDataItem type should include data propertie
       expect(sectors[3].paddingAngle).toBe(5);
     });
   });
+
+  describe('when maxRadius is set', () => {
+    // https://github.com/recharts/recharts/issues/4885
+    // maxRadius should cap the radius that percentage-based innerRadius/outerRadius resolve against,
+    // regardless of how much bigger the chart's own width/height are.
+    const renderMaxRadiusTestCase = (maxRadius: number | undefined) =>
+      createSelectorTestCase(({ children }) => (
+        <PieChart width={800} height={800}>
+          <Pie
+            dataKey="value"
+            data={[{ name: 'A', value: 400 }]}
+            cx="50%"
+            cy="50%"
+            outerRadius="80%"
+            maxRadius={maxRadius}
+            id="pie-id"
+          />
+          {children}
+        </PieChart>
+      ));
+
+    it('should resolve percentage outerRadius against maxRadius when provided', () => {
+      const { spy } = renderMaxRadiusTestCase(100)(state => selectPieSectors(state, 'pie-id', []));
+      const sectors = spy.mock.lastCall?.[0];
+      assertNotNull(sectors);
+      expect(sectors[0].outerRadius).toBe(80);
+    });
+
+    it('should fall back to a radius derived from chart size when maxRadius is not provided', () => {
+      const { spy } = renderMaxRadiusTestCase(undefined)(state => selectPieSectors(state, 'pie-id', []));
+      const sectors = spy.mock.lastCall?.[0];
+      assertNotNull(sectors);
+      expect(sectors[0].outerRadius).toBe(316);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes #4885.

`<Pie maxRadius={...}>` had no visible effect. The radius that percentage-based `innerRadius`/`outerRadius` resolve against was computed in `parseCoordinateOfPie` purely from the chart's width/height (`getMaxRadius(width, height)`), completely ignoring the `maxRadius` prop.

The prop wasn't entirely dead — it's already used a few lines below to compute a *different* fallback value (for label-line positioning), which is presumably why it looked wired up on a first read. But that value is never fed back into the actual sector geometry, so setting `maxRadius` alone never changed the rendered size of the pie.

## Fix

`parseCoordinateOfPie` now prefers the explicit `pieSettings.maxRadius` over the width/height-derived default, consistent with how the prop is already used for the label-positioning fallback a few lines down.

## Test plan

- Added two tests to `test/state/selectors/pieSelectors.spec.tsx`: one asserting `outerRadius` resolves against an explicit `maxRadius` (`"80%"` of `maxRadius=100` → `80`), one confirming the previous width/height-derived fallback still applies when `maxRadius` is omitted.
- Full `test/polar` and `test/state` suites pass (953 tests, no regressions).
- `npm run lint` passes on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pie chart radius calculations to honor an explicitly configured maximum radius (including when set to `0`).
  * Refined percentage-based inner/outer radius resolution so values are correctly capped by the configured maximum.

* **Tests**
  * Expanded selector test coverage for pie sectors with and without a configured maximum radius, including percentage handling and the `0` max-radius edge case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->