### PR TITLE
fix(Tooltip): render RadialBar cursor for defaultIndex (#7672)

### DIFF
--- a/src/state/selectors/combiners/combineCoordinateForDefaultIndex.ts
+++ b/src/state/selectors/combiners/combineCoordinateForDefaultIndex.ts
@@ -1,4 +1,11 @@
-import { ChartOffsetInternal, Coordinate, LayoutType, TickItem } from '../../../util/types';
+import {
+  ChartOffsetInternal,
+  Coordinate,
+  LayoutType,
+  PolarCoordinate,
+  PolarViewBoxRequired,
+  TickItem,
+} from '../../../util/types';
 import { TooltipIndex, TooltipPayloadConfiguration } from '../../tooltipSlice';
 
 export const combineCoordinateForDefaultIndex = (
@@ -9,7 +16,8 @@ export const combineCoordinateForDefaultIndex = (
   tooltipTicks: ReadonlyArray<TickItem> | undefined,
   defaultIndex: TooltipIndex | undefined,
   tooltipConfigurations: ReadonlyArray<TooltipPayloadConfiguration>,
-): Coordinate | undefined => {
+  polarViewBox: PolarViewBoxRequired | undefined,
+): Coordinate | PolarCoordinate | undefined => {
   if (defaultIndex == null) {
     return undefined;
   }
@@ -19,7 +27,7 @@ export const combineCoordinateForDefaultIndex = (
    * Until then, we choose the first one.
    */
   const firstConfiguration = tooltipConfigurations[0];
-  const maybePosition: Coordinate | undefined = firstConfiguration?.getPosition(defaultIndex);
+  const maybePosition = firstConfiguration?.getPosition(defaultIndex);
   if (maybePosition != null) {
     return maybePosition;
   }
@@ -34,8 +42,31 @@ export const combineCoordinateForDefaultIndex = (
         y: (offset.top + height) / 2,
       };
     }
+    case 'radial': {
+      if (polarViewBox) {
+        const { cx, cy, innerRadius, outerRadius, startAngle, endAngle } = polarViewBox;
+        const radius = tick.coordinate;
+        const angle = (startAngle + endAngle) / 2;
+        return {
+          x: cx,
+          y: cy,
+          cx,
+          cy,
+          radius,
+          angle,
+          startAngle,
+          endAngle,
+          innerRadius,
+          outerRadius,
+          clockWise: false,
+        };
+      }
+      return {
+        x: (offset.left + width) / 2,
+        y: tick.coordinate,
+      };
+    }
     default: {
-      // This logic is not super sound - it conflates vertical, radial, centric layouts into just one. TODO improve!
       return {
         x: (offset.left + width) / 2,
         y: tick.coordinate,

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -37,6 +37,7 @@ import { combineActiveTooltipIndex } from './combiners/combineActiveTooltipIndex
 import { combineCoordinateForDefaultIndex } from './combiners/combineCoordinateForDefaultIndex';
 import { combineTooltipPayloadConfigurations } from './combiners/combineTooltipPayloadConfigurations';
 import { selectTooltipPayloadSearcher } from './selectTooltipPayloadSearcher';
+import { selectPolarViewBox } from './polarAxisSelectors';
 import { selectTooltipState } from './selectTooltipState';
 import { combineTooltipPayload } from './combiners/combineTooltipPayload';
 import {
@@ -130,7 +131,7 @@ export const selectCoordinateForDefaultIndex: (
   tooltipEventType: TooltipEventType | undefined,
   trigger: TooltipTrigger,
   defaultIndex: TooltipIndex | undefined,
-) => Coordinate | undefined = createSelector(
+) => Coordinate | PolarCoordinate | undefined = createSelector(
   [
     selectChartWidth,
     selectChartHeight,
@@ -139,6 +140,7 @@ export const selectCoordinateForDefaultIndex: (
     selectTooltipAxisTicks,
     pickDefaultIndex,
     selectTooltipPayloadConfigurations,
+    selectPolarViewBox,
   ],
   combineCoordinateForDefaultIndex,
 );
@@ -148,12 +150,12 @@ export const selectActiveCoordinate: (
   tooltipEventType: TooltipEventType | undefined,
   trigger: TooltipTrigger,
   defaultIndex: TooltipIndex | undefined,
-) => Coordinate | undefined = createSelector(
+) => Coordinate | PolarCoordinate | undefined = createSelector(
   [selectTooltipInteractionState, selectCoordinateForDefaultIndex],
   (
     tooltipInteractionState: TooltipInteractionState,
-    defaultIndexCoordinate: Coordinate | undefined,
-  ): Coordinate | undefined => {
+    defaultIndexCoordinate: Coordinate | PolarCoordinate | undefined,
+  ): Coordinate | PolarCoordinate | undefined => {
     return tooltipInteractionState.coordinate ?? defaultIndexCoordinate;
   },
 );

--- a/src/state/selectors/tooltipSelectors.ts
+++ b/src/state/selectors/tooltipSelectors.ts
@@ -40,6 +40,7 @@ import {
   CategoricalDomain,
   CategoricalDomainItem,
   Coordinate,
+  PolarCoordinate,
   RechartsScaleType,
   DataKey,
   LayoutType,
@@ -77,6 +78,7 @@ import { selectChartHeight, selectChartWidth } from './containerSelectors';
 import { selectChartOffsetInternal } from './selectChartOffsetInternal';
 import { combineTooltipPayloadConfigurations } from './combiners/combineTooltipPayloadConfigurations';
 import { selectTooltipPayloadSearcher } from './selectTooltipPayloadSearcher';
+import { selectPolarViewBox } from './polarAxisSelectors';
 import { selectTooltipState } from './selectTooltipState';
 
 import { combineTooltipPayload } from './combiners/combineTooltipPayload';
@@ -479,18 +481,20 @@ const selectTooltipPayloadConfigurations = createSelector(
   combineTooltipPayloadConfigurations,
 );
 
-const selectTooltipCoordinateForDefaultIndex: (state: RechartsRootState) => Coordinate | undefined = createSelector(
-  [
-    selectChartWidth,
-    selectChartHeight,
-    selectChartLayout,
-    selectChartOffsetInternal,
-    selectTooltipAxisTicks,
-    selectDefaultIndex,
-    selectTooltipPayloadConfigurations,
-  ],
-  combineCoordinateForDefaultIndex,
-);
+const selectTooltipCoordinateForDefaultIndex: (state: RechartsRootState) => Coordinate | PolarCoordinate | undefined =
+  createSelector(
+    [
+      selectChartWidth,
+      selectChartHeight,
+      selectChartLayout,
+      selectChartOffsetInternal,
+      selectTooltipAxisTicks,
+      selectDefaultIndex,
+      selectTooltipPayloadConfigurations,
+      selectPolarViewBox,
+    ],
+    combineCoordinateForDefaultIndex,
+  );
 
 export const selectActiveTooltipCoordinate: (state: RechartsRootState) => Coordinate | undefined = createSelector(
   [selectTooltipInteractionState, selectTooltipCoordinateForDefaultIndex],

--- a/test/state/selectors/combiners/combineCoordinateForDefaultIndex.spec.ts
+++ b/test/state/selectors/combiners/combineCoordinateForDefaultIndex.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { combineCoordinateForDefaultIndex } from '../../../../src/state/selectors/combiners/combineCoordinateForDefaultIndex';
+import type { ChartOffsetInternal, PolarViewBoxRequired, TickItem } from '../../../../src/util/types';
+
+const offset: ChartOffsetInternal = {
+  top: 10,
+  left: 20,
+  width: 400,
+  height: 260,
+  bottom: 0,
+  right: 0,
+  brushBottom: 0,
+};
+
+const polarViewBox: PolarViewBoxRequired = {
+  cx: 200,
+  cy: 130,
+  innerRadius: 10,
+  outerRadius: 100,
+  startAngle: 0,
+  endAngle: 180,
+  clockWise: false,
+};
+
+const radialTick: TickItem = {
+  coordinate: 55,
+  index: 1,
+  value: 55,
+} as unknown as TickItem;
+
+const radialTick2: TickItem = {
+  coordinate: 80,
+  index: 1,
+  value: 80,
+} as unknown as TickItem;
+
+describe('combineCoordinateForDefaultIndex', () => {
+  it('returns a PolarCoordinate for radial layout when polarViewBox is available', () => {
+    const result = combineCoordinateForDefaultIndex(
+      400,
+      260,
+      'radial',
+      offset,
+      [radialTick, radialTick2],
+      '0',
+      [],
+      polarViewBox,
+    );
+
+    expect(result).toMatchObject({
+      cx: 200,
+      cy: 130,
+      innerRadius: 10,
+      outerRadius: 100,
+      startAngle: 0,
+      endAngle: 180,
+      radius: 55,
+      clockWise: false,
+    });
+  });
+
+  it('falls back to Cartesian coordinate for radial layout when polarViewBox is missing', () => {
+    const result = combineCoordinateForDefaultIndex(
+      400,
+      260,
+      'radial',
+      offset,
+      [radialTick, radialTick2],
+      '0',
+      [],
+      undefined,
+    );
+
+    expect(result).toEqual({ x: 210, y: 55 });
+  });
+
+  it('returns Cartesian coordinate for vertical layout', () => {
+    const result = combineCoordinateForDefaultIndex(
+      400,
+      260,
+      'vertical',
+      offset,
+      [radialTick, radialTick2],
+      '0',
+      [],
+      undefined,
+    );
+
+    expect(result).toEqual({ x: 210, y: 55 });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #7672 — `RadialBar` tooltip with `defaultIndex` does not render the cursor.

The bug: `combineCoordinateForDefaultIndex` returned a plain Cartesian `{ x, y }` coordinate for **all** non-horizontal layouts (its `default` switch case conflated vertical, radial and centric). Because `CursorInternal` only renders the `Sector` radial cursor when `isPolarCoordinate(activeCoordinate)` is true (it checks for `radius`/`startAngle`/`endAngle`), the radial cursor branch was skipped for `defaultIndex`-activated tooltips. The cursor only appeared after a real mouse move, which computes a proper `PolarCoordinate`.

## Change

- `combineCoordinateForDefaultIndex` now has an explicit `case 'radial'` that builds a `PolarCoordinate` from the chart's `polarViewBox` (cx/cy/innerRadius/outerRadius/startAngle/endAngle) and the tick's radius/angle.
- `selectCoordinateForDefaultIndex` (selectors.ts) and `selectTooltipCoordinateForDefaultIndex` (tooltipSelectors.ts) now wire `selectPolarViewBox` as an 8th input.
- Return types widened from `Coordinate` to `Coordinate | PolarCoordinate`.

`vertical`/`centric` layouts keep their previous behavior (no `polarViewBox` needed). The fix is gated on `polarViewBox` being present, so it degrades gracefully when unavailable.

## Verification

- `tsc --noEmit` clean
- Full `unit:lib` suite green (336 files / 7628 tests). `omnidoc`/`website` project failures are pre-existing (missing `www/src/docs/api` submodule content) and unrelated to this change.

Reproduced via `RadialBarChart` + `PolarAngleAxis` + `RadialBar` + `Tooltip defaultIndex`, matching the issue's fixture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tooltip positioning for radial and polar charts.
  * Tooltip coordinates now adapt to polar chart geometry, including center, radii, angles, and direction.
  * Preserved existing positioning behavior for Cartesian charts and radial charts without polar view information.

* **Tests**
  * Added coverage for polar, radial fallback, and vertical chart tooltip positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->