### PR TITLE
Funnel theme support

### DIFF
--- a/src/cartesian/Funnel.tsx
+++ b/src/cartesian/Funnel.tsx
@@ -54,6 +54,7 @@ import { GraphicalItemId } from '../state/graphicalItemsSlice';
 import { RegisterGraphicalItemId } from '../context/RegisterGraphicalItemId';
 import { WithIdRequired } from '../util/useUniqueId';
 import { useCartesianChartLayout } from '../context/chartLayoutContext';
+import { useRechartsTheme } from '../theme/RechartsThemeContext';
 
 export type FunnelTrapezoidItem = TrapezoidProps &
   TrapezoidViewBox & {
@@ -514,7 +515,11 @@ export const defaultFunnelProps = {
   stroke: '#fff',
 } as const satisfies Partial<Props>;
 
-function FunnelImpl(props: WithIdRequired<RequiresDefaultProps<Props, typeof defaultFunnelProps>>) {
+function FunnelImpl(
+  props: WithIdRequired<RequiresDefaultProps<Props, typeof defaultFunnelProps>> & {
+    indexedStyles: ReadonlyArray<Record<string, unknown>>;
+  },
+) {
   const plotArea = usePlotArea();
 
   const {
@@ -529,6 +534,7 @@ function FunnelImpl(props: WithIdRequired<RequiresDefaultProps<Props, typeof def
     nameKey,
     lastShapeType,
     id,
+    indexedStyles,
     ...everythingElse
   } = props;
 
@@ -546,6 +552,7 @@ function FunnelImpl(props: WithIdRequired<RequiresDefaultProps<Props, typeof def
       customWidth: props.width,
       cells,
       presentationProps,
+      indexedStyles,
       id,
     }),
     [
@@ -558,6 +565,7 @@ function FunnelImpl(props: WithIdRequired<RequiresDefaultProps<Props, typeof def
       props.width,
       cells,
       presentationProps,
+      indexedStyles,
       id,
     ],
   );
@@ -745,12 +753,45 @@ export function computeFunnelTrapezoids({
  * @consumes CartesianViewBoxContext
  * @provides LabelListContext
  * @provides CellReader
+ * @consumes RechartsThemeContext
  */
 function FunnelFn(outsideProps: Props) {
-  const { id: externalId, ...props } = resolveDefaultProps(outsideProps, defaultFunnelProps);
+  const theme = useRechartsTheme();
+
+  /*
+   * Funnel is per-index: each trapezoid at index `i` picks its styles from
+   * graphical[i % graphicalItems.length]. The user's explicit presentation
+   * props still win, so the theme only supplies the values that were omitted.
+   */
+  const indexedStyles: ReadonlyArray<Record<string, unknown>> = useMemo(() => {
+    const { graphicalItems } = theme;
+    if (graphicalItems == null || graphicalItems.length === 0) {
+      return [];
+    }
+    return graphicalItems.map((style): Record<string, unknown> => {
+      const themed: Record<string, unknown> = {};
+      if (outsideProps.fill === undefined && style.fill !== undefined) themed.fill = style.fill;
+      if (outsideProps.stroke === undefined && style.stroke !== undefined) themed.stroke = style.stroke;
+      if (outsideProps.strokeWidth === undefined && style.strokeWidth !== undefined) {
+        themed.strokeWidth = style.strokeWidth;
+      }
+      if (outsideProps.strokeOpacity === undefined && style.strokeOpacity !== undefined) {
+        themed.strokeOpacity = style.strokeOpacity;
+      }
+      if (outsideProps.fillOpacity === undefined && style.fillOpacity !== undefined) {
+        themed.fillOpacity = style.fillOpacity;
+      }
+      if (outsideProps.strokeDasharray === undefined && style.strokeDasharray !== undefined) {
+        themed.strokeDasharray = style.strokeDasharray;
+      }
+      return themed;
+    });
+  }, [outsideProps, theme]);
+
+  const { id: externalId, ...resolvedProps } = resolveDefaultProps(outsideProps, defaultFunnelProps);
   return (
     <RegisterGraphicalItemId id={externalId} type="funnel">
-      {id => <FunnelImpl {...props} id={id} />}
+      {id => <FunnelImpl {...resolvedProps} id={id} indexedStyles={indexedStyles} />}
     </RegisterGraphicalItemId>
   );
 }

--- a/src/state/selectors/funnelSelectors.ts
+++ b/src/state/selectors/funnelSelectors.ts
@@ -19,6 +19,12 @@ export type ResolvedFunnelSettings = {
   customWidth?: string | number;
   cells: ReadonlyArray<ReactElement>;
   presentationProps: Record<string, any> | null;
+  /**
+   * Per-index theme styles for the funnel items. Each item at index `i` gets the style at
+   * `i % indexedStyles.length`. Only values not explicitly provided via props are set,
+   * so an explicit prop still wins over the theme.
+   */
+  indexedStyles: ReadonlyArray<Record<string, any>>;
   id: GraphicalItemId;
 };
 
@@ -44,6 +50,7 @@ export const selectFunnelTrapezoids: (
       customWidth,
       cells,
       presentationProps,
+      indexedStyles,
       id: graphicalItemId,
     },
     { chartData },
@@ -55,15 +62,23 @@ export const selectFunnelTrapezoids: (
       displayedData = chartData;
     }
 
+    const styleForIndex = (index: number) =>
+      indexedStyles != null && indexedStyles.length > 0 ? indexedStyles[index % indexedStyles.length] : {};
+
     if (displayedData && displayedData.length) {
       displayedData = displayedData.map((entry: any, index: number) => ({
         payload: entry,
         ...presentationProps,
+        ...styleForIndex(index),
         ...entry,
         ...(cells && cells[index] && cells[index].props),
       }));
     } else if (cells && cells.length) {
-      displayedData = cells.map((cell: ReactElement<CellProps>) => ({ ...presentationProps, ...cell.props }));
+      displayedData = cells.map((cell: ReactElement<CellProps>, index: number) => ({
+        ...presentationProps,
+        ...styleForIndex(index),
+        ...cell.props,
+      }));
     } else {
       return [];
     }

--- a/src/theme/RechartsTheme.ts
+++ b/src/theme/RechartsTheme.ts
@@ -4,7 +4,7 @@ import { LegendProps } from '../index';
 /**
  * Styles shared for rectangular or variable shape components that have an area (Area, Bar, Rectangle)
  */
-type Styles2D = {
+export type Styles2D = {
   stroke?: string;
   strokeOpacity?: number;
   strokeWidth?: number;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Funnel charts now automatically apply theme-defined graphical styles to individual trapezoids when specific presentation styles are not provided.
  - Indexed theme styles are applied consistently to funnels built from both data entries and cells.
  - Explicit styles configured on funnel entries or cells continue to take precedence over theme defaults.

- **Improvements**
  - Funnel styling is now more consistent and flexible across different chart configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->