### PR TITLE
fix(test-vr): make npm run test-vr:ui work reliably in Docker

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -103,6 +103,8 @@ You only need to do this once.
 
 This takes two or three minutes to complete.
 You will need to re-build every time you make a change to dependencies in `package.json`.
+If you forget and get a `Cannot find module '@playwright/test'` (or `vite`) error,
+run `npm run test-vr:prepare` to rebuild the image.
 
 ```sh
 npm run test-vr:prepare

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test-vr:prepare": "npm run build && docker compose up -d --build",
     "test-vr": "docker compose run --rm test-vr playwright-test",
     "test-vr:update": "docker compose run --rm test-vr playwright-test --update-snapshots changed",
-    "test-vr:ui": "docker compose run -p 8080:8080 --rm test-vr playwright-test --ui --ui-host=0.0.0.0 --ui-port=8080",
+    "test-vr:ui": "docker compose run -p 8080:8080 -p 3100:3100 --rm test-vr playwright-test --ui --ui-host=0.0.0.0 --ui-port=8080",
     "test-vr:report": "npx playwright show-report test-vr/playwright-report",
     "bundlewatch": "bundlewatch --config .bundlewatch.config.json",
     "lgtm": "npm run build && npm run lint && npm run test && npm run check-types"

--- a/test-vr/.bin/playwright-test
+++ b/test-vr/.bin/playwright-test
@@ -1,3 +1,62 @@
 #!/bin/bash
 
-npx playwright test --config=/recharts/test-vr/playwright.config.ts "$@"
+# Docker entry wrapper for the test-vr container (ENV PATH points at
+# test-vr/.bin, see playwright-ct.Dockerfile). CI calls playwright directly.
+
+set -u
+
+GALLERY_URL="http://localhost:3100/gallery/index.html"
+TEST_VR_DIR="/recharts/test-vr"
+ROOT_DIR="/recharts"
+
+# docker compose run reuses any existing image; one built before the #7714
+# dependency change (@playwright/test, vite) fails with a cryptic module
+# error. Point at the rebuild instead.
+for module in @playwright/test vite; do
+  if [ ! -f "$ROOT_DIR/node_modules/$module/package.json" ]; then
+    echo "error: '$module' is not installed in the Docker image." >&2
+    echo "The image was probably built before the dependencies in package.json changed." >&2
+    echo "Please rebuild it once with:" >&2
+    echo "  npm run test-vr:prepare" >&2
+    exit 1
+  fi
+done
+
+# UI mode: start Vite outside Playwright's lifecycle. UI-mode global setup
+# reruns on every page connect and restarts whatever webServer Playwright
+# spawned, killing in-flight runs. A server started here is adopted
+# (reuseExistingServer is on outside CI) and never torn down.
+if [[ " $* " == *" --ui "* ]]; then
+  VITE_PID=""
+  start_vite() {
+    echo "Starting the Vite story gallery dev server on port 3100..."
+    # --host 0.0.0.0 so the port published by test-vr:ui is reachable.
+    (cd "$TEST_VR_DIR" && exec npx vite --config vite.config.ts --port 3100 --strictPort --host 0.0.0.0) &
+    VITE_PID=$!
+  }
+  stop_vite() {
+    [ -n "$VITE_PID" ] && kill "$VITE_PID" 2>/dev/null || true
+  }
+  trap 'stop_vite; exit 1' INT TERM
+
+  if curl -fsS -o /dev/null --max-time 2 "$GALLERY_URL" 2>/dev/null; then
+    echo "Reusing an already running Vite dev server on port 3100."
+  else
+    start_vite
+    deadline=$((SECONDS + 90))
+    until curl -fsS -o /dev/null --max-time 2 "$GALLERY_URL" 2>/dev/null; do
+      if [ $SECONDS -ge $deadline ]; then
+        echo "error: Vite did not become ready on port 3100 within 90s." >&2
+        stop_vite
+        exit 1
+      fi
+      sleep 1
+    done
+    echo "Vite dev server is ready."
+  fi
+
+  # exec: Vite stays a child of this container and dies with it.
+  exec npx playwright test --config="$TEST_VR_DIR/playwright.config.ts" "$@"
+fi
+
+npx playwright test --config="$TEST_VR_DIR/playwright.config.ts" "$@"

--- a/test-vr/README.md
+++ b/test-vr/README.md
@@ -152,6 +152,32 @@ Docker is the recommended environment for running visual regression tests and up
 so that screenshots remain consistent across different development machines and operating systems
 (avoiding font, subpixel rendering, and OS differences).
 
+## Running tests in UI mode
+
+`npm run test-vr:ui` opens the Playwright UI at http://localhost:8080 and also exposes the
+story gallery at http://localhost:3100/gallery/index.html.
+
+The gallery dev server is started once per container session (`test-vr/.bin/playwright-test`
+pre-starts it), so reloading the UI or opening a second tab is safe. Prefer running a single
+spec file or test, or the `chromium` project: running all projects is long and CPU heavy.
+
+## Error: Cannot find module '@playwright/test' (or 'vite')
+
+```
+Error: Cannot find module '@playwright/test'
+Require stack:
+- /recharts/test-vr/playwright.config.ts
+...
+```
+
+This means the Docker image was built before the dependencies in `package.json` changed
+(for example after checking out a branch that migrated the test setup). `docker compose run`
+does not rebuild the image automatically. Run once:
+
+```sh
+npm run test-vr:prepare
+```
+
 ## Error: browserType.launch: Executable doesn't exist
 
 Sometimes you may find an error that the `playwright` package no longer matches the `playwright` version in the Docker image:

--- a/test-vr/playwright.config.ts
+++ b/test-vr/playwright.config.ts
@@ -71,6 +71,10 @@ export default defineConfig({
   /*
    * The gallery dev server that renders the stories. Playwright starts it
    * before the tests and mounts stories through window.mount() on this page.
+   *
+   * In UI mode the docker entry wrapper (test-vr/.bin/playwright-test)
+   * pre-starts Vite, so Playwright adopts it and UI page reloads cannot
+   * restart it mid-run (UI-mode global setup reruns on every connect).
    */
   webServer: {
     command: 'npx vite --config vite.config.ts --port 3100 --strictPort',


### PR DESCRIPTION
## Description

`npm run test-vr:ui` didn't work. Playwright UI mode re runs the config's global setup on every page connect, so each reload or new tab tore down the Vite webServer Playwright had started (with `--strictPort`) and launched a fresh one. Reloading the UI or opening a second tab killed the story gallery out from under in flight test runs, causing intermittent `ERR_CONNECTION_REFUSED`.

The docker entry wrapper (`test-vr/.bin/playwright-test`) now pre-starts a persistent Vite dev server when `--ui` is requested and waits until it is ready. Playwright adopts the running server (`reuseExistingServer` is enabled outside CI) and, since it never spawned it, never kills it.

The wrapper also detects Docker images built before the #7714 dependency change (`@playwright/experimental-ct-react` -> `@playwright/test` + `vite`) and prints an actionable `npm run test-vr:prepare` message instead of a bare `Cannot find module '@playwright/test'` crash.

Additional changes: publish port 3100 in the `test-vr:ui` script so the gallery can be opened from the host browser, and document both behaviors in `test-vr/README.md` and `DEVELOPING.md`.

## Related Issue

Follow-up to the review feedback on #7714: https://github.com/recharts/recharts/pull/7714#issuecomment-5560368113

## Motivation and Context

The story gallery migration replaced Playwright's internal CT dev server with an explicit `webServer`, which made the dev server lifecycle dependent on UI client connections. This restores a reliable UI mode workflow for reviewers and contributors.

## How Has This Been Tested?

Ran in Docker with a freshly prepared image:

- Headless run unchanged: `playwright-test --project=chromium App.spec-vr.tsx` passes
- UI mode: tests list, and single tests pass across page reloads and a second open tab while the Vite process PID stays constant (before this change it restarted on every connect)
- `curl -I http://localhost:3100/gallery/index.html` returns 200 from the host while the UI session runs
- Stale-image simulation prints the rebuild hint instead of a module-not-found stack trace
- `tsc --project test-vr`, eslint and prettier pass on the changed files

Note: run `npm run test-vr:prepare` once before testing, the Docker image must be rebuilt after the #7714 dependency change.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - UI test mode now provides access to both the Playwright interface on port 8080 and the story gallery on port 3100.
  - The story gallery starts automatically when running UI tests.

- **Bug Fixes**
  - Added clearer guidance when required test modules are missing, including instructions to rebuild the Docker image.

- **Documentation**
  - Updated development and testing guides with UI mode instructions, available ports, recommended usage, and Docker image troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->