### PR TITLE
fix(omnidoc): strip LinkToApi and resolve correct story name in generated Storybook MDX

### DIFF
--- a/omnidoc/generateStorybookArgs.spec.ts
+++ b/omnidoc/generateStorybookArgs.spec.ts
@@ -8,6 +8,10 @@ describe('stripLinks', () => {
     );
   });
 
+  it('should strip <LinkToApi> tags whose content spans multiple lines', () => {
+    expect(stripLinks('Use <LinkToApi>Reference\nArea</LinkToApi> instead.')).toBe('Use Reference\nArea instead.');
+  });
+
   it('should strip a mix of <a>, <Link> and <LinkToApi> tags in a single string', () => {
     const input =
       'See <a href="https://example.com">external docs</a>, ' +

--- a/omnidoc/generateStorybookArgs.spec.ts
+++ b/omnidoc/generateStorybookArgs.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { stripLinks, getPrimaryStoryName } from './generateStorybookArgs';
+
+describe('stripLinks', () => {
+  it('should strip <LinkToApi> tags while preserving their text content', () => {
+    expect(stripLinks('Consider using the <LinkToApi>ReferenceArea</LinkToApi> component instead.')).toBe(
+      'Consider using the ReferenceArea component instead.',
+    );
+  });
+
+  it('should strip a mix of <a>, <Link> and <LinkToApi> tags in a single string', () => {
+    const input =
+      'See <a href="https://example.com">external docs</a>, ' +
+      'or use <LinkToApi>useOffset</LinkToApi>, ' +
+      'or read the <Link to="/guide">guide</Link>.';
+    expect(stripLinks(input)).toBe('See external docs, or use useOffset, or read the guide.');
+  });
+
+  it('should leave plain text without any tags untouched', () => {
+    expect(stripLinks('Margin is the empty space around the chart.')).toBe(
+      'Margin is the empty space around the chart.',
+    );
+  });
+});
+
+describe('getPrimaryStoryName', () => {
+  it('should return "API" when a story named API is exported, including typed exports', () => {
+    const content = `
+      export default { title: 'Rectangle' };
+      export const API: StoryObj = { args: {} };
+      export const CustomTickWithPadding = { args: {} };
+    `;
+    expect(getPrimaryStoryName(content)).toBe('API');
+  });
+
+  it('should fall back to the first exported story, in file order, when none is named API', () => {
+    const content = `
+      export default { title: 'Radar' };
+      export const General = { args: {} };
+      export const WithLabels = { args: {} };
+    `;
+    expect(getPrimaryStoryName(content)).toBe('General');
+  });
+
+  it('should be case-sensitive when matching the API story name', () => {
+    const content = `
+      export default { title: 'api' };
+      export const General = { args: {} };
+      export const api = { args: {} };
+    `;
+    expect(getPrimaryStoryName(content)).toBe('General');
+  });
+
+  it('should return undefined when the file has no named exports', () => {
+    const content = `
+      export default { title: 'Empty' };
+    `;
+    expect(getPrimaryStoryName(content)).toBeUndefined();
+  });
+});

--- a/omnidoc/generateStorybookArgs.ts
+++ b/omnidoc/generateStorybookArgs.ts
@@ -230,7 +230,7 @@ export function stripLinks(html: string): string {
   return html
     .replace(/<Link\s+[^>]*>(.*?)<\/Link>/g, '$1')
     .replace(/<a\s+[^>]*>(.*?)<\/a>/g, '$1')
-    .replace(/<LinkToApi(?:\s+[^>]*)?>(.*?)<\/LinkToApi>/g, '$1');
+    .replace(/<LinkToApi(?:\s+[^>]*)?>([\s\S]*?)<\/LinkToApi>/g, '$1');
 }
 
 /**
@@ -349,6 +349,12 @@ async function main() {
 
         if (storyName == null) {
           console.warn(`⚠ No exported stories found in ${storiesFile}, skipping MDX generation.`);
+          // Remove any stale MDX from a previous run, since it may reference a story that no longer exists.
+          const staleMdxPath = absoluteStoriesPath.replace(/\.stories\.tsx$/, '.mdx');
+          if (fs.existsSync(staleMdxPath)) {
+            await fs.promises.unlink(staleMdxPath);
+            console.warn(`⚠ Removed stale ${staleMdxPath}.`);
+          }
           continue;
         }
 

--- a/omnidoc/generateStorybookArgs.ts
+++ b/omnidoc/generateStorybookArgs.ts
@@ -222,6 +222,30 @@ export const ${varName}: StorybookArgs = ${JSON.stringify(args, null, 2)};
 }
 
 /**
+ * Strips <Link>, <a> and <LinkToApi> tags from a string, preserving their text content.
+ * LinkToApi must be handled too - a leftover tag breaks the generated MDX at render time,
+ * since it's never imported there.
+ */
+export function stripLinks(html: string): string {
+  return html
+    .replace(/<Link\s+[^>]*>(.*?)<\/Link>/g, '$1')
+    .replace(/<a\s+[^>]*>(.*?)<\/a>/g, '$1')
+    .replace(/<LinkToApi(?:\s+[^>]*)?>(.*?)<\/LinkToApi>/g, '$1');
+}
+
+/**
+ * Picks which exported story to bind the generated MDX's <Canvas>/<Controls> to.
+ * Prefers a story named `API`, otherwise falls back to the first exported story.
+ */
+export function getPrimaryStoryName(storiesFileContent: string): string | undefined {
+  const exportedNames = [...storiesFileContent.matchAll(/^\s*export const (\w+)/gm)].map(match => match[1]);
+  if (exportedNames.length === 0) {
+    return undefined;
+  }
+  return exportedNames.includes('API') ? 'API' : exportedNames[0];
+}
+
+/**
  * Generates MDX documentation for a component
  */
 function generateMdx(
@@ -229,6 +253,7 @@ function generateMdx(
   description: ReactNode,
   parentComponents: ReadonlyArray<string> | undefined,
   childrenComponents: ReadonlyArray<string> | undefined,
+  storyName: string,
 ): string {
   const importPath = `./${componentName}.stories`;
 
@@ -239,7 +264,7 @@ import * as ComponentStories from '${importPath}';
 
 <Meta of={ComponentStories} />
 
-<Canvas of={ComponentStories.API} layout='padded'/>
+<Canvas of={ComponentStories.${storyName}} layout='padded'/>
 `;
 
   if (description) {
@@ -271,7 +296,7 @@ ${childrenComponents.map(c => `- \`<${c}/>\``).join('\n')}
   mdx += `
 ## Props
 
-<Controls of={ComponentStories.API} />
+<Controls of={ComponentStories.${storyName}} />
 `;
 
   return mdx;
@@ -302,13 +327,6 @@ async function main() {
 
   console.log('Generating Storybook ArgTypes and MDX for:', componentsToGenerate);
 
-  /**
-   * Strips <Link> and <a> tags from a string, preserving the text content.
-   */
-  function stripLinks(html: string): string {
-    return html.replace(/<Link\s+[^>]*>(.*?)<\/Link>/g, '$1').replace(/<a\s+[^>]*>(.*?)<\/a>/g, '$1');
-  }
-
   for (const componentName of componentsToGenerate) {
     try {
       // Generate Args
@@ -326,7 +344,21 @@ async function main() {
 
       if (storiesFile) {
         const absoluteStoriesPath = path.resolve(storiesFile);
-        const mdxContent = generateMdx(componentName, description, apiDoc.parentComponents, apiDoc.childrenComponents);
+        const storiesFileContent = await fs.promises.readFile(absoluteStoriesPath, 'utf-8');
+        const storyName = getPrimaryStoryName(storiesFileContent);
+
+        if (storyName == null) {
+          console.warn(`⚠ No exported stories found in ${storiesFile}, skipping MDX generation.`);
+          continue;
+        }
+
+        const mdxContent = generateMdx(
+          componentName,
+          description,
+          apiDoc.parentComponents,
+          apiDoc.childrenComponents,
+          storyName,
+        );
         // Overwrite MDX in-place (next to the stories file)
         const mdxOutputPath = absoluteStoriesPath.replace(/\.stories\.tsx$/, '.mdx');
         await writeFormattedFile(mdxOutputPath, mdxContent, prettierConfig, 'mdx');


### PR DESCRIPTION
## Description

Fixes two issues in the generated Storybook API docs:

1. `stripLinks()` now also strips `<LinkToApi>` tags, not just `<Link>` and `<a>`. The
   generated MDX never imports `LinkToApi`, so a leftover tag was breaking the docs page
   at render time.
2. Added `getPrimaryStoryName()`, which reads the actual exported story name from the
   `.stories.tsx` file instead of assuming `ComponentStories.API`. It prefers a story
   named `API` when one exists, otherwise falls back to the first exported story.

Both live in the same generation flow, so fixed together here.


## Related Issue

Fixes #7711

## Motivation and Context

Some generated Storybook API pages were failing to render.

Descriptions containing internal API links could leave `<LinkToApi>` tags in the generated MDX, where the component is not imported.

Also, some `.stories.tsx` files export stories with names such as `UseMargin` or `General` instead of `API`. The generated MDX still referenced `ComponentStories.API`, which resulted in `of={undefined}` errors.

## How Has This Been Tested?

- Added unit tests in `omnidoc/generateStorybookArgs.spec.ts` covering both fixes.

- Ran `npm run omnidoc` and confirmed `Rectangle.mdx`, `Dot.mdx`, `useMargin.mdx`,
  `useOffset.mdx`, `ReferenceDot.mdx`, `ReferenceArea.mdx` and `SunburstChart.mdx` no
  longer contain an unimported `LinkToApi` tag.

- Confirmed `useMargin.mdx`, `useOffset.mdx`, `usePlotArea.mdx`,
  `useActiveTooltipDataPoints.mdx` and `Radar.mdx` now reference the correct story
  instead of the undefined `ComponentStories.API`.

- Ran `npm run storybook` and opened the affected docs pages, they render without errors.

- `npx eslint` and `npx tsc --project storybook/tsconfig.json` both pass clean.


## Screenshots (if appropriate):

N/A

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [x] I have added tests to cover my changes.
* [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation previews now select the API story when available, or automatically use the first available story.
  * Link tags, including multiline links, are removed while preserving their displayed text.

* **Bug Fixes**
  * Documentation generation now safely skips files without exported stories, provides a warning, and removes outdated generated documentation.
  * Story-specific canvas and control sections now display the correct story.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->