### PR TITLE
fix(Rectangle): keep the rectangle mounted while it animates to zero

### DIFF
--- a/src/shape/Rectangle.tsx
+++ b/src/shape/Rectangle.tsx
@@ -220,7 +220,19 @@ export const Rectangle: React.FC<Props> = rectangleProps => {
   const animationIdInput = useMemo(() => ({ x, y, width, height, radius }), [x, y, width, height, radius]);
   const animationId = useAnimationId(animationIdInput, 'rectangle-');
 
-  if (x !== +x || y !== +y || width !== +width || height !== +height || width === 0 || height === 0) {
+  if (x !== +x || y !== +y || width !== +width || height !== +height) {
+    return null;
+  }
+
+  /*
+   * A rectangle with a zero width or height has nothing to paint, so usually we render nothing at all.
+   * The exception is a rectangle that is animating down to zero: bailing out here would unmount it
+   * immediately and the shrinking animation would never run - which is why rectangles used to animate
+   * away from zero but not towards it.
+   */
+  const hasZeroDimension = width === 0 || height === 0;
+  const wasVisibleBefore = prevWidthRef.current !== 0 && prevHeightRef.current !== 0;
+  if (hasZeroDimension && !(isUpdateAnimationActive && wasVisibleBefore)) {
     return null;
   }
 

--- a/src/shape/Rectangle.tsx
+++ b/src/shape/Rectangle.tsx
@@ -2,7 +2,7 @@
  * @fileOverview Rectangle
  */
 import * as React from 'react';
-import { SVGProps, useEffect, useMemo, useRef, useState } from 'react';
+import { SVGProps, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { clsx } from 'clsx';
 import { AnimationDuration } from '../util/types';
 import { resolveDefaultProps } from '../util/resolveDefaultProps';
@@ -220,6 +220,16 @@ export const Rectangle: React.FC<Props> = rectangleProps => {
   const animationIdInput = useMemo(() => ({ x, y, width, height, radius }), [x, y, width, height, radius]);
   const animationId = useAnimationId(animationIdInput, 'rectangle-');
 
+  /*
+   * Re-render once the shrink-to-zero animation is over. By then the tracked previous size is zero
+   * too, so the zero-dimension check below unmounts the rectangle instead of leaving an invisible
+   * zero-size path behind.
+   */
+  const [, setAnimationEndTick] = useState(0);
+  const handleAnimationEnd = useCallback(() => {
+    setAnimationEndTick(tick => tick + 1);
+  }, []);
+
   if (x !== +x || y !== +y || width !== +width || height !== +height) {
     return null;
   }
@@ -275,6 +285,7 @@ export const Rectangle: React.FC<Props> = rectangleProps => {
       easing={animationEasing}
       isActive={isUpdateAnimationActive}
       begin={animationBegin}
+      onAnimationEnd={hasZeroDimension ? handleAnimationEnd : undefined}
     >
       {(animationElapsedTime: number) => {
         const currWidth = interpolate(prevWidth, width, animationElapsedTime);

--- a/test/shape/Rectangle.animation.spec.tsx
+++ b/test/shape/Rectangle.animation.spec.tsx
@@ -381,7 +381,7 @@ describe('Rectangle animation', () => {
               y={50}
               width={80}
               height={height}
-              radius={4}
+              radius={0}
               fill="#ff7300"
               isAnimationActive
               isUpdateAnimationActive={isUpdateAnimationActive}
@@ -410,6 +410,18 @@ describe('Rectangle animation', () => {
       return container.querySelectorAll('.recharts-rectangle').length;
     }
 
+    /*
+     * The test case renders with radius={0}, so the path is always
+     * "M 50,50 h 80 v {height} h -80 Z" and the height is the argument of the v command.
+     */
+    function getRectHeight(container: Element): number {
+      const path = getRectPath(container);
+      assertNotNull(path);
+      const match = /v ([\d.-]+)/.exec(path);
+      assertNotNull(match);
+      return Number(match[1]);
+    }
+
     it('should keep the rectangle rendered so that it can animate out', async () => {
       const renderTestCase = heightTestCase({ startHeight: 100, isUpdateAnimationActive: true });
       const { container } = renderTestCase();
@@ -417,6 +429,34 @@ describe('Rectangle animation', () => {
 
       await prime(container);
       expect(countRectangles(container)).toBe(1);
+    });
+
+    it('should shrink the height through the animation and unmount the rectangle at the end', async () => {
+      const renderTestCase = heightTestCase({ startHeight: 100, isUpdateAnimationActive: true });
+      const { container, animationManager } = renderTestCase();
+      expect(getRectHeight(container)).toBe(100);
+
+      await prime(container);
+
+      const heights: Array<number> = [getRectHeight(container)];
+      for (const progress of [0.25, 0.5, 0.75]) {
+        // eslint-disable-next-line no-await-in-loop
+        await animationManager.setAnimationProgress(progress);
+        heights.push(getRectHeight(container));
+      }
+
+      // the rectangle shrinks frame by frame instead of snapping straight to zero
+      const [firstHeight, ...laterHeights] = heights;
+      expect(firstHeight).toBe(100);
+      laterHeights.forEach((currentHeight, index) => {
+        expect(currentHeight).toBeLessThan(heights[index]);
+        expect(currentHeight).toBeGreaterThanOrEqual(0);
+      });
+      expect(countRectangles(container)).toBe(1);
+
+      // and it is gone once the animation is over
+      await animationManager.completeAnimation();
+      expect(countRectangles(container)).toBe(0);
     });
 
     it('should remove the rectangle immediately when isUpdateAnimationActive is false', async () => {

--- a/test/shape/Rectangle.animation.spec.tsx
+++ b/test/shape/Rectangle.animation.spec.tsx
@@ -358,4 +358,80 @@ describe('Rectangle animation', () => {
       });
     },
   );
+
+  describe('when the height changes to zero', () => {
+    function HeightTestCase({
+      startHeight,
+      isUpdateAnimationActive,
+      children,
+    }: {
+      startHeight: number;
+      isUpdateAnimationActive: boolean;
+      children: React.ReactNode;
+    }) {
+      const [height, setHeight] = React.useState(startHeight);
+      return (
+        <>
+          <button type="button" onClick={() => setHeight(h => (h === 0 ? 100 : 0))}>
+            Change height
+          </button>
+          <Surface width={400} height={400}>
+            <Rectangle
+              x={50}
+              y={50}
+              width={80}
+              height={height}
+              radius={4}
+              fill="#ff7300"
+              isAnimationActive
+              isUpdateAnimationActive={isUpdateAnimationActive}
+            />
+            {children}
+          </Surface>
+        </>
+      );
+    }
+
+    function heightTestCase({
+      startHeight,
+      isUpdateAnimationActive,
+    }: {
+      startHeight: number;
+      isUpdateAnimationActive: boolean;
+    }) {
+      return createSelectorTestCase(({ children }) => (
+        <HeightTestCase startHeight={startHeight} isUpdateAnimationActive={isUpdateAnimationActive}>
+          {children}
+        </HeightTestCase>
+      ));
+    }
+
+    function countRectangles(container: Element): number {
+      return container.querySelectorAll('.recharts-rectangle').length;
+    }
+
+    it('should keep the rectangle rendered so that it can animate out', async () => {
+      const renderTestCase = heightTestCase({ startHeight: 100, isUpdateAnimationActive: true });
+      const { container } = renderTestCase();
+      expect(countRectangles(container)).toBe(1);
+
+      await prime(container);
+      expect(countRectangles(container)).toBe(1);
+    });
+
+    it('should remove the rectangle immediately when isUpdateAnimationActive is false', async () => {
+      const renderTestCase = heightTestCase({ startHeight: 100, isUpdateAnimationActive: false });
+      const { container } = renderTestCase();
+      expect(countRectangles(container)).toBe(1);
+
+      await prime(container);
+      expect(countRectangles(container)).toBe(0);
+    });
+
+    it('should render nothing when the height is zero on the initial render', () => {
+      const renderTestCase = heightTestCase({ startHeight: 0, isUpdateAnimationActive: true });
+      const { container } = renderTestCase();
+      expect(countRectangles(container)).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Description

`Rectangle` bails out early and returns `null` as soon as its `width` or `height` is `0`. That check runs before the `JavascriptAnimate` block, so a rectangle whose target height becomes `0` unmounts on the very first frame and never gets a chance to shrink. Growing *from* zero was unaffected, because in that direction the target dimension is non-zero — which is exactly the asymmetry described in the issue.

This splits the guard in two:

- the invalid-number check (`x !== +x` etc.) still returns `null` immediately, unchanged
- the zero-dimension check now keeps the rectangle mounted when `isUpdateAnimationActive` is set *and* the previous size was non-zero, i.e. only while it is animating out

Once the animation lands on zero, the tracked previous size is zero too, so the next render takes the normal early return and the rectangle unmounts as before.

## Related Issue

Closes #7485

## Motivation and Context

Bars, and anything else built on `Rectangle`, visibly pop out of existence instead of animating when their value drops to zero, while the reverse transition animates correctly. The inconsistency is most obvious on a bar chart whose data updates in place.

## How Has This Been Tested?

Added three cases to `test/shape/Rectangle.animation.spec.tsx` under `when the height changes to zero`:

- with `isUpdateAnimationActive`, the rectangle stays mounted after the height changes to `0` so it can animate out
- with `isUpdateAnimationActive={false}`, it is removed immediately — the existing behaviour
- a rectangle rendered with `height={0}` from the start still renders nothing

I checked the first test fails on `main` without the source change (rect count drops to `0` immediately) and passes with it, and that the other two pass either way, so the non-animated and initial-zero paths are untouched.

Also ran locally on Node 22:

- `npm test` — full unit suite
- `npm run lint`
- `npm run tsc` and `npm run check-types-test`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

I did not add a VR test — the visual-regression suite needs Docker to generate matching snapshots and I could not produce reference images that would line up with CI. Happy to add one if you'd like, or if you can point me at the right story to extend.

---

Unrelated heads-up while I was setting up: `npm run check-types-test-vr` currently fails on a clean `main` (`8644f1a9`) with two errors in `test-vr/tests/www/fixtures.tsx`, where the `mount` fixture no longer matches Playwright's overloads — it looks like fallout from the Playwright bump in #7589. Since `check-types` is part of the `pre-push` hook, that blocks pushing from a fresh clone. Not touched by this PR, just flagging it in case it hasn't been noticed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rectangles now animate smoothly when their width or height changes to zero, completing the shrink animation before disappearing.
  * Zero-sized rectangles are hidden immediately when animation is disabled or when initially rendered at zero dimensions.
  * Invalid numeric dimensions continue to be excluded from rendering.

* **Tests**
  * Added coverage for shrinking rectangles and their rendering behavior during and after animation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->