### PR TITLE
fix: infinite loop in reduceCSSCalc when a value contains $&

### DIFF
--- a/src/util/ReduceCSSCalc.ts
+++ b/src/util/ReduceCSSCalc.ts
@@ -144,7 +144,15 @@ function calculateParentheses(expr: string): string {
   // eslint-disable-next-line no-cond-assign
   while ((match = PARENTHESES_REGEX.exec(newExpr)) != null) {
     const [, parentheticalExpression] = match;
-    newExpr = newExpr.replace(PARENTHESES_REGEX, calculateArithmetic(parentheticalExpression));
+    /*
+     * Use a replacer function, not a replacement string. In a replacement string
+     * `$&`, `` $` ``, `$'`, `$1` and `$$` are substitution patterns.
+     * calculateArithmetic returns its input unchanged when the input has no
+     * arithmetic operator, so `($&)` expanded to `($&)` and the loop never advanced.
+     * A replacer function returns its value literally.
+     */
+    const replacement = calculateArithmetic(parentheticalExpression);
+    newExpr = newExpr.replace(PARENTHESES_REGEX, () => replacement);
   }
 
   return newExpr;

--- a/test/util/ReduceCssCalcPrototype.spec.ts
+++ b/test/util/ReduceCssCalcPrototype.spec.ts
@@ -125,4 +125,12 @@ describe('reduceCSSCalc', () => {
       });
     });
   });
+
+  // https://github.com/recharts/recharts/issues/7609
+  it.each(['$&', '$`', "$'", '$1', '$$'])(
+    'should terminate when the expression contains the replacement pattern %s',
+    pattern => {
+      expect(reduceCSSCalc(`calc((${pattern}))`)).toEqual(pattern);
+    },
+  );
 });


### PR DESCRIPTION
## Description

`calculateParentheses` passed the result of `calculateArithmetic` to `String.prototype.replace` as the replacement string. In a replacement string, `$&`, `` $` ``, `$'`, `$1` and `$$` are substitution patterns.

`calculateArithmetic` returns its input unchanged when the input has no arithmetic operator. For the input `($&)` the replacement therefore expanded to `($&)`, which is the same value. `newExpr` did not change, the regular expression still matched, and the loop never advanced.

This change puts the value in a replacer function. A replacer function returns its value literally, so no substitution happens.

## Related Issue

https://github.com/recharts/recharts/issues/7609

## Motivation and Context

`reduceCSSCalc` is reachable from the public `<Text>` component. `Text.tsx` builds the expression from the `capHeight` prop:

```js
startDy = reduceCSSCalc(`calc(${capHeight})`);
```

So `<Text capHeight="($&)">hello</Text>` made the render hang. The `try/catch` in `safeEvaluateExpression` did not help, because a loop that never ends throws nothing.

This is the same class of bug as #3899, where `getStrokeDasharray` did not terminate for `strokeDasharray="0"`.

## How Has This Been Tested?

I tested on a checkout of `main` at `74f82ef`, with Node.js v23.11.0.

The new test covers the five substitution patterns. It hangs before this change and it passes after this change:

| Step | Command | Result |
|---|---|---|
| Before the fix | `vitest run -t 'replacement pattern'` | timeout, exit code 124 |
| After the fix | `vitest run -t 'replacement pattern'` | 5 passed |

The whole unit suite also passes after the change. I ran `npm run omnidoc` first, because the API documentation files under `www/src/docs/api` are generated and the `unit:omnidoc` and `unit:website` projects import them.

| Command | Result |
|---|---|
| `npm run test` (`vitest run --project unit:*`) | 317 files passed, 16388 tests passed, exit code 0 |
| `vitest run test/util/ReduceCssCalcPrototype.spec.ts` | 168 passed, exit code 0 |
| `npx eslint src/util/ReduceCSSCalc.ts test/util/ReduceCssCalcPrototype.spec.ts` | exit code 0 |
| `npx prettier --check` on both files | exit code 0 |
| `npx tsc --noEmit` | exit code 0 |

I also compared results before and after the change on the built package, for expressions that are already valid:

| Expression | Before | After |
|---|---|---|
| `calc(123px)` | `'123px'` | `'123px'` |
| `calc(50% + 25%)` | `'75%'` | `'75%'` |
| `calc((10px + 5px) * 2)` | `'30px'` | `'30px'` |
| `calc(10px / 2)` | `'5px'` | `'5px'` |
| `calc(1rem + 2rem - 3rem)` | `'0rem'` | `'0rem'` |
| `calc(10px + (5px * 2))` | `'20px'` | `'20px'` |
| `calc(10px + 5%)` | `''` | `''` |
| `calc(abc)` | `'abc'` | `'abc'` |

Eight expressions gave the same result. The new result `'$&'` matches the result for other text without an arithmetic operator, for example `calc(abc)`.

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed CSS calculation handling for expressions containing special replacement-pattern characters.
  - Preserved original expressions when no valid calculation can be performed.

- **Tests**
  - Added regression coverage for replacement-pattern strings, including `$&`, `$```, `$'`, `$1`, and `$$`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->