### PR TITLE
docs: fix dead React link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Introduction
 
-Recharts is a **Redefined** chart library built with [React](https://facebook.github.io/react/) and [D3](http://d3js.org).
+Recharts is a **Redefined** chart library built with [React](https://react.dev/) and [D3](https://d3js.org).
 
 The main purpose of this library is to help you to write charts in React applications without any pain. Main principles of Recharts are:
 


### PR DESCRIPTION
## Description

Fixes two broken links on the first content line of the README:

- **React** pointed to `https://facebook.github.io/react/`, which returns **HTTP 404** — updated to `https://react.dev/` (React's current official site).
- **D3** used `http://d3js.org` — updated to `https://d3js.org` (the site 301-redirects to HTTPS anyway).

```diff
-Recharts is a **Redefined** chart library built with [React](https://facebook.github.io/react/) and [D3](http://d3js.org).
+Recharts is a **Redefined** chart library built with [React](https://react.dev/) and [D3](https://d3js.org).
```

## Related Issue

Closes #7647.

The README's obsolete `### umd` install section (all four script URLs 404 — React 19 and recharts 3 no longer ship UMD builds) is a separate concern, tracked in #7649; I'm happy to follow up on it once you've decided between removing it or replacing it with an ESM/CDN example.

## Motivation and Context

The dead React link is on the README's first content line, so every visitor to the repo hits a 404.

## How Has This Been Tested?

Documentation-only change. Verified both target URLs return HTTP 200:

- `https://react.dev/` → 200
- `https://d3js.org/` → 200

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. _(N/A — documentation-only change)_
- [ ] I have added a storybook story or VR test _(N/A — documentation-only change)_
