### PR TITLE
fix: preserve treemap navigation history

### DIFF
--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -973,12 +973,12 @@ class TreemapWithState extends PureComponent<InternalTreemapProps, State> {
       const formatRoot = squarify(root, aspectRatio, nodeInset, nodeGap);
 
       const { nestIndex } = this.state;
-      nestIndex.push(node);
+      const nextNestIndex = [...nestIndex, node];
 
       this.setState({
         formatRoot,
         currentRoot: root,
-        nestIndex,
+        nestIndex: nextNestIndex,
       });
     }
     if (onClick) {


### PR DESCRIPTION
## Description

Fix Treemap nested navigation history by avoiding mutation of the existing `nestIndex` state array.

## Related Issue

Fixes #7529

## How Has This Been Tested?

Verified the change with `git diff` and confirmed that the existing `nestIndex` array is no longer mutated directly.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved treemap navigation when opening nested nodes, ensuring selections update reliably without affecting existing navigation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->