### PR TITLE
fix(Bar): stop spurious re-animation on unrelated re-renders

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -287,6 +287,7 @@
   "es6/util/typedDataKey.js",
   "es6/util/types.js",
   "es6/util/useAnimationId.js",
+  "es6/util/useCells.js",
   "es6/util/useElementOffset.js",
   "es6/util/useId.js",
   "es6/util/usePrefersReducedMotion.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -287,6 +287,7 @@
   "lib/util/typedDataKey.js",
   "lib/util/types.js",
   "lib/util/useAnimationId.js",
+  "lib/util/useCells.js",
   "lib/util/useElementOffset.js",
   "lib/util/useId.js",
   "lib/util/usePrefersReducedMotion.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -287,6 +287,7 @@
   "types/util/typedDataKey.d.ts",
   "types/util/types.d.ts",
   "types/util/useAnimationId.d.ts",
+  "types/util/useCells.d.ts",
   "types/util/useElementOffset.d.ts",
   "types/util/useId.d.ts",
   "types/util/usePrefersReducedMotion.d.ts",

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -15,7 +15,6 @@ import { Series } from 'victory-vendor/d3-shape';
 import { Props as RectangleProps, RectRadius } from '../shape/Rectangle';
 import { Layer } from '../container/Layer';
 import { ErrorBarDataItem, ErrorBarDataPointFormatter } from './ErrorBar';
-import { Cell } from '../component/Cell';
 import {
   CartesianLabelListContextProvider,
   CartesianLabelListEntry,
@@ -23,7 +22,6 @@ import {
   LabelListFromLabelProp,
 } from '../component/LabelList';
 import { interpolate, isNan, mathSign, noop } from '../util/DataUtils';
-import { findAllByType } from '../util/ReactUtils';
 import {
   BarPositionPosition,
   getBaseValueOfBar,
@@ -87,6 +85,7 @@ import { ZIndexable, ZIndexLayer } from '../zIndex/ZIndexLayer';
 import { DefaultZIndexes } from '../zIndex/DefaultZIndexes';
 import { getZIndexFromUnknown } from '../zIndex/getZIndexFromUnknown';
 import { propsAreEqual } from '../util/propsAreEqual';
+import { useCells } from '../util/useCells';
 import { AxisId } from '../state/cartesianAxisSlice';
 import { BarStackClipLayer, useStackId } from './BarStack';
 import { useRechartsTheme } from '../theme/RechartsThemeContext';
@@ -1043,7 +1042,12 @@ function BarImpl(props: BarImplProps) {
 
   const isPanorama = useIsPanorama();
 
-  const cells = findAllByType(props.children, Cell);
+  /*
+   * `cells` is an argument to the memoized selector below, so it has to be referentially stable,
+   * otherwise every render of this component is a cache miss that returns a brand new `rects` array,
+   * which changes the animationId, which starts a spurious animation.
+   */
+  const cells = useCells(props.children);
 
   const rects: ReadonlyArray<BarRectangleItem> | undefined = useAppSelector(state =>
     selectBarRectangles(state, props.id, isPanorama, cells),

--- a/src/util/useCells.ts
+++ b/src/util/useCells.ts
@@ -1,0 +1,54 @@
+import { ReactElement, ReactNode, useRef } from 'react';
+import { Cell } from '../component/Cell';
+import { findAllByType } from './ReactUtils';
+import { propsAreEqual } from './propsAreEqual';
+
+/**
+ * A single shared reference for "this graphical item has no Cell children",
+ * which is by far the most common case.
+ */
+const noCells: ReadonlyArray<ReactElement> = [];
+
+function cellsAreEqual(a: ReadonlyArray<ReactElement>, b: ReadonlyArray<ReactElement>): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((cell, index) => {
+    const other = b[index];
+    return other != null && cell.type === other.type && propsAreEqual(cell.props, other.props);
+  });
+}
+
+/**
+ * Reads the `Cell` children of a graphical item and returns a reference that is stable
+ * for as long as the cells themselves do not change.
+ *
+ * `findAllByType` allocates a new array on every call, and JSX allocates new `Cell` elements
+ * every time the parent renders. Cells are an argument to the memoized selectors that compute
+ * the graphical item shapes, so an unstable reference here is a selector cache miss, which
+ * produces a new array of shapes, which changes the animationId, which starts a new animation.
+ *
+ * That animation interpolates between shapes that hold identical values, so nothing appears to
+ * move, but `isAnimating` still flips for the whole animationDuration. Labels are hidden while
+ * a graphical item animates, so they blank out on every unrelated re-render of the surrounding
+ * component - for example while the pointer moves over the chart. The animation callbacks fire
+ * spuriously too, and every shape re-renders at frame rate for as long as it runs.
+ *
+ * @param children children of the graphical item, some of which may be `Cell` elements
+ * @returns the Cell children; the same reference as last render if they are unchanged
+ */
+export function useCells(children: ReactNode): ReadonlyArray<ReactElement> {
+  const previousRef = useRef<ReadonlyArray<ReactElement>>(noCells);
+  const nextCells = findAllByType(children, Cell);
+  const cells = nextCells.length === 0 ? noCells : nextCells;
+
+  if (cellsAreEqual(previousRef.current, cells)) {
+    return previousRef.current;
+  }
+
+  previousRef.current = cells;
+  return cells;
+}

--- a/test/cartesian/Bar/Bar.rerenderStability.spec.tsx
+++ b/test/cartesian/Bar/Bar.rerenderStability.spec.tsx
@@ -1,0 +1,129 @@
+import React, { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Bar, BarChart, Cell, LabelList, Tooltip } from '../../../src';
+import { PageData } from '../../_data';
+import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
+import { mockGetBoundingClientRect } from '../../helper/mockGetBoundingClientRect';
+import { showTooltipOnCoordinate } from '../../component/Tooltip/tooltipTestHelpers';
+import { barChartMouseHoverTooltipSelector } from '../../component/Tooltip/tooltipMouseHoverSelectors';
+
+const smallerData = PageData.slice(0, 2);
+
+const onAnimationStart = vi.fn();
+const onAnimationEnd = vi.fn();
+
+function getLabels(container: Element): ReadonlyArray<string> {
+  return Array.from(container.querySelectorAll('.recharts-label-list text')).map(text => text.textContent ?? '');
+}
+
+function getBarFills(container: Element): ReadonlyArray<string | null> {
+  return Array.from(container.querySelectorAll('.recharts-bar-rectangle path')).map(bar => bar.getAttribute('fill'));
+}
+
+/**
+ * The chart data reference never changes in any of these tests. Only the surrounding component
+ * re-renders, which is what every app does when it holds state next to the chart.
+ *
+ * `<Bar>` has children here, so `React.memo` cannot absorb that re-render: `children` is not on
+ * the `propsAreEqual` allowlist and JSX allocates a new element every time. An inline event
+ * handler such as `onClick={() => {}}` defeats the memo the same way, with no children at all.
+ */
+describe('Bar should not re-animate when the surrounding component re-renders', () => {
+  beforeEach(() => {
+    onAnimationStart.mockClear();
+    onAnimationEnd.mockClear();
+    mockGetBoundingClientRect({ width: 400, height: 400 });
+  });
+
+  describe('without Cell children', () => {
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <BarChart width={400} height={400} data={smallerData}>
+        <Bar
+          dataKey="pv"
+          activeBar={{ fill: 'red' }}
+          onAnimationStart={onAnimationStart}
+          onAnimationEnd={onAnimationEnd}
+        >
+          <LabelList dataKey="pv" />
+        </Bar>
+        <Tooltip />
+        {children}
+      </BarChart>
+    ));
+
+    it('should keep the labels rendered and not restart the animation', async () => {
+      const { container, animationManager, rerenderSameComponent } = renderTestCase();
+      await animationManager.completeAnimation();
+
+      expect(getLabels(container)).toEqual(['2400', '4567']);
+      expect(onAnimationStart).toHaveBeenCalledTimes(1);
+      expect(onAnimationEnd).toHaveBeenCalledTimes(1);
+
+      rerenderSameComponent();
+
+      expect(getLabels(container)).toEqual(['2400', '4567']);
+      expect(onAnimationStart).toHaveBeenCalledTimes(1);
+      expect(onAnimationEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not restart the animation when hovering over the chart', async () => {
+      const { container, animationManager } = renderTestCase();
+      await animationManager.completeAnimation();
+
+      showTooltipOnCoordinate(container, barChartMouseHoverTooltipSelector, { clientX: 100, clientY: 200 });
+      showTooltipOnCoordinate(container, barChartMouseHoverTooltipSelector, { clientX: 300, clientY: 200 });
+
+      expect(getLabels(container)).toEqual(['2400', '4567']);
+      expect(onAnimationStart).toHaveBeenCalledTimes(1);
+      expect(onAnimationEnd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('with Cell children', () => {
+    function BarChartWithCells({ children, fills }: { children: ReactNode; fills: ReadonlyArray<string> }) {
+      return (
+        <BarChart width={400} height={400} data={smallerData}>
+          <Bar dataKey="pv" onAnimationStart={onAnimationStart} onAnimationEnd={onAnimationEnd}>
+            <LabelList dataKey="pv" />
+            {fills.map((fill, index) => (
+              <Cell key={index} fill={fill} />
+            ))}
+          </Bar>
+          {children}
+        </BarChart>
+      );
+    }
+
+    const greenAndBlue = ['green', 'blue'];
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <BarChartWithCells fills={greenAndBlue}>{children}</BarChartWithCells>
+    ));
+
+    it('should keep the labels rendered and not restart the animation', async () => {
+      const { container, animationManager, rerenderSameComponent } = renderTestCase();
+      await animationManager.completeAnimation();
+
+      expect(getBarFills(container)).toEqual(['green', 'blue']);
+      expect(getLabels(container)).toEqual(['2400', '4567']);
+      expect(onAnimationStart).toHaveBeenCalledTimes(1);
+
+      rerenderSameComponent();
+
+      expect(getBarFills(container)).toEqual(['green', 'blue']);
+      expect(getLabels(container)).toEqual(['2400', '4567']);
+      expect(onAnimationStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still apply new Cell props when they actually change', async () => {
+      const { container, animationManager, rerender } = renderTestCase();
+      await animationManager.completeAnimation();
+
+      expect(getBarFills(container)).toEqual(['green', 'blue']);
+
+      rerender(({ children }) => <BarChartWithCells fills={['orange', 'purple']}>{children}</BarChartWithCells>);
+      await animationManager.completeAnimation();
+
+      expect(getBarFills(container)).toEqual(['orange', 'purple']);
+    });
+  });
+});

--- a/test/util/useCells.spec.tsx
+++ b/test/util/useCells.spec.tsx
@@ -1,0 +1,118 @@
+import React, { ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCells } from '../../src/util/useCells';
+import { Cell } from '../../src/component/Cell';
+import { LabelList } from '../../src/component/LabelList';
+
+function renderUseCells(initialChildren: ReactNode) {
+  return renderHook(({ children }) => useCells(children), {
+    initialProps: { children: initialChildren },
+  });
+}
+
+describe('useCells', () => {
+  it('should return an empty array when there are no children', () => {
+    const { result } = renderUseCells(undefined);
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('should return an empty array when no child is a Cell', () => {
+    const { result } = renderUseCells(<LabelList dataKey="pv" />);
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('should return the same empty array reference across renders', () => {
+    const { result, rerender } = renderUseCells(<LabelList dataKey="pv" />);
+    const first = result.current;
+
+    rerender({ children: <LabelList dataKey="pv" /> });
+
+    expect(result.current).toBe(first);
+  });
+
+  it('should return the Cell children and skip everything else', () => {
+    const { result } = renderUseCells(
+      <>
+        <LabelList dataKey="pv" />
+        <Cell fill="green" />
+        <Cell fill="blue" />
+      </>,
+    );
+
+    expect(result.current).toHaveLength(2);
+    expect(result.current.map(cell => cell.props.fill)).toEqual(['green', 'blue']);
+  });
+
+  it('should return the same reference when the cells re-render unchanged', () => {
+    const { result, rerender } = renderUseCells(
+      <>
+        <Cell fill="green" />
+        <Cell fill="blue" />
+      </>,
+    );
+    const first = result.current;
+
+    rerender({
+      children: (
+        <>
+          <Cell fill="green" />
+          <Cell fill="blue" />
+        </>
+      ),
+    });
+
+    expect(result.current).toBe(first);
+  });
+
+  it('should return the same reference when a Cell prop is an equal-but-new object', () => {
+    const { result, rerender } = renderUseCells(<Cell style={{ opacity: 0.5 }} />);
+    const first = result.current;
+
+    rerender({ children: <Cell style={{ opacity: 0.5 }} /> });
+
+    expect(result.current).toBe(first);
+  });
+
+  it('should return a new reference when a Cell prop changes', () => {
+    const { result, rerender } = renderUseCells(<Cell fill="green" />);
+    const first = result.current;
+
+    rerender({ children: <Cell fill="orange" /> });
+
+    expect(result.current).not.toBe(first);
+    expect(result.current[0]?.props.fill).toBe('orange');
+  });
+
+  it('should return a new reference when a Cell is added', () => {
+    const { result, rerender } = renderUseCells(<Cell fill="green" />);
+    const first = result.current;
+
+    rerender({
+      children: (
+        <>
+          <Cell fill="green" />
+          <Cell fill="blue" />
+        </>
+      ),
+    });
+
+    expect(result.current).not.toBe(first);
+    expect(result.current).toHaveLength(2);
+  });
+
+  it('should return the shared empty array when the last Cell is removed', () => {
+    const { result, rerender } = renderUseCells(<Cell fill="green" />);
+
+    rerender({ children: <LabelList dataKey="pv" /> });
+    const afterRemoval = result.current;
+
+    expect(afterRemoval).toEqual([]);
+
+    rerender({ children: undefined });
+
+    expect(result.current).toBe(afterRemoval);
+  });
+});


### PR DESCRIPTION
## Description

`BarImpl` passed the result of `findAllByType(props.children, Cell)` straight into `selectBarRectangles`:

```tsx
const cells = findAllByType(props.children, Cell);

const rects = useAppSelector(state => selectBarRectangles(state, props.id, isPanorama, cells));
```

`findAllByType` allocates a new array on every call, and `cells` is an argument to the memoized selector, so every render of `BarImpl` was a cache miss that returned a brand new `rects` array. `AnimatedItems` feeds `rects` to `useAnimationId`, which compares by reference, so a new array means a new `animationId`, which re-keys `JavascriptAnimate` and starts a new animation — even though the chart data never changed.

This adds `useCells`, which reads the `Cell` children and returns the previous reference while their types and props are unchanged, so the selector keeps its cache. When there are no `Cell` children at all it returns one shared empty array, making the common case a reference check rather than a loop. Props are compared with the existing `propsAreEqual`, so an inline `style={{ ... }}` on a `Cell` does not defeat it.

## Related Issue

Closes #7643

## Motivation and Context

The user-visible symptom is that labels flicker while hovering. Labels are hidden while a Bar animates, so a spurious animation blanks the numbers for the whole `animationDuration`, and anything that re-renders on pointer movement makes that repeat continuously.

Two things made this hard to recognise as an animation bug:

- **The bars do not visibly move.** The restarted animation interpolates from the rectangles already on screen towards rectangles holding identical values, so the interpolation is a visual no-op. Only `isAnimating` flips, and only the labels react to it.
- **It does not reproduce on every chart.** `Bar` is wrapped in `React.memo(BarFn, propsAreEqual)`, which absorbs the parent re-render for simple charts. It stops absorbing when `<Bar>` has children — `children` is not on the `propsAreEqual` allowlist and JSX allocates a new element every render — or when any prop compared by identity changes, such as an inline `onClick`.

The cost is not limited to labels. `onAnimationStart` / `onAnimationEnd` fire on every re-render, and every rectangle re-renders at frame rate for as long as the animation runs.

Measured on a chart re-render with `isAnimationActive={false}`, so these numbers exclude the animation loop that the fix also prevents:

| cells | before | after |
| --- | --- | --- |
| 100 | 10.73 ms | 7.84 ms |
| 1 000 | 99.05 ms | 68.47 ms |
| 10 000 | 943 ms | 623 ms |

It comes out ahead because one cheap comparison pass replaces a full `computeBarRectangles` recompute. In isolation `cellsAreEqual` costs about the same as the `findAllByType` call that already ran on every render (1.84 ms vs 1.65 ms at 10 000 cells).

### Scope

`Funnel` has the same unmemoized `findAllByType` call, and additionally folds `svgPropertiesNoEvents(props)` into the same settings object, which has no stable memo key at all — so `useCells` alone would not fix it.

`Pie`, `Scatter` and `RadialBar` wrap the call in `useMemo(..., [props.children])`, which does not actually help since JSX reallocates `props.children` on every parent render. `useCells` should drop into all three unchanged, but I have only verified the symptom on `Bar`, so I have kept this PR to the verified case rather than claiming fixes I have not demonstrated. Happy to extend it here or in a follow-up, whichever you prefer.

## How Has This Been Tested?

`test/util/useCells.spec.tsx` — 9 unit tests covering the hook directly: stable reference when cells are unchanged, when a prop is an equal-but-new object, and when there are no cells; new reference when a prop changes or a cell is added; and the shared empty array when the last cell is removed.

`test/cartesian/Bar/Bar.rerenderStability.spec.tsx` — 4 rendering tests, with and without `Cell` children, asserting that an unrelated re-render and a hover both leave the labels in place and do not fire the animation callbacks again, plus one test that changed `Cell` props still reach the DOM so the stability cache cannot go stale.

The three behavioural tests fail on `main`: after the entrance animation the chart shows its labels, and a single re-render drops the label count to 0 while `onAnimationStart` fires a second time.

Also run: `npm run lint` (0 errors), `npm run check-types`, `npm test`. The build-output snapshots are updated for the new source file. Two `unit:website` files (`color-mode.client.spec.tsx`, `navigation.spec.tsx`, 10 tests) fail identically on a clean checkout of `main` and are unrelated to this change.

## Screenshots (if appropriate):

Not included — the symptom is a label that disappears and reappears, which a still frame does not convey. The repro in #7643 shows it in a few lines.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

On the last item: I had a story that demonstrated the flicker and removed it again, since the behaviour it showed requires moving the pointer over a live chart and a VR snapshot cannot capture it. The unit and rendering tests pin the behaviour instead. Happy to add a story back if you would like one for manual verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart rendering stability when surrounding components update or tooltips are hovered.
  * Prevented unnecessary bar animations and visual changes when cell styling remains unchanged.
  * Ensured updated cell colors are applied correctly.
* **Tests**
  * Added coverage for stable rerendering, labels, animations, tooltip interactions, and cell updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->