### PR TITLE
docs(brush): add descriptions for Brush props

### DIFF
--- a/omnidoc/commentSimilarityExceptions.ts
+++ b/omnidoc/commentSimilarityExceptions.ts
@@ -65,6 +65,12 @@ export const commentSimilarityExceptions: ReadonlyArray<CommentSimilarityGroup> 
     reason: 'Brush width defaults to chart width, unlike other components',
   },
   {
+    components: ['Brush'],
+    props: ['padding'],
+    reason:
+      'Brush padding applies only to the small overview chart rendered inside the brush, unlike axis padding which is distance from the plot area edge to the first/last tick',
+  },
+  {
     components: ['ErrorBar'],
     props: ['width'],
     reason: 'ErrorBar width describes the width of the serifs, not the whole component',

--- a/src/cartesian/Brush.tsx
+++ b/src/cartesian/Brush.tsx
@@ -55,14 +55,24 @@ export interface BrushProps<DataPointType = any, DataValueType = any> extends Da
    * If left undefined, it will be computed from the chart's offset and margins.
    */
   y?: number;
+  /**
+   * Vertical offset added to the brush's computed y-coordinate.
+   */
   dy?: number;
   /**
    * Width of the brush in pixels.
    * If undefined, defaults to the chart width.
    */
   width?: number;
+  /**
+   * The SVG element's class name.
+   */
   className?: string;
-
+  /**
+   * Custom accessible label applied to the brush's traveller handles. If
+   * not provided, one is generated automatically from the data at the
+   * current start and end index.
+   */
   ariaLabel?: string;
 
   /**
@@ -77,6 +87,11 @@ export interface BrushProps<DataPointType = any, DataValueType = any> extends Da
    * @defaultValue 5
    */
   travellerWidth?: number;
+  /**
+   * Custom element or render function used to render each draggable handle
+   * (the "traveller") at the start and end of the selection. Defaults to a
+   * small rectangle with two vertical lines.
+   */
   traveller?: BrushTravellerType;
   /**
    * Number of data points to skip between chart refreshes.
@@ -84,6 +99,13 @@ export interface BrushProps<DataPointType = any, DataValueType = any> extends Da
    * @defaultValue 1
    */
   gap?: number;
+  /**
+   * Padding applied only to the small overview chart rendered inside the
+   * brush (via `children`) has no effect on the brush's own position or
+   * size.
+   *
+   * @defaultValue {"top":1,"right":1,"bottom":1,"left":1}
+   */
   padding?: Padding;
   /**
    * The default start index of brush.
@@ -99,18 +121,33 @@ export interface BrushProps<DataPointType = any, DataValueType = any> extends Da
    * The formatter function of ticks.
    */
   tickFormatter?: BrushTickFormatter;
-
+  /**
+   * A single chart element (e.g. an AreaChart) rendered as a small preview
+   * inside the brush, showing an overview of the full dataset. If zero or
+   * more than one child is passed, nothing is rendered.
+   */
   children?: ReactElement;
   /**
    * The handler of changing the active scope of brush.
    */
   onChange?: OnBrushUpdate;
+  /**
+   * The handler called when the user finishes dragging a traveller or the
+   * brush slide, receiving the final startIndex and endIndex.
+   */
   onDragEnd?: OnBrushUpdate;
   /**
+   * Delay, in milliseconds, after the mouse leaves the brush, before an
+   * in-progress drag interaction is ended.
+   *
    * @defaultValue 1000
    */
   leaveTimeOut?: number;
   /**
+   * When true, the start and end index labels are always visible. By
+   * default, they only appear while the user is interacting with the brush
+   * (dragging, hovering, or focused via keyboard).
+   *
    * @defaultValue false
    */
   alwaysShowText?: boolean;


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->

Adds JSDoc descriptions for `dy`, `className`, `ariaLabel`, `traveller`,
`padding`, `leaveTimeOut`, `alwaysShowText`, `children`, and `onDragEnd`
on the Brush component, which were previously undocumented. The
component-level description was already present and accurate, so left
unchanged.

Also adds a `commentSimilarityExceptions` entry for Brush's `padding`
prop it refers to spacing around the brush's internal overview chart,
unlike axis padding (distance from the plot area edge to the first/last
tick) needed to pass the `cross-component-prop-comments` consistency
test.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Related to #4438

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
9 out of 13 props on Brush had no description at all in the generated
props table, part of the same gap called out in #4438 (already
addressed for Polygon in a separate PR).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified each prop's behavior directly against the Brush.tsx source
(state updates, handlers, defaultBrushProps) rather than assuming from
naming alone for example confirmed `padding` only affects the internal
overview chart by checking `brushSelectors.ts`, and corrected an initial
wrong assumption about `children` behavior by reading `Children.only`
usage in `Panorama`. Ran `npm run omnidoc` and confirmed all 9
descriptions appear in the Storybook Controls panel. Ran
`omnidoc.spec.ts` and `cross-component-prop-comments.spec.ts` locally 
both pass.

## Screenshots (if appropriate):
N/A  text-only documentation change.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

(none checked documentation-only change, doesn't fit bug fix, new
feature, or breaking change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for Brush properties, including padding, accessibility labels, styling, interaction callbacks, spacing, and display behavior.
  * Documented the distinct padding behavior used by the overview chart.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->