### PR TITLE
Fix axis props with incomplete themes

### DIFF
--- a/src/theme/useBackwardsCompatibleTheme.ts
+++ b/src/theme/useBackwardsCompatibleTheme.ts
@@ -2,14 +2,12 @@ import { RechartsTheme } from './RechartsTheme';
 import { resolvePartialDefaultProps } from '../util/resolveDefaultProps';
 import { useRechartsTheme } from './RechartsThemeContext';
 
-const noStyles = {};
-
 /**
  * Backwards compatible hook for theming.
  *
  * - If the selector returns a theme slice, it is merged with `explicitProps` and acts as defaults.
- * - If no matching theme slice is present, no props are returned - this allows us to set an "empty theme" with completely unstyled chart
- *   This preserves the 2.x defaults for existing charts.
+ * - If no matching theme slice is present, the explicit props are returned without applying legacy defaults.
+ *   This allows an empty theme to leave unspecified styles unstyled while preserving user props.
  *
  * `themeSelector` selects the subset of theme which this component is interested in.
  * The selector is not called in case the theme is undefined.
@@ -43,9 +41,9 @@ export const useBackwardsCompatibleTheme = <Props extends object>(
      * In this case the theme exists but the particular slice does not.
      * This could be that a chunk of the theme is not defined,
      * or it could be the emptyTheme.
-     * Here we see the new theme so let's not mix it with old defaults.
+     * Here we see the new theme so let's not mix it with old defaults, but preserve explicit props.
      */
-    return noStyles;
+    return explicitProps;
   }
   /*
    * And finally a mix of the theme and explicit props.

--- a/test/cartesian/XAxis/XAxis.theme.spec.tsx
+++ b/test/cartesian/XAxis/XAxis.theme.spec.tsx
@@ -58,6 +58,25 @@ describe('XAxis theme', () => {
         expect(firstTick).toHaveAttribute('stroke', 'gold');
         expect(firstTick).toHaveAttribute('stroke-width', '2');
       });
+
+      it('should follow the prop when the theme does not define axis styles', () => {
+        const { container } = rechartsTestRender(
+          <RechartsThemeProvider value={{ graphicalItems: [] }}>
+            <MyChart>
+              <XAxis dataKey="label" stroke="gold" strokeWidth={2} strokeOpacity={0.5} strokeDasharray="1 3" />
+            </MyChart>
+          </RechartsThemeProvider>,
+        );
+        const firstTick = getFirstTick(container);
+        const axisLine = container.querySelector('.recharts-cartesian-axis-line');
+        assertNotNull(axisLine);
+        [firstTick, axisLine].forEach(line => {
+          expect(line).toHaveAttribute('stroke', 'gold');
+          expect(line).toHaveAttribute('stroke-width', '2');
+          expect(line).toHaveAttribute('stroke-opacity', '0.5');
+          expect(line).toHaveAttribute('stroke-dasharray', '1 3');
+        });
+      });
     });
 
     describe('when defined as a theme', () => {

--- a/test/theme/useBackwardsCompatibleTheme.spec.tsx
+++ b/test/theme/useBackwardsCompatibleTheme.spec.tsx
@@ -68,15 +68,14 @@ describe('useBackwardsCompatibleTheme', () => {
     expect(explicitProps).toEqual({ color: 'red' });
   });
 
-  it('returns no styles when the theme has no matching slice', () => {
-    const explicitProps: Props = { color: 'red', size: 10 };
+  it('preserves explicit props without applying legacy defaults when the theme has no matching slice', () => {
+    const explicitProps: Props = { color: 'red' };
 
     const { result } = renderHook(
       () => useBackwardsCompatibleTheme(() => undefined, explicitProps, { color: 'blue', size: 20 }),
       { wrapper: ({ children }) => <RechartsThemeProvider value={theme}>{children}</RechartsThemeProvider> },
     );
 
-    expect(result.current).toEqual({});
-    expect(result.current).not.toBe(explicitProps);
+    expect(result.current).toEqual(explicitProps);
   });
 });


### PR DESCRIPTION
## Description

Return explicit props instead of nothing when merging theme slice.

## Related Issue

Fixes https://github.com/recharts/recharts/issues/7723


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved user-provided styling when a theme exists but does not define matching styles.
  - Prevented legacy default styles from being applied in this situation.
  - Ensured axis and tick-line styling props are consistently applied.

- **Tests**
  - Added coverage for explicit axis and tick-line styling.
  - Updated theme compatibility tests to verify preservation of user-provided props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->