### PR TITLE
fix(Sankey): skip links that point back along the current path

### DIFF
--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -114,8 +114,19 @@ const searchTargetsAndSources = (links: LinkDataItem[], id: number) => {
   return { sourceNodes, sourceLinks, targetLinks, targetNodes };
 };
 
-const updateDepthOfTargets = (tree: SankeyNode[], curNode: SankeyNode) => {
+const updateDepthOfTargets = (tree: SankeyNode[], curNode: SankeyNode, onPath: Set<SankeyNode> = new Set()) => {
   const { targetNodes } = curNode;
+
+  /*
+   * `onPath` holds the nodes on the current recursion path, so a link that points back to one of them
+   * is skipped instead of followed. Depth is the longest path to a node, so it grows on every trip
+   * around a cycle and the `newDepth > target.depth` guard below stays true forever: without this the
+   * recursion has no fixed point and exhausts the call stack.
+   *
+   * This tracks the current path and not every node already seen, because a node in a directed acyclic
+   * graph is legitimately reached again by a longer route, and that is the route whose depth wins.
+   */
+  onPath.add(curNode);
 
   for (let i = 0, len = targetNodes.length; i < len; i++) {
     const targetNode = targetNodes[i];
@@ -124,7 +135,7 @@ const updateDepthOfTargets = (tree: SankeyNode[], curNode: SankeyNode) => {
     }
     const target = tree[targetNode];
 
-    if (target) {
+    if (target && !onPath.has(target)) {
       const newDepth = curNode.depth + 1;
       /*
        * Only recurse when the depth grows. Depth is the longest path to a node, so once it stops increasing
@@ -133,10 +144,12 @@ const updateDepthOfTargets = (tree: SankeyNode[], curNode: SankeyNode) => {
        */
       if (newDepth > target.depth) {
         target.depth = newDepth;
-        updateDepthOfTargets(tree, target);
+        updateDepthOfTargets(tree, target, onPath);
       }
     }
   }
+
+  onPath.delete(curNode);
 };
 
 const getNodesTree = (

--- a/src/chart/Sankey.tsx
+++ b/src/chart/Sankey.tsx
@@ -114,7 +114,7 @@ const searchTargetsAndSources = (links: LinkDataItem[], id: number) => {
   return { sourceNodes, sourceLinks, targetLinks, targetNodes };
 };
 
-const updateDepthOfTargets = (tree: SankeyNode[], curNode: SankeyNode, onPath: Set<SankeyNode> = new Set()) => {
+const updateDepthOfTargets = (tree: SankeyNode[], curNode: SankeyNode, onPath: Set<SankeyNode> = new Set()): void => {
   const { targetNodes } = curNode;
 
   /*

--- a/test/chart/Sankey.spec.tsx
+++ b/test/chart/Sankey.spec.tsx
@@ -1054,6 +1054,27 @@ describe('<Sankey />', () => {
       expect(container.querySelectorAll('.recharts-sankey-link')).toHaveLength(links.length);
     });
 
+    /**
+     * `onPath` is cleared as the recursion unwinds, so a node that is no longer an ancestor can be
+     * entered again by a longer route. Node `d` is reached first at depth 2 through `b`, then at
+     * depth 3 through `c` and `e`, and depth is the longest path, so 3 wins. A guard that tracked
+     * every node already seen instead of the current path would keep the first answer.
+     */
+    it('uses the longer acyclic path when a target is revisited', () => {
+      const data = {
+        nodes: [{ name: 'a' }, { name: 'b' }, { name: 'c' }, { name: 'd' }, { name: 'e' }],
+        links: [
+          { source: 0, target: 1, value: 10 },
+          { source: 1, target: 3, value: 10 },
+          { source: 0, target: 2, value: 10 },
+          { source: 2, target: 4, value: 10 },
+          { source: 4, target: 3, value: 10 },
+        ],
+      };
+
+      expect(computeData({ data, ...computeOptions }).nodes.map(node => node.depth)).toEqual([0, 1, 1, 3, 2]);
+    });
+
     it('gives an acyclic graph the same depths as before', () => {
       const data = {
         nodes,

--- a/test/chart/Sankey.spec.tsx
+++ b/test/chart/Sankey.spec.tsx
@@ -994,4 +994,76 @@ describe('<Sankey />', () => {
       expect(container.querySelectorAll('.recharts-sankey-link')).toHaveLength(links.length);
     });
   });
+
+  describe('layout of graphs that contain a cycle', () => {
+    const computeOptions = {
+      width: 1000,
+      height: 500,
+      iterations: 32,
+      nodeWidth: 10,
+      nodePadding: 10,
+      sort: true,
+      verticalAlign: 'justify',
+      align: 'justify',
+    } as const;
+
+    const nodes = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
+
+    /**
+     * A link that points back to a node already on the path is ordinary flow data: a category that
+     * returns to an earlier stage, or to itself. Depth is the longest path to a node, so it grows on
+     * every trip around a cycle and the recursion has no fixed point.
+     */
+    it('computes the layout for a back edge instead of exhausting the call stack', () => {
+      const data = {
+        nodes,
+        links: [
+          { source: 0, target: 1, value: 10 },
+          { source: 1, target: 2, value: 10 },
+          { source: 2, target: 1, value: 5 },
+        ],
+      };
+
+      expect(() => computeData({ data, ...computeOptions })).not.toThrow();
+      expect(computeData({ data, ...computeOptions }).nodes).toHaveLength(nodes.length);
+    });
+
+    it('computes the layout for a self referencing node', () => {
+      const data = {
+        nodes,
+        links: [
+          { source: 0, target: 1, value: 10 },
+          { source: 1, target: 1, value: 5 },
+        ],
+      };
+
+      expect(() => computeData({ data, ...computeOptions })).not.toThrow();
+      expect(computeData({ data, ...computeOptions }).nodes).toHaveLength(nodes.length);
+    });
+
+    it('renders a graph with a back edge', () => {
+      const links = [
+        { source: 0, target: 1, value: 10 },
+        { source: 1, target: 2, value: 10 },
+        { source: 2, target: 1, value: 5 },
+      ];
+
+      const { container } = render(<Sankey width={1000} height={500} data={{ nodes, links }} />);
+
+      expect(container.querySelectorAll('.recharts-sankey-node')).toHaveLength(nodes.length);
+      expect(container.querySelectorAll('.recharts-sankey-link')).toHaveLength(links.length);
+    });
+
+    it('gives an acyclic graph the same depths as before', () => {
+      const data = {
+        nodes,
+        links: [
+          { source: 0, target: 1, value: 10 },
+          { source: 1, target: 2, value: 10 },
+        ],
+      };
+
+      expect(computeData({ data, ...computeOptions }).nodes.map(node => node.depth)).toEqual([0, 1, 2]);
+    });
+  });
 });


### PR DESCRIPTION
## Description

`updateDepthOfTargets` follows every outgoing link of a node. When a link points
back to a node that is already on the current recursion path, the recursion has
no fixed point.

Depth is the longest path to a node, so it grows by one on every trip around the
cycle. The `newDepth > target.depth` guard is therefore always true, and the
recursion continues until the call stack is exhausted. A three-node graph with
one back edge is enough. So is a single node that links to itself.

This change adds a set of the nodes on the current path. A link into that set is
skipped. Everything else keeps its present behaviour.

The set holds the current path and not every node already visited. That
difference matters: in a graph with no cycle, a node is legitimately reached
again by a longer route, and that route is the one whose depth wins. A
visited-set would stop the second visit and give the wrong depth.

## Related Issue

None. I did not open one first. Please tell me if you would prefer an issue, and
I will file it.

## Motivation and Context

A back edge is ordinary flow data. A category that returns to an earlier stage,
or to itself, describes returns, refunds, retries, or a group that stays where it
is. Nothing in the documentation says a Sankey graph must be acyclic.

**This is a robustness fix and not a security issue.** I checked before I wrote
it. The failure is a `RangeError` thrown during render, which a React error
boundary catches like any other render error; the rest of the page keeps working.
It arrives in 5 to 27 ms and that time does not grow with the graph, because the
stack limit bounds the work. Server-side rendering never reaches the layout at
all. I mention this so nobody spends time treating it as more than it is.

[#7479](https://github.com/recharts/recharts/pull/7479) does not cover it. That
change stopped the combinatorial walk on dense acyclic graphs by pruning to
`newDepth > target.depth`. Around a cycle that condition is what keeps growing,
so the guard stays true and the recursion continues.

Reproduction on 3.10.1:

```jsx
<Sankey
  width={400}
  height={300}
  data={{
    nodes: [{ name: 'a' }, { name: 'b' }],
    links: [
      { source: 0, target: 1, value: 10 },
      { source: 1, target: 1, value: 5 },   // a node that links to itself
    ],
  }}
/>
```

## How Has This Been Tested?

I added four tests to `test/chart/Sankey.spec.tsx`, in a new
`describe('layout of graphs that contain a cycle')` block:

| Test | Before | After |
|---|---|---|
| A back edge computes a layout instead of exhausting the stack | fail | pass |
| A self referencing node computes a layout | fail | pass |
| A graph with a back edge renders | fail | pass |
| An acyclic graph keeps the depths it had | pass | pass |

The fourth is the regression guard. It passes either way on purpose: it shows the
change does not alter the depths of a graph with no cycle.

I checked the first three by reverting only `src/chart/Sankey.tsx` and running
them again, so they fail for the reason stated and not for another one.

| Command | Result |
|---|---|
| `npx vitest run --config vitest.config.mts --project 'unit:*'` | 320 files passed, 16425 tests passed, 0 failed |
| `npx eslint` on both changed files | exit code 0 |
| `npx prettier --check` on both changed files | exit code 0 |
| `npm run check-types-lib` | exit code 0 |
| `npm run check-types-test` | exit code 0 |

Node.js v23.11.0.

**What I did not do.** I did not measure the first affected release. I confirmed
the behaviour on 1.8.5, 1.8.6, 2.0.0, 2.1.0, 2.5.0, 2.10.3, 2.12.7, 2.14.1,
3.0.0, 3.5.0 and 3.10.1, and every one of them exhausts the stack, so the range
is at least as old as the oldest version I tested. I did not add a storybook
story. I did not change what a cyclic graph *looks* like once it renders, and I
have no opinion on whether the layout it produces is the one you would choose —
this only stops the crash.

Please treat the patch as a starting point and not a proposal. If you would
rather reject the cycle earlier, warn about it, or lay it out differently, that
is your call and I am happy to redo it.

## Screenshots (if appropriate):

Not applicable. There is no visual change for a graph with no cycle.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Sankey charts that could fail to finish rendering when their connections formed cycles or self-references.
  - Preserved expected layout behavior for standard acyclic charts.

- **Tests**
  - Added coverage for cyclic and self-referencing Sankey graphs.
  - Verified successful rendering and preservation of node and link counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
