### PR TITLE
fix(radar): keep radar points on their angle axis ticks when the angle range ascends

### DIFF
--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -3,7 +3,7 @@ import { MouseEvent, MutableRefObject, ReactElement, ReactNode, SVGProps, useRef
 import last from 'es-toolkit/compat/last';
 
 import { clsx } from 'clsx';
-import { interpolate, isNullish, noop } from '../util/DataUtils';
+import { interpolate, isNullish, mathSign, noop } from '../util/DataUtils';
 import { polarToCartesian } from '../util/PolarUtils';
 import { getTooltipNameProp, getValueByDataKey } from '../util/ChartUtils';
 import { Polygon } from '../shape/Polygon';
@@ -32,6 +32,7 @@ import { ActivePoints } from '../component/ActivePoints';
 import { TooltipPayloadConfiguration } from '../state/tooltipSlice';
 import { SetTooltipEntrySettings } from '../state/SetTooltipEntrySettings';
 import { selectRadarPoints } from '../state/selectors/radarSelectors';
+import type { AxisRange } from '../state/selectors/axisSelectors';
 import { useAppSelector } from '../state/hooks';
 import { useIsPanorama } from '../context/PanoramaContext';
 import { SetPolarLegendPayload } from '../state/SetLegendPayload';
@@ -201,6 +202,7 @@ export type AngleAxisForRadar = {
   dataKey: DataKey<any> | undefined;
   cx: number;
   cy: number;
+  range: AxisRange;
 };
 
 export type Props<DataPointType = any, DataValueType = any> = Omit<
@@ -308,7 +310,10 @@ export function computeRadarPoints({
   const { cx, cy } = angleAxis;
   let isRange = false;
   const points: RadarPoint[] = [];
-  const angleBandSize = angleAxis.type !== 'number' ? (bandSize ?? 0) : 0;
+  // scaleBand reverses the values it emits for a descending range, so the band offset that lands
+  // the first category on startAngle flips sign with the range direction, same as angle axis ticks.
+  const bandDirection = mathSign(angleAxis.range[0] - angleAxis.range[1]);
+  const angleBandSize = angleAxis.type !== 'number' ? bandDirection * (bandSize ?? 0) : 0;
 
   displayedData.forEach((entry, i) => {
     const name = getValueByDataKey(entry, angleAxis.dataKey, i);

--- a/src/state/selectors/radarSelectors.ts
+++ b/src/state/selectors/radarSelectors.ts
@@ -1,9 +1,14 @@
 import { createSelector } from 'reselect';
 import { RechartsRootState } from '../store';
 import { AngleAxisForRadar, computeRadarPoints, RadarComposedData, RadiusAxisForRadar } from '../../polar/Radar';
-import { BaseAxisWithScale } from './axisSelectors';
+import { AxisRange, BaseAxisWithScale } from './axisSelectors';
 import { selectPolarAxisScale, selectPolarAxisTicks } from './polarScaleSelectors';
-import { selectAngleAxis, selectPolarViewBox, selectRadiusAxis } from './polarAxisSelectors';
+import {
+  selectAngleAxis,
+  selectAngleAxisRangeWithReversed,
+  selectPolarViewBox,
+  selectRadiusAxis,
+} from './polarAxisSelectors';
 import { AxisId } from '../cartesianAxisSlice';
 import { selectChartDataAndAlwaysIgnoreIndexes } from './dataSelectors';
 import { ChartDataState } from '../chartDataSlice';
@@ -89,18 +94,25 @@ const selectAngleAxisTicks = (
   return selectPolarAxisTicks(state, 'angleAxis', angleAxisId, isPanorama);
 };
 
+const selectAngleAxisRangeForRadar = (
+  state: RechartsRootState,
+  _radiusAxisId: AxisId,
+  angleAxisId: AxisId,
+): AxisRange | undefined => selectAngleAxisRangeWithReversed(state, angleAxisId);
+
 export const selectAngleAxisWithScaleAndViewport: (
   state: RechartsRootState,
   _radiusAxisId: AxisId,
   angleAxisId: AxisId,
 ) => AngleAxisForRadar | undefined = createSelector(
-  [selectAngleAxisForRadar, selectPolarAxisScaleForRadar, selectPolarViewBox],
+  [selectAngleAxisForRadar, selectPolarAxisScaleForRadar, selectPolarViewBox, selectAngleAxisRangeForRadar],
   (
     axisOptions: AngleAxisSettings,
     scale: RechartsScale | undefined,
     polarViewBox: PolarViewBoxRequired | undefined,
+    range: AxisRange | undefined,
   ): AngleAxisForRadar | undefined => {
-    if (polarViewBox == null || scale == null) {
+    if (polarViewBox == null || scale == null || range == null) {
       return undefined;
     }
     return {
@@ -109,6 +121,7 @@ export const selectAngleAxisWithScaleAndViewport: (
       dataKey: axisOptions.dataKey,
       cx: polarViewBox.cx,
       cy: polarViewBox.cy,
+      range,
     };
   },
 );

--- a/storybook/stories/API/chart/RadarChart.stories.tsx
+++ b/storybook/stories/API/chart/RadarChart.stories.tsx
@@ -31,3 +31,25 @@ export const API = {
     height: 300,
   },
 };
+
+export const CounterClockwise = {
+  name: 'Counter clockwise',
+  render: (args: Args) => {
+    return (
+      <RadarChart {...args}>
+        <PolarAngleAxis dataKey="name" />
+        <PolarRadiusAxis />
+        <PolarGrid />
+        <Radar dataKey="uv" stroke="green" strokeOpacity={0.7} fill="green" fillOpacity={0.5} strokeWidth={3} />
+      </RadarChart>
+    );
+  },
+  args: {
+    ...getStoryArgsFromArgsTypesObject(RadarChartArgs),
+    data: pageData,
+    width: 800,
+    height: 300,
+    startAngle: -270,
+    endAngle: 90,
+  },
+};

--- a/test/polar/Radar.spec.tsx
+++ b/test/polar/Radar.spec.tsx
@@ -2,7 +2,15 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { expect, it, vi } from 'vitest';
-import { DefaultZIndexes, InternalRadarProps, Radar, RadarChart, RadarPoint, RadarProps } from '../../src';
+import {
+  DefaultZIndexes,
+  InternalRadarProps,
+  PolarAngleAxis,
+  Radar,
+  RadarChart,
+  RadarPoint,
+  RadarProps,
+} from '../../src';
 import { useAppSelector } from '../../src/state/hooks';
 import { selectPolarItemsSettings } from '../../src/state/selectors/polarSelectors';
 import { exampleRadarData } from '../_data';
@@ -13,6 +21,8 @@ import { assertNotNull } from '../helper/assertNotNull';
 import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { selectRadiusAxis } from '../../src/state/selectors/polarAxisSelectors';
+import { selectPolarAngleAxisTicks } from '../../src/state/selectors/polarScaleSelectors';
+import { selectRadarPoints } from '../../src/state/selectors/radarSelectors';
 import { defaultAxisId } from '../../src/state/cartesianAxisSlice';
 
 type Point = { x?: number | string; y?: number | string };
@@ -72,6 +82,53 @@ describe('<Radar />', () => {
           fillOpacity: null,
         },
       ]);
+    });
+  });
+
+  describe.each([
+    {
+      direction: 'clockwise',
+      startAngle: 90,
+      endAngle: -270,
+      expectedAngles: [90, 45, 0, -45, -90, -135, -180, -225],
+      expectedPolygon:
+        'M250,167.68L313.7527,186.2473L445.804,250L319.2965,319.2965L250,419.344L159.9146,340.0854L100.06,250L199.4136,199.4136L250,167.68Z',
+    },
+    {
+      direction: 'counter-clockwise',
+      startAngle: -270,
+      endAngle: 90,
+      expectedAngles: [-315, -270, -225, -180, -135, -90, -45, 0],
+      expectedPolygon:
+        'M308.209,191.791L250,159.84L111.5457,111.5457L152,250L130.2557,369.7443L250,377.4L356.0236,356.0236L321.54,250L308.209,191.791Z',
+    },
+  ])('in a chart rotating $direction', ({ startAngle, endAngle, expectedAngles, expectedPolygon }) => {
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <RadarChart width={500} height={500} data={exampleRadarData} startAngle={startAngle} endAngle={endAngle}>
+        <PolarAngleAxis dataKey="name" />
+        <Radar dataKey="value" id="radar-value" isAnimationActive={false} />
+        {children}
+      </RadarChart>
+    ));
+
+    it('should put every point on the angle axis tick that carries the same category', () => {
+      const ticks = renderTestCase(state => selectPolarAngleAxisTicks(state, 'angleAxis', defaultAxisId, false)).spy
+        .mock.lastCall?.[0];
+      const radarPoints = renderTestCase(state =>
+        selectRadarPoints(state, defaultAxisId, defaultAxisId, false, 'radar-value'),
+      ).spy.mock.lastCall?.[0];
+      assertNotNull(ticks);
+      assertNotNull(radarPoints);
+
+      const expected = exampleRadarData.map((entry, index) => [entry.name, expectedAngles[index]]);
+      expect(ticks.map(tick => [tick.value, tick.coordinate])).toEqual(expected);
+      expect(radarPoints.points.map(point => [point.name, point.angle])).toEqual(expected);
+    });
+
+    it('should render a polygon', () => {
+      const { container } = renderTestCase();
+
+      expectRadarPolygons(container, [{ d: expectedPolygon, fill: null, fillOpacity: null }]);
     });
   });
 

--- a/test/state/selectors/radarSelectors.spec.tsx
+++ b/test/state/selectors/radarSelectors.spec.tsx
@@ -573,6 +573,7 @@ describe('selectAngleAxisWithScaleAndViewport', () => {
       cx: 250,
       cy: 250,
       dataKey: 'value',
+      range: [90, -270],
       scale: expect.toBeRechartsScale({ domain: [420, 460, 999, 500, 864, 650, 765, 365], range: [-270, 90] }),
       type: 'category',
     });


### PR DESCRIPTION
## Description

`computeRadarPoints` offsets every radar point by the angle axis band size, unsigned. `combineAxisTicks` offsets angle axis ticks by the same band, but signed: `mathSign(axisRange[0] - axisRange[1]) * 2 * offset` in `src/state/selectors/axisSelectors.ts`. The two agree only while the range descends, which is the RadarChart default (`startAngle=90`, `endAngle=-270`).

Swap the two angles to draw counter-clockwise (as suggested in #1828), or set `reversed` on the angle axis, and the range ascends. d3 `scaleBand` only reverses the values it emits for a descending range, so the ticks move one band one way and the points one band the other way, and every point ends up two bands from the tick that carries its own category.

The direction cannot be recovered from the scale: `rechartsScaleFactory` stores `[Math.min(...range), Math.max(...range)]`, so `scale.range()` is `[-270, 90]` for both `startAngle=90, endAngle=-270` and its inverse. This passes the `reversed`-aware angle axis range into `AngleAxisForRadar` and applies to the points the same sign the ticks already use.

## Related Issue

#2619

## Motivation and Context

Reproduction, 8 categories over 360 degrees, so one band is 45 degrees:

```jsx
<RadarChart width={500} height={500} data={data} startAngle={-270} endAngle={90}>
  <PolarAngleAxis dataKey="name" />
  <Radar dataKey="value" />
</RadarChart>
```

Angle of the first category, measured on `main`:

| chart | angle axis tick | radar point |
| --- | --- | --- |
| `startAngle=90`, `endAngle=-270` (default, clockwise) | 90 | 90 |
| `startAngle=-270`, `endAngle=90` (counter-clockwise) | -315 | -225 |
| `startAngle=0`, `endAngle=360` | -45 | 45 |
| default chart, `<PolarAngleAxis reversed />` | -315 | -225 |

After this change all four rows have the point sitting on its own tick: 90/90, -315/-315, -45/-45, -315/-315. The clockwise row is untouched, and so is every other angle in it: 90, 45, 0, -45, -90, -135, -180, -225 before and after.

The polygon path for the counter-clockwise chart above:

```
before  M191.791,191.791L159.84,250L111.5457,388.4543L250,348L369.7443,369.7443...
after   M308.209,191.791L250,159.84L111.5457,111.5457L152,250L130.2557,369.7443...
```

The first vertex checks out by hand: the first category has radius 82.32 in a 500x500 chart, and `polarToCartesian(250, 250, 82.32, -315)` is `(308.209, 191.791)`.

### What this does not fix

The issue also reports the first tick landing one band away from `startAngle` on an ascending range: with `startAngle=-270` the first tick is at -315 rather than -270. That is the tick offset itself, in `combineAxisTicks`, and it is shared with RadialBarChart, whose defaults (`startAngle=0`, `endAngle=360`) sit on the same ascending branch. Replacing the expression with `axisRange[0] > axisRange[1] ? 2 * offset : 0` does place the first tick on `startAngle` in both directions, but it rewrites 10 existing expectations, 7 in `test/polar/PolarAngleAxis/PolarAngleAxis.spec.tsx` and 3 in `test/polar/PolarGrid.spec.tsx`, almost all of them RadialBarChart. That is a visible change to RadialBarChart label placement and deserves its own decision, so I left it out. Happy to open a follow-up if you want it.

What this PR does fix is the part that makes the chart unreadable: the polygon no longer disagrees with its own labels.

## How Has This Been Tested?

`test/polar/Radar.spec.tsx` gets a `describe.each` over both rotation directions. For each direction it asserts that the angle axis tick coordinates and the radar point angles are both exactly the expected list, and that the rendered polygon path matches. The clockwise case is the control: its expected path is character for character the one already asserted higher up in the same file, so the common direction is provably unchanged.

Counterfactual, source reverted and tests kept: the two counter-clockwise tests fail and the two clockwise ones pass.

```
FAIL test/polar/Radar.spec.tsx > <Radar /> > in a chart rotating 'counter-clockwise' > should put every point on the angle axis tick that carries the same category
AssertionError: expected [ [ 'iPhone 3GS', -225 ], ...(7) ] to deeply equal [ [ 'iPhone 3GS', -315 ], ...(7) ]

FAIL test/polar/Radar.spec.tsx > <Radar /> > in a chart rotating 'counter-clockwise' > should render a polygon
AssertionError: expected [ { ...(3) } ] to deeply equal [ { ...(3) } ]
```

`test/state/selectors/radarSelectors.spec.tsx` needed one line for the new `range` field on the selector result.

`npm run test-lib`, before: 324 files, 6392 passed, 6415 total, 0 failures.
After: 324 files, 6396 passed, 6419 total, 0 failures.

`npm run check-types` and `eslint` on the changed files are clean. The new storybook story passes the smoke test. No VR test and no existing story uses `startAngle`, `endAngle` or `reversed` on a radar chart, so no existing snapshot moves.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Radar chart category positioning when the angle axis is configured to run counter-clockwise.
  * Ensured radar points, axis ticks, and rendered polygons remain aligned across clockwise and counter-clockwise orientations.

* **Documentation**
  * Added a Radar chart example demonstrating counter-clockwise rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->