### PR TITLE
Automate visual regression theme variants

### DIFF
--- a/.agents/skills/vr-test-migration/SKILL.md
+++ b/.agents/skills/vr-test-migration/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: vr-test-migration
+description: Migrate a legacy Recharts visual-regression spec to automatic theme variants
+---
+
+# Migrate one visual-regression spec
+
+Use this skill when one `test-vr` spec should move from the legacy browser-only
+fixture to the automatic legacy/light/dark fixture.
+
+## Non-negotiable scope
+
+This skill migrates exactly one `*.spec-vr.tsx` file per run. At the start of
+the run, execute the selector script:
+
+```sh
+node .agents/skills/vr-test-migration/find-next-spec.mjs
+```
+
+The script prints one repository-relative path: that is the only spec file to
+migrate. It selects the first legacy spec that imports the old `test` fixture
+and does not import `testWithThemes`; specs that explicitly use `legacyTest`
+remain intentional compatibility exceptions. Do not select a different file,
+run the script in a loop, or migrate multiple specs in one change. If the
+script exits with status 1, no legacy spec remains and the run must stop with
+that report. The script also verifies that the selected spec has a companion
+`.story.tsx` file; any other nonzero exit is a blocker, not a reason to choose
+another spec.
+
+Inspect the selected spec's companion story and imported helpers as needed.
+Supporting edits are allowed only when required to complete that one spec's
+migration; do not migrate another spec, rewrite shared compatibility helpers,
+or create a central exclusion list. If the selected spec is blocked, report
+the blocker instead of moving on to the next file.
+
+Read `DEVELOPING.md`, `AGENTS.md`, `test-vr/README.md`, and
+`.agents/skills/vr-test/SKILL.md` before editing. Inspect the target spec, its
+companion story file, any imported story helpers, and the snapshots for the
+target spec.
+
+## Fixture model
+
+`test-vr/tests/fixtures.ts` exposes two migration paths:
+
+- `testWithThemes` is the default for migrated and newly authored specs. Each
+  test runs in the legacy, light, and dark projects for each browser.
+- `test` is an alias for the legacy-only compatibility fixture. `legacyTest`
+  is the explicit name for the same behavior when a spec intentionally cannot
+  be migrated yet.
+
+Legacy projects retain the names `chromium`, `firefox`, and `webkit`, so their
+existing snapshots remain stable. The new projects are
+`chromium-light`, `chromium-dark`, `firefox-light`, `firefox-dark`,
+`webkit-light`, and `webkit-dark`.
+
+The gallery selects the Recharts variant at the rendering boundary:
+
+- `legacy`: no `RechartsThemeProvider` and a white canvas;
+- `light`: `RechartsThemeProvider` with `lightTheme` and a white canvas;
+- `dark`: `RechartsThemeProvider` with `darkTheme` and a black canvas.
+
+The selected variant is not a story prop. A migrated story must not receive
+`testTheme`, and a migrated spec must not put a theme name in its test title or
+custom screenshot name.
+
+## Migration workflow
+
+### 1. Inspect the target
+
+Identify:
+
+- the fixture import and every `test`, `test.describe`, `test.use`, and hook
+  reference in the spec;
+- every `testTheme` prop passed to `mountStory`;
+- `themedStory`, `applyTestTheme`, `WithLightTheme`, `WithDarkTheme`, and
+  `TestColorModeProvider` usage in the story graph;
+- tests that differ only by a light/dark theme choice;
+- explicit `RechartsThemeProvider` usage that may intentionally test nesting;
+- browser `colorScheme` or `page.emulateMedia` settings.
+
+Do not assume that a website color-mode provider and a Recharts theme are the
+same thing. `colorScheme` controls the browser's `prefers-color-scheme` media
+query; the Recharts theme is selected by the Playwright project.
+
+### 2. Switch the spec fixture
+
+Change the fixture import to `testWithThemes` and update all references in the
+file, including hooks and describe blocks:
+
+```tsx
+import { expect, testWithThemes } from '../fixtures';
+
+testWithThemes.beforeEach(async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+});
+
+testWithThemes('LineChart', async ({ mountStory }) => {
+  const component = await mountStory('App/LineChart');
+  await expect(component).toHaveScreenshot();
+});
+```
+
+Preserve unrelated Playwright options such as `colorScheme`, viewport, reduced
+motion, and timeouts. Only change the fixture that controls the Recharts
+variant.
+
+### 3. Remove theme props from mounts
+
+Remove `testTheme: 'default'`, `testTheme: 'light'`, and `testTheme: 'dark'`
+from `mountStory` props. Keep all real story props:
+
+```tsx
+// Before
+await mountStory('www/AreaChartApiExamples/SimpleAreaChart', {
+  testTheme: 'light',
+  isAnimationActive: false,
+});
+
+// After
+await mountStory('www/AreaChartApiExamples/SimpleAreaChart', {
+  isAnimationActive: false,
+});
+```
+
+If multiple tests mount the same story and differ only by `testTheme`, normally
+consolidate them into one ordinary scenario. The automatic fixture captures
+all three variants. Keep separate tests only when they exercise another
+independent dimension, such as a browser color mode, interaction, or different
+story props.
+
+Rename tests so they describe the scenario, not the theme. For example,
+`SimpleAreaChart dark mode` becomes `SimpleAreaChart` when the only difference
+was the Recharts theme.
+
+### 4. Simplify story wrappers
+
+If a story uses `themedStory` only to select `RechartsThemeProvider`, remove the
+helper import and export the underlying component directly:
+
+```tsx
+// Before
+import { themedStory } from './StoryTheme';
+
+export const SimpleAreaChart = themedStory(SimpleAreaChartComponent);
+
+// After
+export const SimpleAreaChart = SimpleAreaChartComponent;
+```
+
+Remove `WithLightTheme` and `WithDarkTheme` wrappers when they only provide the
+theme now supplied by the gallery. Do not remove an explicit provider that is
+the subject of a nested-theme test; instead decide whether that test should
+run with a selected outer variant or use a structured exception.
+
+`StoryTheme.tsx` also supplies website CSS and `ColorModeProvider` behavior.
+Preserve those concerns intentionally when the story needs them, but do not
+use `testTheme` to choose a Recharts theme. A story that needs website color
+mode can keep a provider such as `TestColorModeProvider`, while the spec uses
+`colorScheme` for the browser media query.
+
+### 5. Configure intentional exceptions
+
+Do not encode exclusions in test titles. Use fixture metadata:
+
+```tsx
+testWithThemes.describe('website color mode', { tag: '@recharts-theme-legacy' }, () => {
+  testWithThemes.use({ colorScheme: 'dark' });
+
+  testWithThemes('dark website', async ({ mountStory }) => {
+    const component = await mountStory('www/dark-mode/SimpleLineChartStory');
+    await expect(component).toHaveScreenshot();
+  });
+});
+```
+
+For a file, describe block, or individual test that should run in a selected
+set of variants, use:
+
+```tsx
+testWithThemes.use({ rechartsThemes: ['legacy', 'light'] });
+```
+
+Use `@recharts-theme-legacy`, `@recharts-theme-light`, and
+`@recharts-theme-dark` tags when the exception is local to a test or describe
+scope. Multiple tags select multiple variants, and tags take precedence over
+the `rechartsThemes` option. Keep `colorScheme` separate from both.
+
+### 6. Generate and review snapshots
+
+First list the targeted projects and tests:
+
+```sh
+npm run test-vr -- test-vr/tests/path/to/Target.spec-vr.tsx --list
+```
+
+Run the target in Docker:
+
+```sh
+npm run test-vr -- test-vr/tests/path/to/Target.spec-vr.tsx
+```
+
+The first migrated run should keep the existing legacy snapshots and add
+light/dark snapshots for each assertion. If new snapshots are expected, update
+only the target:
+
+```sh
+npm run test-vr:update -- test-vr/tests/path/to/Target.spec-vr.tsx
+```
+
+Use `--project=chromium-light` or `--grep=ScenarioName` when narrowing an
+update. Review the complete diff. Do not delete legacy snapshots because a
+new project has a different suffix, and do not commit `test-results` or
+`playwright-report`.
+
+For intentional exceptions, verify that the skipped projects are the only
+missing variants. A test using `@recharts-theme-legacy` should not produce
+light or dark snapshots, while another ordinary migrated test in the same
+spec should still produce all selected variants.
+
+## Validation checklist
+
+- The target spec imports and uses `testWithThemes`.
+- No migrated mount passes `testTheme`.
+- No migrated test title or screenshot name encodes a Recharts theme.
+- Story wrappers no longer select Recharts themes through props.
+- Website `ColorModeProvider` and CSS dependencies were preserved only where
+  they are independently required.
+- Browser `colorScheme` behavior remains unchanged.
+- Variant tags or `rechartsThemes` options document every intentional
+  exception.
+- Existing legacy snapshots remain unchanged unless the story itself changed.
+- New light and dark snapshots are present for ordinary migrated assertions.
+- `npm run check-types-test-vr` passes.
+- ESLint and Prettier pass for the changed files.

--- a/.agents/skills/vr-test-migration/find-next-spec.mjs
+++ b/.agents/skills/vr-test-migration/find-next-spec.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, '../../..');
+const testsDirectory = path.join(repositoryRoot, 'test-vr', 'tests');
+
+function findSpecs(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return findSpecs(entryPath);
+    }
+    return entry.isFile() && entry.name.endsWith('.spec-vr.tsx') ? [entryPath] : [];
+  });
+}
+
+function isLegacySpec(specPath) {
+  const source = readFileSync(specPath, 'utf8');
+  const importsThemeFixture = /import\s*\{[^}]*\btestWithThemes\b[^}]*\}\s*from\s*['"][^'"]*fixtures['"]/m.test(source);
+  const importsLegacyFixture = /import\s*\{[^}]*\btest\b[^}]*\}\s*from\s*['"][^'"]*fixtures['"]/m.test(source);
+
+  return !importsThemeFixture && importsLegacyFixture;
+}
+
+const legacySpecs = findSpecs(testsDirectory).filter(isLegacySpec).sort();
+
+if (legacySpecs.length === 0) {
+  console.error('No legacy visual-regression spec remains to migrate.');
+  process.exit(1);
+}
+
+const nextSpec = legacySpecs[0];
+const companionStory = nextSpec.replace(/\.spec-vr\.tsx$/, '.story.tsx');
+
+if (!statSync(companionStory, { throwIfNoEntry: false })?.isFile()) {
+  console.error(
+    `Cannot migrate ${path.relative(repositoryRoot, nextSpec)}: missing companion story ${path.relative(
+      repositoryRoot,
+      companionStory,
+    )}.`,
+  );
+  process.exit(2);
+}
+
+console.log(path.relative(repositoryRoot, nextSpec));

--- a/.agents/skills/vr-test/SKILL.md
+++ b/.agents/skills/vr-test/SKILL.md
@@ -41,9 +41,9 @@ export const LineChartStory = () => (
 
 ```tsx
 // test-vr/tests/App.spec-vr.tsx
-import { expect, test } from './fixtures';
+import { expect, testWithThemes } from './fixtures';
 
-test('LineChart', async ({ mountStory }) => {
+testWithThemes('LineChart', async ({ mountStory }) => {
   const component = await mountStory('App/LineChartStory');
   await expect(component).toHaveScreenshot();
 });
@@ -58,13 +58,12 @@ Stories can accept serializable props. Pass them as the second argument to `moun
 
 ```tsx
 import type { LineChartHasMultiSeries } from './LineChartApiExamples.story';
-import { expect, test } from '../fixtures';
+import { expect, testWithThemes } from '../fixtures';
 
-test('LineChartHasMultiSeries', async ({ mountStory }) => {
+testWithThemes('LineChartHasMultiSeries', async ({ mountStory }) => {
   const component = await mountStory<typeof LineChartHasMultiSeries>(
     'www/LineChartApiExamples/LineChartHasMultiSeries',
     {
-      testTheme: 'light',
       defaultIndex: 2,
     },
   );
@@ -74,6 +73,51 @@ test('LineChartHasMultiSeries', async ({ mountStory }) => {
 
 Keep the JSX in the story file rather than declaring a component inside the spec. This lets the
 gallery resolve the story by id and keeps the same rendering path for tests and manual review.
+
+## Fixture and project structure
+
+New specs use `testWithThemes` from `test-vr/tests/fixtures`. The fixture runs
+each test in the following nine projects:
+
+| Projects                                          | Recharts rendering                                      |
+| ------------------------------------------------- | ------------------------------------------------------- |
+| `chromium`, `firefox`, `webkit`                   | `legacy`: no `RechartsThemeProvider`, white canvas      |
+| `chromium-light`, `firefox-light`, `webkit-light` | `RechartsThemeProvider` with `lightTheme`, white canvas |
+| `chromium-dark`, `firefox-dark`, `webkit-dark`    | `RechartsThemeProvider` with `darkTheme`, black canvas  |
+
+The Playwright project selects the variant through the gallery URL and metadata.
+The story does not receive a theme prop. Never add `testTheme` to a new story,
+put a theme name in the test title, or pass a custom screenshot name.
+
+The exported `test` fixture is the legacy-only compatibility entry point used
+by existing specs, and `legacyTest` is its explicit name. Keep those fixtures
+local to specs that are not ready for light and dark baselines. The old
+`test-vr/tests/www/StoryTheme.tsx` helper is also compatibility code for
+unmigrated website stories. For migration work, use
+`.agents/skills/vr-test-migration/SKILL.md`.
+
+## Intentional variant exceptions
+
+Suppress variants with structured fixture configuration rather than test-title
+wording:
+
+```tsx
+testWithThemes.describe('website color mode', { tag: '@recharts-theme-legacy' }, () => {
+  testWithThemes.use({ colorScheme: 'dark' });
+
+  testWithThemes('dark website', async ({ mountStory }) => {
+    const component = await mountStory('www/dark-mode/SimpleLineChartStory');
+    await expect(component).toHaveScreenshot();
+  });
+});
+```
+
+The `@recharts-theme-legacy`, `@recharts-theme-light`, and
+`@recharts-theme-dark` tags select Recharts variants and are inherited by
+nested tests. Multiple tags can select multiple variants. Alternatively, set
+`testWithThemes.use({ rechartsThemes: ['legacy', 'light'] })` at file,
+`describe`, or test scope. Tags take precedence over the fixture option.
+`colorScheme` remains the browser's independent `prefers-color-scheme` setting.
 
 ## Running tests
 
@@ -89,7 +133,8 @@ Run the full suite with:
 npm run test-vr
 ```
 
-The full suite may take 20+ minutes. Prefer a targeted file or grep while developing:
+The full suite runs all nine projects and may take 20+ minutes. Prefer a
+targeted file, project, or grep while developing:
 
 ```sh
 npm run test-vr -- test-vr/tests/Legend.spec-vr.tsx
@@ -99,8 +144,14 @@ npm run test-vr -- test-vr/tests/Legend.spec-vr.tsx
 npm run test-vr -- --grep=Legend
 ```
 
-The default configuration runs Chromium, Firefox, and WebKit. If a screenshot is missing, the test
-generates a baseline for each browser; commit those files in `test-vr/__snapshots__`.
+```sh
+npm run test-vr -- --project=chromium-dark --grep=Legend
+```
+
+If a screenshot is missing, a `testWithThemes` spec generates a baseline for
+each selected browser/theme project. A legacy spec generates only the existing
+browser baselines. Review and commit intentional files in
+`test-vr/__snapshots__`.
 
 ## Updating screenshots
 
@@ -120,6 +171,9 @@ npm run test-vr:update -- --grep=Legend
 npm run test-vr:update -- test-vr/tests/Legend.spec-vr.tsx
 ```
 
+Use `--project` or `--grep` for a smaller update. Do not update all projects
+while migrating one spec unless you intend to review every generated baseline.
+
 ## Playwright UI and the story preview
 
 Run UI mode with:
@@ -134,12 +188,14 @@ click through all stories using their default props.
 
 The URL http://localhost:3100/gallery/index.html is intentionally a blank Playwright mount target.
 Playwright navigates there before calling `window.mount`; it does not contain a story list and does
-not require a story query parameter. If either host port is already in use, free it before starting
-UI mode or change the host-side port mapping in the command.
+not require a story query parameter. Theme projects add the `rechartsTheme`
+query parameter automatically; opening the mount page directly shows the
+legacy/no-provider path. If either host port is already in use, free it before
+starting UI mode or change the host-side port mapping in the command.
 
 The HTML report is served at http://localhost:9323 after `npm run test-vr:prepare`.
 
 Tests and screenshot generation require Docker. If Docker is unavailable, do not attempt to run the
 visual-regression suite locally.
 
-For additional details, see `test-vr/README.md`.
+For additional details, see `test-vr/README.md` and `DEVELOPING.md`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,7 +450,7 @@ jobs:
         run: ./run-test.sh "${{ matrix.test_dir }}" "file:${{ runner.temp }}/${{ env.PACKED_ARTIFACT_NAME }}"
 
   vr_tests:
-    name: VR Tests (${{ matrix.browser }})
+    name: VR Tests (${{ matrix.project }})
     permissions:
       contents: read
       id-token: write
@@ -465,7 +465,16 @@ jobs:
       # Run all browsers even if one fails so we get a full picture.
       fail-fast: false
       matrix:
-        browser: [chromium, firefox, webkit]
+        project:
+          - chromium
+          - firefox
+          - webkit
+          - chromium-light
+          - chromium-dark
+          - firefox-light
+          - firefox-dark
+          - webkit-light
+          - webkit-dark
     steps:
       - name: Checkout Recharts Repository
         uses: actions/checkout@v4
@@ -480,10 +489,10 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Run Visual Regression Tests (${{ matrix.browser }})
+      - name: Run Visual Regression Tests (${{ matrix.project }})
         id: vr_test_step
         # VR tests resolve recharts via a Vite source alias, so no build step is needed.
-        run: npx playwright test --config=test-vr/playwright.config.ts --project=${{ matrix.browser }}
+        run: npx playwright test --config=test-vr/playwright.config.ts --project=${{ matrix.project }}
         # Continue even if tests fail so the blob report can still be uploaded.
         continue-on-error: true
 
@@ -499,7 +508,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: vr-blob-report-${{ matrix.browser }}
+          name: vr-blob-report-${{ matrix.project }}
           path: test-vr/blob-report
           retention-days: 1
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,21 @@ and try to improve the code style where possible and where relevant to the curre
 Do not attempt to fix too much at once, or when it is not related to the current changes.
 
 Do not focus too much on fitting the existing style, if it is not ideal.
+
+## Visual regression tests
+
+Read `test-vr/README.md` and `.agents/skills/vr-test/SKILL.md` before adding or
+changing Playwright visual-regression tests. New specs use `testWithThemes`
+from `test-vr/tests/fixtures`, which automatically renders legacy, light, and
+dark Recharts theme variants. Do not expose theme selection through story
+props, theme-specific test titles, or custom screenshot names.
+
+Existing specs may continue to use the legacy `test` fixture while they are
+migrated one spec at a time. When asked to migrate one, follow
+`.agents/skills/vr-test-migration/SKILL.md`; do not create a central exclusion
+list. Keep `prefers-color-scheme` (`colorScheme`) separate from Recharts theme
+selection, and use the documented fixture options or `@recharts-theme-*` tags
+for intentional exceptions.
+
+Run visual-regression tests and update screenshots through Docker only. Do not
+commit generated `test-results` or `playwright-report` output.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -94,6 +94,17 @@ by story id with the `mountStory` fixture. See `test-vr/README.md` for details.
 The Playwright mount page at `/gallery/index.html` is intentionally blank until a test calls
 `window.mount`; it is not a human-facing story index.
 
+New VR specs should import `testWithThemes` from `test-vr/tests/fixtures`. Each
+test runs in legacy, light, and dark projects for Chromium, Firefox, and
+WebKit. The legacy `test` export remains available for existing specs during
+incremental migration and preserves the current browser-only snapshot names.
+Do not pass a Recharts theme through story props or test titles. Use
+`testWithThemes.use({ rechartsThemes: [...] })` or
+`@recharts-theme-legacy`, `@recharts-theme-light`, and
+`@recharts-theme-dark` tags for intentional exceptions. These selectors control
+the Recharts theme only; Playwright's `colorScheme` remains the independent
+`prefers-color-scheme` setting.
+
 ### Prerequisites
 
 Playwright tests are running inside Docker. You will need to have Docker installed and running.
@@ -118,6 +129,13 @@ Now, the usual loop. Write a new test, run it, fix it, repeat.
 npm run test-vr
 ```
 
+To run one spec or one project while developing:
+
+```sh
+npm run test-vr -- test-vr/tests/ThemeVariants.spec-vr.tsx
+npm run test-vr -- --project=chromium-dark --grep="LineChart"
+```
+
 Alternatively, the UI playwright mode is available as well:
 
 ```sh
@@ -135,13 +153,27 @@ If you want to record new snapshots or update the old ones, you can run:
 npm run test-vr:update
 ```
 
-You will see new files created in the `test-vr/__snapshots__` directory, please commit them to the repository!
+For a targeted migration, update only the affected spec and project set:
+
+```sh
+npm run test-vr:update -- test-vr/tests/ThemeVariants.spec-vr.tsx
+npm run test-vr:update -- --project=chromium-light --grep="LineChart"
+```
+
+New `testWithThemes` specs add light and dark snapshots while retaining the
+legacy browser snapshots. Existing `test` specs must not receive new theme
+baselines until they are explicitly migrated. Commit intentional files created
+in `test-vr/__snapshots__`; do not commit `test-results` or
+`playwright-report`.
 
 ### See VR test results
 
 Open http://localhost:9323 in your browser to see the results of the tests.
 The CLI will tell you to run a "show-report" which is not necessary because there is already a Docker container running
 in the background and serving the report. Just open the URL in your browser.
+
+CI runs all nine configured projects: `chromium`, `firefox`, `webkit`, and the
+`-light` and `-dark` project for each browser.
 
 # Manual testing
 
@@ -197,6 +229,9 @@ npm run test-vr:ui
 The same command serves the human-facing story preview at
 http://localhost:3100/gallery/preview.html. The Playwright-only mount target at
 http://localhost:3100/gallery/index.html remains blank when opened directly.
+Theme projects select their variant through the Playwright project
+configuration; opening the mount target directly does not preview the project
+matrix.
 
 # Releasing new versions
 

--- a/test-vr/README.md
+++ b/test-vr/README.md
@@ -35,7 +35,9 @@ export function LineChart() {
 
 ```tsx
 // test-vr/tests/App.spec-vr.tsx
-test('LineChart', async ({ mountStory }) => {
+import { expect, testWithThemes } from './fixtures';
+
+testWithThemes('LineChart', async ({ mountStory }) => {
   const component = await mountStory('App/LineChart');
   await expect(component).toHaveScreenshot();
 });
@@ -67,9 +69,64 @@ import type { LegendPosition } from './LegendPosition.story';
 const component = await mountStory<typeof LegendPosition>('LegendPosition/LegendPosition', { offset: 30 });
 ```
 
-The `www` tests have a shared story helper `test-vr/tests/www/StoryTheme.tsx` with a `themedStory()` factory and a
-`testTheme` prop (`'default' | 'light' | 'dark'`) that picks the theme wrapper the test needs, mirroring the old
-`testWithLightTheme` / `testWithDarkTheme` fixtures.
+## Recharts theme variants
+
+New visual-regression specs should import `testWithThemes` from
+`test-vr/tests/fixtures`:
+
+```tsx
+import { expect, testWithThemes } from './fixtures';
+
+testWithThemes('LineChart', async ({ mountStory }) => {
+  const component = await mountStory('App/LineChart');
+  await expect(component).toHaveScreenshot();
+});
+```
+
+Each `testWithThemes` test runs in three Playwright projects for each browser:
+
+| Project suffix                              | Gallery rendering                         | Canvas |
+| ------------------------------------------- | ----------------------------------------- | ------ |
+| no suffix (`chromium`, `firefox`, `webkit`) | No `RechartsThemeProvider` (`legacy`)     | White  |
+| `-light`                                    | `RechartsThemeProvider` with `lightTheme` | White  |
+| `-dark`                                     | `RechartsThemeProvider` with `darkTheme`  | Black  |
+
+The selected theme is supplied by the Playwright project and resolved inside
+the gallery boundary. It is not a story prop. Do not add a `testTheme` prop,
+put a theme name in a test title, or pass a custom screenshot name. Project
+names make the snapshots separate and deterministic, for example
+`LineChart-1-chromium-light-linux.png`.
+
+The `test` export is the staged, legacy-only fixture used by existing specs;
+`legacyTest` is its explicit name for new specs that intentionally need
+compatibility behavior. Existing specs may keep using it until their
+individual migration adds light and dark baselines. Use
+[the VR migration skill](../.agents/skills/vr-test-migration/SKILL.md) for that
+work. The old `test-vr/tests/www/StoryTheme.tsx` helper and its `testTheme`
+prop are also compatibility code for unmigrated website specs; do not use them
+in new stories.
+
+Intentional exceptions can suppress variants with structured fixture options at
+file, `test.describe`, or individual test scope:
+
+```tsx
+testWithThemes.describe('website color mode', { tag: '@recharts-theme-legacy' }, () => {
+  testWithThemes.use({ colorScheme: 'dark' });
+
+  testWithThemes('dark website', async ({ mountStory }) => {
+    const component = await mountStory('www/dark-mode/SimpleLineChartStory');
+    await expect(component).toHaveScreenshot();
+  });
+});
+```
+
+The tag selects the Recharts rendering variant; `colorScheme` still controls
+the browser's `prefers-color-scheme` media query. To select multiple variants
+without tags, use `testWithThemes.use({ rechartsThemes: ['legacy', 'light'] })`.
+Tags such as `@recharts-theme-legacy`, `@recharts-theme-light`, and
+`@recharts-theme-dark` are inherited by nested tests and take precedence over
+the fixture option. This is useful for website color-mode tests: the browser
+color scheme and the Recharts theme are independent dimensions.
 
 ## How to run tests
 
@@ -78,7 +135,8 @@ See [DEVELOPING.md](../DEVELOPING.md) for basic instructions on how to run the t
 Now that you know, let's go into more detail here.
 
 This whole setup runs in Docker and only in Docker so that we can have a consistent environment
-which will allow us to avoid test flakes due to different fonts and box shadows and whatnot.
+which will allow us to avoid test flakes due to different fonts and box shadows and whatnot. The
+full suite runs the three legacy browser projects plus the six browser/theme projects.
 
 The basic commands are prepared in `package.json` but you can go beyond that too
 and use whatever dockers allows you to do.

--- a/test-vr/gallery/main.tsx
+++ b/test-vr/gallery/main.tsx
@@ -11,8 +11,16 @@
 import * as React from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot, type Root } from 'react-dom/client';
+import { darkTheme, lightTheme, RechartsThemeProvider } from 'recharts';
 
 type StoryComponent = React.ComponentType<Record<string, unknown>>;
+type RechartsThemeVariant = 'legacy' | 'light' | 'dark';
+
+const rootElement = document.getElementById('root');
+if (rootElement === null) {
+  throw new Error('The gallery page must contain an element with id "root".');
+}
+const galleryElement = rootElement;
 
 /*
  * Vite analyzes import.meta.glob statically, relative to this file, so the
@@ -30,6 +38,36 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isComponent(value: unknown): value is StoryComponent {
   return typeof value === 'function';
+}
+
+function isRechartsThemeVariant(value: unknown): value is RechartsThemeVariant {
+  return value === 'legacy' || value === 'light' || value === 'dark';
+}
+
+function getRechartsTheme(): RechartsThemeVariant {
+  const value = new URLSearchParams(window.location.search).get('rechartsTheme');
+  return isRechartsThemeVariant(value) ? value : 'legacy';
+}
+
+function setCanvasBackground(theme: RechartsThemeVariant) {
+  if (theme === 'dark') {
+    galleryElement.style.backgroundColor = 'black';
+  } else if (theme === 'light') {
+    galleryElement.style.backgroundColor = 'white';
+  } else {
+    galleryElement.style.backgroundColor = '';
+  }
+}
+
+function renderWithRechartsTheme(theme: RechartsThemeVariant, story: React.ReactNode): React.ReactNode {
+  switch (theme) {
+    case 'light':
+      return <RechartsThemeProvider value={lightTheme}>{story}</RechartsThemeProvider>;
+    case 'dark':
+      return <RechartsThemeProvider value={darkTheme}>{story}</RechartsThemeProvider>;
+    default:
+      return story;
+  }
 }
 
 async function resolveStory(storyId: string): Promise<StoryComponent> {
@@ -55,11 +93,6 @@ async function resolveStory(storyId: string): Promise<StoryComponent> {
   return story;
 }
 
-const rootElement = document.getElementById('root');
-if (rootElement === null) {
-  throw new Error('The gallery page must contain an element with id "root".');
-}
-
 /*
  * The root is created once and reused across window.mount calls. Re-rendering
  * into the same root lets React reconcile in place, which is what preserves
@@ -77,18 +110,21 @@ declare global {
 window.mount = async ({ story, props }) => {
   const Story = await resolveStory(story);
   const storyProps: Record<string, unknown> = props ?? {};
-  const galleryRoot = root ?? createRoot(rootElement);
+  const theme = getRechartsTheme();
+  setCanvasBackground(theme);
+  const galleryRoot = root ?? createRoot(galleryElement);
   root = galleryRoot;
   /*
    * flushSync makes a render error reject the promise returned by mount()
    * instead of being swallowed by React.
    */
   flushSync(() => {
-    galleryRoot.render(<Story {...storyProps} />);
+    galleryRoot.render(renderWithRechartsTheme(theme, <Story {...storyProps} />));
   });
 };
 
 window.unmount = async () => {
   root?.unmount();
   root = undefined;
+  setCanvasBackground('legacy');
 };

--- a/test-vr/playwright.config.ts
+++ b/test-vr/playwright.config.ts
@@ -3,6 +3,36 @@ import path from 'path';
 
 const galleryUrl = 'http://localhost:3100/gallery/index.html';
 
+const browserProjects = [
+  {
+    name: 'chromium',
+    use: { ...devices['Desktop Chrome'] },
+    metadata: { rechartsTheme: 'legacy' },
+  },
+  {
+    name: 'firefox',
+    use: { ...devices['Desktop Firefox'] },
+    metadata: { rechartsTheme: 'legacy' },
+  },
+  {
+    name: 'webkit',
+    use: { ...devices['Desktop Safari'] },
+    metadata: { rechartsTheme: 'legacy' },
+  },
+];
+
+const themedProjects = browserProjects.flatMap(project =>
+  (['light', 'dark'] as const).map(rechartsTheme => ({
+    ...project,
+    name: `${project.name}-${rechartsTheme}`,
+    use: {
+      ...project.use,
+      baseURL: `${galleryUrl}?rechartsTheme=${rechartsTheme}`,
+    },
+    metadata: { rechartsTheme },
+  })),
+);
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -109,18 +139,5 @@ export default defineConfig({
   },
 
   /* Configure projects for major browsers */
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-  ],
+  projects: [...browserProjects, ...themedProjects],
 });

--- a/test-vr/tests/ThemeVariants.spec-vr.tsx
+++ b/test-vr/tests/ThemeVariants.spec-vr.tsx
@@ -1,0 +1,7 @@
+import { expect, testWithThemes } from './fixtures';
+
+testWithThemes('renders the selected Recharts theme variant', async ({ mountStory, rechartsTheme }) => {
+  const component = await mountStory('ThemeVariants/ThemeVariants');
+
+  await expect(component).toHaveAttribute('data-recharts-theme', rechartsTheme);
+});

--- a/test-vr/tests/ThemeVariants.story.tsx
+++ b/test-vr/tests/ThemeVariants.story.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { darkTheme, lightTheme, useRechartsTheme } from 'recharts';
+
+export function ThemeVariants() {
+  const theme = useRechartsTheme();
+  let variant = 'legacy';
+  if (theme === darkTheme) {
+    variant = 'dark';
+  } else if (theme === lightTheme) {
+    variant = 'light';
+  } else if (theme !== undefined) {
+    variant = 'unexpected';
+  }
+
+  return <div data-recharts-theme={variant}>{variant}</div>;
+}

--- a/test-vr/tests/fixtures.ts
+++ b/test-vr/tests/fixtures.ts
@@ -7,26 +7,103 @@
  * points at that child, otherwise it points at the root itself.
  * This keeps toHaveScreenshot() capturing the same bounding box as before.
  */
-import { test as base, expect, type Locator, type PlaywrightTestArgs } from '@playwright/test';
+import { test as base, expect, type Locator, type PlaywrightTestArgs, type TestInfo } from '@playwright/test';
+
+export type RechartsThemeVariant = 'legacy' | 'light' | 'dark';
 
 type MountStory = PlaywrightTestArgs['mount'];
 
-export const test = base.extend<{ mountStory: MountStory }>({
-  mountStory: async ({ mount }, use) => {
-    const mountStory: MountStory = async (storyId, props) => {
-      const root = await mount(storyId, props);
-      const children = root.locator(':scope > *');
-      const component: Locator = (await children.count()) === 1 ? children.first() : root;
+type TestOptions = {
+  /**
+   * Recharts theme variants allowed for the current test.
+   *
+   * This is an option fixture so it can be configured with test.use() at file,
+   * describe, or individual test scope.
+   */
+  rechartsThemes: readonly RechartsThemeVariant[];
+};
 
-      return Object.assign(component, {
-        update: root.update,
-        unmount: root.unmount,
-      });
-    };
+type TestFixtures = {
+  mountStory: MountStory;
+  rechartsTheme: RechartsThemeVariant;
+};
 
-    // eslint-disable-next-line react-hooks/rules-of-hooks -- we are in a test fixture not a React hook
-    await use(mountStory);
-  },
-});
+const allRechartsThemes: readonly RechartsThemeVariant[] = ['legacy', 'light', 'dark'];
+
+function isRechartsThemeVariant(value: unknown): value is RechartsThemeVariant {
+  return value === 'legacy' || value === 'light' || value === 'dark';
+}
+
+function getProjectRechartsTheme(testInfo: TestInfo): RechartsThemeVariant {
+  const projectTheme = testInfo.project.metadata?.rechartsTheme;
+  return isRechartsThemeVariant(projectTheme) ? projectTheme : 'legacy';
+}
+
+function getTaggedRechartsThemes(testInfo: TestInfo): RechartsThemeVariant[] {
+  const taggedThemes = testInfo.tags.flatMap(tag => {
+    const match = /^@recharts-theme-(legacy|light|dark)$/.exec(tag);
+    if (match === null || !isRechartsThemeVariant(match[1])) {
+      return [];
+    }
+    return [match[1]];
+  });
+
+  return [...new Set(taggedThemes)];
+}
+
+function getAllowedRechartsThemes(
+  rechartsThemes: readonly RechartsThemeVariant[],
+  testInfo: TestInfo,
+): readonly RechartsThemeVariant[] {
+  const taggedThemes = getTaggedRechartsThemes(testInfo);
+  return taggedThemes.length > 0 ? taggedThemes : rechartsThemes;
+}
+
+function createTest(defaultThemes: readonly RechartsThemeVariant[]) {
+  return base.extend<TestOptions & TestFixtures>({
+    rechartsThemes: [defaultThemes, { option: true }],
+
+    rechartsTheme: async ({ rechartsThemes: _rechartsThemes }, use, testInfo) => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks -- we are in a test fixture not a React hook
+      await use(getProjectRechartsTheme(testInfo));
+    },
+
+    mountStory: async ({ mount, rechartsTheme, rechartsThemes }, use, testInfo) => {
+      const allowedThemes = getAllowedRechartsThemes(rechartsThemes, testInfo);
+      if (!allowedThemes.includes(rechartsTheme)) {
+        testInfo.skip(true, `Recharts theme "${rechartsTheme}" is not enabled for this test`);
+      }
+
+      const mountStory: MountStory = async (storyId, props) => {
+        const root = await mount(storyId, props);
+        const children = root.locator(':scope > *');
+        const component: Locator = (await children.count()) === 1 ? children.first() : root;
+
+        return Object.assign(component, {
+          update: root.update,
+          unmount: root.unmount,
+        });
+      };
+
+      // eslint-disable-next-line react-hooks/rules-of-hooks -- we are in a test fixture not a React hook
+      await use(mountStory);
+    },
+  });
+}
+
+/*
+ * Existing specs use this fixture and therefore keep their legacy-only
+ * snapshot set while they are migrated. `legacyTest` is the explicit name for
+ * new specs that intentionally need the compatibility behavior.
+ */
+export const legacyTest = createTest(['legacy']);
+export const test = legacyTest;
+
+/*
+ * New specs should use this fixture. It creates one test execution for each
+ * browser/theme project and automatically supplies the selected theme to the
+ * gallery boundary.
+ */
+export const testWithThemes = createTest(allRechartsThemes);
 
 export { expect };


### PR DESCRIPTION
Closes https://github.com/recharts/recharts/issues/7736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Visual regression tests now support legacy, light, and dark Recharts themes across Chromium, Firefox, and WebKit.
  - The gallery can render a selected theme through the `rechartsTheme` query parameter.
  - Added coverage verifying theme selection in rendered stories.

- **Documentation**
  - Updated development and testing guides with theme selection, project commands, snapshot handling, and migration guidance.
  - Added workflow guidance for migrating legacy visual regression tests incrementally.

- **CI**
  - Continuous integration now runs and reports results for all nine browser/theme projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->