### PR TITLE
fix(RadialBar): implement minAngle prop for minimum bar angle

### DIFF
--- a/src/polar/Pie.tsx
+++ b/src/polar/Pie.tsx
@@ -367,7 +367,7 @@ export interface PieProps<DataPointType = any, DataValueType = any>
   /** the max radius of pie */
   maxRadius?: number;
   /**
-   * The minimum angle of each unzero data.
+   * The minimum angle of each non-zero segment.
    * @defaultValue 0
    */
   minAngle?: number;

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -798,8 +798,12 @@ export function computeRadialBarDataItems({
         }
 
         // Zero-value bars are excluded so a truly empty bar never gets an artificial sliver.
-        if (minAngle > 0 && deltaAngle !== 0 && Math.abs(deltaAngle) < minAngle) {
-          const delta = mathSign(deltaAngle) * (minAngle - Math.abs(deltaAngle));
+        // Negative minAngle is normalized the same way Pie normalizes pieSettings.minAngle.
+        // Note: like minPointSize above, this expands each bar independently, so a stacked
+        // bar's expansion can overlap into its neighbor's range. That is an existing
+        // limitation shared with minPointSize, not something new to minAngle.
+        if (Math.abs(minAngle) > 0 && deltaAngle !== 0 && Math.abs(deltaAngle) < Math.abs(minAngle)) {
+          const delta = mathSign(deltaAngle) * (Math.abs(minAngle) - Math.abs(deltaAngle));
           endAngle += delta;
         }
         backgroundSector = {

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -416,6 +416,13 @@ export interface InternalRadialBarProps<DataPointType = any, DataValueType = any
   legendType?: LegendType;
   maxBarSize?: number;
   /**
+   * The minimum angle, in degrees, for a non-zero bar in `radial` layout (the default). Bars whose
+   * natural angle would fall below this threshold are extended to meet it, so small values stay visible.
+   * Bars with a value of zero are never extended.
+   * @defaultValue 0
+   */
+  minAngle?: number;
+  /**
    * @defaultValue 0
    */
   minPointSize?: number;
@@ -634,6 +641,7 @@ function RadialBarImpl(props: WithIdRequired<PropsWithDefaults>) {
       hide: false,
       id: props.id,
       dataKey: props.dataKey,
+      minAngle: props.minAngle,
       minPointSize: props.minPointSize,
       stackId: getNormalizedStackId(props.stackId),
       maxBarSize: props.maxBarSize,
@@ -645,6 +653,7 @@ function RadialBarImpl(props: WithIdRequired<PropsWithDefaults>) {
     [
       props.id,
       props.dataKey,
+      props.minAngle,
       props.minPointSize,
       props.stackId,
       props.maxBarSize,
@@ -691,6 +700,7 @@ export const defaultRadialBarProps = {
   isAnimationActive: 'auto',
   label: false,
   legendType: 'rect',
+  minAngle: 0,
   minPointSize: 0,
   radiusAxisId: 0,
   shape: defaultRadialBarShape,
@@ -715,6 +725,7 @@ export function computeRadialBarDataItems({
   bandSize,
   pos,
   angleAxis,
+  minAngle,
   minPointSize,
   cx,
   cy,
@@ -735,6 +746,7 @@ export function computeRadialBarDataItems({
   bandSize: number;
   pos: BarPositionPosition;
   angleAxis: BaseAxisWithScale;
+  minAngle: number;
   minPointSize: number;
   cx: number;
   cy: number;
@@ -778,11 +790,18 @@ export function computeRadialBarDataItems({
       });
       if (innerRadius != null && endAngle != null && startAngle != null) {
         outerRadius = innerRadius + pos.size;
-        const deltaAngle = endAngle - startAngle;
+        let deltaAngle = endAngle - startAngle;
 
         if (Math.abs(minPointSize) > 0 && Math.abs(deltaAngle) < Math.abs(minPointSize)) {
           const delta = mathSign(deltaAngle || minPointSize) * (Math.abs(minPointSize) - Math.abs(deltaAngle));
 
+          endAngle += delta;
+          deltaAngle = endAngle - startAngle;
+        }
+
+        // Zero-value bars are excluded so a truly empty bar never gets an artificial sliver.
+        if (minAngle > 0 && deltaAngle !== 0 && Math.abs(deltaAngle) < minAngle) {
+          const delta = mathSign(deltaAngle) * (minAngle - Math.abs(deltaAngle));
           endAngle += delta;
         }
         backgroundSector = {
@@ -888,6 +907,7 @@ export function RadialBar<DataPointType = any, DataValueType = any>(
             radiusAxisId={props.radiusAxisId ?? defaultRadialBarProps.radiusAxisId}
             stackId={getNormalizedStackId(props.stackId)}
             barSize={props.barSize}
+            minAngle={props.minAngle}
             minPointSize={props.minPointSize}
             maxBarSize={props.maxBarSize}
           />

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -416,9 +416,7 @@ export interface InternalRadialBarProps<DataPointType = any, DataValueType = any
   legendType?: LegendType;
   maxBarSize?: number;
   /**
-   * The minimum angle, in degrees, for a non-zero bar in `radial` layout (the default). Bars whose
-   * natural angle would fall below this threshold are extended to meet it, so small values stay visible.
-   * Bars with a value of zero are never extended.
+   * The minimum angle of each non-zero bar.
    * @defaultValue 0
    */
   minAngle?: number;

--- a/src/state/selectors/radialBarSelectors.ts
+++ b/src/state/selectors/radialBarSelectors.ts
@@ -406,7 +406,7 @@ export const selectRadialBarSectors: (
     ) {
       return [];
     }
-    const { dataKey, minPointSize } = radialBarSettings;
+    const { dataKey, minAngle, minPointSize } = radialBarSettings;
     const { cx, cy, startAngle, endAngle } = polarViewBox;
     const displayedData = chartData.slice(dataStartIndex, dataEndIndex + 1);
     const numericAxis = layout === 'centric' ? radiusAxis : angleAxis;
@@ -424,6 +424,7 @@ export const selectRadialBarSectors: (
       displayedData,
       endAngle,
       layout,
+      minAngle,
       minPointSize,
       pos,
       radiusAxis,

--- a/src/state/types/RadialBarSettings.ts
+++ b/src/state/types/RadialBarSettings.ts
@@ -3,6 +3,7 @@ import { BasePolarGraphicalItemSettings } from '../graphicalItemsSlice';
 
 export interface RadialBarSettings extends BasePolarGraphicalItemSettings, MaybeStackedGraphicalItem {
   type: 'radialBar';
+  minAngle: number;
   minPointSize: number;
   maxBarSize: number | undefined;
 }

--- a/test/polar/PolarAngleAxis/PolarAngleAxis.spec.tsx
+++ b/test/polar/PolarAngleAxis/PolarAngleAxis.spec.tsx
@@ -1754,6 +1754,7 @@ describe('<PolarAngleAxis />', () => {
           {
             id: expect.stringMatching('radialBar-'),
             maxBarSize: undefined,
+            minAngle: 0,
             minPointSize: 0,
             barSize: undefined,
             stackId: undefined,
@@ -1927,6 +1928,7 @@ describe('<PolarAngleAxis />', () => {
           {
             id: expect.stringMatching('radialBar-'),
             maxBarSize: undefined,
+            minAngle: 0,
             minPointSize: 0,
             barSize: undefined,
             stackId: undefined,
@@ -2036,6 +2038,7 @@ describe('<PolarAngleAxis />', () => {
           {
             id: expect.stringMatching('radialBar-'),
             maxBarSize: undefined,
+            minAngle: 0,
             minPointSize: 0,
             barSize: undefined,
             stackId: undefined,

--- a/test/polar/RadialBar/RadialBar.spec.tsx
+++ b/test/polar/RadialBar/RadialBar.spec.tsx
@@ -51,6 +51,7 @@ describe('<RadialBar />', () => {
     const radialBarSettings: RadialBarSettings = {
       id: 'radial-bar-uv',
       dataKey: 'pv',
+      minAngle: 0,
       minPointSize: 0,
       stackId: undefined,
       maxBarSize: undefined,
@@ -75,6 +76,7 @@ describe('<RadialBar />', () => {
         {
           id: expect.stringMatching('radialBar-'),
           maxBarSize: undefined,
+          minAngle: 0,
           minPointSize: 0,
           angleAxisId: 0,
           barSize: undefined,
@@ -436,10 +438,76 @@ describe('<RadialBar />', () => {
     });
   });
 
+  describe('minAngle', () => {
+    // https://github.com/recharts/recharts/issues/2986
+    const data = [
+      { name: 'A', pv: 100 },
+      { name: 'B', pv: 5 },
+      { name: 'C', pv: 0 },
+    ];
+
+    const radialBarSettings: RadialBarSettings = {
+      id: 'radial-bar-min-angle',
+      dataKey: 'pv',
+      minAngle: 30,
+      minPointSize: 0,
+      stackId: undefined,
+      maxBarSize: undefined,
+      barSize: undefined,
+      type: 'radialBar',
+      angleAxisId: 0,
+      radiusAxisId: 0,
+      data: undefined,
+      hide: false,
+    };
+
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <RadialBarChart width={500} height={500} data={data}>
+        <RadialBar isAnimationActive={false} dataKey="pv" minAngle={30} />
+        {children}
+      </RadialBarChart>
+    ));
+
+    it('forwards the minAngle prop from RadialBar into its Redux settings', () => {
+      const { spy } = renderTestCase(state => selectPolarItemsSettings(state, 'angleAxis', 0));
+      expectLastCalledWith(spy, [
+        {
+          id: expect.stringMatching('radialBar-'),
+          maxBarSize: undefined,
+          minAngle: 30,
+          minPointSize: 0,
+          angleAxisId: 0,
+          barSize: undefined,
+          data: undefined,
+          dataKey: 'pv',
+          hide: false,
+          radiusAxisId: 0,
+          stackId: undefined,
+          type: 'radialBar',
+        },
+      ]);
+    });
+
+    it('extends a bar below the threshold, leaves a zero-value bar at zero degrees, and leaves an already-large bar untouched', () => {
+      const { spy } = renderTestCase(state => selectRadialBarSectors(state, 0, 0, radialBarSettings, undefined));
+      const lastResult = spy.mock.calls.at(-1)?.[0] as ReadonlyArray<RadialBarDataItem>;
+      const angles = lastResult.map(({ startAngle, endAngle }) => ({ startAngle, endAngle }));
+      expect(angles).toEqual([
+        // 100 out of a domain of [0, 100] naturally reaches the full 360°, well above minAngle
+        { startAngle: 0, endAngle: 360 },
+        // 5 out of 100 naturally is only 18°, extended up to the 30° minAngle
+        { startAngle: 0, endAngle: 30 },
+        // 0 stays at 0°, minAngle must never manufacture a visible sliver for an empty bar
+        { startAngle: 0, endAngle: 0 },
+      ]);
+    });
+  });
+
   describe('with configured axes', () => {
     const radialBarSettings: RadialBarSettings = {
       id: 'my-radial-bar',
       dataKey: 'pv',
+      minAngle: 0,
       minPointSize: 0,
       stackId: undefined,
       maxBarSize: undefined,
@@ -474,6 +542,7 @@ describe('<RadialBar />', () => {
           stackId: undefined,
           type: 'radialBar',
           maxBarSize: undefined,
+          minAngle: 0,
           minPointSize: 0,
         },
       ]);
@@ -826,6 +895,7 @@ describe('<RadialBar />', () => {
     const radialBarSettings: RadialBarSettings = {
       id: 'my-radial-bar',
       dataKey: 'rings',
+      minAngle: 0,
       minPointSize: 0,
       stackId: undefined,
       maxBarSize: undefined,
@@ -861,6 +931,7 @@ describe('<RadialBar />', () => {
           stackId: undefined,
           type: 'radialBar',
           maxBarSize: undefined,
+          minAngle: 0,
           minPointSize: 0,
         },
       ]);
@@ -1304,6 +1375,7 @@ describe('<RadialBar />', () => {
         dataKey: 'value',
         hide: false,
         radiusAxisId: 0,
+        minAngle: 0,
         minPointSize: 0,
         maxBarSize: undefined,
       };

--- a/test/polar/RadialBar/RadialBar.spec.tsx
+++ b/test/polar/RadialBar/RadialBar.spec.tsx
@@ -44,6 +44,7 @@ import { RadialBarSettings } from '../../../src/state/types/RadialBarSettings';
 import { expectLastCalledWith } from '../../helper/expectLastCalledWith';
 import { userEventSetup } from '../../helper/userEventSetup';
 import { assertZIndexLayerOrder } from '../../helper/assertZIndexLayerOrder';
+import { assertNotNull } from '../../helper/assertNotNull';
 import { RadialBarDataItem } from '../../../src/polar/RadialBar';
 
 describe('<RadialBar />', () => {
@@ -490,7 +491,8 @@ describe('<RadialBar />', () => {
 
     it('extends a bar below the threshold, leaves a zero-value bar at zero degrees, and leaves an already-large bar untouched', () => {
       const { spy } = renderTestCase(state => selectRadialBarSectors(state, 0, 0, radialBarSettings, undefined));
-      const lastResult = spy.mock.calls.at(-1)?.[0] as ReadonlyArray<RadialBarDataItem>;
+      const lastResult: ReadonlyArray<RadialBarDataItem> | undefined = spy.mock.calls.at(-1)?.[0];
+      assertNotNull(lastResult);
       const angles = lastResult.map(({ startAngle, endAngle }) => ({ startAngle, endAngle }));
       expect(angles).toEqual([
         // 100 out of a domain of [0, 100] naturally reaches the full 360°, well above minAngle

--- a/test/polar/RadialBar/RadialBar.spec.tsx
+++ b/test/polar/RadialBar/RadialBar.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, Mock, test, vi } from 'vitest';
+import { createSelector } from 'reselect';
 import {
   DefaultZIndexes,
   PolarAngleAxis,
@@ -11,6 +12,7 @@ import {
   RadialBarProps,
 } from '../../../src';
 import { useAppSelector } from '../../../src/state/hooks';
+import { RechartsRootState } from '../../../src/state/store';
 import { selectPolarItemsSettings } from '../../../src/state/selectors/polarSelectors';
 import { PageData, ringsData } from '../../_data';
 import { expectRadialBars } from '../../helper/expectRadialBars';
@@ -502,6 +504,95 @@ describe('<RadialBar />', () => {
         // 0 stays at 0°, minAngle must never manufacture a visible sliver for an empty bar
         { startAngle: 0, endAngle: 0 },
       ]);
+    });
+
+    it('treats a negative minAngle the same as its positive counterpart, matching how Pie normalizes minAngle', () => {
+      const negativeSettings: RadialBarSettings = { ...radialBarSettings, minAngle: -30 };
+      const negativeRenderTestCase = createSelectorTestCase(({ children }) => (
+        <RadialBarChart width={500} height={500} data={data}>
+          <RadialBar isAnimationActive={false} dataKey="pv" minAngle={-30} />
+          {children}
+        </RadialBarChart>
+      ));
+      const { spy } = negativeRenderTestCase(state => selectRadialBarSectors(state, 0, 0, negativeSettings, undefined));
+      const lastResult: ReadonlyArray<RadialBarDataItem> | undefined = spy.mock.calls.at(-1)?.[0];
+      assertNotNull(lastResult);
+      const angles = lastResult.map(({ startAngle, endAngle }) => ({ startAngle, endAngle }));
+      // Same expansion as minAngle={30}: the small bar is still extended up to 30°.
+      expect(angles).toEqual([
+        { startAngle: 0, endAngle: 360 },
+        { startAngle: 0, endAngle: 30 },
+        { startAngle: 0, endAngle: 0 },
+      ]);
+    });
+
+    it('can overlap stacked bars, same as the pre-existing minPointSize behavior', () => {
+      // minAngle expands each bar's angle independently, without knowledge of its stacked
+      // neighbor. minPointSize has always had this same limitation in `radial` layout - this
+      // test pins the current, known-imperfect behavior rather than asserting it is correct.
+      const stackedData = [{ name: 'A', a: 1, b: 99 }];
+
+      const stackedRenderTestCase = createSelectorTestCase(({ children }) => (
+        <RadialBarChart width={500} height={500} data={stackedData}>
+          <RadialBar isAnimationActive={false} dataKey="a" stackId="s" minAngle={30} />
+          <RadialBar isAnimationActive={false} dataKey="b" stackId="s" minAngle={30} />
+          {children}
+        </RadialBarChart>
+      ));
+
+      // Settings must come from the real registered items (with their real, auto-generated
+      // ids) rather than a hand-rolled object, otherwise the stacked-data lookup silently
+      // fails to find a match and each bar falls back to its raw, non-cumulative value.
+      //
+      // This is wrapped in createSelector (rather than a plain function) because the test
+      // harness asserts that calling the selector twice on the same state returns a
+      // referentially stable result, the same guarantee every real selector in this codebase
+      // provides.
+      const selectStackedAAndB = createSelector(
+        [
+          (state: RechartsRootState) =>
+            selectPolarItemsSettings(state, 'angleAxis', 0) as ReadonlyArray<RadialBarSettings>,
+        ],
+        allSettings => {
+          // Both bars register asynchronously; ignore intermediate renders where only one has.
+          if (allSettings.length < 2) {
+            return undefined;
+          }
+          const settingsA = allSettings.find(s => s.dataKey === 'a');
+          const settingsB = allSettings.find(s => s.dataKey === 'b');
+          assertNotNull(settingsA);
+          assertNotNull(settingsB);
+          return { settingsA, settingsB };
+        },
+      );
+      const selectStackedSectors = createSelector(
+        [selectStackedAAndB, (state: RechartsRootState) => state],
+        (found, state) => {
+          if (found == null) {
+            return undefined;
+          }
+          return {
+            a: selectRadialBarSectors(state, 0, 0, found.settingsA, undefined),
+            b: selectRadialBarSectors(state, 0, 0, found.settingsB, undefined),
+          };
+        },
+      );
+
+      const { spy } = stackedRenderTestCase(selectStackedSectors);
+      const lastResult = spy.mock.calls.at(-1)?.[0];
+      assertNotNull(lastResult);
+      const { a: resultA, b: resultB } = lastResult;
+
+      // The angle axis domain here is [0, 99] (the larger of the two raw values), not [0, 100].
+      // Bar 'a' (cumulative range [0, 1]) naturally spans [0, 3.64], expanded to [0, 30] by minAngle.
+      expect(resultA[0].startAngle).toBe(0);
+      expect(resultA[0].endAngle).toBe(30);
+
+      // Bar 'b' (cumulative range [1, 100], stacked on top of 'a') naturally spans [3.64, 360],
+      // well above the threshold so it is untouched - but that overlaps bar 'a's expanded range
+      // by roughly 26.4°.
+      expect(resultB[0].startAngle).toBeCloseTo(360 / 99, 5);
+      expect(resultB[0].endAngle).toBe(360);
     });
   });
 

--- a/test/state/selectors/radialBarSelectors.spec.tsx
+++ b/test/state/selectors/radialBarSelectors.spec.tsx
@@ -10,6 +10,7 @@ describe('selectRadialBarSectors', () => {
   const radialBarSettings: RadialBarSettings = {
     id: 'radial-bar-uv',
     dataKey: 'pv',
+    minAngle: 0,
     minPointSize: 0,
     stackId: undefined,
     maxBarSize: undefined,


### PR DESCRIPTION
## Description

`RadialBar` has a `minAngle` prop listed on the API docs, but it was never wired into the component — only `Pie` had it, so passing `minAngle` to `RadialBar` was silently ignored.

This adds a real `minAngle` prop to `RadialBar`: when a non-zero bar's natural angle falls below the threshold, its `endAngle` is extended to meet the minimum, so small values stay visible. Bars with a value of exactly zero are explicitly excluded, so they never get an artificial sliver.

## Related Issue

Fixes #2986

There was an earlier attempt at this in #7147, which implemented the same idea but never received a maintainer review and was closed from inactivity. It also had a bug where a zero-value bar could receive a fake sliver (`mathSign(deltaAngle || minAngle)` treats `deltaAngle === 0` as non-zero). This PR avoids that by only applying the expansion when `deltaAngle !== 0`.

## Motivation and Context

Bars representing small values in a `RadialBarChart` could render invisibly thin, or not visible at all, with no way for consumers to guarantee a minimum visible angle — despite the docs implying this was already supported.

## How Has This Been Tested?

- Added a new test verifying: a bar below the threshold is extended to `minAngle`, a bar already above the threshold is untouched, and a zero-value bar stays at 0° (no artificial sliver).
- Added a test confirming the `minAngle` prop on `<RadialBar>` is correctly forwarded into Redux state.
- Updated 11 existing test assertions that check the full settings object shape, since it now includes `minAngle`.
- Ran the full test suite (`npm test`), typecheck, and lint locally — all passing.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `minAngle` option for radial bars to ensure non-zero segments meet the configured minimum angular span.
  * Zero-value segments remain at zero degrees, while segments already exceeding the threshold remain unchanged.
  * Negative minimum-angle values are handled consistently with positive values.
  * Improved the description of the pie chart minimum-angle option.

* **Tests**
  * Added coverage for minimum-angle behavior across radial bar configurations and selector scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->