### PR TITLE
fix(axis): stop a two-tick axis whose domain crosses zero from overflowing the stack

### DIFF
--- a/src/util/scale/getNiceTickValues.ts
+++ b/src/util/scale/getNiceTickValues.ts
@@ -151,7 +151,7 @@ export const getTickOfSingleValue = (value: number, tickCount: number, allowDeci
  *
  * @param  min              The minimum value of an interval
  * @param  max              The maximum value of an interval
- * @param  tickCount        The count of ticks
+ * @param  tickCount        The count of ticks. An interval with 0 strictly inside it always uses at least 3.
  * @param  allowDecimals    Allow the ticks to be decimals or not
  * @param  correctionFactor A correction factor
  * @return The step, minimum value of ticks, maximum value of ticks
@@ -177,8 +177,12 @@ export const calculateStep = (
     };
   }
 
+  // An interval with 0 strictly inside it gets a tick at 0 plus one on either side of it,
+  // so fewer than three ticks never fit and the correction below would recurse forever.
+  const count = min < 0 && max > 0 ? Math.max(tickCount, 3) : tickCount;
+
   // The step which is easy to understand between two ticks
-  const step = stepFn(new Decimal(max).sub(min).div(tickCount - 1), allowDecimals, correctionFactor);
+  const step = stepFn(new Decimal(max).sub(min).div(count - 1), allowDecimals, correctionFactor);
 
   // A medial value of ticks
   let middle;
@@ -197,14 +201,14 @@ export const calculateStep = (
   let upCount = Math.ceil(new Decimal(max).sub(middle).div(step).toNumber());
   const scaleCount = belowCount + upCount + 1;
 
-  if (scaleCount > tickCount) {
+  if (scaleCount > count) {
     // When more ticks need to cover the interval, step should be bigger.
-    return calculateStep(min, max, tickCount, allowDecimals, correctionFactor + 1, stepFn);
+    return calculateStep(min, max, count, allowDecimals, correctionFactor + 1, stepFn);
   }
-  if (scaleCount < tickCount) {
+  if (scaleCount < count) {
     // When less ticks can cover the interval, we should add some additional ticks
-    upCount = max > 0 ? upCount + (tickCount - scaleCount) : upCount;
-    belowCount = max > 0 ? belowCount : belowCount + (tickCount - scaleCount);
+    upCount = max > 0 ? upCount + (count - scaleCount) : upCount;
+    belowCount = max > 0 ? belowCount : belowCount + (count - scaleCount);
   }
 
   return {
@@ -219,7 +223,8 @@ export const calculateStep = (
  * if it makes them more rounded and nice.
  *
  * @param tuple of [min,max] min: The minimum value, max: The maximum value
- * @param tickCount     The count of ticks
+ * @param tickCount     The count of ticks. An interval with 0 strictly inside it always returns at least
+ *                      3 ticks because 0 itself is always one of them.
  * @param allowDecimals Allow the ticks to be decimals or not
  * @param niceTicksMode The algorithm to use for calculating nice ticks.
  * @return array of ticks

--- a/test/cartesian/YAxis/YAxis.ticks.spec.tsx
+++ b/test/cartesian/YAxis/YAxis.ticks.spec.tsx
@@ -18,6 +18,11 @@ const dataWithDecimals = PageData.map(item => ({
   pv: item.pv / 100,
 }));
 
+const dataCrossingZero = [
+  { name: 'a', pv: -10 },
+  { name: 'b', pv: 10 },
+];
+
 const defaultExpectedYAxisSettings: RenderableAxisSettings = {
   allowDataOverflow: false,
   allowDecimals: true,
@@ -269,6 +274,31 @@ describe('YAxis ticks', () => {
         { textContent: '70', x: '57', y: '174' },
         { textContent: '140', x: '57', y: '83.00000000000001' },
         { textContent: '200', x: '57', y: '5' },
+      ]);
+    });
+  });
+
+  describe("with domain=['auto', 'auto'] and tickCount=2 and data that crosses zero", () => {
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <LineChart width={500} height={300} data={dataCrossingZero}>
+        <XAxis dataKey="name" />
+        <YAxis domain={['auto', 'auto']} tickCount={2} />
+        <Line dataKey="pv" />
+        {children}
+      </LineChart>
+    ));
+
+    it('should select niceTicks with zero in the middle', () => {
+      const { spy } = renderTestCase(state => selectNiceTicks(state, 'yAxis', 0, false));
+      expectLastCalledWith(spy, [-10, 0, 10]);
+    });
+
+    it('should render 3 ticks', () => {
+      const { container } = renderTestCase();
+      expectYAxisTicks(container, [
+        { textContent: '-10', x: '57', y: '265' },
+        { textContent: '0', x: '57', y: '135' },
+        { textContent: '10', x: '57', y: '5' },
       ]);
     });
   });

--- a/test/util/scale/getNiceTickValues.spec.ts
+++ b/test/util/scale/getNiceTickValues.spec.ts
@@ -104,6 +104,13 @@ describe('getNiceTickValues', () => {
       expect(step.tickMin.toNumber()).toBe(-100);
       expect(step.tickMax.toNumber()).toBe(100);
     });
+
+    it('should use 3 ticks when the interval contains 0 but fewer are requested', () => {
+      const step = calculateStep(-100, 100, 2, true, 0);
+      expect(step.step.toNumber()).toBe(100);
+      expect(step.tickMin.toNumber()).toBe(-100);
+      expect(step.tickMax.toNumber()).toBe(100);
+    });
   });
 
   describe('getNiceTickValues', () => {
@@ -281,6 +288,19 @@ describe('getNiceTickValues', () => {
       const scales = getNiceTickValues([0, 0.000013202017268238587], 5);
       expect(scales).toEqual([0, 0.0000035, 0.000007, 0.0000105, 0.000014]);
     });
+
+    it('should return 3 ticks when the interval contains 0 and only 2 ticks are requested', () => {
+      expect(getNiceTickValues([-10, 10], 2)).toEqual([-10, 0, 10]);
+      expect(getNiceTickValues([-1, 100], 2)).toEqual([-100, 0, 100]);
+    });
+
+    it('should return 3 ticks when the interval contains 0, 2 ticks are requested and decimals are not allowed', () => {
+      expect(getNiceTickValues([-0.5, 0.5], 2, false)).toEqual([-1, 0, 1]);
+    });
+
+    it('should return 3 reversed ticks when min is bigger than max, the interval contains 0 and 2 ticks are requested', () => {
+      expect(getNiceTickValues([10, -10], 2)).toEqual([10, 0, -10]);
+    });
   });
 
   describe('getSnap125Step', () => {
@@ -379,6 +399,11 @@ describe('getNiceTickValues', () => {
     it('should handle very large numbers [0, 1e100], 6', () => {
       const scales = getNiceTickValues([0, 1e100], 6, true, 'snap125');
       expect(scales).toEqual([0, 2e99, 4e99, 6e99, 8e99, 1e100]);
+    });
+
+    it('should return 3 ticks when the interval contains 0 and only 2 ticks are requested', () => {
+      expect(getNiceTickValues([-10, 10], 2, true, 'snap125')).toEqual([-10, 0, 10]);
+      expect(getNiceTickValues([-10, 10], 2, false, 'snap125')).toEqual([-10, 0, 10]);
     });
   });
 

--- a/test/util/scale/getNiceTickValues.spec.ts
+++ b/test/util/scale/getNiceTickValues.spec.ts
@@ -301,6 +301,19 @@ describe('getNiceTickValues', () => {
     it('should return 3 reversed ticks when min is bigger than max, the interval contains 0 and 2 ticks are requested', () => {
       expect(getNiceTickValues([10, -10], 2)).toEqual([10, 0, -10]);
     });
+
+    it("should return 3 ticks when the interval contains 0, 2 ticks are requested and niceTicks is 'snap125'", () => {
+      expect(getNiceTickValues([-10, 10], 2, true, 'snap125')).toEqual([-10, 0, 10]);
+    });
+
+    it('should still return 2 ticks when the interval only touches 0 at an end', () => {
+      expect(getNiceTickValues([0, 10], 2)).toEqual([0, 10]);
+      expect(getNiceTickValues([-10, 0], 2)).toEqual([-10, 0]);
+      expect(getNiceTickValues([0, 10], 2, true, 'snap125')).toEqual([0, 10]);
+      expect(getNiceTickValues([-10, 0], 2, true, 'snap125')).toEqual([-10, 0]);
+      expect(getNiceTickValues([0, 10], 2, false)).toEqual([0, 10]);
+      expect(getNiceTickValues([-10, 0], 2, false, 'snap125')).toEqual([-10, 0]);
+    });
   });
 
   describe('getSnap125Step', () => {


### PR DESCRIPTION
## Description

`calculateStep` pins the medial tick to `0` whenever the interval contains it:

```ts
// When 0 is inside the interval, 0 should be a tick
if (min <= 0 && max >= 0) {
  middle = new Decimal(0);
}
```

With `0` *strictly* inside, `belowCount` and `upCount` are both at least 1, so
`scaleCount = belowCount + upCount + 1` is never less than 3. When the caller asks for 2,
the `scaleCount > tickCount` branch recurses with `correctionFactor + 1` — and a larger step
cannot bring three ticks down to two, so it never terminates:

```js
> getNiceTickValues([-10, 10], 2)
Uncaught RangeError: Maximum call stack size exceeded
```

The same crash reaches the chart, because `selectNiceTicks` calls `getNiceTickValues` for
any `'auto'` keyword in the domain. This throws out of render and takes down the whole chart:

```jsx
<LineChart width={500} height={300} data={[{ name: 'a', pv: -10 }, { name: 'b', pv: 10 }]}>
  <XAxis dataKey="name" />
  <YAxis domain={['auto', 'auto']} tickCount={2} />
  <Line dataKey="pv" />
</LineChart>
```

`tickCount={3}` on the same chart is fine, and a domain that merely *touches* zero
(`[0, 10]`, `[-10, 0]`) is fine — the medial tick lands on an end, so 2 ticks fit.

With `niceTicks='snap125'` the recursion does escape, but only once `getSnap125Step` has
multiplied `magnitude` up to `Infinity`. Depending on `allowDecimals` that surfaces as
`[0, Infinity]` ticks or as `Error: [DecimalError] Invalid argument: Infinity`.

## Related Issue

None open that I could find — I searched issues and PRs for `tickCount`, `Maximum call
stack`, and `tickCount={2}` before writing this. Found while property-testing
`getNiceTickValues`/`getTickValuesFixedDomain` for tick count, ordering, uniform step,
domain coverage, and integer-only output.

## Motivation and Context

`tickCount` is a public axis prop and `getNiceTickValues` is a public export
(`src/index.ts`, "so this can be used as a replacement for what is in recharts-scale"), so
both entry points are reachable from user code. A stack overflow during render is
unrecoverable for the chart, and `2` is a natural value to reach for on a small or sparkline-
sized axis.

Reproduces on published `recharts@3.10.1` and on `recharts-scale@0.4.5`, so it predates the
port into this repo.

The fix floors the tick count at 3 when `0` is strictly inside the interval, giving the
correction loop a reachable target:

```ts
const count = min < 0 && max > 0 ? Math.max(tickCount, 3) : tickCount;
```

Three is the honest minimum here: a tick at zero plus one on each side is what the pinning
rule above already asks for. It also produces the nicest available answer rather than merely
avoiding the crash — `[-10, 10]` with `tickCount={2}` now yields `[-10, 0, 10]`, and
`[-1, 100]` yields `[-100, 0, 100]`.

Nothing changes for `tickCount >= 3`, nor for any interval that does not strictly contain
zero — `Math.max` is the identity in the first case and the branch is not taken in the
second. Both step algorithms (`getAdaptiveStep` and `getSnap125Step`) go through
`calculateStep`, so both are covered by the one change.

## How Has This Been Tested?

- Added unit tests to `test/util/scale/getNiceTickValues.spec.ts` covering `calculateStep`
  directly, `getNiceTickValues` with and without decimals, the reversed `min > max` case,
  and `niceTicks='snap125'`.
- Added a chart-level case to `test/cartesian/YAxis/YAxis.ticks.spec.tsx` for
  `domain={['auto', 'auto']} tickCount={2}` over data that crosses zero, asserting the
  selected nice ticks and the three rendered tick labels.
- All 7 new assertions fail with `RangeError: Maximum call stack size exceeded` on `main`
  and pass with the fix.
- `npm run test` — 7466 passed, 0 failed (the 7 failing *files* are `www` API-doc specs that
  need `npm run omnidoc` first; unrelated to this change and failing the same way before it).
- `npm run lint`, `npm run check-types-lib`, `npm run check-types-test` — clean.
- Property test over 40,000 random `[min, max] × tickCount × allowDecimals × niceTicks`
  combinations: it crashed on the very first zero-crossing `tickCount=2` case before the fix;
  afterwards every case satisfies tick count, strict ordering, uniform step, domain coverage,
  and integer-only ticks when `allowDecimals` is false. Not included in the diff — it is a
  search tool, not a regression test.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

The doc box is ticked for the JSDoc on `calculateStep` and `getNiceTickValues`, which now
state the three-tick minimum. No storybook story or VR test: the before state is a thrown
`RangeError`, so there is nothing for a story to render, and the two axis tests assert the
tick values and label positions directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic axis tick generation for ranges that cross zero, ensuring at least three ticks are shown.
  * Corrected tick spacing and distribution for reversed ranges and configurations that disallow decimals.
  * Preserved two-tick behavior for ranges that only touch zero.

* **Tests**
  * Added coverage confirming zero-crossing ranges produce expected tick values and labels on charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->