### PR TITLE
fix(Bar): apply the theme strokeDasharray like the other graphical items

### DIFF
--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -1252,6 +1252,7 @@ function BarFn(outsideProps: Props) {
   const themeStroke = outsideProps.stroke ?? graphicalItemStyle?.stroke;
   const themeStrokeWidth = outsideProps.strokeWidth ?? graphicalItemStyle?.strokeWidth;
   const themeStrokeOpacity = outsideProps.strokeOpacity ?? graphicalItemStyle?.strokeOpacity;
+  const themeStrokeDasharray = outsideProps.strokeDasharray ?? graphicalItemStyle?.strokeDasharray;
   const themeFillOpacity = outsideProps.fillOpacity ?? graphicalItemStyle?.fillOpacity;
 
   const themedProps: Partial<Props> = {};
@@ -1259,6 +1260,7 @@ function BarFn(outsideProps: Props) {
   if (themeStroke !== undefined) themedProps.stroke = themeStroke;
   if (themeStrokeWidth !== undefined) themedProps.strokeWidth = themeStrokeWidth;
   if (themeStrokeOpacity !== undefined) themedProps.strokeOpacity = themeStrokeOpacity;
+  if (themeStrokeDasharray !== undefined) themedProps.strokeDasharray = themeStrokeDasharray;
   if (themeFillOpacity !== undefined) themedProps.fillOpacity = themeFillOpacity;
 
   // Report all props to Redux store first, before calling any hooks, to avoid circular dependencies.

--- a/test/cartesian/Bar/Bar.theme.spec.tsx
+++ b/test/cartesian/Bar/Bar.theme.spec.tsx
@@ -46,6 +46,11 @@ describe('Bar theme', () => {
     return bar?.getAttribute('fill-opacity') ?? null;
   }
 
+  function getBarStrokeDasharray(container: ReturnType<typeof rechartsTestRender>['container']): string | null {
+    const bar = getAllBarPaths(container)[0];
+    return bar?.getAttribute('stroke-dasharray') ?? null;
+  }
+
   describe('fill', () => {
     describe('when not defined at all (no provider)', () => {
       it('should have no fill (legacy behavior)', () => {
@@ -178,6 +183,38 @@ describe('Bar theme', () => {
           </RechartsThemeProvider>,
         );
         expect(getBarFillOpacity(container)).toBe('0.7');
+      });
+    });
+  });
+
+  describe('strokeDasharray', () => {
+    describe('when defined as a theme', () => {
+      it('should use the theme strokeDasharray value', () => {
+        const { container } = rechartsTestRender(
+          <RechartsThemeProvider
+            value={{
+              graphicalItems: [{ stroke: 'red', strokeDasharray: '5 10' }],
+            }}
+          >
+            <MyChart />
+          </RechartsThemeProvider>,
+        );
+        expect(getBarStrokeDasharray(container)).toBe('5 10');
+      });
+    });
+
+    describe('when both prop and theme are defined', () => {
+      it('should prefer the prop over the theme', () => {
+        const { container } = rechartsTestRender(
+          <RechartsThemeProvider
+            value={{
+              graphicalItems: [{ stroke: 'red', strokeDasharray: '5 10' }],
+            }}
+          >
+            <MyChart barProps={{ strokeDasharray: '1 2' }} />
+          </RechartsThemeProvider>,
+        );
+        expect(getBarStrokeDasharray(container)).toBe('1 2');
       });
     });
   });


### PR DESCRIPTION
Fixes #7635

`RechartsTheme.graphicalItems` entries are typed as `Styles2D`, which includes `strokeDasharray`. `Line`, `Area`, `Scatter`, `Radar` and `RadialBar` all read it from the theme; `Bar` builds its `themedProps` from `fill`, `stroke`, `strokeWidth`, `strokeOpacity` and `fillOpacity` only, so the theme value never reaches the rectangle. A theme that sets `strokeDasharray` dashes every graphical item except the bars.

`Bar` already honours `strokeDasharray` when it arrives as a prop, so the only gap was the theme lookup. This adds the two missing lines, following the shape `RadialBar` uses (`src/polar/RadialBar.tsx:835` and `:843`).

Verification, rebased onto `main` at 55dfcc674a1:

- The new `strokeDasharray` case in `test/cartesian/Bar/Bar.theme.spec.tsx` fails without the change (`expected null to be '5 10'`) and passes with it. Checked by restoring `src/cartesian/Bar.tsx` from `main` and leaving the test file in place.
- The prop-over-theme case passes both before and after, which confirms the prop path was never broken.
- `npm run test-lib` (`vitest --project unit:lib`): 303 files, 6174 passed, 6 expected fail, 16 skipped, 1 todo.
- `npx eslint src/cartesian/Bar.tsx test/cartesian/Bar/Bar.theme.spec.tsx` and `npm run check-types-lib` (`tsc --noEmit`) are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bar chart elements now correctly apply the configured stroke dash pattern from the theme.
  * Explicit stroke dash pattern settings on individual bars take precedence over themed defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->