### PR TITLE
fix: declare @types/react as an optional peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,9 +123,15 @@
         "node": ">=18"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,13 @@
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "@types/react": "*"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.0 || 2.x.x",


### PR DESCRIPTION
## Description

Declares `@types/react` as an optional peer dependency.

```json
"peerDependencies": {
  "@types/react": "*"
},
"peerDependenciesMeta": {
  "@types/react": { "optional": true }
}
```

Optional, so JavaScript consumers are not warned about a package they do not need.

## Related Issue

Fixes #7709.

## Motivation and Context

Recharts' type files do `import * as React from 'react'`, but `@types/react` is not declared. Under a strict, non-hoisted `node_modules` those types cannot resolve React, every component's types degrade, and consumers see:

```text
error TS2607: JSX element class does not support attributes because it does not have a 'props' property
error TS2786: 'Bar' cannot be used as a JSX component
```

Bun's isolated linker, pnpm and Yarn PnP all resolve a symlink to its real path before walking parent directories, so a package sees only what it declares. `react` is declared and resolves; `@types/react` is not.

Same fix that `@radix-ui/*` and `posthog-js@1.422.5` already ship.

## How Has This Been Tested?

In an Electron + React 19 app on Bun 1.4 with `linker = "isolated"`, recharts accounted for 122 TypeScript errors across 8 files. Applying this exact change as a local patch takes those to 0. Full app suite passes after: typecheck clean, lint clean, 168 unit tests.

`npm install --package-lock-only` regenerated the lockfile; the diff is the peer entry only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

Package metadata only, so there is no code path to unit test and no rendering behaviour to story. The regression it prevents is only observable from a real install under a strict linker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package compatibility requirements to support projects that use React type definitions.
  * Made the React type definitions dependency optional for improved installation flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->