### PR TITLE
fix(useElementOffset): prevent measurement feedback loops

### DIFF
--- a/src/util/useElementOffset.ts
+++ b/src/util/useElementOffset.ts
@@ -133,14 +133,5 @@ export function useElementOffset(extraDependencies: ReadonlyArray<unknown> = [])
 
   useEffect(measureElement, [measureElement, ...extraDependencies]);
 
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      observerRef.current?.disconnect();
-      observerRef.current = null;
-      elementRef.current = null;
-    };
-  }, []);
-
   return [lastBoundingBox, updateBoundingBox];
 }

--- a/src/util/useElementOffset.ts
+++ b/src/util/useElementOffset.ts
@@ -50,19 +50,14 @@ export type ElementOffset = {
 export type SetElementOffset = (node: HTMLElement | null) => void;
 
 /**
- * Checks whether two ElementOffset values differ by more than `EPS` (1px) in any dimension.
+ * Checks whether two ElementOffset sizes differ by more than `EPS` (1px).
  *
  * @param a - the first ElementOffset to compare
  * @param b - the second ElementOffset to compare
- * @returns true if any dimension differs by more than 1px
+ * @returns true if width or height differs by more than 1px
  */
-function hasSignificantChange(a: ElementOffset, b: ElementOffset): boolean {
-  return (
-    Math.abs(a.height - b.height) > EPS ||
-    Math.abs(a.left - b.left) > EPS ||
-    Math.abs(a.top - b.top) > EPS ||
-    Math.abs(a.width - b.width) > EPS
-  );
+function hasSignificantSizeChange(a: ElementOffset, b: ElementOffset): boolean {
+  return Math.abs(a.height - b.height) > EPS || Math.abs(a.width - b.width) > EPS;
 }
 
 /**
@@ -82,9 +77,10 @@ function readElementOffset(node: HTMLElement): ElementOffset {
 }
 
 /**
- * Use this to listen to element layout changes.
+ * Use this to listen to element size changes.
  *
- * Very useful for reading actual sizes of DOM elements relative to the viewport.
+ * Very useful for reading actual sizes of DOM elements. The returned position is a snapshot from the last size change;
+ * position changes alone do not update the returned value.
  *
  * Uses ResizeObserver to automatically detect size changes of the observed element.
  *
@@ -94,45 +90,55 @@ function readElementOffset(node: HTMLElement): ElementOffset {
 export function useElementOffset(extraDependencies: ReadonlyArray<unknown> = []): [ElementOffset, SetElementOffset] {
   const [lastBoundingBox, setLastBoundingBox] = useState<ElementOffset>({ height: 0, left: 0, top: 0, width: 0 });
   const observerRef = useRef<ResizeObserver | null>(null);
+  const elementRef = useRef<HTMLElement | null>(null);
   const lastBoundingBoxRef = useRef(lastBoundingBox);
-  lastBoundingBoxRef.current = lastBoundingBox;
+
+  const measureElement = useCallback(() => {
+    const node = elementRef.current;
+    if (node == null) {
+      return;
+    }
+
+    const box = readElementOffset(node);
+    if (hasSignificantSizeChange(box, lastBoundingBoxRef.current)) {
+      lastBoundingBoxRef.current = box;
+      setLastBoundingBox(box);
+    }
+  }, []);
 
   const updateBoundingBox = useCallback(
     (node: HTMLElement | null) => {
+      elementRef.current = node;
+
       // Disconnect any previously active ResizeObserver
-      if (observerRef.current != null) {
-        observerRef.current.disconnect();
-        observerRef.current = null;
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+
+      if (node == null) {
+        return;
       }
 
-      if (node != null) {
-        // Measure immediately on ref attach
-        const box = readElementOffset(node);
-        if (hasSignificantChange(box, lastBoundingBoxRef.current)) {
-          setLastBoundingBox(box);
-        }
+      // Measure immediately on ref attach
+      measureElement();
 
-        // Set up ResizeObserver for future size changes
-        if (typeof ResizeObserver !== 'undefined') {
-          const observer = new ResizeObserver(() => {
-            const newBox = readElementOffset(node);
-            if (hasSignificantChange(newBox, lastBoundingBoxRef.current)) {
-              setLastBoundingBox(newBox);
-            }
-          });
-          observer.observe(node);
-          observerRef.current = observer;
-        }
+      // Set up ResizeObserver for future size changes
+      if (typeof ResizeObserver !== 'undefined') {
+        const observer = new ResizeObserver(measureElement);
+        observer.observe(node);
+        observerRef.current = observer;
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [...extraDependencies],
+    [measureElement],
   );
+
+  useEffect(measureElement, [measureElement, ...extraDependencies]);
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
       observerRef.current?.disconnect();
+      observerRef.current = null;
+      elementRef.current = null;
     };
   }, []);
 

--- a/test/util/useElementOffset.spec.tsx
+++ b/test/util/useElementOffset.spec.tsx
@@ -1,17 +1,32 @@
+import React, { StrictMode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, renderHook } from '@testing-library/react';
+import { act, render, renderHook, screen } from '@testing-library/react';
 import { useElementOffset } from '../../src/util/useElementOffset';
 import { getMockDomRect } from '../helper/mockGetBoundingClientRect';
+
+function ElementOffsetTest({ dependency }: { dependency: string }) {
+  const [offset, updateOffset] = useElementOffset([dependency]);
+
+  return (
+    <div data-testid="measured-element" data-width={offset.width} data-height={offset.height} ref={updateOffset} />
+  );
+}
 
 describe('useElementOffset', () => {
   let resizeObserverCallback: (() => void) | undefined,
     observeSpy: ReturnType<typeof vi.fn>,
-    disconnectSpy: ReturnType<typeof vi.fn>;
+    disconnectSpy: ReturnType<typeof vi.fn>,
+    resizeObserverIsActive: boolean;
 
   beforeEach(() => {
     resizeObserverCallback = undefined;
-    observeSpy = vi.fn();
-    disconnectSpy = vi.fn();
+    resizeObserverIsActive = false;
+    observeSpy = vi.fn(() => {
+      resizeObserverIsActive = true;
+    });
+    disconnectSpy = vi.fn(() => {
+      resizeObserverIsActive = false;
+    });
     vi.stubGlobal(
       'ResizeObserver',
       vi.fn(function ResizeObserverMock(cb: () => void) {
@@ -20,6 +35,12 @@ describe('useElementOffset', () => {
       }),
     );
   });
+
+  const triggerResizeObserver = () => {
+    if (resizeObserverIsActive) {
+      resizeObserverCallback?.();
+    }
+  };
 
   it('should return initial zero values', () => {
     const { result } = renderHook(() => useElementOffset());
@@ -65,7 +86,7 @@ describe('useElementOffset', () => {
     expect(result.current[0].height).toBe(50);
 
     act(() => {
-      resizeObserverCallback?.();
+      triggerResizeObserver();
     });
     expect(result.current[0].height).toBe(120);
   });
@@ -83,7 +104,7 @@ describe('useElementOffset', () => {
     expect(result.current[0].height).toBe(50);
 
     act(() => {
-      resizeObserverCallback?.();
+      triggerResizeObserver();
     });
     // Height change of 0.5 is below EPS=1, should not update
     expect(result.current[0].height).toBe(50);
@@ -103,43 +124,47 @@ describe('useElementOffset', () => {
     const initialOffset = result.current[0];
 
     act(() => {
-      resizeObserverCallback?.();
+      triggerResizeObserver();
     });
 
     expect(getBoundingClientRect).toHaveBeenCalledTimes(2);
     expect(result.current[0]).toBe(initialOffset);
   });
 
-  it('should keep the ref callback stable when an extra dependency changes', () => {
-    const { result, rerender } = renderHook(({ dependency }) => useElementOffset([dependency]), {
-      initialProps: { dependency: 'before' },
-    });
-    const initialRefCallback = result.current[1];
-
-    rerender({ dependency: 'after' });
-
-    expect(result.current[1]).toBe(initialRefCallback);
-  });
-
-  it('should remeasure the current node without recreating its observer when an extra dependency changes', () => {
-    const node = document.createElement('div');
+  it('should remeasure the attached node without recreating its observer when an extra dependency changes', () => {
     let currentRect = getMockDomRect({ width: 100, height: 50 });
-    vi.spyOn(node, 'getBoundingClientRect').mockImplementation(() => currentRect);
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => currentRect);
 
-    const { result, rerender } = renderHook(({ dependency }) => useElementOffset([dependency]), {
-      initialProps: { dependency: 'before' },
-    });
-    act(() => {
-      result.current[1](node);
-    });
-    expect(result.current[0]).toEqual({ width: 100, height: 50, left: 0, top: 0 });
+    const { rerender } = render(<ElementOffsetTest dependency="before" />);
+    expect(screen.getByTestId('measured-element')).toHaveAttribute('data-width', '100');
+    expect(screen.getByTestId('measured-element')).toHaveAttribute('data-height', '50');
 
     currentRect = getMockDomRect({ width: 200, height: 80 });
-    rerender({ dependency: 'after' });
+    rerender(<ElementOffsetTest dependency="after" />);
 
-    expect(result.current[0]).toEqual({ width: 200, height: 80, left: 0, top: 0 });
+    expect(screen.getByTestId('measured-element')).toHaveAttribute('data-width', '200');
+    expect(screen.getByTestId('measured-element')).toHaveAttribute('data-height', '80');
     expect(observeSpy).toHaveBeenCalledTimes(1);
     expect(disconnectSpy).not.toHaveBeenCalled();
+  });
+
+  it('should keep observing size changes after Strict Mode replays effects', () => {
+    let currentRect = getMockDomRect({ width: 100, height: 50 });
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => currentRect);
+
+    render(
+      <StrictMode>
+        <ElementOffsetTest dependency="dependency" />
+      </StrictMode>,
+    );
+    currentRect = getMockDomRect({ width: 200, height: 80 });
+
+    act(() => {
+      triggerResizeObserver();
+    });
+
+    expect(screen.getByTestId('measured-element')).toHaveAttribute('data-width', '200');
+    expect(screen.getByTestId('measured-element')).toHaveAttribute('data-height', '80');
   });
 
   it('should not create a ResizeObserver when node is null', () => {
@@ -171,16 +196,14 @@ describe('useElementOffset', () => {
   });
 
   it('should disconnect the ResizeObserver on unmount', () => {
-    const node = document.createElement('div');
-    vi.spyOn(node, 'getBoundingClientRect').mockReturnValue(getMockDomRect({ width: 100, height: 50 }));
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(
+      getMockDomRect({ width: 100, height: 50 }),
+    );
 
-    const { result, unmount } = renderHook(() => useElementOffset());
-    act(() => {
-      result.current[1](node);
-    });
+    const { unmount } = render(<ElementOffsetTest dependency="dependency" />);
 
     unmount();
-    expect(disconnectSpy).toHaveBeenCalled();
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should disconnect the previous observer when node is set to null', () => {

--- a/test/util/useElementOffset.spec.tsx
+++ b/test/util/useElementOffset.spec.tsx
@@ -4,7 +4,7 @@ import { useElementOffset } from '../../src/util/useElementOffset';
 import { getMockDomRect } from '../helper/mockGetBoundingClientRect';
 
 describe('useElementOffset', () => {
-  let resizeObserverCallback: ((entries: ResizeObserverEntry[]) => void) | undefined,
+  let resizeObserverCallback: (() => void) | undefined,
     observeSpy: ReturnType<typeof vi.fn>,
     disconnectSpy: ReturnType<typeof vi.fn>;
 
@@ -14,7 +14,7 @@ describe('useElementOffset', () => {
     disconnectSpy = vi.fn();
     vi.stubGlobal(
       'ResizeObserver',
-      vi.fn(function ResizeObserverMock(cb: (entries: ResizeObserverEntry[]) => void) {
+      vi.fn(function ResizeObserverMock(cb: () => void) {
         resizeObserverCallback = cb;
         return { observe: observeSpy, unobserve: vi.fn(), disconnect: disconnectSpy };
       }),
@@ -65,7 +65,7 @@ describe('useElementOffset', () => {
     expect(result.current[0].height).toBe(50);
 
     act(() => {
-      resizeObserverCallback?.([] as unknown as ResizeObserverEntry[]);
+      resizeObserverCallback?.();
     });
     expect(result.current[0].height).toBe(120);
   });
@@ -83,10 +83,63 @@ describe('useElementOffset', () => {
     expect(result.current[0].height).toBe(50);
 
     act(() => {
-      resizeObserverCallback?.([] as unknown as ResizeObserverEntry[]);
+      resizeObserverCallback?.();
     });
     // Height change of 0.5 is below EPS=1, should not update
     expect(result.current[0].height).toBe(50);
+  });
+
+  it('should ignore position-only changes', () => {
+    const node = document.createElement('div');
+    const getBoundingClientRect = vi
+      .spyOn(node, 'getBoundingClientRect')
+      .mockReturnValueOnce(getMockDomRect({ width: 100, height: 50, left: 10, top: 20 }))
+      .mockReturnValue(getMockDomRect({ width: 100, height: 50, left: 110, top: 220 }));
+
+    const { result } = renderHook(() => useElementOffset());
+    act(() => {
+      result.current[1](node);
+    });
+    const initialOffset = result.current[0];
+
+    act(() => {
+      resizeObserverCallback?.();
+    });
+
+    expect(getBoundingClientRect).toHaveBeenCalledTimes(2);
+    expect(result.current[0]).toBe(initialOffset);
+  });
+
+  it('should keep the ref callback stable when an extra dependency changes', () => {
+    const { result, rerender } = renderHook(({ dependency }) => useElementOffset([dependency]), {
+      initialProps: { dependency: 'before' },
+    });
+    const initialRefCallback = result.current[1];
+
+    rerender({ dependency: 'after' });
+
+    expect(result.current[1]).toBe(initialRefCallback);
+  });
+
+  it('should remeasure the current node without recreating its observer when an extra dependency changes', () => {
+    const node = document.createElement('div');
+    let currentRect = getMockDomRect({ width: 100, height: 50 });
+    vi.spyOn(node, 'getBoundingClientRect').mockImplementation(() => currentRect);
+
+    const { result, rerender } = renderHook(({ dependency }) => useElementOffset([dependency]), {
+      initialProps: { dependency: 'before' },
+    });
+    act(() => {
+      result.current[1](node);
+    });
+    expect(result.current[0]).toEqual({ width: 100, height: 50, left: 0, top: 0 });
+
+    currentRect = getMockDomRect({ width: 200, height: 80 });
+    rerender({ dependency: 'after' });
+
+    expect(result.current[0]).toEqual({ width: 200, height: 80, left: 0, top: 0 });
+    expect(observeSpy).toHaveBeenCalledTimes(1);
+    expect(disconnectSpy).not.toHaveBeenCalled();
   });
 
   it('should not create a ResizeObserver when node is null', () => {


### PR DESCRIPTION
## Description

Stabilize element measurements used by Tooltip and Legend.

- Keep the callback ref returned by `useElementOffset` stable when its extra dependencies change.
- Remeasure the currently attached element from an effect when those dependencies change, without detaching the ref or recreating its `ResizeObserver`.
- Only publish changes to width and height. Position-only changes from `getBoundingClientRect()` are ignored because current consumers only use the measured size.
- Keep observer setup and teardown within the callback-ref lifecycle. This ensures the observer remains active when Strict Mode replays effects while still disconnecting it when the element is detached or unmounted.
- Add regression tests covering position-only changes, dependency-driven measurements, observer reuse, Strict Mode, and unmount cleanup.

## Related Issue

Related to #6847 and #7463.

This complements #7474, which addresses portal state updates during React 19 Suspense cleanup. This PR addresses the separate element-measurement feedback path.

## Motivation and Context

`Tooltip` and `Legend` pass dynamic values such as payload and active state to `useElementOffset`.

Previously, those values were dependencies of the callback ref itself. When a dependency changed, React received a new ref callback and detached and reattached the DOM ref. That disconnected and recreated the `ResizeObserver` and performed another measurement.

The hook also treated changes to `left` and `top` as state changes. Because `getBoundingClientRect()` includes transforms, a moving Tooltip could report a different position even when its size had not changed. Publishing that position caused another render and could create a measurement feedback loop.

This was especially problematic when charts were hidden and revealed through React 19 Suspense, and it is also related to Tooltip movement in Safari.

The ref callback is now stable. Dependency changes explicitly remeasure the attached element, and state is updated only when width or height changes.

## How Has This Been Tested?

Added and updated unit tests for `useElementOffset` covering:

- Position-only bounding-box changes do not publish new state.
- Changing an extra dependency remeasures the attached element.
- Dependency changes do not detach the ref or recreate its `ResizeObserver`.
- Size changes continue to be reported after Strict Mode replays effects.
- The observer is disconnected when the DOM element unmounts.
- Existing ResizeObserver lifecycle and EPS threshold behavior remains unchanged.

Validation performed with Node.js 24 and the repository's React 18.3.1 test environment:

- Full build completed successfully.
- 13 build-output tests passed.
- 339 unit-test files passed.
- 16,602 unit tests passed.
- All TypeScript projects passed.
- ESLint completed with no errors.

## Screenshots (if appropriate):

Not applicable. This change affects measurement lifecycle behavior and does not intentionally change chart appearance.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Size tracking now responds only to element width and height changes, ignoring position-only movement.
  * Measurements refresh when dependencies change and when an element is attached.
  * Observation continues reliably through component updates and Strict Mode behavior.
  * Observer cleanup is handled correctly when elements change or are removed.

* **Documentation**
  * Clarified that the hook tracks size changes and records position snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->