### PR TITLE
fix(XAxis): move the first equidistantPreserveStart label inwards

### DIFF
--- a/src/cartesian/getEquidistantTicks.ts
+++ b/src/cartesian/getEquidistantTicks.ts
@@ -19,6 +19,7 @@ export function getEquidistantTicks(
   // For now, start from every tick
   let stepsize = 1;
   let start = initialStart;
+  let headCoord: number | undefined;
 
   while (stepsize <= result.length) {
     // Given stepsize, evaluate whether every stepsize-th tick can be shown.
@@ -28,7 +29,12 @@ export function getEquidistantTicks(
 
     // Break condition - If we have evaluated all the ticks, then we are done.
     if (entry === undefined) {
-      return getEveryNth(ticks, stepsize);
+      const shownTicks = getEveryNth(ticks, stepsize);
+      const head = shownTicks[0];
+      if (headCoord == null || head == null) {
+        return shownTicks;
+      }
+      return [{ ...head, tickCoord: headCoord }, ...shownTicks.slice(1)];
     }
 
     // Check if the element collides with the next element
@@ -42,7 +48,18 @@ export function getEquidistantTicks(
       return size;
     };
 
-    const tickCoord = entry.coordinate;
+    let tickCoord = entry.coordinate;
+
+    if (index === 0) {
+      // The first tick sits in the middle of the first band, so its label can hang over the start
+      // boundary; move it inwards, the same way getTicksStart does for `preserveStart`.
+      const headGap = sign * (tickCoord - (sign * getSize()) / 2 - start);
+      if (headGap < 0) {
+        tickCoord -= headGap * sign;
+        headCoord = tickCoord;
+      }
+    }
+
     // We will always show the first tick.
     const isShow = index === 0 || isVisible(sign, tickCoord, getSize, start, end);
 

--- a/test/cartesian/getEquidistantTicks.spec.ts
+++ b/test/cartesian/getEquidistantTicks.spec.ts
@@ -29,7 +29,30 @@ describe('getEquidistantTicks', () => {
       ticks.push({ value: ticksThatFit.includes(index) ? 10 : 1000, coordinate: index * 50, index, offset: 0 });
     }
     const result = getEquidistantTicks(1, { start: 0, end: 10 * 50 }, getTickSize, ticks, 0);
-    expect(result).toEqual(resultingTicks.map(index => ticks[index]));
+    const expectedTicks: Array<CartesianTickItem> = resultingTicks.map(index => ticks[index]);
+    // The first tick sits on the axis start, so half of its label hangs outside and its
+    // tickCoord moves inwards.
+    expectedTicks[0] = { ...expectedTicks[0], tickCoord: getTickSize(ticks[0]) / 2 };
+    expect(result).toEqual(expectedTicks);
+  });
+
+  it('should move the first tick label inwards when it overflows the start boundary', () => {
+    // 10 ticks, 50px apart, the first one centered on the start of the axis so that
+    // half of its 100px wide label overflows the boundary.
+    const ticks: ReadonlyArray<CartesianTickItem> = Array.from({ length: 10 }, (_, index) => ({
+      value: index,
+      coordinate: index * 50,
+      index,
+      offset: 0,
+    }));
+
+    const result = getEquidistantTicks(1, { start: 0, end: 500 }, () => 100, ticks, 20);
+
+    // The first tick keeps its coordinate, only its label moves inside the boundary.
+    expect(result[0].coordinate).toBe(0);
+    expect(result[0].tickCoord).toBe(50);
+    // The moved label takes up the space between 0 and 100, so every fourth tick fits.
+    expect(result.map(t => t.value)).toEqual([0, 4, 8]);
   });
 });
 


### PR DESCRIPTION
## Description

`getEquidistantTicks` always shows the first tick, and it shows it at its raw `coordinate`.
On a band axis that coordinate is the middle of the first band, so half of the first label
sits to the left of the axis start and gets clipped by the SVG. `getTicksStart` already
avoids this for `interval="preserveStart"` by moving the label through `tickCoord` while the
tick line stays on `coordinate`, and `getEquidistantPreserveEndTicks` does the same for the
end tick since #7697. `equidistantPreserveStart` was the only one of the four that did not.

This moves the first label inwards the same way, and measures the following ticks against the
moved label instead of the original coordinate, so the spacing search sees where the label
actually is.

To reproduce, an `XAxis` with `interval="equidistantPreserveStart"` on a category axis with
enough categories that the first band is narrower than its label: the first label is cut off
at the left edge of the chart, while the same axis with `interval="preserveStart"` renders it
fully.

## Related Issue

No open issue. Same class as #7696 / #7697, on the start side.

## Motivation and Context

The three other `preserve*` intervals keep their anchor tick inside the axis. This makes the
fourth one consistent, so a chart does not lose the label it was told to preserve.

## How Has This Been Tested?

`test/cartesian/getEquidistantTicks.spec.ts` gets a new case that mirrors the existing
`should move the end tick inwards instead of dropping every other tick`: ten ticks 50px apart
with the first one on the axis start and 100px wide labels. It asserts that the first tick
keeps `coordinate: 0` and gains `tickCoord: 50`, and that the returned ticks are `[0, 4, 8]`,
because the moved label now occupies the space from 0 to 100. Without the source change the
assertion on `tickCoord` reports `expected undefined to be 50`.

The existing parametrised case in the same file also asserts the new `tickCoord` on its first
tick; it uses ticks that start exactly on the axis boundary, so the first label overflows
there too. The set of ticks it returns is unchanged.

`npm run test-lib`, `npm run check-types` and `npm run lint` pass.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cartesian axis tick positioning when the first label would overflow the axis boundary.
  * Adjusted the first tick’s rendered position inward to improve label visibility and tick spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->