### PR TITLE
fix: guard reduceCSSCalc against ReDoS from pathological calc() input

### DIFF
--- a/src/util/ReduceCSSCalc.ts
+++ b/src/util/ReduceCSSCalc.ts
@@ -158,7 +158,20 @@ function calculateParentheses(expr: string): string {
   return newExpr;
 }
 
+/*
+ * Guard against pathological input. A long run of digits followed by an
+ * arithmetic operator with no valid right-hand operand makes the operand
+ * regexes above backtrack quadratically (a ReDoS), which can freeze the
+ * rendering thread. Legitimate CSS length expressions used for text layout
+ * are only a few dozen characters, so anything longer is treated as invalid.
+ */
+const MAX_EXPRESSION_LENGTH = 1000;
+
 function evaluateExpression(expression: string): string {
+  if (expression.length > MAX_EXPRESSION_LENGTH) {
+    return STR_NAN;
+  }
+
   let newExpr = expression.replace(/\s+/g, '');
   newExpr = calculateParentheses(newExpr);
   newExpr = calculateArithmetic(newExpr);

--- a/test/util/ReduceCssCalcPrototype.spec.ts
+++ b/test/util/ReduceCssCalcPrototype.spec.ts
@@ -133,4 +133,16 @@ describe('reduceCSSCalc', () => {
       expect(reduceCSSCalc(`calc((${pattern}))`)).toEqual(pattern);
     },
   );
+
+  it.each([
+    () => `calc(${'9'.repeat(50000)}+)`,
+    () => `calc(${'9'.repeat(50000)}*)`,
+    () => `calc(${'9'.repeat(50000)}+@)`,
+  ])('should resolve quickly for a pathological digit run followed by an operator (ReDoS guard)', getInput => {
+    const input = getInput();
+    const start = Date.now();
+    expect(reduceCSSCalc(input)).toEqual('');
+    // Without the length guard this backtracks quadratically and takes many seconds.
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
 });


### PR DESCRIPTION
### Summary

`reduceCSSCalc` (used to resolve `calc()` expressions for text layout) is vulnerable to a **regular-expression denial of service (ReDoS)**. A long run of digits immediately followed by an arithmetic operator with no valid right-hand operand - e.g. `calc(999…999+)` or `calc(999…999*)` - makes the operand-matching regexes backtrack **quadratically**, blocking the rendering thread.

Measured on the current `main` (`reduceCSSCalc` called directly):

| input | time |
| --- | --- |
| `calc('9'×10000 + '+')` | ~470 ms |
| `calc('9'×20000 + '+')` | ~1.8 s |
| `calc('9'×40000 + '+')` | ~7.4 s |

Doubling the input roughly quadruples the time - classic O(n²) backtracking. `*`, and an invalid right operand such as `+@`, trigger the same blowup.

### Reachability

These `calc()` strings are built from the public `<Text>` component's `capHeight` / `lineHeight` props:

```
startDy = reduceCSSCalc(`calc(${capHeight})`);
startDy = reduceCSSCalc(`calc(${(wordsByLines.length - 1) / 2} * -${lineHeight} + (${capHeight} / 2))`);
```

so a pathological prop value reaches the evaluator unchecked and can freeze the UI. This is the same evaluator that was recently hardened for the `$&` infinite loop (#7610 / #7609).

### Fix

Add a length guard in `evaluateExpression`. Legitimate CSS length expressions for text layout are only a few dozen characters (the largest real expression here is ~23), so anything past a generous 1000-char bound is treated as invalid and returns an empty result. This bounds the worst case to sub-millisecond while leaving all valid expressions untouched.

### Tests

Adds regression tests asserting the pathological inputs resolve to `''` in well under a second. Full `ReduceCssCalcPrototype.spec.ts` suite and `Text.spec.tsx` pass; `tsc` and eslint are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against excessively long CSS calculation expressions.
  * Prevented pathological or invalid expressions from causing slow processing.
  * Invalid oversized expressions now fail safely instead of being evaluated.

* **Tests**
  * Added regression coverage for very large and malformed expressions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->