### PR TITLE
fix(util): keep LRUCache within maxSize and refresh recency for undefined values

### DIFF
--- a/src/util/LRUCache.ts
+++ b/src/util/LRUCache.ts
@@ -11,11 +11,14 @@ export class LRUCache<K, V> {
   }
 
   get(key: K): V | undefined {
-    const value = this.cache.get(key);
-    if (value !== undefined) {
-      this.cache.delete(key);
-      this.cache.set(key, value);
+    // `has` rather than an `undefined` check on the value: `undefined` is a storable
+    // value, and treating it as a miss would leave that entry's recency unchanged.
+    if (!this.cache.has(key)) {
+      return undefined;
     }
+    const value = this.cache.get(key) as V;
+    this.cache.delete(key);
+    this.cache.set(key, value);
     return value;
   }
 
@@ -23,9 +26,12 @@ export class LRUCache<K, V> {
     if (this.cache.has(key)) {
       this.cache.delete(key);
     } else if (this.cache.size >= this.maxSize) {
-      const firstKey = this.cache.keys().next().value;
-      if (firstKey != null) {
-        this.cache.delete(firstKey);
+      // Ask the iterator whether it produced a key, instead of testing the key itself:
+      // `null` and `undefined` are valid Map keys, so a nullish check would skip the
+      // eviction and let the cache grow past `maxSize`.
+      const oldest = this.cache.keys().next();
+      if (!oldest.done) {
+        this.cache.delete(oldest.value);
       }
     }
     this.cache.set(key, value);

--- a/test/util/LRUCache.spec.ts
+++ b/test/util/LRUCache.spec.ts
@@ -78,4 +78,32 @@ describe('LRUCache', () => {
     expect(singleCache.get('b')).toBe(2);
     expect(singleCache.size()).toBe(1);
   });
+
+  test('should evict when the oldest key is nullish', () => {
+    const nullishCache = new LRUCache<string | null | undefined, number>(2);
+
+    nullishCache.set(null, 1);
+    nullishCache.set(undefined, 2);
+    nullishCache.set('c', 3);
+
+    expect(nullishCache.size()).toBe(2);
+    expect(nullishCache.get(null)).toBeUndefined();
+    expect(nullishCache.get(undefined)).toBe(2);
+    expect(nullishCache.get('c')).toBe(3);
+  });
+
+  test('should update LRU order when accessing an entry stored as undefined', () => {
+    const undefinedCache = new LRUCache<string, number | undefined>(2);
+
+    undefinedCache.set('a', undefined);
+    undefinedCache.set('b', 2);
+
+    // Reading 'a' makes it the most recently used, so 'b' is the one to evict.
+    undefinedCache.get('a');
+    undefinedCache.set('c', 3);
+
+    expect(undefinedCache.size()).toBe(2);
+    expect(undefinedCache.get('b')).toBeUndefined();
+    expect(undefinedCache.get('c')).toBe(3);
+  });
 });


### PR DESCRIPTION
Found by probing `src/util/` invariants rather than from a bug report, so there's no issue to link. Two of `LRUCache`'s own contracts break for legitimate key and value types.

**1. The cache grows past `maxSize` when the oldest key is `null` or `undefined`.**

```js
const cache = new LRUCache(2)
cache.set(null, 1)
cache.set(undefined, 2)
cache.set('c', 3)
cache.size() // 3, and it keeps climbing from here
```

Eviction reads the oldest key and then guards it with `if (firstKey != null)`. The guard is there because `keys().next().value` is `undefined` on an empty map, but `null` and `undefined` are both valid `Map` keys, so when the oldest entry legitimately has one, the guard reads it as "nothing to evict" and skips the delete. The entry is then added anyway and the cache is over capacity permanently. Asking the iterator whether it actually produced a key (`!oldest.done`) separates "empty" from "the key happens to be nullish".

**2. `get()` doesn't refresh recency when the stored value is `undefined`.**

```js
const cache = new LRUCache(2)
cache.set('a', undefined)
cache.set('b', 2)
cache.get('a')   // should make 'a' most recent
cache.set('c', 3)
cache.get('b')   // 2 - 'b' survived, 'a' was evicted instead
```

`get` decides whether to re-insert by testing `value !== undefined`, which can't tell a stored `undefined` from a miss. So reading that entry silently doesn't count as a use, and the LRU order is wrong from then on — the wrong entry gets evicted. `has()` answers the question the code is actually asking.

To be straight about impact: neither is reachable through Recharts today. The only call site is `stringCache` in `DOMUtils`, which is `LRUCache<string, Size>` and never stores `undefined`. But the class is generic, ships in the build, and has its own spec file that tests it as a general structure — capacity, eviction, LRU order — so these are the invariants that file already asserts, just for key and value types it doesn't currently try.

## Testing

Two tests added to `test/util/LRUCache.spec.ts`, one per bug. Reverting only `src/util/LRUCache.ts` and re-running fails exactly those two and leaves the existing 7 passing:

```
× should evict when the oldest key is nullish
× should update LRU order when accessing an entry stored as undefined
  Tests  2 failed | 7 passed (9)
```

With the fix, 9/9 pass, and the whole `test/util/` directory is green at 50 files / 1106 tests. eslint clean. `tsc` reports the same 10 pre-existing errors before and after, none in this file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache eviction when keys are `null` or `undefined`, preventing the cache from exceeding its configured capacity.
  * Corrected cache access behavior so entries storing `undefined` remain valid and have their usage priority updated.

* **Tests**
  * Added coverage for nullish keys and undefined values during cache eviction and access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->