### PR TITLE
docs: fix dead UMD install links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ $ deno add recharts react-is
 The UMD build is also available on unpkg.com:
 
 ```html
-<script src="https://unpkg.com/react/umd/react.production.min.js"></script>
-<script src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"></script>
-<script src="https://unpkg.com/react-is/umd/react-is.production.min.js"></script>
-<script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
+<script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+<script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+<script src="https://unpkg.com/react-is@18/umd/react-is.production.min.js"></script>
+<script src="https://unpkg.com/recharts/umd/Recharts.js"></script>
 ```
 
 Then you can find the library on `window.Recharts`.


### PR DESCRIPTION
## Description

Fixes the dead script URLs in the README `### umd` install section (follow-up to #7649).

- React removed its UMD builds in v19, so the unversioned `react` / `react-dom` / `react-is` scripts now 404. Locked them to `@18`, which still ships UMD — per @PavelVanecek's suggestion in #7649.
- recharts still ships a UMD build, but as `Recharts.js` (no longer minified), so `Recharts.min.js` 404s. Updated the filename.

## Related Issue

Closes #7649.

## Motivation and Context

Anyone following the documented UMD/CDN setup currently hits four 404s on the first copy-paste.

## How Has This Been Tested?

Documentation-only change. Verified each replacement URL returns HTTP 200:

- `https://unpkg.com/react@18/umd/react.production.min.js` → 200
- `https://unpkg.com/react-dom@18/umd/react-dom.production.min.js` → 200
- `https://unpkg.com/react-is@18/umd/react-is.production.min.js` → 200
- `https://unpkg.com/recharts/umd/Recharts.js` → 200

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated UMD installation examples to use React 18 packages.
  * Corrected the Recharts bundle filename in the examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->