### PR TITLE
Add interactive visual regression gallery

### DIFF
--- a/.agents/skills/vr-test/SKILL.md
+++ b/.agents/skills/vr-test/SKILL.md
@@ -5,93 +5,112 @@ description: Create visual regression tests
 
 # What is a visual regression test?
 
-VR test is a playwright test that renders a component and compares the rendered output to a baseline snapshot.
+VR tests are Playwright tests that render a story and compare the rendered output to a baseline
+snapshot. Recharts runs these tests in Docker using Playwright's component testing model and a Vite
+story gallery.
 
-# Writing a new test
+## Story and spec structure
 
-To write a new test, create a new file in the `test-vr/tests` directory. The file must end with `.spec-vr.tsx` to be picked up by the test runner.
+Each visual-regression spec has a matching story file in `test-vr/tests`:
 
-Here is an example of a simple test:
+```text
+test-vr/tests/App.story.tsx
+test-vr/tests/App.spec-vr.tsx
+```
+
+The story file exports one or more React components. The spec imports `test` and `expect` from the
+shared fixtures and mounts a story by its story id:
 
 ```tsx
+// test-vr/tests/App.story.tsx
 import * as React from 'react';
-import { test, expect } from '@playwright/experimental-ct-react';
-import PieChartDefaultIndex from '../../../www/src/components/GuideView/ActiveIndex/PieChartDefaultIndex';
+import { CartesianGrid, Legend, Line, LineChart, XAxis, YAxis } from '../../src';
+import { pageData } from '../../storybook/stories/data';
 
-test('PieChartDefaultIndex', async ({ mount }) => {
-  const component = await mount(<PieChartDefaultIndex isAnimationActive={false} />);
+export const LineChartStory = () => (
+  <LineChart width={800} height={500} data={pageData}>
+    <CartesianGrid strokeDasharray="3 3" />
+    <XAxis dataKey="name" />
+    <YAxis />
+    <Legend />
+    <Line dataKey="pv" stroke="#8884d8" />
+    <Line dataKey="uv" stroke="#82ca9d" />
+  </LineChart>
+);
+```
+
+```tsx
+// test-vr/tests/App.spec-vr.tsx
+import { expect, test } from './fixtures';
+
+test('LineChart', async ({ mountStory }) => {
+  const component = await mountStory('App/LineChartStory');
   await expect(component).toHaveScreenshot();
 });
 ```
 
-## Playwright CT specialty
+The story id is the path of the story file under `test-vr/tests/` without the `.story.tsx` suffix,
+followed by the exported component name. For example,
+`www/LineChartApiExamples/LineChartHasMultiSeries` refers to the
+`LineChartHasMultiSeries` export from `test-vr/tests/www/LineChartApiExamples.story.tsx`.
 
-Playwright component testing (CT) allows us to render React components in isolation and test them. The `mount` function is used to render the component, and the `expect(component).toHaveScreenshot()` assertion compares the rendered output to a baseline screenshot.
-
-There is one specialty that is different from other testing frameworks. Playwright CT does not support components declared inside the test file. Instead it requires us to define the component in a separate file and import it.
-
-Example:
+Stories can accept serializable props. Pass them as the second argument to `mountStory`:
 
 ```tsx
-// file: test-vr/tests/Legend.spec-vr.tsx
-import * as React from 'react';
-import { test, expect } from '@playwright/experimental-ct-react';
-import LegendTestComponent from './LegendTestComponent';
+import type { LineChartHasMultiSeries } from './LineChartApiExamples.story';
+import { expect, test } from '../fixtures';
 
-test('correct test: this works', async ({ mount }) => {
-  const component = await mount(<LegendTestComponent />);
-  await expect(component).toHaveScreenshot();
-});
-
-function LegendTestComponent2() {
-  return (
-    <div>
-      <p>This will not work because the component is declared inside the test file</p>
-    </div>
+test('LineChartHasMultiSeries', async ({ mountStory }) => {
+  const component = await mountStory<typeof LineChartHasMultiSeries>(
+    'www/LineChartApiExamples/LineChartHasMultiSeries',
+    {
+      testTheme: 'light',
+      defaultIndex: 2,
+    },
   );
-}
-
-test('incorrect test: this does not work and throws when running the test', async ({ mount }) => {
-  const component = await mount(<LegendTestComponent2 />);
   await expect(component).toHaveScreenshot();
 });
 ```
 
-This is described in https://playwright.dev/docs/test-components#test-stories in case you want to read details.
+Keep the JSX in the story file rather than declaring a component inside the spec. This lets the
+gallery resolve the story by id and keeps the same rendering path for tests and manual review.
 
-# Running the test
+## Running tests
 
-To run the full suite of VR tests, run:
+The tests run inside Docker. Build the image and start the report server once with:
+
+```sh
+npm run test-vr:prepare
+```
+
+Run the full suite with:
 
 ```sh
 npm run test-vr
 ```
 
-Note that this may take 20+ minutes to run (because Recharts has almost 1000 VR tests). This is good for final verification but usually you will want to run a single file instead:
-
-```sh
-npm run test-vr -- --grep=Legend
-```
-
-Which will run only tests with "Legend" in their name. You can also specify the path to a specific test file:
+The full suite may take 20+ minutes. Prefer a targeted file or grep while developing:
 
 ```sh
 npm run test-vr -- test-vr/tests/Legend.spec-vr.tsx
 ```
 
-This will compare the screenshots. If there is no screenshot, it will generate three new screenshots. Why three? Because we run the same on three browsers.
+```sh
+npm run test-vr -- --grep=Legend
+```
 
-These screenshots must be committed to the repository together with the test. Our CI only verifies the tests, but does not generate or update snapshots. So if you are adding a new test, you must add the generated screenshots to the commit. If you are updating an existing test, you must replace the old screenshots with the new ones in the commit.
+The default configuration runs Chromium, Firefox, and WebKit. If a screenshot is missing, the test
+generates a baseline for each browser; commit those files in `test-vr/__snapshots__`.
 
-# Updating screenshots
+## Updating screenshots
 
-If you have made changes to the source code, or changes to the VR test itself that affect the rendered output, you will need to update the baseline screenshots. To do this, run:
+If source or story changes affect the rendered output, update the baselines:
 
 ```sh
 npm run test-vr:update
 ```
 
-This updates all screenshots for all tests. If you want to update screenshots for a specific test, you can use the same grep or file path options as when running the tests:
+Use the same file or grep selectors for a targeted update:
 
 ```sh
 npm run test-vr:update -- --grep=Legend
@@ -101,8 +120,26 @@ npm run test-vr:update -- --grep=Legend
 npm run test-vr:update -- test-vr/tests/Legend.spec-vr.tsx
 ```
 
-Screenshots generation depends on docker. If docker is not available in your environment, you will not be able to run the tests or update screenshots. If that happens, notify the user and move on.
+## Playwright UI and the story preview
 
-# More instructions
+Run UI mode with:
 
-If you need more instructions please see `test-vr/README.md`
+```sh
+npm run test-vr:ui
+```
+
+This publishes the Playwright UI at http://localhost:8080 and the Vite gallery at port 3100.
+Open http://localhost:3100/gallery/preview.html for a human-facing navigation page that lets you
+click through all stories using their default props.
+
+The URL http://localhost:3100/gallery/index.html is intentionally a blank Playwright mount target.
+Playwright navigates there before calling `window.mount`; it does not contain a story list and does
+not require a story query parameter. If either host port is already in use, free it before starting
+UI mode or change the host-side port mapping in the command.
+
+The HTML report is served at http://localhost:9323 after `npm run test-vr:prepare`.
+
+Tests and screenshot generation require Docker. If Docker is unavailable, do not attempt to run the
+visual-regression suite locally.
+
+For additional details, see `test-vr/README.md`.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -87,10 +87,12 @@ npm run test-storybook
 
 ## Run visual regression tests (using playwright)
 
-The VR tests use the Playwright component testing model with stories and a gallery:
+The VR tests use Playwright's component testing model with stories and a Vite gallery:
 https://playwright.dev/docs/test-components.
 The JSX for each scenario lives in a `*.story.tsx` file next to the spec, and the spec mounts it
 by story id with the `mountStory` fixture. See `test-vr/README.md` for details.
+The Playwright mount page at `/gallery/index.html` is intentionally blank until a test calls
+`window.mount`; it is not a human-facing story index.
 
 ### Prerequisites
 
@@ -121,6 +123,11 @@ Alternatively, the UI playwright mode is available as well:
 ```sh
 npm run test-vr:ui
 ```
+
+This starts Playwright UI on http://localhost:8080 and keeps the Vite gallery server available on
+port 3100. While the command is running, use http://localhost:3100/gallery/preview.html to browse
+and click through the stories manually. The preview page mounts each selected story with its
+default props. Do not expect `/gallery/index.html` to display a navigation page.
 
 If you want to record new snapshots or update the old ones, you can run:
 
@@ -180,12 +187,16 @@ and in storybook UI. For low fidelity tests, use unit tests or VR tests instead.
 
 ## Playwright UI mode
 
-You can also use Playwright in UI mode for manual testing. This opens a browser window where you can see the tests running,
-and you can see before & after.
+You can also use Playwright in UI mode for manual testing. This opens the Playwright UI where you
+can see the tests running and inspect before-and-after snapshots:
 
 ```sh
 npm run test-vr:ui
 ```
+
+The same command serves the human-facing story preview at
+http://localhost:3100/gallery/preview.html. The Playwright-only mount target at
+http://localhost:3100/gallery/index.html remains blank when opened directly.
 
 # Releasing new versions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       dockerfile: ./test-vr/playwright-ct.Dockerfile
     ports:
       - '9323:9323'
+      - '3100:3100'
     command: >
       sh -c "npx playwright show-report /recharts/test-vr/playwright-report --host 0.0.0.0 --port 9323"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       dockerfile: ./test-vr/playwright-ct.Dockerfile
     ports:
       - '9323:9323'
-      - '3100:3100'
     command: >
       sh -c "npx playwright show-report /recharts/test-vr/playwright-report --host 0.0.0.0 --port 9323"
     volumes:

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test-vr:prepare": "npm run build && docker compose up -d --build",
     "test-vr": "docker compose run --rm test-vr playwright-test",
     "test-vr:update": "docker compose run --rm test-vr playwright-test --update-snapshots changed",
-    "test-vr:ui": "docker compose run -p 8080:8080 --rm test-vr playwright-test --ui --ui-host=0.0.0.0 --ui-port=8080",
+    "test-vr:ui": "docker compose run -p 8080:8080 -p 3100:3100 --rm test-vr sh -c 'npx vite --config test-vr/vite.config.ts --host 0.0.0.0 --port 3100 --strictPort & exec playwright-test --ui --ui-host=0.0.0.0 --ui-port=8080'",
     "test-vr:report": "npx playwright show-report test-vr/playwright-report",
     "bundlewatch": "bundlewatch --config .bundlewatch.config.json",
     "lgtm": "npm run build && npm run lint && npm run test && npm run check-types"

--- a/test-vr/README.md
+++ b/test-vr/README.md
@@ -118,9 +118,13 @@ Please commit this folder to the repository - this is the baseline.
 
 ### `gallery`
 
-The story gallery page used by the component tests: https://playwright.dev/docs/test-components.
-It is served by the Vite dev server configured in `./vite.config.ts` on port 3100,
+The story gallery pages used by the component tests: https://playwright.dev/docs/test-components.
+They are served by the Vite dev server configured in `./vite.config.ts` on port 3100,
 which Playwright starts automatically through the `webServer` option in `./playwright.config.ts`.
+
+`gallery/index.html` is the blank mount target used by Playwright. To browse stories manually,
+open `http://localhost:3100/gallery/preview.html` while the gallery server is running.
+The preview page provides navigation and mounts the selected story with its default props.
 
 ### `playwright-report`
 

--- a/test-vr/gallery/preview.css
+++ b/test-vr/gallery/preview.css
@@ -1,0 +1,148 @@
+:root {
+  color: #1f2937;
+  background: #f3f4f6;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  min-width: 960px;
+}
+
+button,
+summary {
+  font: inherit;
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.gallery-sidebar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow-y: auto;
+  padding: 24px 16px;
+  color: #e5e7eb;
+  background: #111827;
+}
+
+.gallery-sidebar h1 {
+  margin: 0 8px 4px;
+  color: #fff;
+  font-size: 18px;
+}
+
+.gallery-sidebar p {
+  margin: 0 8px 24px;
+  color: #9ca3af;
+  font-size: 13px;
+}
+
+.story-group {
+  margin: 0 0 4px;
+}
+
+.story-group summary {
+  padding: 8px;
+  color: #d1d5db;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  list-style-position: inside;
+  overflow-wrap: anywhere;
+}
+
+.story-group summary:hover {
+  color: #fff;
+}
+
+.story-list {
+  display: grid;
+  gap: 2px;
+  padding: 0 0 8px 18px;
+}
+
+.story-button {
+  padding: 7px 8px;
+  border: 0;
+  border-radius: 4px;
+  color: #d1d5db;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  text-align: left;
+  overflow-wrap: anywhere;
+}
+
+.story-button:hover {
+  color: #fff;
+  background: #374151;
+}
+
+.story-button[aria-current='true'] {
+  color: #fff;
+  background: #2563eb;
+}
+
+.gallery-content {
+  min-width: 0;
+}
+
+.gallery-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 20px 32px;
+  border-bottom: 1px solid #e5e7eb;
+  background: rgb(255 255 255 / 95%);
+  backdrop-filter: blur(8px);
+}
+
+.gallery-header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.gallery-header code {
+  color: #6b7280;
+  font-size: 13px;
+  font-weight: 400;
+}
+
+.story-canvas {
+  min-height: calc(100vh - 74px);
+  padding: 32px;
+  overflow: auto;
+  background: #fff;
+}
+
+.story-canvas > * {
+  margin: 0 auto;
+}
+
+.gallery-empty {
+  padding: 32px;
+}

--- a/test-vr/gallery/preview.html
+++ b/test-vr/gallery/preview.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Recharts visual regression gallery</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./preview.tsx"></script>
+  </body>
+</html>

--- a/test-vr/gallery/preview.tsx
+++ b/test-vr/gallery/preview.tsx
@@ -1,0 +1,145 @@
+import * as React from 'react';
+import { createRoot } from 'react-dom/client';
+import './preview.css';
+
+type StoryComponent = React.ComponentType<Record<string, unknown>>;
+type StoryModule = Record<string, unknown>;
+
+type Story = {
+  id: string;
+  file: string;
+  name: string;
+  component: StoryComponent;
+};
+
+const storyModules = import.meta.glob<StoryModule>('../tests/**/*.story.{tsx,jsx}', { eager: true });
+
+function storyFileFromPath(file: string): string {
+  return file.replace(/^\.\.\/tests\//, '').replace(/\.story\.\w+$/, '');
+}
+
+function isComponent(value: unknown): value is StoryComponent {
+  return typeof value === 'function';
+}
+
+const stories: Story[] = Object.entries(storyModules)
+  .flatMap(([file, module]) => {
+    const storyFile = storyFileFromPath(file);
+
+    return Object.entries(module).flatMap(([name, value]) => {
+      if (!isComponent(value)) {
+        return [];
+      }
+
+      return [
+        {
+          id: `${storyFile}/${name}`,
+          file: storyFile,
+          name,
+          component: value,
+        },
+      ];
+    });
+  })
+  .sort((left, right) => left.id.localeCompare(right.id));
+
+const storyGroups = Array.from(
+  stories
+    .reduce((groups, story) => {
+      const group = groups.get(story.file);
+      if (group === undefined) {
+        groups.set(story.file, [story]);
+      } else {
+        group.push(story);
+      }
+      return groups;
+    }, new Map<string, Story[]>())
+    .entries(),
+).map(([file, groupedStories]) => ({ file, stories: groupedStories }));
+
+function getStoryIdFromUrl(): string | undefined {
+  const storyId = new URLSearchParams(window.location.search).get('story');
+  return storyId !== null && stories.some(story => story.id === storyId) ? storyId : stories[0]?.id;
+}
+
+function StoryPreview({ story }: { story: Story }) {
+  const Story = story.component;
+  const props: Record<string, unknown> = {};
+
+  return (
+    <div className="story-canvas">
+      <Story {...props} />
+    </div>
+  );
+}
+
+function PreviewApp() {
+  const [selectedStoryId, setSelectedStoryId] = React.useState<string | undefined>(getStoryIdFromUrl);
+  const selectedStory = stories.find(story => story.id === selectedStoryId);
+
+  React.useEffect(() => {
+    const handlePopState = () => {
+      setSelectedStoryId(getStoryIdFromUrl());
+    };
+    window.addEventListener('popstate', handlePopState);
+
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  function selectStory(storyId: string) {
+    const url = new URL(window.location.href);
+    url.searchParams.set('story', storyId);
+    window.history.pushState(null, '', url);
+    setSelectedStoryId(storyId);
+  }
+
+  if (selectedStory === undefined) {
+    return <main className="gallery-empty">No stories were found.</main>;
+  }
+
+  return (
+    <div className="gallery">
+      <aside className="gallery-sidebar">
+        <h1>Recharts story gallery</h1>
+        <p>Select a visual-regression story to preview it.</p>
+        {storyGroups.map(group => (
+          <details
+            key={group.file}
+            className="story-group"
+            open={group.stories.some(story => story.id === selectedStory.id)}
+          >
+            <summary>{group.file}</summary>
+            <nav className="story-list" aria-label={`${group.file} stories`}>
+              {group.stories.map(story => (
+                <button
+                  key={story.id}
+                  type="button"
+                  className="story-button"
+                  aria-current={story.id === selectedStory.id}
+                  onClick={() => selectStory(story.id)}
+                >
+                  {story.name}
+                </button>
+              ))}
+            </nav>
+          </details>
+        ))}
+      </aside>
+      <main className="gallery-content">
+        <header className="gallery-header">
+          <h2>
+            {selectedStory.name} <code>{selectedStory.id}</code>
+          </h2>
+        </header>
+        <StoryPreview key={selectedStory.id} story={selectedStory} />
+      </main>
+    </div>
+  );
+}
+
+const rootElement = document.getElementById('root');
+if (rootElement === null) {
+  throw new Error('The gallery preview page must contain an element with id "root".');
+}
+
+createRoot(rootElement).render(<PreviewApp />);

--- a/test-vr/vite.config.ts
+++ b/test-vr/vite.config.ts
@@ -13,13 +13,13 @@ const repoRoot = path.join(__dirname, '..');
 
 export default defineConfig({
   /*
-   * The gallery index.html lives at test-vr/gallery/index.html, served at
-   * http://localhost:3100/gallery/index.html.
+   * The Playwright mount page lives at test-vr/gallery/index.html. The
+   * human-facing preview is available at test-vr/gallery/preview.html.
    */
   root: __dirname,
   cacheDir: path.join(repoRoot, 'node_modules/.vite-test-vr'),
   optimizeDeps: {
-    entries: ['gallery/index.html', 'tests/**/*.story.tsx'],
+    entries: ['gallery/index.html', 'gallery/preview.html', 'tests/**/*.story.tsx'],
   },
   resolve: {
     alias: {
@@ -39,6 +39,7 @@ export default defineConfig({
     },
   },
   server: {
+    host: true,
     port: 3100,
     strictPort: true,
   },


### PR DESCRIPTION
Fix test-vr:ui command, plus add a gallery viewer for convenience

Followup from https://github.com/recharts/recharts/pull/7714

Related issue https://github.com/recharts/recharts/issues/7595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browsable visual regression gallery with grouped stories, story selection, and default-prop previews.
  * Added support for opening the gallery in Playwright UI mode.
  * Made the gallery available through a dedicated local preview server.

* **Documentation**
  * Updated visual regression testing guidance for story-based workflows, targeted test runs, browser baselines, gallery usage, and preview URLs.
  * Clarified the distinction between the blank test mount and the human-facing story preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->