### PR TITLE
fix(Brush): honor a selection of the first data point only

### DIFF
--- a/src/state/chartDataSlice.ts
+++ b/src/state/chartDataSlice.ts
@@ -49,6 +49,27 @@ export const initialChartDataState: ChartDataState = {
   dataEndIndex: 0,
 };
 
+/**
+ * Brush start and end indexes address the chart-level data array. Their initial value is
+ * `0` and `0`, which is also a valid selection of the first data item, so they can only be
+ * applied when the chart has data of its own. Charts where every graphical item brings its
+ * own data leave the indexes at the initial value, and slicing with them would cut every
+ * item array down to its first entry.
+ *
+ * @param chartDataState the chart data slice state
+ * @returns a `[startIndex, endIndex]` pair, inclusive on both ends
+ */
+export function getBrushSliceIndexes({
+  chartData,
+  dataStartIndex,
+  dataEndIndex,
+}: ChartDataState): [startIndex: number, endIndex: number] {
+  if (chartData == null || chartData.length === 0) {
+    return [0, Infinity];
+  }
+  return [dataStartIndex, dataEndIndex];
+}
+
 type BrushStartEndIndexActionPayload = Partial<BrushStartEndIndex>;
 
 const chartDataSlice = createSlice({

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -46,7 +46,7 @@ import {
   numericalDomainSpecifiedWithoutRequiringData,
   parseNumericalUserDomain,
 } from '../../util/isDomainSpecifiedByUser';
-import { AppliedChartData, ChartData, ChartDataState } from '../chartDataSlice';
+import { AppliedChartData, ChartData, ChartDataState, getBrushSliceIndexes } from '../chartDataSlice';
 import { getPercentValue, hasDuplicate, isNan, isNotNil, isNumOrStr, mathSign } from '../../util/DataUtils';
 import {
   BaseCartesianGraphicalItemSettings,
@@ -731,7 +731,7 @@ export const selectStackGroups: (
 
 export const combineDomainOfStackGroups = (
   stackGroups: AllStackGroups | undefined,
-  { dataStartIndex, dataEndIndex }: ChartDataState,
+  chartDataState: ChartDataState,
   axisType: AllAxisTypes,
   domainFromUserPreference: NumberDomain | undefined,
 ): NumberDomain | undefined => {
@@ -743,7 +743,8 @@ export const combineDomainOfStackGroups = (
     // ZAxis ignores stacks
     return undefined;
   }
-  return getDomainOfStackGroups(stackGroups, dataStartIndex, dataEndIndex);
+  const [startIndex, endIndex] = getBrushSliceIndexes(chartDataState);
+  return getDomainOfStackGroups(stackGroups, startIndex, endIndex);
 };
 
 const selectAllowsDataOverflow: (state: RechartsRootState, axisType: AllAxisTypes, axisId: AxisId) => boolean =

--- a/src/state/selectors/combiners/combineTooltipPayload.ts
+++ b/src/state/selectors/combiners/combineTooltipPayload.ts
@@ -6,7 +6,7 @@ import {
   TooltipPayloadEntry,
   TooltipPayloadSearcher,
 } from '../../tooltipSlice';
-import { ChartData, ChartDataState } from '../../chartDataSlice';
+import { ChartData, ChartDataState, getBrushSliceIndexes } from '../../chartDataSlice';
 import { DataKey, TooltipEventType } from '../../../util/types';
 import { findEntryInArray } from '../../../util/DataUtils';
 import { getTooltipEntry, getValueByDataKey } from '../../../util/ChartUtils';
@@ -98,14 +98,15 @@ export const combineTooltipPayload = (
   if (activeIndex == null || tooltipPayloadSearcher == null) {
     return undefined;
   }
-  const { chartData, computedData, dataStartIndex, dataEndIndex } = chartDataState;
+  const { chartData, computedData } = chartDataState;
+  const [sliceStartIndex, sliceEndIndex] = getBrushSliceIndexes(chartDataState);
 
   const init: Array<TooltipPayloadEntry> = [];
 
   return tooltipPayloadConfigurations.reduce((agg, { dataDefinedOnItem, settings }): Array<TooltipPayloadEntry> => {
     const finalData = selectFinalData(dataDefinedOnItem, chartData);
 
-    const sliced = Array.isArray(finalData) ? getSliced(finalData, dataStartIndex, dataEndIndex) : finalData;
+    const sliced = Array.isArray(finalData) ? getSliced(finalData, sliceStartIndex, sliceEndIndex) : finalData;
 
     const finalDataKey: DataKey<any> | undefined = settings?.dataKey ?? tooltipAxisDataKey;
     // BaseAxisProps does not support nameKey but it could!

--- a/src/util/getSliced.ts
+++ b/src/util/getSliced.ts
@@ -2,8 +2,5 @@ export function getSliced<T>(arr: ReadonlyArray<T>, startIndex: number, endIndex
   if (!Array.isArray(arr)) {
     return arr;
   }
-  if (arr && startIndex + endIndex !== 0) {
-    return arr.slice(startIndex, endIndex + 1);
-  }
-  return arr;
+  return arr.slice(startIndex, endIndex + 1);
 }

--- a/test/cartesian/Brush.spec.tsx
+++ b/test/cartesian/Brush.spec.tsx
@@ -1,7 +1,18 @@
 import React, { useState } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { BarChart, Brush, BrushProps, ComposedChart, Customized, Line, LineChart, ReferenceLine } from '../../src';
+import {
+  Bar,
+  BarChart,
+  Brush,
+  BrushProps,
+  ComposedChart,
+  Customized,
+  Line,
+  LineChart,
+  ReferenceLine,
+  YAxis,
+} from '../../src';
 import { assertNotNull } from '../helper/assertNotNull';
 import { useAppSelector } from '../../src/state/hooks';
 import { selectAxisRangeWithReverse, selectDisplayedData } from '../../src/state/selectors/axisSelectors';
@@ -11,6 +22,7 @@ import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { selectChartDataWithIndexes } from '../../src/state/selectors/dataSelectors';
 import { useIsPanorama } from '../../src/context/PanoramaContext';
 import { expectBrush } from '../helper/expectBrush';
+import { expectYAxisTicks } from '../helper/expectAxisTicks';
 import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 import { userEventSetup } from '../helper/userEventSetup';
 
@@ -775,6 +787,27 @@ describe('<Brush />', () => {
         x: '100',
         y: '90',
       });
+    });
+  });
+  describe('when the selection is the first data point only', () => {
+    const singlePointData = [{ value: 10 }, { value: 200 }, { value: 300 }, { value: 400 }];
+
+    it('should compute the axis domain from the selected point alone', () => {
+      const { container } = render(
+        <BarChart width={400} height={300} data={singlePointData}>
+          <YAxis />
+          <Bar dataKey="value" stackId="stack" />
+          <Brush startIndex={0} endIndex={0} />
+        </BarChart>,
+      );
+
+      expectYAxisTicks(container, [
+        { textContent: '0', x: '57', y: '255' },
+        { textContent: '3', x: '57', y: '192.5' },
+        { textContent: '6', x: '57', y: '130' },
+        { textContent: '9', x: '57', y: '67.5' },
+        { textContent: '12', x: '57', y: '5' },
+      ]);
     });
   });
 });

--- a/test/util/getSliced.spec.ts
+++ b/test/util/getSliced.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { getSliced } from '../../src/util/getSliced';
+
+describe('getSliced', () => {
+  const array = ['a', 'b', 'c', 'd'];
+
+  it('should return the elements between the two indexes, inclusive on both ends', () => {
+    expect(getSliced(array, 1, 2)).toEqual(['b', 'c']);
+  });
+
+  it('should return a single element when the two indexes are equal', () => {
+    expect(getSliced(array, 2, 2)).toEqual(['c']);
+  });
+
+  it('should return the first element only when both indexes are zero', () => {
+    expect(getSliced(array, 0, 0)).toEqual(['a']);
+  });
+
+  it('should return the whole array when the range covers it', () => {
+    expect(getSliced(array, 0, array.length - 1)).toEqual(array);
+  });
+
+  it('should return the whole array when the end index is Infinity', () => {
+    expect(getSliced(array, 0, Infinity)).toEqual(array);
+  });
+
+  it('should return an empty array when the end index is before the start index', () => {
+    expect(getSliced(array, 2, 1)).toEqual([]);
+  });
+
+  it('should return the input as-is when it is not an array', () => {
+    const notAnArray = { length: 2 } as unknown as ReadonlyArray<string>;
+    expect(getSliced(notAnArray, 0, 1)).toBe(notAnArray);
+  });
+});


### PR DESCRIPTION
## Description

`getSliced` skipped the slice when `startIndex + endIndex === 0`:

```ts
if (arr && startIndex + endIndex !== 0) {
  return arr.slice(startIndex, endIndex + 1);
}
return arr;
```

`startIndex = 0, endIndex = 0` is a valid selection of the first data point, so a Brush set to
that range was read as no selection at all, and both callers worked on the full data: the
stacked axis domain (`combineDomainOfStackGroups`) and the tooltip payload
(`combineTooltipPayload`).

Removing the condition alone regresses a different case. `dataStartIndex` and `dataEndIndex`
start at `0`/`0` in `initialChartDataState`, and a chart whose data lives on the graphical
items rather than on the chart keeps those values, so an unconditional slice cuts each item
array down to its first entry (`AreaChart.stacked.spec.tsx` covers that: it fails with the
condition simply deleted).

So this PR separates the two cases instead. `getBrushSliceIndexes` reads the chart data state
and returns `[0, Infinity]` when there is no chart-level data for the indexes to address, and
the stored pair otherwise. `getSliced` then always slices.

## Related Issue

Fixes #7613

## Motivation and Context

A chart with a Brush at `startIndex={0} endIndex={0}` draws a single point but scales the axis
to every point, so the bar fills a fraction of the plot area that has nothing to do with the
selection. Every other place that applies these indexes already does a plain
`chartData.slice(dataStartIndex, dataEndIndex + 1)` (`dataSelectors`, `barSelectors`,
`areaSelectors`, `scatterSelectors`, `radialBarSelectors`), so the two disagreed.

## How Has This Been Tested?

- `test/util/getSliced.spec.ts` (new): unit coverage for the function, including `0, 0`,
  equal indexes, an `Infinity` end, a reversed range, and a non-array input.
- `test/cartesian/Brush.spec.tsx` (new case): renders a stacked `BarChart` over
  `[10, 200, 300, 400]` with `<Brush startIndex={0} endIndex={0} />` and asserts the Y axis
  ticks. Before this change the ticks are `0, 100, 200, 300, 400`; after it they are
  `0, 3, 6, 9, 12`. I confirmed the case fails on `main` and passes with the fix.
- `npm run test`: 7415 passed, no new failures. Seven files fail before and after this change
  (`unit:omnidoc` and `unit:website`); they fail to import the generated `docs/api` in a fresh
  checkout, which is unrelated to this diff.
- `npm run lint`, `npm run check-types-lib`, `npm run check-types-test`: clean for the files
  touched here.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chart domains and Y-axis ticks when brushing to select a single data point.
  * Corrected tooltip data slicing for empty, full-range, and boundary selections.
  * Improved handling of reversed ranges, zero indexes, and non-array data during slicing.

* **Tests**
  * Added regression coverage for brushed chart selections and slicing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->