### PR TITLE
Add useAppStateReader hook for lazy state access

### DIFF
--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -22,6 +22,16 @@ type EqualityFn<T> = (a: T, b: T) => boolean;
 const refEquality: EqualityFn<unknown> = (a, b) => a === b;
 
 /**
+ * Returns a stable function that reads the current Redux state on demand (or `undefined` outside
+ * of a chart). Unlike {@link useAppSelector} it does NOT subscribe: use it to resolve state lazily
+ * inside event handlers when subscribing would re-render on every store update.
+ */
+export function useAppStateReader(): () => RechartsRootState | undefined {
+  const context = useContext(RechartsReduxContext);
+  return useMemo(() => (context ? context.store.getState : noop), [context]);
+}
+
+/**
  * This is a recharts variant of `useSelector` from 'react-redux' package.
  *
  * The difference is that react-redux version will throw an Error when used outside of Redux context.

--- a/test/state/hooks.spec.tsx
+++ b/test/state/hooks.spec.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { useAppDispatch, useAppSelector } from '../../src/state/hooks';
+import { useAppDispatch, useAppSelector, useAppStateReader } from '../../src/state/hooks';
 import { createRechartsStore } from '../../src/state/store';
 import { RechartsStoreProvider } from '../../src/state/RechartsStoreProvider';
 import { setChartData } from '../../src/state/chartDataSlice';
@@ -57,6 +57,89 @@ describe('useAppSelector', () => {
         <Spy />
       </RechartsStoreProvider>,
     );
+  });
+});
+
+describe('useAppStateReader', () => {
+  it('should return a function that returns undefined when used outside of Redux context', () => {
+    expect.assertions(1);
+    const Spy = (): null => {
+      const readState = useAppStateReader();
+      expect(readState()).toBe(undefined);
+      return null;
+    };
+    render(<Spy />);
+  });
+
+  it('should not throw an error when used outside of Redux context', () => {
+    const Spy = (): null => {
+      const readState = useAppStateReader();
+      readState();
+      return null;
+    };
+    expect(() => render(<Spy />)).not.toThrow();
+  });
+
+  it('should return a function that reads the current state when inside a Redux context', () => {
+    expect.assertions(1);
+    const Spy = (): null => {
+      const readState = useAppStateReader();
+      expect(readState()).not.toBe(undefined);
+      return null;
+    };
+    render(
+      <RechartsStoreProvider>
+        <Spy />
+      </RechartsStoreProvider>,
+    );
+  });
+
+  it('should read the latest state on demand without subscribing to updates', () => {
+    expect.assertions(4);
+    const store = createRechartsStore();
+    const renderSpy = vi.fn();
+    const readStateRef: { current: ReturnType<typeof useAppStateReader> | null } = { current: null };
+    const Spy = (): null => {
+      renderSpy();
+      readStateRef.current = useAppStateReader();
+      return null;
+    };
+    render(
+      // @ts-expect-error React-Redux types demand that the context internal value is not null, but we have that as default.
+      <Provider context={RechartsReduxContext} store={store}>
+        <Spy />
+      </Provider>,
+    );
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    expect(readStateRef.current!()!.chartData.chartData).toBe(undefined);
+
+    store.dispatch(setChartData([{ value: 1 }]));
+
+    // The reader is not subscribed, so the store update must not trigger a re-render...
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    // ...but calling it afterwards must still return the latest state.
+    expect(readStateRef.current!()!.chartData.chartData).toEqual([{ value: 1 }]);
+  });
+
+  it('should return a stable function reference across re-renders while the context is unchanged', () => {
+    expect.assertions(1);
+    const readers: Array<ReturnType<typeof useAppStateReader>> = [];
+    const Spy = (): null => {
+      readers.push(useAppStateReader());
+      return null;
+    };
+    const { rerender } = render(
+      <RechartsStoreProvider>
+        <Spy />
+      </RechartsStoreProvider>,
+    );
+    rerender(
+      <RechartsStoreProvider>
+        <Spy />
+      </RechartsStoreProvider>,
+    );
+    expect(readers[0]).toBe(readers[1]);
   });
 });
 


### PR DESCRIPTION
## Description

Adds a new `useAppStateReader` hook that returns a stable function for reading the current Redux state on demand without subscribing to updates. This hook is useful for resolving state lazily inside event handlers where subscribing would cause unnecessary re-renders on every store update.

The hook:
- Returns a function that reads the current state via `store.getState()`
- Returns `undefined` when used outside of a Redux context (gracefully handles missing context)
- Does NOT subscribe to store updates (unlike `useAppSelector`)
- Returns a stable function reference across re-renders when the context is unchanged

## Motivation and Context

This hook addresses the use case where components need to access the current state synchronously within event handlers or callbacks without triggering re-renders on every state change. The existing `useAppSelector` hook subscribes to updates, which causes re-renders whenever the selected state changes—this is inefficient when you only need to read state on-demand.

## How Has This Been Tested?

Comprehensive unit tests have been added covering:
- Behavior outside Redux context (returns undefined, doesn't throw)
- Behavior inside Redux context (returns current state)
- Lazy state reading without subscription (store updates don't trigger re-renders, but latest state is still readable)
- Stable function reference across re-renders

All tests pass and validate the hook's behavior in various scenarios.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have added tests to cover my changes.

https://claude.ai/code/session_01NQP3HPQR8RcJHmDJauvpdN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a hook for lazily reading the latest application state without subscribing to updates.
  - The hook safely returns no state outside the chart context and provides a stable reader function.

- **Tests**
  - Added coverage for context handling, on-demand state freshness, stable references, and avoiding unnecessary re-renders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->