### PR TITLE
feat(zoom): apply viewport windows to Cartesian rendering

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -299,6 +299,7 @@
   "es6/util/useUniqueId.js",
   "es6/util/zoom",
   "es6/util/zoom/ZoomOptions.js",
+  "es6/util/zoom/transform.js",
   "es6/util/zoom/viewport.js",
   "es6/util/zoom/viewportWindow.js",
   "es6/util/zoom/zoomActions.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -299,6 +299,7 @@
   "lib/util/useUniqueId.js",
   "lib/util/zoom",
   "lib/util/zoom/ZoomOptions.js",
+  "lib/util/zoom/transform.js",
   "lib/util/zoom/viewport.js",
   "lib/util/zoom/viewportWindow.js",
   "lib/util/zoom/zoomActions.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -299,6 +299,7 @@
   "types/util/useUniqueId.d.ts",
   "types/util/zoom",
   "types/util/zoom/ZoomOptions.d.ts",
+  "types/util/zoom/transform.d.ts",
   "types/util/zoom/viewport.d.ts",
   "types/util/zoom/viewportWindow.d.ts",
   "types/util/zoom/zoomActions.d.ts",

--- a/src/cartesian/CartesianAxis.tsx
+++ b/src/cartesian/CartesianAxis.tsx
@@ -356,6 +356,7 @@ function RenderedTicksReporter({
       return noop;
     }
     return () => {
+      lastDispatchedTicksRef.current = null;
       dispatch(
         removeRenderedTicks({
           axisId,

--- a/src/cartesian/CartesianGrid.tsx
+++ b/src/cartesian/CartesianGrid.tsx
@@ -11,11 +11,15 @@ import { defaultCartesianAxisProps } from './CartesianAxis';
 import { useChartHeight, useChartWidth, useOffsetInternal } from '../context/chartLayoutContext';
 import { AxisId } from '../state/cartesianAxisSlice';
 import { selectAxisPropsNeededForCartesianGridTicksGenerator } from '../state/selectors/axisSelectors';
+import { selectIsZoomed } from '../state/selectors/zoomSelectors';
 import { useAppSelector } from '../state/hooks';
+import { RechartsRootState } from '../state/store';
 import { useIsPanorama } from '../context/PanoramaContext';
+import { useClipPathId } from '../container/ClipPathProvider';
 import { RequiresDefaultProps, resolveDefaultProps } from '../util/resolveDefaultProps';
 import { svgPropertiesNoEvents } from '../util/svgPropertiesNoEvents';
 import { isPositiveNumber } from '../util/isWellBehavedNumber';
+import { areScalesApproximatelyEqual, areValueArraysApproximatelyEqual } from '../util/propsAreEqual';
 import { ZIndexable, ZIndexLayer } from '../zIndex/ZIndexLayer';
 import { DefaultZIndexes } from '../zIndex/DefaultZIndexes';
 import { Styles2D } from '../theme/RechartsTheme';
@@ -452,6 +456,52 @@ const defaultHorizontalCoordinatesGenerator: HorizontalCoordinatesGenerator = (
     syncWithTicks,
   );
 
+function areGridAxisScalesEqual(
+  a: AxisPropsForCartesianGridTicksGeneration['scale'],
+  b: AxisPropsForCartesianGridTicksGeneration['scale'],
+  realScaleType: AxisPropsForCartesianGridTicksGeneration['realScaleType'],
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (realScaleType == null) {
+    return false;
+  }
+  return areScalesApproximatelyEqual(a, b);
+}
+
+function areGridAxisPropsEqual(
+  a: AxisPropsForCartesianGridTicksGeneration | undefined,
+  b: AxisPropsForCartesianGridTicksGeneration | undefined,
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a == null || b == null) {
+    return false;
+  }
+  return (
+    a.angle === b.angle &&
+    a.axisType === b.axisType &&
+    a.interval === b.interval &&
+    a.isCategorical === b.isCategorical &&
+    a.minTickGap === b.minTickGap &&
+    a.orientation === b.orientation &&
+    a.realScaleType === b.realScaleType &&
+    a.tick === b.tick &&
+    a.tickCount === b.tickCount &&
+    a.tickFormatter === b.tickFormatter &&
+    a.type === b.type &&
+    a.unit === b.unit &&
+    areValueArraysApproximatelyEqual(a.categoricalDomain, b.categoricalDomain) &&
+    areValueArraysApproximatelyEqual(a.duplicateDomain, b.duplicateDomain) &&
+    areValueArraysApproximatelyEqual(a.niceTicks, b.niceTicks) &&
+    areValueArraysApproximatelyEqual(a.range, b.range) &&
+    areValueArraysApproximatelyEqual(a.ticks, b.ticks) &&
+    areGridAxisScalesEqual(a.scale, b.scale, a.realScaleType)
+  );
+}
+
 export const defaultCartesianGridProps = {
   horizontal: true,
   vertical: true,
@@ -495,11 +545,25 @@ export function CartesianGrid(props: Props) {
     propsIncludingDefaults;
 
   const isPanorama = useIsPanorama();
-  const xAxis: AxisPropsForCartesianGridTicksGeneration | undefined = useAppSelector(state =>
-    selectAxisPropsNeededForCartesianGridTicksGenerator(state, 'xAxis', xAxisId, isPanorama),
+  const isZoomed = useAppSelector(selectIsZoomed);
+  const clipPathId = useClipPathId();
+  const selectXAxis = React.useCallback(
+    (state: RechartsRootState) =>
+      selectAxisPropsNeededForCartesianGridTicksGenerator(state, 'xAxis', xAxisId, isPanorama),
+    [isPanorama, xAxisId],
   );
-  const yAxis: AxisPropsForCartesianGridTicksGeneration | undefined = useAppSelector(state =>
-    selectAxisPropsNeededForCartesianGridTicksGenerator(state, 'yAxis', yAxisId, isPanorama),
+  const selectYAxis = React.useCallback(
+    (state: RechartsRootState) =>
+      selectAxisPropsNeededForCartesianGridTicksGenerator(state, 'yAxis', yAxisId, isPanorama),
+    [isPanorama, yAxisId],
+  );
+  const xAxis = useAppSelector<AxisPropsForCartesianGridTicksGeneration | undefined>(
+    selectXAxis,
+    areGridAxisPropsEqual,
+  );
+  const yAxis = useAppSelector<AxisPropsForCartesianGridTicksGeneration | undefined>(
+    selectYAxis,
+    areGridAxisPropsEqual,
   );
 
   const themeProps = useBackwardsCompatibleTheme(
@@ -580,9 +644,23 @@ export function CartesianGrid(props: Props) {
     }
   }
 
+  /*
+   * When zoomed, the generators place grid lines across the stretched range, so most land outside
+   * the plotting area. The filter is a coarse cull so a deep zoom doesn't render hundreds of
+   * invisible lines; the clip path below cuts the survivors exactly at the plot edge, whatever
+   * their stroke width.
+   */
+  if (isZoomed) {
+    horizontalPoints = horizontalPoints?.filter(p => p >= y - 0.5 && p <= y + height + 0.5);
+    verticalPoints = verticalPoints?.filter(p => p >= x - 0.5 && p <= x + width + 0.5);
+  }
+
   return (
     <ZIndexLayer zIndex={propsIncludingDefaults.zIndex}>
-      <g className="recharts-cartesian-grid">
+      <g
+        className="recharts-cartesian-grid"
+        clipPath={isZoomed && clipPathId != null ? `url(#${clipPathId})` : undefined}
+      >
         <Background
           fill={themeProps.fill}
           fillOpacity={themeProps.fillOpacity}

--- a/src/cartesian/GraphicalItemClipPath.tsx
+++ b/src/cartesian/GraphicalItemClipPath.tsx
@@ -10,6 +10,7 @@ import {
   selectYAxisSettings,
 } from '../state/selectors/axisSelectors';
 import { usePlotArea } from '../hooks';
+import { isFullViewport } from '../util/zoom/viewport';
 
 type GraphicalItemClipPathProps = {
   xAxisId: AxisId;
@@ -21,8 +22,15 @@ export function useNeedsClip(xAxisId: AxisId, yAxisId: AxisId) {
   const xAxis = useAppSelector(state => selectXAxisSettings(state, xAxisId));
   const yAxis = useAppSelector(state => selectYAxisSettings(state, yAxisId));
 
-  const needClipX: boolean = xAxis?.allowDataOverflow ?? implicitXAxis.allowDataOverflow;
-  const needClipY: boolean = yAxis?.allowDataOverflow ?? implicitYAxis.allowDataOverflow;
+  /*
+   * When a dimension is zoomed, the data is drawn into a stretched range that extends past the
+   * plotting area, so it must always be clipped - regardless of the axis `allowDataOverflow` prop.
+   */
+  const zoomedX = useAppSelector(state => !isFullViewport(state.zoom.x)) ?? false;
+  const zoomedY = useAppSelector(state => !isFullViewport(state.zoom.y)) ?? false;
+
+  const needClipX: boolean = (xAxis?.allowDataOverflow ?? implicitXAxis.allowDataOverflow) || zoomedX;
+  const needClipY: boolean = (yAxis?.allowDataOverflow ?? implicitYAxis.allowDataOverflow) || zoomedY;
   const needClip = needClipX || needClipY;
 
   return { needClip, needClipX, needClipY };

--- a/src/component/Cursor.tsx
+++ b/src/component/Cursor.tsx
@@ -19,6 +19,9 @@ import { getCursorPoints } from '../util/cursor/getCursorPoints';
 import { useChartLayout, useOffsetInternal } from '../context/chartLayoutContext';
 import { useTooltipAxisBandSize } from '../context/useTooltipAxis';
 import { useChartName } from '../state/selectors/selectors';
+import { useAppSelector } from '../state/hooks';
+import { selectIsZoomed } from '../state/selectors/zoomSelectors';
+import { useClipPathId } from '../container/ClipPathProvider';
 import { TooltipIndex, TooltipPayload } from '../state/tooltipSlice';
 import { svgPropertiesNoEventsFromUnknown } from '../util/svgPropertiesNoEvents';
 import { Styles2D } from '../theme/RechartsTheme';
@@ -86,6 +89,13 @@ export function CursorInternal(props: CursorConnectedProps) {
   const cursorPropsBeforeGeometry = activeTheme == null ? cursorThemeProps : {};
   const cursorPropsAfterGeometry = activeTheme?.cursor != null && !isValidElement(cursor) ? cursorThemeProps : {};
 
+  /*
+   * When zoomed, the cursor (especially the thick band cursor of bar charts) can spill over the
+   * plot edges, so clip it to the plotting area - the same clip the graphical items already use.
+   */
+  const clipPathId = useClipPathId();
+  const isZoomed = useAppSelector(selectIsZoomed) ?? false;
+
   // The cursor is a part of the Tooltip, and it should be shown (by default) when the Tooltip is active.
   const activeCoordinate = coordinate;
   const activePayload = payload;
@@ -136,9 +146,11 @@ export function CursorInternal(props: CursorConnectedProps) {
     className: clsx('recharts-tooltip-cursor', extraClassName),
   };
 
+  const cursorElement = <RenderCursor cursor={cursor} cursorComp={cursorComp} cursorProps={cursorProps} />;
+
   return (
     <ZIndexLayer zIndex={props.zIndex ?? preferredZIndex}>
-      <RenderCursor cursor={cursor} cursorComp={cursorComp} cursorProps={cursorProps} />
+      {isZoomed && clipPathId ? <g clipPath={`url(#${clipPathId})`}>{cursorElement}</g> : cursorElement}
     </ZIndexLayer>
   );
 }

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -37,7 +37,10 @@ const refEquality: EqualityFn<unknown> = (a, b) => a === b;
  * @param selector for pulling things out of Redux store; will not be called if the store is not accessible
  * @return whatever the selector returned; or undefined when outside of Redux store
  */
-export function useAppSelector<T>(selector: (state: RechartsRootState) => T): T | undefined {
+export function useAppSelector<T>(
+  selector: (state: RechartsRootState) => T,
+  equalityFn: EqualityFn<T | undefined> = refEquality,
+): T | undefined {
   const context = useContext(RechartsReduxContext);
 
   const outOfContextSelector: (state: RechartsRootState | undefined) => T | undefined = useMemo(() => {
@@ -57,6 +60,6 @@ export function useAppSelector<T>(selector: (state: RechartsRootState) => T): T 
     context ? context.store.getState : noop,
     context ? context.store.getState : noop,
     outOfContextSelector,
-    refEquality,
+    equalityFn,
   );
 }

--- a/src/state/renderedTicksSlice.ts
+++ b/src/state/renderedTicksSlice.ts
@@ -10,6 +10,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { castDraft, WritableDraft } from 'immer';
 import { TickItem } from '../util/types';
+import { areRenderedTicksEqual } from '../util/propsAreEqual';
 import { AxisId } from './cartesianAxisSlice';
 
 type RenderedTicksAxisState = {
@@ -39,6 +40,9 @@ export const renderedTicksSlice = createSlice({
       }>,
     ) => {
       const { axisType, axisId, ticks } = action.payload;
+      if (areRenderedTicksEqual(state[axisType][axisId], ticks)) {
+        return;
+      }
       state[axisType][axisId] = castDraft(ticks);
     },
     removeRenderedTicks: (

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -89,6 +89,7 @@ import { emptyArraysAreEqualCheck } from './arrayEqualityCheck';
 import { AllAxisTypes, RenderableAxisType, selectTooltipAxisType } from './selectTooltipAxisType';
 import { selectTooltipAxisId } from './selectTooltipAxisId';
 import { RechartsScale, rechartsScaleFactory } from '../../util/scale/RechartsScale';
+import { applyViewportToRange, AxisViewport, FULL_VIEWPORT, isFullViewport } from '../../util/zoom/viewport';
 import { combineCheckedDomain } from './combiners/combineCheckedDomain';
 import { CustomScaleDefinition } from '../../util/scale/CustomScaleDefinition';
 import { combineConfiguredScale } from './combiners/combineConfiguredScale';
@@ -1603,13 +1604,51 @@ export const selectCheckedAxisDomain: (
   combineCheckedDomain,
 );
 
+const selectViewportForAxisType = (state: RechartsRootState, axisType: RenderableAxisType): AxisViewport => {
+  if (axisType === 'xAxis') {
+    return state.zoom.x;
+  }
+  if (axisType === 'yAxis') {
+    return state.zoom.y;
+  }
+  // Only the cartesian x and y axes can be zoomed; everything else stays at the full viewport.
+  return FULL_VIEWPORT;
+};
+
+/**
+ * The axis range after the current zoom viewport has been applied - this is the single place where
+ * zoom enters the rendering pipeline. Feeding the stretched range into the scale makes data, ticks,
+ * grid, reference lines and the inverse scale (tooltip/cursor) all zoom together.
+ *
+ * Returns the range unchanged for the full (default) viewport and for the brush panorama, so an
+ * un-zoomed chart - and the brush overview - render exactly as before.
+ */
+export const selectZoomedAxisRangeWithReverse: (
+  state: RechartsRootState,
+  axisType: RenderableAxisType,
+  axisId: AxisId,
+  isPanorama: boolean,
+) => AxisRange | undefined = createSelector(
+  [
+    selectAxisRangeWithReverse,
+    selectViewportForAxisType,
+    (_state: RechartsRootState, _axisType: RenderableAxisType, _axisId: AxisId, isPanorama: boolean) => isPanorama,
+  ],
+  (axisRange, viewport, isPanorama) => {
+    if (axisRange == null || isPanorama || isFullViewport(viewport)) {
+      return axisRange;
+    }
+    return applyViewportToRange(axisRange, viewport);
+  },
+);
+
 const selectConfiguredScale: (
   state: RechartsRootState,
   axisType: RenderableAxisType,
   axisId: AxisId,
   isPanorama: boolean,
 ) => CustomScaleDefinition | undefined = createSelector(
-  [selectBaseAxis, selectRealScaleType, selectCheckedAxisDomain, selectAxisRangeWithReverse],
+  [selectBaseAxis, selectRealScaleType, selectCheckedAxisDomain, selectZoomedAxisRangeWithReverse],
   combineConfiguredScale,
 );
 
@@ -2091,7 +2130,7 @@ export const combineAxisTicks = (
     })
     .filter(isNotNil);
 };
-export const selectTicksOfAxis: (
+const selectUnfilteredTicksOfAxis: (
   state: RechartsRootState,
   axisType: RenderableAxisType,
   axisId: AxisId,
@@ -2109,6 +2148,28 @@ export const selectTicksOfAxis: (
     pickAxisType,
   ],
   combineAxisTicks,
+);
+
+/**
+ * When an axis is zoomed, its scale maps the full domain across a stretched range, so some ticks
+ * (and therefore grid lines and axis labels) fall outside the plotting area. This drops those ticks
+ * so the axis and grid stay within bounds. When not zoomed it returns the ticks unchanged.
+ */
+export const selectTicksOfAxis: (
+  state: RechartsRootState,
+  axisType: RenderableAxisType,
+  axisId: AxisId,
+  isPanorama: boolean,
+) => ReadonlyArray<CartesianTickItem> | undefined = createSelector(
+  [selectUnfilteredTicksOfAxis, selectAxisRange, selectViewportForAxisType],
+  (ticks, axisRange, viewport) => {
+    if (ticks == null || axisRange == null || isFullViewport(viewport)) {
+      return ticks;
+    }
+    const min = Math.min(axisRange[0], axisRange[1]) - 0.5;
+    const max = Math.max(axisRange[0], axisRange[1]) + 0.5;
+    return ticks.filter(tick => tick.coordinate >= min && tick.coordinate <= max);
+  },
 );
 
 /**

--- a/src/state/selectors/tooltipSelectors.ts
+++ b/src/state/selectors/tooltipSelectors.ts
@@ -58,6 +58,7 @@ import { ReferenceAreaSettings, ReferenceDotSettings, ReferenceLineSettings } fr
 import { selectChartName, selectReverseStackOrder, selectStackOffsetType } from './rootPropsSelectors';
 import { isNotNil, mathSign } from '../../util/DataUtils';
 import { combineAxisRangeWithReverse } from './combiners/combineAxisRangeWithReverse';
+import { applyViewportToRange, FULL_VIEWPORT, isFullViewport } from '../../util/zoom/viewport';
 import { TooltipIndex, TooltipInteractionState, TooltipPayload, TooltipSettingsState } from '../tooltipSlice';
 
 import {
@@ -73,6 +74,7 @@ import { selectTooltipSettings } from './selectTooltipSettings';
 import { combineTooltipInteractionState } from './combiners/combineTooltipInteractionState';
 import { combineActiveTooltipIndex } from './combiners/combineActiveTooltipIndex';
 import { combineCoordinateForDefaultIndex } from './combiners/combineCoordinateForDefaultIndex';
+import { selectIsZoomed } from './zoomSelectors';
 import { selectChartHeight, selectChartWidth } from './containerSelectors';
 import { selectChartOffsetInternal } from './selectChartOffsetInternal';
 import { combineTooltipPayloadConfigurations } from './combiners/combineTooltipPayloadConfigurations';
@@ -94,6 +96,7 @@ import { isWellBehavedNumber } from '../../util/isWellBehavedNumber';
 import { combineRealScaleType } from './combiners/combineRealScaleType';
 import { combineConfiguredScale } from './combiners/combineConfiguredScale';
 import { CustomScaleDefinition } from '../../util/scale/CustomScaleDefinition';
+import { transformCoordinateByCameraZoom } from '../../util/zoom/transform';
 
 export const selectTooltipAxisRealScaleType: (state: RechartsRootState) => RechartsScaleType | undefined =
   createSelector([selectTooltipAxis, selectHasBar, selectChartName], combineRealScaleType);
@@ -312,12 +315,33 @@ export const selectTooltipAxisRangeWithReverse: (state: RechartsRootState) => Ax
   combineAxisRangeWithReverse,
 );
 
+/**
+ * Same as {@link selectTooltipAxisRangeWithReverse} but with the current zoom viewport applied, so
+ * the tooltip's scale, ticks and cursor stay aligned with the zoomed data. Only the tooltip's own
+ * (index) axis is zoomed; the range is returned unchanged when not zoomed.
+ */
+const selectTooltipZoomedAxisRangeWithReverse: (state: RechartsRootState) => AxisRange | undefined = createSelector(
+  [selectTooltipAxisRangeWithReverse, selectTooltipAxisType, (state: RechartsRootState) => state.zoom],
+  (range, axisType, zoom) => {
+    if (range == null) {
+      return range;
+    }
+    let viewport = FULL_VIEWPORT;
+    if (axisType === 'xAxis') {
+      viewport = zoom.x;
+    } else if (axisType === 'yAxis') {
+      viewport = zoom.y;
+    }
+    return isFullViewport(viewport) ? range : applyViewportToRange(range, viewport);
+  },
+);
+
 const selectTooltipConfiguredScale: (state: RechartsRootState) => CustomScaleDefinition | undefined = createSelector(
   [
     selectTooltipAxis,
     selectTooltipAxisRealScaleType,
     selectTooltipAxisDomainIncludingNiceTicks,
-    selectTooltipAxisRangeWithReverse,
+    selectTooltipZoomedAxisRangeWithReverse,
   ],
   combineConfiguredScale,
 );
@@ -492,17 +516,83 @@ const selectTooltipCoordinateForDefaultIndex: (state: RechartsRootState) => Coor
   combineCoordinateForDefaultIndex,
 );
 
-export const selectActiveTooltipCoordinate: (state: RechartsRootState) => Coordinate | undefined = createSelector(
-  [selectTooltipInteractionState, selectTooltipCoordinateForDefaultIndex],
+/**
+ * The active tooltip's coordinate recomputed from its index against the current (zoomed) ticks, so it
+ * tracks the data point as the chart zooms/pans, independent of where the pointer is.
+ */
+const selectActiveTooltipCoordinateFromIndex: (state: RechartsRootState) => Coordinate | undefined = createSelector(
+  [
+    selectChartWidth,
+    selectChartHeight,
+    selectChartLayout,
+    selectChartOffsetInternal,
+    selectTooltipAxisTicks,
+    selectActiveTooltipIndex,
+    selectTooltipPayloadConfigurations,
+  ],
+  (width, height, layout, offset, ticks, activeIndex, configurations) =>
+    combineCoordinateForDefaultIndex(width, height, layout, offset, ticks, activeIndex ?? undefined, configurations),
+);
+
+/**
+ * Coordinate used to synthesize chart-wrapper pointer moves. Camera transforms are deliberately not
+ * applied because pointer hit-testing runs against the untransformed SVG geometry.
+ */
+export const selectTooltipPointerCoordinate: (state: RechartsRootState) => Coordinate | undefined = createSelector(
+  [
+    selectTooltipInteractionState,
+    selectTooltipCoordinateForDefaultIndex,
+    selectActiveTooltipCoordinateFromIndex,
+    selectChartLayout,
+    selectIsZoomed,
+  ],
   (
     tooltipInteractionState: TooltipInteractionState | undefined,
     defaultIndexCoordinate: Coordinate | undefined,
+    activeIndexCoordinate: Coordinate | undefined,
+    layout: LayoutType,
+    isZoomed: boolean,
   ): Coordinate | undefined => {
-    if (tooltipInteractionState?.coordinate) {
-      return tooltipInteractionState.coordinate;
+    const stored = tooltipInteractionState?.coordinate;
+    /*
+     * While zoomed/panned, the stored pixel coordinate goes stale as the data moves under the chart -
+     * panning from an axis or scrollbar, or dragging off the chart, never refreshes it, so the cursor
+     * would freeze. Follow the active data point along the zoomed axis using its live index
+     * coordinate. Cartesian layouts keep the pointer's perpendicular position when available;
+     * polar x/y components must remain paired as one point.
+     */
+    if (isZoomed && activeIndexCoordinate != null) {
+      if (stored != null && (layout === 'horizontal' || layout === 'vertical')) {
+        return layout === 'horizontal'
+          ? { x: activeIndexCoordinate.x, y: stored.y }
+          : { x: stored.x, y: activeIndexCoordinate.y };
+      }
+      return activeIndexCoordinate;
     }
-
+    if (stored) {
+      return stored;
+    }
     return defaultIndexCoordinate;
+  },
+);
+
+export const selectActiveTooltipCoordinate: (state: RechartsRootState) => Coordinate | undefined = createSelector(
+  [
+    selectTooltipPointerCoordinate,
+    selectChartName,
+    selectChartOffsetInternal,
+    (state: RechartsRootState) => state.zoom,
+  ],
+  (coordinate, chartName, offset, zoom): Coordinate | undefined => {
+    if (coordinate == null || offset == null) {
+      return coordinate;
+    }
+    return transformCoordinateByCameraZoom(
+      coordinate,
+      { x: offset.left, y: offset.top, width: offset.width, height: offset.height },
+      chartName,
+      zoom,
+    );
   },
 );
 

--- a/src/util/propsAreEqual.ts
+++ b/src/util/propsAreEqual.ts
@@ -1,4 +1,6 @@
 import { shallowEqual } from 'react-redux';
+import { TickItem } from './types';
+import { RechartsScale } from './scale/RechartsScale';
 
 const propsToShallowCompare = new Set<string>([
   'axisLine',
@@ -91,4 +93,93 @@ export function propsAreEqual<T extends Record<string, unknown>>(prevProps: T, n
     }
   }
   return true;
+}
+
+/* ---------------------------------------------------------------------------------------------- *
+ * Approximate (epsilon-aware) value equality, used to keep Redux subscriptions and reducers
+ * idempotent under floating-point churn while zooming/panning.
+ * ---------------------------------------------------------------------------------------------- */
+
+/**
+ * Value-equality helpers with a small numeric tolerance.
+ *
+ * High-frequency zoom/pan gestures recompute geometry on every event; positions can differ by
+ * sub-pixel float noise even when nothing visibly moved. These helpers let reporters, reducers and
+ * selector subscriptions treat such values as unchanged, which breaks render feedback loops and
+ * keeps drags smooth. Shared by the rendered-ticks reporter/slice and CartesianGrid.
+ */
+
+const EPSILON = 1e-6;
+
+export function areNumbersApproximatelyEqual(a: number | undefined, b: number | undefined): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a == null || b == null) {
+    return false;
+  }
+  if (Number.isNaN(a) && Number.isNaN(b)) {
+    return true;
+  }
+  return Math.abs(a - b) < EPSILON;
+}
+
+export function areChartValuesApproximatelyEqual(a: unknown, b: unknown): boolean {
+  if (typeof a === 'number' && typeof b === 'number') {
+    return areNumbersApproximatelyEqual(a, b);
+  }
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+  return Object.is(a, b);
+}
+
+export function areValueArraysApproximatelyEqual(
+  a: ReadonlyArray<unknown> | undefined,
+  b: ReadonlyArray<unknown> | undefined,
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a == null || b == null || a.length !== b.length) {
+    return false;
+  }
+  return a.every((entry, index) => areChartValuesApproximatelyEqual(entry, b[index]));
+}
+
+/**
+ * Compares two scales by their observable domain, range and bandwidth outputs. The scale
+ * implementation/type and other configuration are intentionally not compared.
+ */
+export function areScalesApproximatelyEqual(a: RechartsScale | undefined, b: RechartsScale | undefined): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a == null || b == null) {
+    return false;
+  }
+  return (
+    areValueArraysApproximatelyEqual(a.domain(), b.domain()) &&
+    areValueArraysApproximatelyEqual(a.range(), b.range()) &&
+    areNumbersApproximatelyEqual(a.bandwidth?.(), b.bandwidth?.())
+  );
+}
+
+export function areRenderedTicksEqual(
+  a: ReadonlyArray<TickItem> | null | undefined,
+  b: ReadonlyArray<TickItem>,
+): boolean {
+  if (a == null || a.length !== b.length) {
+    return false;
+  }
+  return a.every((tick, index) => {
+    const next = b[index];
+    return (
+      next != null &&
+      tick.value === next.value &&
+      areNumbersApproximatelyEqual(tick.coordinate, next.coordinate) &&
+      areNumbersApproximatelyEqual(tick.offset, next.offset) &&
+      tick.index === next.index
+    );
+  });
 }

--- a/src/util/zoom/transform.ts
+++ b/src/util/zoom/transform.ts
@@ -1,0 +1,124 @@
+import { Coordinate } from '../types';
+import { AxisViewport, clampViewport, FULL_VIEWPORT, getViewportWidth, isFullViewport } from './viewport';
+
+type PlotArea = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type ZoomStateLike = {
+  x: AxisViewport;
+  y: AxisViewport;
+};
+
+type CameraZoomMode = 'independent' | 'uniform';
+
+/*
+ * Camera zoom is a chart capability, not a consequence of whether an axis component happened to
+ * register. Cartesian charts commonly omit visible axes while still using implicit x/y scales, so
+ * treating an empty axis registry as a camera chart would apply both range zoom and a second SVG
+ * transform.
+ */
+const cameraZoomModes: Readonly<Partial<Record<string, CameraZoomMode>>> = {
+  FunnelChart: 'independent',
+  PieChart: 'uniform',
+  RadarChart: 'uniform',
+  RadialBarChart: 'uniform',
+  Sankey: 'independent',
+  Sunburst: 'uniform',
+  Treemap: 'independent',
+};
+
+function getViewportCenter(viewport: AxisViewport): number {
+  return (viewport.startRatio + viewport.endRatio) / 2;
+}
+
+export function resizeViewportAroundCenter(viewport: AxisViewport, targetWidth: number): AxisViewport {
+  const width = Math.max(Math.min(targetWidth, 1), 0);
+  if (!Number.isFinite(width) || width <= 0) {
+    return clampViewport(viewport);
+  }
+  const center = getViewportCenter(viewport);
+  const startRatio = center - width / 2;
+  const endRatio = center + width / 2;
+  return clampViewport({ startRatio, endRatio });
+}
+
+export function getUniformZoomState(zoom: ZoomStateLike): ZoomStateLike {
+  const xWidth = getViewportWidth(zoom.x);
+  const yWidth = getViewportWidth(zoom.y);
+  const targetWidth = Math.min(xWidth, yWidth);
+
+  if (!Number.isFinite(targetWidth) || targetWidth >= 1) {
+    return { x: FULL_VIEWPORT, y: FULL_VIEWPORT };
+  }
+
+  return {
+    x: resizeViewportAroundCenter(zoom.x, targetWidth),
+    y: resizeViewportAroundCenter(zoom.y, targetWidth),
+  };
+}
+
+/**
+ * Returns the render-time viewport projection for a camera-zoom chart, or `undefined` for charts
+ * whose x/y scales already apply zoom. This never mutates or normalizes the public/store viewport.
+ */
+export function getCameraZoomState(chartName: string | undefined, zoom: ZoomStateLike): ZoomStateLike | undefined {
+  const cameraZoomMode = chartName == null ? undefined : cameraZoomModes[chartName];
+  if (cameraZoomMode == null) {
+    return undefined;
+  }
+  return cameraZoomMode === 'uniform' ? getUniformZoomState(zoom) : zoom;
+}
+
+export function getZoomTransformForPlot(plot: PlotArea, zoom: ZoomStateLike): string | null {
+  if (plot.width <= 0 || plot.height <= 0 || (isFullViewport(zoom.x) && isFullViewport(zoom.y))) {
+    return null;
+  }
+
+  const scaleX = 1 / getViewportWidth(zoom.x);
+  const scaleY = 1 / getViewportWidth(zoom.y);
+  const translateX = -plot.x - zoom.x.startRatio * plot.width;
+  const translateY = -plot.y - zoom.y.startRatio * plot.height;
+
+  return `translate(${plot.x} ${plot.y}) scale(${scaleX} ${scaleY}) translate(${translateX} ${translateY})`;
+}
+
+export function transformCoordinateByZoom(
+  coordinate: Coordinate | undefined,
+  plot: PlotArea,
+  zoom: ZoomStateLike,
+): Coordinate | undefined {
+  if (coordinate == null) {
+    return undefined;
+  }
+
+  const transform = getZoomTransformForPlot(plot, zoom);
+  if (transform == null) {
+    return coordinate;
+  }
+
+  const scaleX = 1 / getViewportWidth(zoom.x);
+  const scaleY = 1 / getViewportWidth(zoom.y);
+
+  return {
+    x: plot.x + (coordinate.x - plot.x - zoom.x.startRatio * plot.width) * scaleX,
+    y: plot.y + (coordinate.y - plot.y - zoom.y.startRatio * plot.height) * scaleY,
+  };
+}
+
+/**
+ * Projects a raw SVG coordinate into wrapper/screen space for camera-zoom charts. Scale-based
+ * cartesian charts are returned unchanged because their coordinates already include range zoom.
+ */
+export function transformCoordinateByCameraZoom(
+  coordinate: Coordinate | undefined,
+  plot: PlotArea,
+  chartName: string | undefined,
+  zoom: ZoomStateLike,
+): Coordinate | undefined {
+  const cameraZoomState = getCameraZoomState(chartName, zoom);
+  return cameraZoomState == null ? coordinate : transformCoordinateByZoom(coordinate, plot, cameraZoomState);
+}

--- a/test/state/selectors/axisSelectors.spec.tsx
+++ b/test/state/selectors/axisSelectors.spec.tsx
@@ -1968,11 +1968,6 @@ describe('selectErrorBarsSettings', () => {
             direction: 'x',
           },
         ]);
-        /*
-         * 4 renders: (1) chart size set, (2) addErrorBar fires, (3) chart data slice selector
-         * recomputes due to selectDisplayedData reference change, (4) auto-batched axes+items registered.
-         * This is consistent with the horizontal LineChart baseline which also expects 4 renders.
-         */
         expect(spy).toHaveBeenCalledTimes(3);
       });
 
@@ -2062,11 +2057,6 @@ describe('selectErrorBarsSettings', () => {
             direction: 'x',
           },
         ]);
-        /*
-         * 4 renders: (1) chart size set, (2) addErrorBar fires, (3) chart data slice selector
-         * recomputes due to selectDisplayedData reference change, (4) auto-batched axes+items registered.
-         * This is consistent with the horizontal LineChart baseline which also expects 4 renders.
-         */
         expect(spy).toHaveBeenCalledTimes(3);
       });
 

--- a/test/state/selectors/tooltipSelectors.zoom.spec.tsx
+++ b/test/state/selectors/tooltipSelectors.zoom.spec.tsx
@@ -1,0 +1,271 @@
+import React, { type ReactNode } from 'react';
+import { act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { Bar, BarChart, Pie, PieChart, Tooltip, XAxis, YAxis } from '../../../src';
+import { useAppDispatch } from '../../../src/state/hooks';
+import { setMouseOverAxisIndex } from '../../../src/state/tooltipSlice';
+import { setAxisViewport, setZoom } from '../../../src/state/zoomSlice';
+import { selectChartOffsetInternal } from '../../../src/state/selectors/selectChartOffsetInternal';
+import {
+  selectActiveTooltipCoordinate,
+  selectTooltipAxisScale,
+  selectTooltipAxisTicks,
+  selectTooltipPointerCoordinate,
+} from '../../../src/state/selectors/tooltipSelectors';
+import type { AppDispatch } from '../../../src/state/store';
+import type { CartesianLayout, ChartOffsetInternal, Coordinate, TickItem } from '../../../src/util/types';
+import { assertNotNull } from '../../helper/assertNotNull';
+import { createSelectorTestCase } from '../../helper/createSelectorTestCase';
+import { useAppSelectorWithStableTest } from '../../helper/selectorTestHelpers';
+
+const cartesianData = [
+  { name: 'A', value: 10 },
+  { name: 'B', value: 20 },
+  { name: 'C', value: 30 },
+  { name: 'D', value: 40 },
+];
+
+const pieData = [
+  { name: 'A', value: 1 },
+  { name: 'B', value: 2 },
+  { name: 'C', value: 3 },
+];
+
+type ProbeCallbacks = {
+  onDispatch: (dispatch: AppDispatch) => void;
+  onTicks: (ticks: ReadonlyArray<TickItem> | undefined) => void;
+  onOffset: (offset: ChartOffsetInternal | undefined) => void;
+  onPointer: (coordinate: Coordinate | undefined) => void;
+};
+
+function SelectorProbes({ onDispatch, onTicks, onOffset, onPointer }: ProbeCallbacks): null {
+  onDispatch(useAppDispatch());
+  onTicks(useAppSelectorWithStableTest(selectTooltipAxisTicks));
+  onOffset(useAppSelectorWithStableTest(selectChartOffsetInternal));
+  onPointer(useAppSelectorWithStableTest(selectTooltipPointerCoordinate));
+  return null;
+}
+
+function createCartesianChart(
+  layout: CartesianLayout,
+  defaultIndex: number | undefined,
+  callbacks: ProbeCallbacks,
+): React.ComponentType<{ children: ReactNode }> {
+  return function CartesianChart({ children }): React.JSX.Element {
+    return (
+      <BarChart
+        width={320}
+        height={240}
+        layout={layout}
+        data={cartesianData}
+        margin={{ top: 10, right: 20, bottom: 30, left: 40 }}
+      >
+        {layout === 'horizontal' ? <XAxis dataKey="name" /> : <XAxis type="number" dataKey="value" />}
+        {layout === 'horizontal' ? <YAxis /> : <YAxis type="category" dataKey="name" />}
+        <Bar dataKey="value" />
+        <Tooltip defaultIndex={defaultIndex} />
+        <SelectorProbes {...callbacks} />
+        {children}
+      </BarChart>
+    );
+  };
+}
+
+function createPieChart(callbacks: ProbeCallbacks): React.ComponentType<{ children: ReactNode }> {
+  return function PieChartTestCase({ children }): React.JSX.Element {
+    return (
+      <PieChart width={320} height={240} margin={{ top: 10, right: 20, bottom: 30, left: 40 }}>
+        <Pie data={pieData} dataKey="value" nameKey="name" />
+        <Tooltip defaultIndex={1} />
+        <SelectorProbes {...callbacks} />
+        {children}
+      </PieChart>
+    );
+  };
+}
+
+function getLastValue<T>(spy: { mock: { calls: ReadonlyArray<ReadonlyArray<T | undefined>> } }): T {
+  const call = spy.mock.calls[spy.mock.calls.length - 1];
+  const value = call?.[0];
+  assertNotNull(value);
+  return value;
+}
+
+function dispatchAndFlush(dispatch: AppDispatch | undefined, action: Parameters<AppDispatch>[0]): void {
+  assertNotNull(dispatch);
+  act(() => {
+    dispatch(action);
+    vi.runOnlyPendingTimers();
+  });
+}
+
+describe('tooltip selectors with zoom', () => {
+  it('applies the x viewport to a horizontal tooltip scale', () => {
+    let dispatch: AppDispatch | undefined;
+    const callbacks: ProbeCallbacks = {
+      onDispatch: value => {
+        dispatch = value;
+      },
+      onTicks: () => {},
+      onOffset: () => {},
+      onPointer: () => {},
+    };
+    const renderTestCase = createSelectorTestCase(createCartesianChart('horizontal', undefined, callbacks));
+    const { spy } = renderTestCase(selectTooltipAxisScale);
+    const fullScale = getLastValue(spy);
+
+    dispatchAndFlush(dispatch, setAxisViewport({ dimension: 'x', viewport: { startRatio: 0.25, endRatio: 0.75 } }));
+
+    const zoomedScale = getLastValue(spy);
+    const fullRange = fullScale.range();
+    const zoomedRange = zoomedScale.range();
+    expect(zoomedRange[1] - zoomedRange[0]).toBeCloseTo((fullRange[1] - fullRange[0]) * 2);
+  });
+
+  it('applies the y viewport to a vertical tooltip scale', () => {
+    let dispatch: AppDispatch | undefined;
+    const callbacks: ProbeCallbacks = {
+      onDispatch: value => {
+        dispatch = value;
+      },
+      onTicks: () => {},
+      onOffset: () => {},
+      onPointer: () => {},
+    };
+    const renderTestCase = createSelectorTestCase(createCartesianChart('vertical', undefined, callbacks));
+    const { spy } = renderTestCase(selectTooltipAxisScale);
+    const fullScale = getLastValue(spy);
+
+    dispatchAndFlush(dispatch, setAxisViewport({ dimension: 'y', viewport: { startRatio: 0.25, endRatio: 0.75 } }));
+
+    const zoomedScale = getLastValue(spy);
+    const fullRange = fullScale.range();
+    const zoomedRange = zoomedScale.range();
+    expect(zoomedRange[1] - zoomedRange[0]).toBeCloseTo((fullRange[1] - fullRange[0]) * 2);
+  });
+
+  it('keeps the stored perpendicular coordinate while following a zoomed horizontal index', () => {
+    let dispatch: AppDispatch | undefined, ticks: ReadonlyArray<TickItem> | undefined;
+    const callbacks: ProbeCallbacks = {
+      onDispatch: value => {
+        dispatch = value;
+      },
+      onTicks: value => {
+        ticks = value;
+      },
+      onOffset: () => {},
+      onPointer: () => {},
+    };
+    const renderTestCase = createSelectorTestCase(createCartesianChart('horizontal', undefined, callbacks));
+    const { spy } = renderTestCase(selectTooltipPointerCoordinate);
+    const stored = { x: 17, y: 83 };
+
+    const chartDispatch = dispatch;
+    assertNotNull(chartDispatch);
+    act(() => {
+      chartDispatch(setAxisViewport({ dimension: 'x', viewport: { startRatio: 0.25, endRatio: 0.75 } }));
+      chartDispatch(setMouseOverAxisIndex({ activeIndex: '1', activeDataKey: undefined, activeCoordinate: stored }));
+      vi.runOnlyPendingTimers();
+    });
+
+    const activeTick = ticks?.find(tick => tick.index === 1);
+    assertNotNull(activeTick);
+    expect(getLastValue(spy)).toEqual({ x: activeTick.coordinate, y: stored.y });
+  });
+
+  it('keeps the stored perpendicular coordinate while following a zoomed vertical index', () => {
+    let dispatch: AppDispatch | undefined, ticks: ReadonlyArray<TickItem> | undefined;
+    const callbacks: ProbeCallbacks = {
+      onDispatch: value => {
+        dispatch = value;
+      },
+      onTicks: value => {
+        ticks = value;
+      },
+      onOffset: () => {},
+      onPointer: () => {},
+    };
+    const renderTestCase = createSelectorTestCase(createCartesianChart('vertical', undefined, callbacks));
+    const { spy } = renderTestCase(selectTooltipPointerCoordinate);
+    const stored = { x: 71, y: 19 };
+
+    const chartDispatch = dispatch;
+    assertNotNull(chartDispatch);
+    act(() => {
+      chartDispatch(setAxisViewport({ dimension: 'y', viewport: { startRatio: 0.25, endRatio: 0.75 } }));
+      chartDispatch(setMouseOverAxisIndex({ activeIndex: '2', activeDataKey: undefined, activeCoordinate: stored }));
+      vi.runOnlyPendingTimers();
+    });
+
+    const activeTick = ticks?.find(tick => tick.index === 2);
+    assertNotNull(activeTick);
+    expect(getLastValue(spy)).toEqual({ x: stored.x, y: activeTick.coordinate });
+  });
+
+  it('falls back to the default index coordinate without stored interaction coordinates', () => {
+    let dispatch: AppDispatch | undefined,
+      ticks: ReadonlyArray<TickItem> | undefined,
+      offset: ChartOffsetInternal | undefined;
+    const callbacks: ProbeCallbacks = {
+      onDispatch: value => {
+        dispatch = value;
+      },
+      onTicks: value => {
+        ticks = value;
+      },
+      onOffset: value => {
+        offset = value;
+      },
+      onPointer: () => {},
+    };
+    const renderTestCase = createSelectorTestCase(createCartesianChart('horizontal', 2, callbacks));
+    const { spy } = renderTestCase(selectTooltipPointerCoordinate);
+
+    expect(dispatch).toBeDefined();
+    const activeTick = ticks?.find(tick => tick.index === 2);
+    assertNotNull(activeTick);
+    assertNotNull(offset);
+    const chartOffset = offset;
+    expect(getLastValue(spy)).toEqual({
+      x: activeTick.coordinate,
+      y: (chartOffset.top + 240) / 2,
+    });
+  });
+
+  it('projects camera-chart tooltip coordinates through the uniform zoom viewport', () => {
+    let dispatch: AppDispatch | undefined, offset: ChartOffsetInternal | undefined, rawPointer: Coordinate | undefined;
+    const callbacks: ProbeCallbacks = {
+      onDispatch: value => {
+        dispatch = value;
+      },
+      onTicks: () => {},
+      onOffset: value => {
+        offset = value;
+      },
+      onPointer: value => {
+        rawPointer = value;
+      },
+    };
+    const renderTestCase = createSelectorTestCase(createPieChart(callbacks));
+    const { spy } = renderTestCase(selectActiveTooltipCoordinate);
+
+    dispatchAndFlush(
+      dispatch,
+      setZoom({
+        x: { startRatio: 0.25, endRatio: 0.75 },
+        y: { startRatio: 0.25, endRatio: 0.75 },
+      }),
+    );
+
+    assertNotNull(rawPointer);
+    const raw = rawPointer;
+    assertNotNull(offset);
+    const chartOffset = offset;
+    const projected = getLastValue(spy);
+    const expectedX = chartOffset.left + (raw.x - chartOffset.left - chartOffset.width * 0.25) * 2;
+    const expectedY = chartOffset.top + (raw.y - chartOffset.top - chartOffset.height * 0.25) * 2;
+
+    expect(projected?.x).toBeCloseTo(expectedX);
+    expect(projected?.y).toBeCloseTo(expectedY);
+  });
+});

--- a/test/util/propsAreEqual.spec.ts
+++ b/test/util/propsAreEqual.spec.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { propsAreEqual } from '../../src/util/propsAreEqual';
+import {
+  areNumbersApproximatelyEqual,
+  areRenderedTicksEqual,
+  areScalesApproximatelyEqual,
+  propsAreEqual,
+} from '../../src/util/propsAreEqual';
+import type { RechartsScale } from '../../src/util/scale/RechartsScale';
+import type { TickItem } from '../../src/util/types';
 
 describe('propsAreEqual', () => {
   it('should return true for identical props', () => {
@@ -71,5 +78,78 @@ describe('propsAreEqual', () => {
     const props1 = { a: 1, [propName]: { x: 10, y: 20 } };
     const props2 = { a: 1, [propName]: { x: 10, y: 30 } };
     expect(propsAreEqual(props1, props2)).toBe(false);
+  });
+});
+
+describe('approximate chart value equality', () => {
+  describe('areNumbersApproximatelyEqual', () => {
+    it('accepts values within the numeric tolerance', () => {
+      expect(areNumbersApproximatelyEqual(10, 10 + 0.5e-6)).toBe(true);
+      expect(areNumbersApproximatelyEqual(10, 10 + 2e-6)).toBe(false);
+      expect(areNumbersApproximatelyEqual(undefined, undefined)).toBe(true);
+      expect(areNumbersApproximatelyEqual(undefined, 10)).toBe(false);
+    });
+
+    it('treats NaN values as equal', () => {
+      expect(areNumbersApproximatelyEqual(Number.NaN, Number.NaN)).toBe(true);
+    });
+  });
+
+  describe('areRenderedTicksEqual', () => {
+    const ticks: ReadonlyArray<TickItem> = [
+      { value: 'A', coordinate: 10, offset: 2, index: 0 },
+      { value: 'B', coordinate: 20, offset: 2, index: 1 },
+    ];
+
+    it('accepts rendered ticks with sub-pixel coordinate and offset changes', () => {
+      expect(
+        areRenderedTicksEqual(ticks, [
+          { value: 'A', coordinate: 10 + 0.5e-6, offset: 2 - 0.5e-6, index: 0 },
+          { value: 'B', coordinate: 20, offset: 2, index: 1 },
+        ]),
+      ).toBe(true);
+    });
+
+    it('rejects changed tick metadata, coordinates, offsets, and lengths', () => {
+      expect(areRenderedTicksEqual(undefined, ticks)).toBe(false);
+      expect(areRenderedTicksEqual(ticks, [{ ...ticks[0], value: 'changed' }, ticks[1]])).toBe(false);
+      expect(areRenderedTicksEqual(ticks, [{ ...ticks[0], coordinate: 10.1 }, ticks[1]])).toBe(false);
+      expect(areRenderedTicksEqual(ticks, [{ ...ticks[0], offset: 2.1 }, ticks[1]])).toBe(false);
+      expect(areRenderedTicksEqual(ticks, [{ ...ticks[0], index: 2 }, ticks[1]])).toBe(false);
+      expect(areRenderedTicksEqual(ticks, [ticks[0]])).toBe(false);
+    });
+  });
+
+  describe('areScalesApproximatelyEqual', () => {
+    function createScale(map: (input: unknown) => number): RechartsScale {
+      return {
+        domain: () => [0, 1],
+        range: () => [0, 100],
+        rangeMin: () => 0,
+        rangeMax: () => 100,
+        isInRange: () => true,
+        bandwidth: () => 10,
+        map,
+      };
+    }
+
+    it('ignores mapped coordinates when scale metadata is equal', () => {
+      const first = createScale(() => 10);
+      const second = createScale(() => 90);
+
+      expect(areScalesApproximatelyEqual(first, second)).toBe(true);
+    });
+
+    it('rejects scales with different observable metadata', () => {
+      const first = createScale(() => 10);
+      const second: RechartsScale = {
+        ...createScale(() => 10),
+        range: () => [0, 200],
+        rangeMax: () => 200,
+      };
+
+      expect(areScalesApproximatelyEqual(first, second)).toBe(false);
+      expect(areScalesApproximatelyEqual(first, undefined)).toBe(false);
+    });
   });
 });

--- a/test/util/zoom/transform.spec.ts
+++ b/test/util/zoom/transform.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getCameraZoomState,
+  getUniformZoomState,
+  getZoomTransformForPlot,
+  transformCoordinateByCameraZoom,
+  transformCoordinateByZoom,
+} from '../../../src/util/zoom/transform';
+import { AxisViewport, FULL_VIEWPORT } from '../../../src/util/zoom/viewport';
+
+const plot = { x: 10, y: 20, width: 100, height: 200 };
+
+const partialZoom = {
+  x: { startRatio: 0.2, endRatio: 0.6 },
+  y: { startRatio: 0.25, endRatio: 0.75 },
+};
+
+describe('zoom transforms', () => {
+  describe('getZoomTransformForPlot', () => {
+    it('does not transform a full viewport', () => {
+      expect(getZoomTransformForPlot(plot, { x: FULL_VIEWPORT, y: FULL_VIEWPORT })).toBeNull();
+    });
+
+    it('projects independent partial viewports into the plot', () => {
+      expect(getZoomTransformForPlot(plot, partialZoom)).toBe('translate(10 20) scale(2.5 2) translate(-30 -70)');
+    });
+  });
+
+  describe('camera zoom modes', () => {
+    it('keeps a fully visible uniform camera viewport unchanged', () => {
+      const zoom = { x: FULL_VIEWPORT, y: FULL_VIEWPORT };
+
+      expect(getCameraZoomState('PieChart', zoom)).toEqual(zoom);
+      expect(getUniformZoomState(zoom)).toEqual(zoom);
+    });
+
+    it('keeps independent camera viewports unchanged', () => {
+      expect(getCameraZoomState('FunnelChart', partialZoom)).toBe(partialZoom);
+      expect(getCameraZoomState('LineChart', partialZoom)).toBeUndefined();
+    });
+
+    it('uses the narrowest centered viewport for uniform camera charts', () => {
+      const zoom = {
+        x: { startRatio: 0.1, endRatio: 0.9 },
+        y: { startRatio: 0.25, endRatio: 0.75 },
+      };
+
+      expect(getCameraZoomState('PieChart', zoom)).toEqual({
+        x: { startRatio: 0.25, endRatio: 0.75 },
+        y: { startRatio: 0.25, endRatio: 0.75 },
+      });
+      expect(getUniformZoomState(zoom)).toEqual({
+        x: { startRatio: 0.25, endRatio: 0.75 },
+        y: { startRatio: 0.25, endRatio: 0.75 },
+      });
+    });
+  });
+
+  describe('coordinate projection', () => {
+    it('leaves coordinates unchanged for a full viewport', () => {
+      const coordinate = { x: 50, y: 120 };
+
+      expect(transformCoordinateByZoom(coordinate, plot, { x: FULL_VIEWPORT, y: FULL_VIEWPORT })).toBe(coordinate);
+      expect(
+        transformCoordinateByCameraZoom(coordinate, plot, 'PieChart', { x: FULL_VIEWPORT, y: FULL_VIEWPORT }),
+      ).toBe(coordinate);
+    });
+
+    it('projects coordinates through independent camera zoom', () => {
+      expect(transformCoordinateByZoom({ x: 50, y: 120 }, plot, partialZoom)).toEqual({ x: 60, y: 120 });
+      expect(transformCoordinateByCameraZoom({ x: 50, y: 120 }, plot, 'FunnelChart', partialZoom)).toEqual({
+        x: 60,
+        y: 120,
+      });
+    });
+
+    it('projects coordinates through uniform camera zoom', () => {
+      const zoom: { x: AxisViewport; y: AxisViewport } = {
+        x: { startRatio: 0.1, endRatio: 0.9 },
+        y: { startRatio: 0.25, endRatio: 0.75 },
+      };
+
+      expect(transformCoordinateByCameraZoom({ x: 50, y: 120 }, plot, 'PieChart', zoom)).toEqual({ x: 40, y: 120 });
+    });
+
+    it('returns undefined when no coordinate is provided', () => {
+      expect(transformCoordinateByZoom(undefined, plot, partialZoom)).toBeUndefined();
+      expect(transformCoordinateByCameraZoom(undefined, plot, 'PieChart', partialZoom)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Breaking down https://github.com/recharts/recharts/pull/7450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved zoom behavior across Cartesian charts, including synchronized axes, scales, grid lines, labels, and plot boundaries.
  - Enhanced tooltip positioning and coordinate tracking while zoomed.
  - Added zoom-aware transformations for supported chart types.

- **Bug Fixes**
  - Prevented cursors, grid lines, and other graphical elements from rendering outside the zoomed plot area.
  - Reduced unnecessary visual updates when rendered ticks or chart values have not meaningfully changed.
  - Improved handling of floating-point differences for smoother chart rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->