### PR TITLE
chore(eslint): remove stale bundle-viz ignore, ignore .claude dir

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,8 +42,8 @@ const customIgnores = [
     ignores: ['./www/docs'],
   },
   {
-    name: 'bundle-viz',
-    ignores: ['./bundle-viz'],
+    name: 'claude',
+    ignores: ['.claude', '**/CLAUDE.local.md', '**/*.claude-checkpoint'],
   },
 ];
 


### PR DESCRIPTION
## Summary
- Remove the `bundle-viz` ignore from `eslint.config.mjs` since that folder no longer exists
- Add ignores for the `.claude` directory and other Claude-related temporary files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality checks to exclude Claude-related configuration and checkpoint files.
  * Removed the previous exclusion for bundle visualization files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->