### PR TITLE
docs(PolarGrid): add missing description for radialLines prop

### DIFF
--- a/src/polar/PolarGrid.tsx
+++ b/src/polar/PolarGrid.tsx
@@ -61,7 +61,7 @@ interface PolarGridProps extends ZIndexable {
    */
   gridType?: 'polygon' | 'circle';
   /**
-   * Whether to render the radial lines extending from the center to the outer edge at each angle.
+   * Whether to render the radial lines extending from the inner radius to the outer edge at each angle.
    * When false, only the circular or polygonal grid lines are rendered.
    * @defaultValue true
    */

--- a/src/polar/PolarGrid.tsx
+++ b/src/polar/PolarGrid.tsx
@@ -61,6 +61,8 @@ interface PolarGridProps extends ZIndexable {
    */
   gridType?: 'polygon' | 'circle';
   /**
+   * Whether to render the radial lines extending from the center to the outer edge at each angle.
+   * When false, only the circular or polygonal grid lines are rendered.
    * @defaultValue true
    */
   radialLines?: boolean;


### PR DESCRIPTION
## Description

The `radialLines` prop on `PolarGrid` only had a `@defaultValue true` tag with no actual description — unlike every other prop on the component, which all have one. This meant it showed up undocumented on the API reference site and in Storybook controls.

## Related Issue

Fixes #2578

There was a previous attempt at this exact fix (#7081), but it was closed unmerged within about a minute of being opened, with no comment explaining why. The gap was still present in the code, so I'm resubmitting it.

## Motivation and Context

Every other `PolarGrid` prop has a human-readable description. `radialLines` was the one exception, which is confusing for anyone checking the docs to understand what it does.

## How Has This Been Tested?

- Verified all 39 existing `PolarGrid` unit tests still pass (this is a JSDoc-only change with no behavior change).
- Ran the repo's `omnidoc` test suite, which regenerates API docs from JSDoc comments, to confirm the new description is picked up correctly.
- Ran typecheck and lint locally — both clean.

## Screenshots (if appropriate):

N/A (JSDoc-only change)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the `radialLines` option for polar grids, including its effect on radial and circular or polygonal grid lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->