### PR TITLE
fix(XAxis): equidistantPreserveEnd renders a single tick when the end label overflows

### DIFF
--- a/src/cartesian/getEquidistantTicks.ts
+++ b/src/cartesian/getEquidistantTicks.ts
@@ -87,6 +87,7 @@ export function getEquidistantPreserveEndTicks(
     const offset = (len - 1) % stepsize;
     let start = initialStart; // `start` tracks the coordinate of the last successfully drawn tick + gap
     let ok = true;
+    let tailCoord: number | undefined;
 
     // 2. Iterate through the end-anchored sequence: offset, offset + stepsize, ..., len - 1
     for (let index = offset; index < len; index += stepsize) {
@@ -105,7 +106,20 @@ export function getEquidistantPreserveEndTicks(
         return size;
       };
 
-      const tickCoord = entry.coordinate;
+      let tickCoord = entry.coordinate;
+
+      // The last tick is centered on the last band, so its label usually overflows
+      // the end boundary and fails the visibility check. Move it inwards, the same
+      // way getTicksStart does for `preserveEnd`, instead of rejecting the stepsize
+      // because of it - otherwise every stepsize below `len` gets rejected and the
+      // axis ends up showing a single tick.
+      if (index === len - 1) {
+        const tailGap = sign * (tickCoord + (sign * getSize()) / 2 - end);
+        if (tailGap > 0) {
+          tickCoord -= tailGap * sign;
+        }
+        tailCoord = tickCoord;
+      }
 
       // 3. Apply visibility logic (including the first tick special case)
       // The reviewer says *not* to unconditionally bypass checks for the last tick.
@@ -131,7 +145,7 @@ export function getEquidistantPreserveEndTicks(
       for (let index = offset; index < len; index += stepsize) {
         const tick = ticks[index];
         if (tick != null) {
-          finalTicks.push(tick);
+          finalTicks.push(index === len - 1 && tailCoord != null ? { ...tick, tickCoord: tailCoord } : tick);
         }
       }
       return finalTicks;

--- a/test/cartesian/getEquidistantTicks.spec.ts
+++ b/test/cartesian/getEquidistantTicks.spec.ts
@@ -71,4 +71,23 @@ describe('getEquidistantPreserveEndTicks', () => {
     // We expect indices 0, 2, 4 (Values A, C, E)
     expect(result.map(t => t.value)).toEqual(['A', 'C', 'E']);
   });
+
+  it('should move the end tick inwards instead of dropping every other tick', () => {
+    // 10 ticks, 50px apart, the last one centered on the end of the axis so that
+    // half of its 100px wide label overflows the boundary.
+    const ticks: ReadonlyArray<CartesianTickItem> = Array.from({ length: 10 }, (_, index) => ({
+      value: index,
+      coordinate: (index + 1) * 50,
+      index,
+      offset: 0,
+    }));
+
+    const result = getEquidistantPreserveEndTicks(1, { start: 0, end: 500 }, () => 100, ticks, 20);
+
+    // Every third tick collides with the moved end tick, so every fourth one is shown.
+    expect(result.map(t => t.value)).toEqual([1, 5, 9]);
+    // The end tick keeps its coordinate, only its label moves inside the boundary.
+    expect(result[result.length - 1].coordinate).toBe(500);
+    expect(result[result.length - 1].tickCoord).toBe(450);
+  });
 });


### PR DESCRIPTION
## Description

`getEquidistantPreserveEndTicks` now moves the last tick's label inwards when it overflows the end boundary, instead of letting that overflow reject the whole stepsize. The tick's `coordinate` stays put and only `tickCoord` moves, so the tick line stays on the data point and just the text shifts. That is the same trick `getTicksStart` already uses for `preserveEnd`.

## Related Issue

Fixes #7696. Related: #6642, #6661, where the interval was added.

## Motivation and Context

The last tick sits on the center of the last band, so half its label hangs past the axis end and `isVisible` rejects it. Since every candidate sequence includes index `len - 1`, every `stepsize < len` gets rejected, and the only one left is `stepsize === len`, whose lone tick skips the check because `index === offset`. Result: charts render exactly one label, and the wider the chart the more likely it is, since more points mean narrower bands.

With the fix, the tail is moved inside the boundary first and then checked normally, so if the shift would make it collide with its neighbour the stepsize is still rejected and a larger one is tried. No check is bypassed.

## How Has This Been Tested?

- New unit test in `test/cartesian/getEquidistantTicks.spec.ts`: 10 ticks 50px apart, the last centered on the axis end with a 100px label. Before: `[9]`. After: `[1, 5, 9]`, with the end tick keeping `coordinate: 500` and getting `tickCoord: 450`.
- `npm run test-lib`: 315 files, 6280 tests, all pass. Full `npm run test` has 7 failing files in `unit:omnidoc` and `unit:website`, all pre-existing on `main` in a fresh clone, they need the generated `src/docs/api`.
- `npm run lint`, `npm run check-types-lib`, `npm run check-types-test`: clean.
- Repro from the issue: https://codesandbox.io/s/6332vv (1 label on 3.10.1, where `preserveStartEnd` on the same data and width draws 6).
- Also verified against a real app with this patched into `node_modules`: a 1255px chart over a 3 month range went from 1 label to 7, tick coordinate spacing exactly uniform, end label 40px inside the boundary.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart tick placement when the final label extends beyond the chart boundary.
  * Preserved evenly spaced, end-anchored ticks instead of unnecessarily removing alternating ticks.
  * Adjusted oversized end labels inward while retaining the final tick’s correct coordinate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->