### PR TITLE
docs: note pre-push hook timeout for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,9 @@ npm run test -- path/to/TestFile.spec.tsx
 If you run all tests at once using `npm test`, it may take a long time to complete.
 Only do that when you want to verify that everything is working correctly.
 
+This project has a thorough pre-push git hook (build, test, check-types, lint) that can take around
+5 minutes to complete. When running `git push`, allow a timeout of up to 10 minutes.
+
 This project has a long history. You may observe some inconsistencies in coding style.
 When making changes, prefer current best practices as described in CONTRIBUTING.md,
 and try to improve the code style where possible and where relevant to the current task.


### PR DESCRIPTION
## Summary
- The pre-push hook (build, test, check-types, lint) takes around 5 minutes to run, which can exceed default agent tool timeouts.
- Adds a note to AGENTS.md telling agents to allow up to 10 minutes when running `git push`.

## Test plan
- N/A (documentation-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance that pre-push validation may take several minutes.
  * Documented the recommended timeout for completing build, test, type-check, and lint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->