### PR TITLE
fix(Treemap): give nest breadcrumbs a stable key

### DIFF
--- a/src/chart/Treemap.tsx
+++ b/src/chart/Treemap.tsx
@@ -9,7 +9,7 @@ import { Polygon } from '../shape/Polygon';
 import { Rectangle } from '../shape/Rectangle';
 import { getValueByDataKey } from '../util/ChartUtils';
 import { COLOR_PANEL } from '../util/Constants';
-import { isNan, noop, uniqueId } from '../util/DataUtils';
+import { isNan, noop } from '../util/DataUtils';
 import { getStringSize } from '../util/DOMUtils';
 import {
   AnimationDuration,
@@ -1078,7 +1078,7 @@ class TreemapWithState extends PureComponent<InternalTreemapProps, State> {
             // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
             <div
               onClick={this.handleNestIndex.bind(this, item, i)}
-              key={`nest-index-${uniqueId()}`}
+              key={`nest-index-${i}-${name}`}
               className="recharts-treemap-nest-index-box"
               style={{
                 cursor: 'pointer',

--- a/test/chart/Treemap.spec.tsx
+++ b/test/chart/Treemap.spec.tsx
@@ -268,6 +268,33 @@ describe('<Treemap />', () => {
     expect(container.querySelectorAll('.recharts-rectangle').length).toBe(initialNodeCount);
   });
 
+  test('keeps the same breadcrumb elements across re-renders', () => {
+    const props = {
+      data: exampleTreemapData,
+      dataKey: 'value',
+      height: 250,
+      isAnimationActive: false,
+      nameKey: 'name',
+      type: 'nest' as const,
+      width: 500,
+    };
+    const { container, getByText, rerender } = render(<Treemap {...props} />);
+
+    fireEvent.click(getByText('A'));
+
+    const before = Array.from(container.querySelectorAll('.recharts-treemap-nest-index-box'));
+    expect(before).toHaveLength(2);
+
+    rerender(<Treemap {...props} />);
+
+    const after = Array.from(container.querySelectorAll('.recharts-treemap-nest-index-box'));
+    expect(after).toHaveLength(2);
+    // React must reuse the nodes rather than unmounting and recreating them: a breadcrumb that is
+    // replaced between mousedown and mouseup never receives the click.
+    expect(after[0]).toBe(before[0]);
+    expect(after[1]).toBe(before[1]);
+  });
+
   test('clicking current root cell in nest mode does not drill repeatedly', () => {
     const { container, getByText } = render(
       <Treemap


### PR DESCRIPTION
## Description

Fixes #7519 — or at least the mechanism I can find behind it. `renderNestIndex` keys each breadcrumb with `uniqueId()`:

```jsx
key={`nest-index-${uniqueId()}`}
```

`uniqueId()` returns a new value every call, so every render produces new keys and React unmounts and recreates all of the breadcrumb elements rather than reusing them.

That matters for clicking. A browser only fires `click` when `mousedown` and `mouseup` land on the same element; if they land on different ones it fires `click` on their common ancestor instead, which here is the wrapper div with no handler. So any render between the two — a tooltip update, a hover, a parent re-render — swaps out the element under the pointer and the click quietly does nothing. That matches the report: the breadcrumb looks clickable, and nothing happens.

Keyed on the breadcrumb's position and name instead, which is stable across renders. The path is ordered and short, so the index is a fine key here.

## Motivation and Context

Beyond the click, the current key means every breadcrumb is torn down and rebuilt on each render, which is wasted work in a component that re-renders on hover.

Being upfront about what I could and couldn't verify: I could not reproduce the failing click in jsdom. `fireEvent.click` dispatches a click directly, so it never exercises the mousedown/mouseup pairing that the remount breaks, and back navigation passes there both before and after this change — I checked drilling two levels and clicking an intermediate breadcrumb, and it returns correctly either way. What I could verify, and what the test covers, is the remount itself. If you can still reproduce the original problem with this applied, it's a different cause and I'd want to keep digging.

One thing I noticed and deliberately left alone: `handleClick` does `nestIndex.push(node)` on the array held in state before passing it to `setState`, so it mutates current state in place. It doesn't cause a visible bug today because `setState` re-renders regardless, but it makes `prevState` unreliable for anything that compares against it. Happy to fix it here or separately if you want.

## How Has This Been Tested?

Added `keeps the same breadcrumb elements across re-renders` next to the existing nest navigation tests. It drills in, captures the breadcrumb elements, re-renders with identical props, and asserts the same DOM nodes come back. It fails on `main` (`expected <div …(2)></div> to be <div …(2)></div>`) and passes with the change.

`Treemap.spec.tsx`, `Treemap.theme.spec.tsx` and `Treemap.typed.spec.tsx` are green (34 tests), `eslint` and `tsc --noEmit` clean.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Treemap breadcrumb stability when navigating into nested nodes and re-rendering.
  * Breadcrumb elements are now preserved correctly instead of being recreated unnecessarily.

* **Tests**
  * Added regression coverage for nested Treemap breadcrumb behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->