### PR TITLE
docs(polygon): add description for Polygon component

### DIFF
--- a/src/shape/Polygon.tsx
+++ b/src/shape/Polygon.tsx
@@ -77,12 +77,26 @@ const getRanglePath = (
 };
 
 interface PolygonProps {
+  /**
+   * The SVG element's class name.
+   */
   className?: string;
+
   /**
    * The coordinates of all the vertexes of the polygon, like an array of objects with x and y coordinates.
    */
   points?: ReadonlyArray<Coordinate>;
+  /**
+   * An optional second set of coordinates. When provided, Polygon fills the
+   * area enclosed between `points` and `baseLinePoints` similar to a data
+   * line and its baseline. If `stroke` is set (and isn't `"none"`), the
+   * outline of `points` and of `baseLinePoints` are also each stroked
+   * separately. Used e.g. by Radar in "range" mode to draw a min/max band.
+   */
   baseLinePoints?: ReadonlyArray<Coordinate>;
+  /**
+   * Whether to connect the curve across null points.
+   */
   connectNulls?: boolean;
 
   /**
@@ -121,6 +135,16 @@ interface PolygonProps {
 
 export type Props = Omit<SVGProps<SVGPolygonElement>, 'points'> & PolygonProps;
 
+/**
+ * Renders a polygon shape from an array of x/y coordinates, closing the
+ * outline into a filled shape by default. If the given points contain a
+ * gap (an invalid or missing coordinate) and `connectNulls` is not set,
+ * the outline is split into separate, unclosed subpaths around that gap
+ * instead of forming a single closed shape. Used internally by polar
+ * components such as Radar and PolarGrid to draw chart shapes. Accepts
+ * standard SVG presentation attributes (e.g. `stroke`, `fill`,
+ * `strokeWidth`) for styling, since it wraps a native SVG path element.
+ */
 export const Polygon: React.FC<Props> = props => {
   const { points, className, baseLinePoints, connectNulls, ...others } = props;
 

--- a/src/shape/Polygon.tsx
+++ b/src/shape/Polygon.tsx
@@ -77,12 +77,25 @@ const getRanglePath = (
 };
 
 interface PolygonProps {
+  /**
+   * The SVG element's class name.
+   */
   className?: string;
+
   /**
    * The coordinates of all the vertexes of the polygon, like an array of objects with x and y coordinates.
    */
   points?: ReadonlyArray<Coordinate>;
+  /**
+   * An optional second set of coordinates. When provided, Polygon fills the
+   * area enclosed between `points` and `baseLinePoints` similar to a data
+   * line and its baseline and strokes each outline separately. Used e.g.
+   * by Radar in "range" mode to draw a min/max band.
+   */
   baseLinePoints?: ReadonlyArray<Coordinate>;
+  /**
+   * Whether to connect the curve across null points.
+   */
   connectNulls?: boolean;
 
   /**
@@ -121,6 +134,13 @@ interface PolygonProps {
 
 export type Props = Omit<SVGProps<SVGPolygonElement>, 'points'> & PolygonProps;
 
+/**
+ * Renders a closed polygon shape from an array of x/y coordinates. Used
+ * internally by polar components such as Radar and PolarGrid to draw
+ * chart shapes. Accepts standard SVG presentation attributes (e.g.
+ * `stroke`, `fill`, `strokeWidth`) for styling, since it wraps a native
+ * SVG path element.
+ */
 export const Polygon: React.FC<Props> = props => {
   const { points, className, baseLinePoints, connectNulls, ...others } = props;
 


### PR DESCRIPTION

## Description

Adds JSDoc descriptions for the Polygon component and its `baseLinePoints`,
`connectNulls`, and `className` props, which were previously undocumented.
The component description also mentions that Polygon accepts standard
SVG presentation attributes (`stroke`, `fill`, etc.) for styling, since
these are inherited from SVGProps and not declared in this file, so they
can't be documented individually via JSDoc.

## Related Issue

Related to #4438

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The Polygon API docs page (recharts.github.io/en-US/api/Polygon) only
listed props with no explanation of what the component does or how to
use it the exact gap called out in #4438. `baseLinePoints` and
`connectNulls` had no description at all in the props table.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Verified behavior of `baseLinePoints` and `connectNulls` using the
existing `UsingBaselinePoints` and `UsingConnectNulls` Storybook stories,
cross-checked against the implementation in `getRanglePath`/`getSinglePolygonPath`.
Ran `npm run omnidoc` and confirmed the new descriptions appear correctly
in the Storybook Controls panel. Also had to adjust the initial wording
for `connectNulls` and `className` to pass the existing
`cross-component-prop-comments` consistency test.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
N/A  text-only documentation change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

(none checked this is a documentation-only change; it doesn't fit
bug fix, new feature, or breaking change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified polygon documentation, including gap handling and the behavior of closed versus unclosed paths.
  * Added detail about when outlines are stroked.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->