### PR TITLE
fix(PolarGrid): drop the duplicate radial line where the angle axis wraps around

### DIFF
--- a/src/state/selectors/polarGridSelectors.ts
+++ b/src/state/selectors/polarGridSelectors.ts
@@ -1,15 +1,16 @@
 import { createSelector } from 'reselect';
 import { RechartsRootState } from '../store';
 import { AxisId } from '../cartesianAxisSlice';
-import { selectPolarAxisTicks } from './polarScaleSelectors';
+import { selectPolarAngleAxisTicks, selectPolarAxisTicks } from './polarScaleSelectors';
 import { CartesianTickItem } from '../../util/types';
 
 export type PolarAngles = Array<number>;
 
 export type PolarRadius = Array<number>;
 
+// The angle axis is circular, so its first and last tick can land on the same angle.
 const selectAngleAxisTicks = (state: RechartsRootState, anglexisId: AxisId) =>
-  selectPolarAxisTicks(state, 'angleAxis', anglexisId, false);
+  selectPolarAngleAxisTicks(state, 'angleAxis', anglexisId, false);
 
 export const selectPolarGridAngles: (state: RechartsRootState, angleAxisId: AxisId) => PolarAngles | undefined =
   createSelector(

--- a/test/polar/PolarGrid.spec.tsx
+++ b/test/polar/PolarGrid.spec.tsx
@@ -439,6 +439,23 @@ describe('<PolarGrid />', () => {
 
       expectPolarGridCircles(container, []);
     });
+
+    test('Does not repeat the angle where a full circle numerical axis wraps around', () => {
+      const { container } = render(
+        <RadarChart width={300} height={300} data={pageData}>
+          <Radar dataKey="uv" />
+          <PolarAngleAxis type="number" />
+          <PolarGrid />
+        </RadarChart>,
+      );
+
+      const endpoints = Array.from(container.querySelectorAll<SVGLineElement>('.recharts-polar-grid-angle line')).map(
+        line => `${Math.round(Number(line.getAttribute('x2')))},${Math.round(Number(line.getAttribute('y2')))}`,
+      );
+
+      expect(new Set(endpoints).size).toBe(endpoints.length);
+      expect(endpoints).toHaveLength(container.querySelectorAll('.recharts-polar-angle-axis-tick').length);
+    });
   });
 
   describe('as a child of RadialBarChart with explicit axes', () => {
@@ -788,7 +805,7 @@ describe('<PolarGrid />', () => {
 
     it('should select grid angles', () => {
       const { spy } = renderTestCase(state => selectPolarGridAngles(state, 0));
-      expectLastCalledWith(spy, [0, 40, 80, 120, 160, 200, 240, 280, 320, 360]);
+      expectLastCalledWith(spy, [0, 40, 80, 120, 160, 200, 240, 280, 320]);
     });
 
     it('should render lines', () => {
@@ -848,12 +865,6 @@ describe('<PolarGrid />', () => {
           x2: '238.86115540180143',
           y1: '150',
           y2: '224.5633627236386',
-        },
-        {
-          x1: '150',
-          x2: '266',
-          y1: '150',
-          y2: '150.00000000000003',
         },
       ]);
     });
@@ -924,12 +935,6 @@ describe('<PolarGrid />', () => {
             y1: '150',
             y2: '150',
           },
-          {
-            x1: '150',
-            x2: '266',
-            y1: '150',
-            y2: '150.00000000000003',
-          },
         ]);
       });
 
@@ -960,7 +965,7 @@ describe('<PolarGrid />', () => {
 
       it('should select angles', () => {
         const { spy } = renderTestCase(state => selectPolarGridAngles(state, 'axis-pv'));
-        expectLastCalledWith(spy, [0, 180, 360]);
+        expectLastCalledWith(spy, [0, 180]);
       });
     });
 
@@ -1155,37 +1160,37 @@ describe('<PolarGrid />', () => {
           {
             cx: 150,
             cy: 150,
-            d: 'M 158.28571428571428,150L 141.71428571428572,150L 158.28571428571428,150Z',
+            d: 'M 158.28571428571428,150L 141.71428571428572,150Z',
           },
           {
             cx: 150,
             cy: 150,
-            d: 'M 174.85714285714286,150L 125.14285714285714,150L 174.85714285714286,150Z',
+            d: 'M 174.85714285714286,150L 125.14285714285714,150Z',
           },
           {
             cx: 150,
             cy: 150,
-            d: 'M 191.42857142857142,150L 108.57142857142858,150L 191.42857142857142,150Z',
+            d: 'M 191.42857142857142,150L 108.57142857142858,150Z',
           },
           {
             cx: 150,
             cy: 150,
-            d: 'M 208,150L 92,150L 208,150Z',
+            d: 'M 208,150L 92,150Z',
           },
           {
             cx: 150,
             cy: 150,
-            d: 'M 224.57142857142856,150L 75.42857142857143,150L 224.57142857142856,150.00000000000003Z',
+            d: 'M 224.57142857142856,150L 75.42857142857143,150Z',
           },
           {
             cx: 150,
             cy: 150,
-            d: 'M 241.14285714285717,150L 58.85714285714285,150L 241.14285714285717,150.00000000000003Z',
+            d: 'M 241.14285714285717,150L 58.85714285714285,150Z',
           },
           {
             cx: 150,
             cy: 150,
-            d: 'M 257.7142857142857,150L 42.28571428571426,150L 257.7142857142857,150.00000000000003Z',
+            d: 'M 257.7142857142857,150L 42.28571428571426,150Z',
           },
         ]);
         expectPolarGridCircles(container, []);


### PR DESCRIPTION
## Problem

`PolarAngleAxis` gets its ticks from `selectPolarAngleAxisTicks`, which collapses ticks that land on the same angle once normalized to `[0, 360)`. That deduplication exists because the angle axis is circular, so a full circle domain produces a first and last tick at the same place.

`PolarGrid` did not use it. `selectPolarGridAngles` read the raw `selectPolarAxisTicks`, so with a numerical angle axis spanning a full circle the grid drew two radial lines exactly on top of each other, and `getPolygonPath` repeated the first vertex before the closing `Z`, adding a zero length segment to every concentric polygon.

The overlap is visible: the doubled line renders darker than its neighbours whenever `strokeOpacity` is below 1, and the radial line count disagrees with the tick count of the very axis it is supposed to follow.

Reproduction:

```jsx
<RadarChart width={300} height={300} data={data}>
  <Radar dataKey="uv" />
  <PolarAngleAxis type="number" />
  <PolarGrid />
</RadarChart>
```

13 radial grid lines are rendered for 12 angle axis ticks, and the first and last lines are the same line.

## Fix

`selectPolarGridAngles` now reads the same deduplicated ticks the axis uses. `selectPolarGridRadii` is untouched: the radius axis is not circular and has nothing to collapse.

## Tests

Added a regression test in `test/polar/PolarGrid.spec.tsx` asserting that no two radial grid lines share an endpoint and that the line count matches the rendered angle axis tick count. It fails before the fix with 12 unique endpoints for 13 lines.

Five existing expectations in the same file had the duplicate baked into them and are updated:

- `should select grid angles` lost the trailing `360`, which duplicated `0`
- `should select angles` lost the trailing `360` for the same reason
- two `should render lines` cases lost the repeated line at `x2="266" y2="150.00000000000003"`, identical to the first line at `x2="266" y2="150"`
- `should render polygons` lost the repeated first vertex in each path

`npm run test` and `npm run check-types` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed polar angle grids so full-circle axes no longer render a duplicate grid line at the 360° wraparound point.
  - Corrected angle-axis tick selection for more accurate polar grid rendering.

- **Tests**
  - Added coverage to verify unique angle grid-line endpoints and correct alignment with numerical axis ticks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->