### PR TITLE
[docs] On website display link to all SVG props each component accepts

### DIFF
--- a/omnidoc/generateApiDoc.spec.ts
+++ b/omnidoc/generateApiDoc.spec.ts
@@ -233,4 +233,9 @@ describe('generateApiDoc', () => {
     expect(simpleAreaChart).toBeDefined();
     expect(simpleAreaChart?.name).toBe('Simple Area Chart');
   });
+
+  it('should include the inherited SVG element in API metadata', async () => {
+    const apiDoc = await generateApiDoc('Bar', reader, exampleReader, contextMap, { allExports });
+    expect(apiDoc.svgParent).toBe('SVGPathElement');
+  });
 });

--- a/omnidoc/generateApiDoc.ts
+++ b/omnidoc/generateApiDoc.ts
@@ -454,6 +454,7 @@ async function generateApiDoc(
   const apiDoc: ApiDoc = {
     name: componentName,
     props,
+    svgParent: projectReader.getSVGParentOf(componentName) ?? undefined,
   };
 
   if (!componentNames.includes(componentName)) {
@@ -536,7 +537,13 @@ function stringifyLocalizedRichText(value: Partial<Record<string, string>>): str
 }
 
 function stringifyApiDoc(apiDoc: ApiDoc): string {
-  let result = `{"name": "${apiDoc.name}","props": [`;
+  let result = `{"name": "${apiDoc.name}",`;
+
+  if (apiDoc.svgParent) {
+    result += `"svgParent": ${JSON.stringify(apiDoc.svgParent)},`;
+  }
+
+  result += `"props": [`;
 
   apiDoc.props.forEach(prop => {
     result += `{`;

--- a/omnidoc/readProject.spec.ts
+++ b/omnidoc/readProject.spec.ts
@@ -902,6 +902,14 @@ describe('readProject', () => {
     expect(reader.getSVGParentOf('ReferenceLine')).toBe('SVGLineElement');
   });
 
+  it('should resolve SVG components through nested aliases and interfaces', () => {
+    expect(reader.getSVGParentOf('Area')).toBe('SVGPathElement');
+    expect(reader.getSVGParentOf('Line')).toBe('SVGPathElement');
+    expect(reader.getSVGParentOf('Bar')).toBe('SVGPathElement');
+    expect(reader.getSVGParentOf('ReferenceArea')).toBe('SVGPathElement');
+    expect(reader.getSVGParentOf('Cell')).toBe('SVGElement');
+  });
+
   it('should get default value of a prop', () => {
     expect(reader.getDefaultValueOf('ReferenceLine', 'position')).toEqual({ type: 'known', value: 'middle' });
   });

--- a/omnidoc/readProject.ts
+++ b/omnidoc/readProject.ts
@@ -10,6 +10,7 @@ import {
   Symbol as TsMorphSymbol,
   SymbolFlags,
   Type,
+  TypeNode,
 } from 'ts-morph';
 import { isReactComponent } from './isReactComponent';
 import { DefaultValue, DocReader } from './DocReader';
@@ -401,33 +402,102 @@ export class ProjectDocReader implements DocReader {
     return properties.filter(p => p.name === prop);
   }
 
-  private extractSVGElementFromType(type: Type | undefined): string | null {
+  private extractSVGElementFromTypeNode(
+    typeNode: TypeNode | undefined,
+    visitedTypes: Set<Type>,
+    visitedDeclarations: Set<Node>,
+  ): string | null {
+    if (!typeNode) {
+      return null;
+    }
+
+    if (Node.isTypeReference(typeNode)) {
+      const typeResult = this.extractSVGElementFromType(typeNode.getType(), visitedTypes, visitedDeclarations);
+      if (typeResult) return typeResult;
+
+      for (const typeArgument of typeNode.getTypeArguments()) {
+        const argumentResult = this.extractSVGElementFromTypeNode(typeArgument, visitedTypes, visitedDeclarations);
+        if (argumentResult) return argumentResult;
+      }
+    } else if (Node.isIntersectionTypeNode(typeNode) || Node.isUnionTypeNode(typeNode)) {
+      for (const childTypeNode of typeNode.getTypeNodes()) {
+        const childResult = this.extractSVGElementFromTypeNode(childTypeNode, visitedTypes, visitedDeclarations);
+        if (childResult) return childResult;
+      }
+    } else if (Node.isParenthesizedTypeNode(typeNode)) {
+      return this.extractSVGElementFromTypeNode(typeNode.getTypeNode(), visitedTypes, visitedDeclarations);
+    }
+
+    return null;
+  }
+
+  private extractSVGElementFromType(
+    type: Type | undefined,
+    visitedTypes: Set<Type> = new Set(),
+    visitedDeclarations: Set<Node> = new Set(),
+  ): string | null {
     if (!type) {
       return null;
     }
-    // Handle intersection types
+
+    if (visitedTypes.has(type)) {
+      return null;
+    }
+    visitedTypes.add(type);
+
+    const svgElementMatch = type.getText().match(/\b(SVG[A-Za-z]*Element)\b/);
+    if (svgElementMatch) {
+      return svgElementMatch[1] ?? null;
+    }
+
+    // Handle intersection and union types.
     if (type.isIntersection()) {
       for (const intersectionType of type.getIntersectionTypes()) {
-        const result = this.extractSVGElementFromType(intersectionType);
+        const result = this.extractSVGElementFromType(intersectionType, visitedTypes, visitedDeclarations);
+        if (result) return result;
+      }
+    }
+    if (type.isUnion()) {
+      for (const unionType of type.getUnionTypes()) {
+        const result = this.extractSVGElementFromType(unionType, visitedTypes, visitedDeclarations);
         if (result) return result;
       }
     }
 
-    // Check if this is a type reference
-    const typeNode = type.getSymbol()?.getDeclarations()?.[0];
-    if (typeNode) {
-      const typeText = type.getText();
+    // Follow instantiated type arguments, which is needed for aliases such as
+    // SVGPropsAndEvents<RectangleProps>.
+    for (const typeArgument of type.getAliasTypeArguments()) {
+      const result = this.extractSVGElementFromType(typeArgument, visitedTypes, visitedDeclarations);
+      if (result) return result;
+    }
 
-      // Look for SVGProps<SVGXxxElement> pattern
-      const svgPropsMatch = typeText.match(/SVGProps<(SVG\w+Element)>/);
-      if (svgPropsMatch) {
-        return svgPropsMatch[1];
+    // Follow local type aliases and interface inheritance without inspecting
+    // interface members, where SVG element types may only be used as callback
+    // parameters or custom shape types.
+    const typeSymbol = type.getAliasSymbol() ?? type.getSymbol();
+    for (const declaration of typeSymbol?.getDeclarations() ?? []) {
+      if (visitedDeclarations.has(declaration)) {
+        continue;
       }
+      visitedDeclarations.add(declaration);
 
-      // Look for Omit<SVGProps<SVGXxxElement>, ...> pattern
-      const omitMatch = typeText.match(/Omit<[^,]*SVGProps<(SVG\w+Element)>/);
-      if (omitMatch) {
-        return omitMatch[1];
+      if (Node.isTypeAliasDeclaration(declaration)) {
+        const typeNode = declaration.getTypeNode();
+        const aliasSvgElementMatch = typeNode?.getText().match(/\b(SVG[A-Za-z]*Element)\b/);
+        if (aliasSvgElementMatch) {
+          return aliasSvgElementMatch[1] ?? null;
+        }
+
+        const result = this.extractSVGElementFromType(typeNode?.getType(), visitedTypes, visitedDeclarations);
+        if (result) return result;
+
+        const nodeResult = this.extractSVGElementFromTypeNode(typeNode, visitedTypes, visitedDeclarations);
+        if (nodeResult) return nodeResult;
+      } else if (Node.isInterfaceDeclaration(declaration)) {
+        for (const extendedType of declaration.getExtends()) {
+          const result = this.extractSVGElementFromType(extendedType.getType(), visitedTypes, visitedDeclarations);
+          if (result) return result;
+        }
       }
     }
 

--- a/www/src/docs/api/types.ts
+++ b/www/src/docs/api/types.ts
@@ -23,6 +23,7 @@ export type ApiDoc = {
   name: string;
   desc?: string | Partial<Record<SupportedLocale, ReactNode>>;
   props: ReadonlyArray<ApiProps>;
+  svgParent?: string;
   returnValue?: string;
   returnDesc?: string | Partial<Record<SupportedLocale, ReactNode>>;
   parentComponents?: ReadonlyArray<string>;

--- a/www/src/views/APIView.css
+++ b/www/src/views/APIView.css
@@ -62,6 +62,10 @@
     }
   }
 
+  .svg-props-note {
+    line-height: 1.5;
+  }
+
   .props-list {
     .props-item {
       border-bottom: 1px solid #f5f5f5;

--- a/www/src/views/APIViewNew.tsx
+++ b/www/src/views/APIViewNew.tsx
@@ -39,6 +39,8 @@ function PropsExamples({ examples, locale }: PropsExamplesProps) {
 type PropsListProps = {
   props: ReadonlyArray<ApiProps>;
   locale: SupportedLocale;
+  componentName: string;
+  svgParent?: string;
 };
 
 type PropsSection = 'current' | 'deprecated' | 'events';
@@ -75,10 +77,60 @@ type PropsSectionProps = {
   section: PropsSection;
   isExpanded: boolean;
   onToggle: (section: PropsSection) => void;
+  componentName?: string;
+  svgAttributeTarget?: SvgAttributeTarget;
 };
 
-function PropsSection({ entries, locale, section, isExpanded, onToggle }: PropsSectionProps) {
-  if (entries.length === 0) {
+type SvgAttributeTarget = {
+  linkText: string;
+  suffix: string;
+  url: string;
+};
+
+function getSvgAttributeTarget(svgParent: string): SvgAttributeTarget {
+  if (svgParent === 'SVGElement') {
+    return {
+      linkText: 'SVG attributes',
+      suffix: '',
+      url: 'https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute',
+    };
+  }
+
+  if (svgParent === 'SVGGraphicsElement') {
+    return {
+      linkText: 'graphics',
+      suffix: ' SVG attributes',
+      url: 'https://developer.mozilla.org/en-US/docs/Web/API/SVGGraphicsElement',
+    };
+  }
+
+  const elementName = /^SVG(.+)Element$/.exec(svgParent)?.[1];
+  if (!elementName) {
+    return {
+      linkText: svgParent,
+      suffix: ' SVG attributes',
+      url: 'https://developer.mozilla.org/en-US/docs/Web/SVG',
+    };
+  }
+
+  const tagName = elementName === 'SVG' ? 'svg' : elementName.charAt(0).toLowerCase() + elementName.slice(1);
+  return {
+    linkText: tagName,
+    suffix: ' SVG attributes',
+    url: `https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/${tagName}`,
+  };
+}
+
+function PropsSection({
+  entries,
+  locale,
+  section,
+  isExpanded,
+  onToggle,
+  componentName,
+  svgAttributeTarget,
+}: PropsSectionProps) {
+  if (entries.length === 0 && !svgAttributeTarget) {
     return null;
   }
 
@@ -91,7 +143,16 @@ function PropsSection({ entries, locale, section, isExpanded, onToggle }: PropsS
           <i className="expander">{isExpanded ? 'Click to collapse' : 'Click to expand'}</i>
         </button>
       </h4>
-      {isExpanded ? (
+      {svgAttributeTarget && componentName ? (
+        <p className="svg-props-note">
+          {componentName} also accepts all{' '}
+          <a href={svgAttributeTarget.url} target="_blank" rel="noreferrer">
+            {svgAttributeTarget.linkText}
+          </a>
+          {svgAttributeTarget.suffix}.
+        </p>
+      ) : null}
+      {isExpanded && entries.length > 0 ? (
         <ul className="props-list" id={sectionId}>
           {entries.map((entry: ApiProps) => (
             <li className="props-item" key={entry.name} id={entry.name}>
@@ -147,7 +208,7 @@ function PropsSection({ entries, locale, section, isExpanded, onToggle }: PropsS
   );
 }
 
-function PropsList({ props, locale }: PropsListProps) {
+function PropsList({ props, locale, componentName, svgParent }: PropsListProps) {
   const [expandedSections, setExpandedSections] = useState(getInitialExpandedSections);
   const toggleSection = (section: PropsSection) => {
     setExpandedSections(previousSections => {
@@ -161,13 +222,14 @@ function PropsList({ props, locale }: PropsListProps) {
     });
   };
 
-  if (!props.length) {
+  if (!props.length && !svgParent) {
     return null;
   }
 
   const currentProps = props.filter(prop => !prop.deprecated && !prop.name.startsWith('on'));
   const deprecatedProps = props.filter(prop => prop.deprecated);
   const events = props.filter(prop => !prop.deprecated && prop.name.startsWith('on'));
+  const svgAttributeTarget = svgParent ? getSvgAttributeTarget(svgParent) : undefined;
 
   return (
     <>
@@ -177,6 +239,8 @@ function PropsList({ props, locale }: PropsListProps) {
         section="current"
         isExpanded={expandedSections.current}
         onToggle={toggleSection}
+        componentName={componentName}
+        svgAttributeTarget={svgAttributeTarget}
       />
       <PropsSection
         entries={deprecatedProps}
@@ -346,7 +410,7 @@ function APIViewNewImpl({ params }: APIViewNewImplProps) {
           </div>
         )}
 
-        <PropsList props={api && api.props} locale={locale} />
+        <PropsList props={api && api.props} locale={locale} componentName={api.name} svgParent={api.svgParent} />
       </div>
     </div>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - API documentation now identifies inherited SVG element types for components.
  - SVG attributes are displayed with links when components have no regular props or alongside existing props.
  - Empty properties sections are hidden while relevant SVG attribute notes remain visible.

- **Bug Fixes**
  - Improved SVG parent detection across aliases, inherited interfaces, unions, and nested type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->