### PR TITLE
Stop hasDuplicate reporting Object.prototype keys as duplicates

### DIFF
--- a/src/util/DataUtils.ts
+++ b/src/util/DataUtils.ts
@@ -94,14 +94,16 @@ export const hasDuplicate = (ary: ReadonlyArray<unknown>): boolean => {
   }
 
   const len = ary.length;
-  const cache: Record<string, boolean> = {};
+  // A Set rather than an object literal: keys like `constructor` or `toString` are inherited from
+  // Object.prototype, so an object lookup reports them as seen before they have been added.
+  const cache = new Set<string>();
 
   for (let i = 0; i < len; i++) {
-    if (!cache[String(ary[i])]) {
-      cache[String(ary[i])] = true;
-    } else {
+    const key = String(ary[i]);
+    if (cache.has(key)) {
       return true;
     }
+    cache.add(key);
   }
 
   return false;

--- a/test/util/DataUtils.spec.ts
+++ b/test/util/DataUtils.spec.ts
@@ -149,6 +149,21 @@ describe('hasDuplicate', () => {
   it('[1, 12] should return false', () => {
     expect(hasDuplicate([1, 12])).toBe(false);
   });
+
+  it.each(['constructor', 'toString', 'valueOf', 'hasOwnProperty', 'isPrototypeOf', '__proto__'])(
+    'a single %s should return false',
+    key => {
+      expect(hasDuplicate([key])).toBe(false);
+    },
+  );
+
+  it('should still find a duplicate among Object.prototype keys', () => {
+    expect(hasDuplicate(['constructor', 'toString', 'constructor'])).toBe(true);
+  });
+
+  it('should not treat a category named like an Object.prototype key as a duplicate', () => {
+    expect(hasDuplicate(['apples', 'constructor', 'pears'])).toBe(false);
+  });
 });
 
 describe('interpolate', () => {


### PR DESCRIPTION
`hasDuplicate` keeps the values it has already seen in an object literal and asks `if (!cache[key])`. Object literals inherit from `Object.prototype`, so that lookup answers "seen already" for keys nobody added:

```js
hasDuplicate(['constructor'])      // true
hasDuplicate(['toString'])         // true
hasDuplicate(['apples', 'constructor', 'pears'])  // true
```

One element is enough. `constructor`, `toString`, `valueOf`, `hasOwnProperty`, `isPrototypeOf`, `propertyIsEnumerable`, `toLocaleString` and `__proto__` all hit it.

It reaches charts through `axisSelectors`, which calls it in two places to decide whether a category axis really has duplicated categories:

```ts
axisSettings.allowDuplicatedCategory && hasDuplicate(categoricalDomain)
```

So a category axis whose data contains a category named `constructor` takes the duplicate branch even though every category is distinct. Niche in the sense that you need such a category, not niche in the sense that it needs anything unusual otherwise, and a chart about JavaScript itself is a pretty ordinary thing to build.

A `Set` has no inherited keys, so the lookup only answers for values that were actually added. Values are still keyed with `String()`, so nothing else moves: `['12', 12]` still counts as a duplicate, `[{}, {}]` still does, and `[1, 12]` still does not. The three existing assertions cover exactly those and still pass.

Seven added assertions fail on `main` and pass here. `DataUtils.spec.ts` is green at 73, `axisSelectors.spec.tsx` at 116, and eslint, prettier and `tsc --noEmit` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected duplicate detection for values matching built-in object property names.
  * Genuine duplicates continue to be identified accurately.

* **Tests**
  * Added coverage for special property names, including `constructor`, `toString`, and `__proto__`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->