### PR TITLE
Render all theme variants in VR gallery preview

### DIFF
--- a/.agents/skills/vr-test/SKILL.md
+++ b/.agents/skills/vr-test/SKILL.md
@@ -183,12 +183,15 @@ npm run test-vr:ui
 ```
 
 This publishes the Playwright UI at http://localhost:8080 and the Vite gallery at port 3100.
-Open http://localhost:3100/gallery/preview.html for a human-facing navigation page that lets you
-click through all stories using their default props.
+Open http://localhost:3100/gallery/preview.html for a human-facing navigation page that shows each
+selected story in three stacked legacy, light, and dark panels. Each panel loads the Playwright
+mount page (`index.html?story=…&rechartsTheme=…`) in an isolated iframe, with an open-in-new-tab
+link for the single variant.
 
 The URL http://localhost:3100/gallery/index.html is intentionally a blank Playwright mount target.
 Playwright navigates there before calling `window.mount`; it does not contain a story list and does
-not require a story query parameter. Theme projects add the `rechartsTheme`
+not require a story query parameter. A `?story=` URL auto-mounts the story for iframe panels and
+open-in-new-tab links. Theme projects add the `rechartsTheme`
 query parameter automatically; opening the mount page directly shows the
 legacy/no-provider path. If either host port is already in use, free it before
 starting UI mode or change the host-side port mapping in the command.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -92,7 +92,7 @@ https://playwright.dev/docs/test-components.
 The JSX for each scenario lives in a `*.story.tsx` file next to the spec, and the spec mounts it
 by story id with the `mountStory` fixture. See `test-vr/README.md` for details.
 The Playwright mount page at `/gallery/index.html` is intentionally blank until a test calls
-`window.mount`; it is not a human-facing story index.
+`window.mount` or the URL includes `?story=`; it is not a human-facing story index.
 
 New VR specs should import `testWithThemes` from `test-vr/tests/fixtures`. Each
 test runs in legacy, light, and dark projects for Chromium, Firefox, and
@@ -144,8 +144,9 @@ npm run test-vr:ui
 
 This starts Playwright UI on http://localhost:8080 and keeps the Vite gallery server available on
 port 3100. While the command is running, use http://localhost:3100/gallery/preview.html to browse
-and click through the stories manually. The preview page mounts each selected story with its
-default props. Do not expect `/gallery/index.html` to display a navigation page.
+and click through the stories manually. The preview page shows each selected story in three stacked
+legacy, light, and dark panels that reuse the Playwright mount page, with open-in-new-tab links for
+each variant. Do not expect `/gallery/index.html` to display a navigation page.
 
 If you want to record new snapshots or update the old ones, you can run:
 
@@ -227,11 +228,11 @@ npm run test-vr:ui
 ```
 
 The same command serves the human-facing story preview at
-http://localhost:3100/gallery/preview.html. The Playwright-only mount target at
-http://localhost:3100/gallery/index.html remains blank when opened directly.
-Theme projects select their variant through the Playwright project
-configuration; opening the mount target directly does not preview the project
-matrix.
+http://localhost:3100/gallery/preview.html. Each selected story renders in three stacked legacy,
+light, and dark panels that reuse the Playwright mount page (`index.html?story=…&rechartsTheme=…`).
+The Playwright-only mount target at http://localhost:3100/gallery/index.html remains blank when
+opened directly without `?story=`. Theme projects select their variant through the Playwright project
+configuration; opening the mount target directly does not preview the project matrix.
 
 # Releasing new versions
 

--- a/test-vr/README.md
+++ b/test-vr/README.md
@@ -180,9 +180,12 @@ The story gallery pages used by the component tests: https://playwright.dev/docs
 They are served by the Vite dev server configured in `./vite.config.ts` on port 3100,
 which Playwright starts automatically through the `webServer` option in `./playwright.config.ts`.
 
-`gallery/index.html` is the blank mount target used by Playwright. To browse stories manually,
-open `http://localhost:3100/gallery/preview.html` while the gallery server is running.
-The preview page provides navigation and mounts the selected story with its default props.
+`gallery/index.html` is the blank mount target used by Playwright. It auto-mounts a story only when
+`?story=` is present in the URL. To browse stories manually, open
+`http://localhost:3100/gallery/preview.html` while the gallery server is running.
+The preview page provides navigation and shows each selected story in three stacked panels — legacy,
+light, and dark — that reuse the Playwright mount page (`index.html?story=…&rechartsTheme=…`), with
+open-in-new-tab links for each variant.
 
 ### `playwright-report`
 

--- a/test-vr/gallery/main.tsx
+++ b/test-vr/gallery/main.tsx
@@ -11,10 +11,9 @@
 import * as React from 'react';
 import { flushSync } from 'react-dom';
 import { createRoot, type Root } from 'react-dom/client';
-import { darkTheme, lightTheme, RechartsThemeProvider } from 'recharts';
+import { getRechartsTheme, renderWithRechartsTheme, setCanvasBackground } from './theme';
 
 type StoryComponent = React.ComponentType<Record<string, unknown>>;
-type RechartsThemeVariant = 'legacy' | 'light' | 'dark';
 
 const rootElement = document.getElementById('root');
 if (rootElement === null) {
@@ -38,36 +37,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isComponent(value: unknown): value is StoryComponent {
   return typeof value === 'function';
-}
-
-function isRechartsThemeVariant(value: unknown): value is RechartsThemeVariant {
-  return value === 'legacy' || value === 'light' || value === 'dark';
-}
-
-function getRechartsTheme(): RechartsThemeVariant {
-  const value = new URLSearchParams(window.location.search).get('rechartsTheme');
-  return isRechartsThemeVariant(value) ? value : 'legacy';
-}
-
-function setCanvasBackground(theme: RechartsThemeVariant) {
-  if (theme === 'dark') {
-    galleryElement.style.backgroundColor = 'black';
-  } else if (theme === 'light') {
-    galleryElement.style.backgroundColor = 'white';
-  } else {
-    galleryElement.style.backgroundColor = '';
-  }
-}
-
-function renderWithRechartsTheme(theme: RechartsThemeVariant, story: React.ReactNode): React.ReactNode {
-  switch (theme) {
-    case 'light':
-      return <RechartsThemeProvider value={lightTheme}>{story}</RechartsThemeProvider>;
-    case 'dark':
-      return <RechartsThemeProvider value={darkTheme}>{story}</RechartsThemeProvider>;
-    default:
-      return story;
-  }
 }
 
 async function resolveStory(storyId: string): Promise<StoryComponent> {
@@ -111,7 +80,7 @@ window.mount = async ({ story, props }) => {
   const Story = await resolveStory(story);
   const storyProps: Record<string, unknown> = props ?? {};
   const theme = getRechartsTheme();
-  setCanvasBackground(theme);
+  setCanvasBackground(galleryElement, theme);
   const galleryRoot = root ?? createRoot(galleryElement);
   root = galleryRoot;
   /*
@@ -126,5 +95,14 @@ window.mount = async ({ story, props }) => {
 window.unmount = async () => {
   root?.unmount();
   root = undefined;
-  setCanvasBackground('legacy');
+  setCanvasBackground(galleryElement, 'legacy');
 };
+
+setCanvasBackground(galleryElement, getRechartsTheme());
+
+const storyFromUrl = new URLSearchParams(window.location.search).get('story');
+if (storyFromUrl !== null) {
+  window.mount({ story: storyFromUrl }).catch(() => {
+    // Unknown story ids from the URL are ignored.
+  });
+}

--- a/test-vr/gallery/preview.css
+++ b/test-vr/gallery/preview.css
@@ -132,15 +132,52 @@ summary {
   font-weight: 400;
 }
 
-.story-canvas {
-  min-height: calc(100vh - 74px);
+.story-variants {
+  display: grid;
+  gap: 24px;
   padding: 32px;
-  overflow: auto;
-  background: #fff;
 }
 
-.story-canvas > * {
-  margin: 0 auto;
+.story-panel {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.story-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e5e7eb;
+  background: #f9fafb;
+}
+
+.story-panel-header h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.story-panel-link {
+  color: #2563eb;
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.story-panel-link:hover {
+  text-decoration: underline;
+}
+
+.story-panel-frame {
+  overflow-x: auto;
+}
+
+.story-panel-iframe {
+  display: block;
+  border: 0;
 }
 
 .gallery-empty {

--- a/test-vr/gallery/preview.tsx
+++ b/test-vr/gallery/preview.tsx
@@ -1,15 +1,20 @@
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
+import {
+  buildMountUrl,
+  getIframeSeamFillBackground,
+  RECHARTS_THEME_PANEL_LABELS,
+  RECHARTS_THEME_VARIANTS,
+  type RechartsThemeVariant,
+} from './theme';
 import './preview.css';
 
-type StoryComponent = React.ComponentType<Record<string, unknown>>;
 type StoryModule = Record<string, unknown>;
 
 type Story = {
   id: string;
   file: string;
   name: string;
-  component: StoryComponent;
 };
 
 const storyModules = import.meta.glob<StoryModule>('../tests/**/*.story.{tsx,jsx}', { eager: true });
@@ -18,7 +23,7 @@ function storyFileFromPath(file: string): string {
   return file.replace(/^\.\.\/tests\//, '').replace(/\.story\.\w+$/, '');
 }
 
-function isComponent(value: unknown): value is StoryComponent {
+function isComponent(value: unknown): value is React.ComponentType<Record<string, unknown>> {
   return typeof value === 'function';
 }
 
@@ -36,7 +41,6 @@ const stories: Story[] = Object.entries(storyModules)
           id: `${storyFile}/${name}`,
           file: storyFile,
           name,
-          component: value,
         },
       ];
     });
@@ -62,13 +66,153 @@ function getStoryIdFromUrl(): string | undefined {
   return storyId !== null && stories.some(story => story.id === storyId) ? storyId : stories[0]?.id;
 }
 
-function StoryPreview({ story }: { story: Story }) {
-  const Story = story.component;
-  const props: Record<string, unknown> = {};
+const AUTOSIZE_DEADBAND_PX = 2;
+const IFRAME_MIN_HEIGHT_PX = 200;
+
+/*
+ * Size each iframe to its document scroll box. Width uses max(panel width,
+ * document scroll width) so wide charts scroll the panel, not the iframe.
+ * Writes are deferred out of ResizeObserver callbacks and guarded by a 2px
+ * deadband to avoid layout feedback loops.
+ */
+function autosizeIframe(
+  iframe: HTMLIFrameElement,
+  panel: HTMLElement,
+  onSizeChange: (width: number, height: number) => void,
+): () => void {
+  let currentWidth = 0,
+    currentHeight = 0,
+    contentObserver: ResizeObserver | undefined,
+    rafId: number | undefined;
+
+  const measureAndUpdate = () => {
+    const doc = iframe.contentWindow?.document;
+    if (doc === undefined) {
+      return;
+    }
+
+    const { scrollWidth, scrollHeight } = doc.documentElement;
+    const panelWidth = panel.clientWidth;
+    const nextWidth = Math.max(panelWidth, scrollWidth);
+    const nextHeight = scrollHeight;
+
+    if (
+      Math.abs(nextWidth - currentWidth) < AUTOSIZE_DEADBAND_PX &&
+      Math.abs(nextHeight - currentHeight) < AUTOSIZE_DEADBAND_PX
+    ) {
+      return;
+    }
+
+    currentWidth = nextWidth;
+    currentHeight = nextHeight;
+
+    if (rafId !== undefined) {
+      cancelAnimationFrame(rafId);
+    }
+    rafId = requestAnimationFrame(() => {
+      onSizeChange(currentWidth, currentHeight);
+      rafId = undefined;
+    });
+  };
+
+  const setupContentObserver = () => {
+    const { contentWindow } = iframe;
+    if (contentWindow === null) {
+      return;
+    }
+
+    const { document: doc } = contentWindow;
+    const ResizeObserverCtor = (contentWindow as Window & typeof globalThis).ResizeObserver;
+    if (ResizeObserverCtor === undefined) {
+      return;
+    }
+
+    contentObserver?.disconnect();
+    const observer = new ResizeObserverCtor(() => {
+      measureAndUpdate();
+    });
+    contentObserver = observer;
+    observer.observe(doc.documentElement);
+    measureAndUpdate();
+  };
+
+  const handleLoad = () => {
+    setupContentObserver();
+  };
+
+  iframe.addEventListener('load', handleLoad);
+  if (iframe.contentDocument?.readyState === 'complete') {
+    handleLoad();
+  }
+
+  const panelObserver = new ResizeObserver(() => {
+    measureAndUpdate();
+    if (iframe.contentDocument?.readyState === 'complete') {
+      setupContentObserver();
+    }
+  });
+  panelObserver.observe(panel);
+
+  return () => {
+    iframe.removeEventListener('load', handleLoad);
+    contentObserver?.disconnect();
+    panelObserver.disconnect();
+    if (rafId !== undefined) {
+      cancelAnimationFrame(rafId);
+    }
+  };
+}
+
+function StoryVariantPanel({ storyId, variant }: { storyId: string; variant: RechartsThemeVariant }) {
+  const panelRef = React.useRef<HTMLDivElement>(null);
+  const iframeRef = React.useRef<HTMLIFrameElement>(null);
+  const [size, setSize] = React.useState({ width: 0, height: IFRAME_MIN_HEIGHT_PX });
+  const mountUrl = buildMountUrl(storyId, variant);
+
+  React.useEffect(() => {
+    const panel = panelRef.current;
+    const iframe = iframeRef.current;
+    if (panel === null || iframe === null) {
+      return undefined;
+    }
+
+    return autosizeIframe(iframe, panel, (width, height) => {
+      setSize({ width, height });
+    });
+  }, [storyId, variant]);
 
   return (
-    <div className="story-canvas">
-      <Story {...props} />
+    <section className="story-panel">
+      <header className="story-panel-header">
+        <h3>{RECHARTS_THEME_PANEL_LABELS[variant]}</h3>
+        <a className="story-panel-link" href={mountUrl} target="_blank" rel="noreferrer">
+          Open in new tab
+        </a>
+      </header>
+      <div className="story-panel-frame" ref={panelRef}>
+        <iframe
+          ref={iframeRef}
+          key={`${storyId}-${variant}`}
+          title={`${storyId} (${variant})`}
+          src={mountUrl}
+          className="story-panel-iframe"
+          style={{
+            width: size.width > 0 ? `${size.width}px` : '100%',
+            height: `${size.height}px`,
+            background: getIframeSeamFillBackground(variant),
+          }}
+        />
+      </div>
+    </section>
+  );
+}
+
+function StoryVariants({ storyId }: { storyId: string }) {
+  return (
+    <div className="story-variants">
+      {RECHARTS_THEME_VARIANTS.map(variant => (
+        <StoryVariantPanel key={variant} storyId={storyId} variant={variant} />
+      ))}
     </div>
   );
 }
@@ -131,7 +275,7 @@ function PreviewApp() {
             {selectedStory.name} <code>{selectedStory.id}</code>
           </h2>
         </header>
-        <StoryPreview key={selectedStory.id} story={selectedStory} />
+        <StoryVariants key={selectedStory.id} storyId={selectedStory.id} />
       </main>
     </div>
   );

--- a/test-vr/gallery/theme.ts
+++ b/test-vr/gallery/theme.ts
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { darkTheme, lightTheme, RechartsThemeProvider } from 'recharts';
+
+export type RechartsThemeVariant = 'legacy' | 'light' | 'dark';
+
+export const RECHARTS_THEME_VARIANTS = ['legacy', 'light', 'dark'] as const;
+
+export const RECHARTS_THEME_PANEL_LABELS: Record<RechartsThemeVariant, string> = {
+  legacy: 'Legacy',
+  light: 'Light',
+  dark: 'Dark',
+};
+
+export function isRechartsThemeVariant(value: unknown): value is RechartsThemeVariant {
+  return value === 'legacy' || value === 'light' || value === 'dark';
+}
+
+export function getRechartsTheme(): RechartsThemeVariant {
+  const value = new URLSearchParams(window.location.search).get('rechartsTheme');
+  return isRechartsThemeVariant(value) ? value : 'legacy';
+}
+
+export function setCanvasBackground(element: HTMLElement, theme: RechartsThemeVariant) {
+  /* eslint-disable no-param-reassign -- intentional DOM style mutation */
+  if (theme === 'dark') {
+    element.style.backgroundColor = 'black';
+  } else if (theme === 'light') {
+    element.style.backgroundColor = 'white';
+  } else {
+    element.style.backgroundColor = '';
+  }
+  /* eslint-enable no-param-reassign */
+}
+
+export function renderWithRechartsTheme(theme: RechartsThemeVariant, story: React.ReactNode): React.ReactNode {
+  switch (theme) {
+    case 'light':
+      return React.createElement(RechartsThemeProvider, { value: lightTheme }, story);
+    case 'dark':
+      return React.createElement(RechartsThemeProvider, { value: darkTheme }, story);
+    default:
+      return story;
+  }
+}
+
+export function getIframeSeamFillBackground(theme: RechartsThemeVariant): string {
+  return theme === 'dark' ? 'black' : 'white';
+}
+
+export function buildMountUrl(storyId: string, variant: RechartsThemeVariant): string {
+  const params = new URLSearchParams({ story: storyId, rechartsTheme: variant });
+  return `./index.html?${params.toString()}`;
+}

--- a/test-vr/tests/PreviewGallery.spec-vr.tsx
+++ b/test-vr/tests/PreviewGallery.spec-vr.tsx
@@ -1,0 +1,39 @@
+import { expect, legacyTest } from './fixtures';
+
+legacyTest.skip(
+  ({ rechartsTheme }) => rechartsTheme !== 'legacy',
+  'the gallery preview embeds all three Recharts variants in one page',
+);
+
+legacyTest.describe.configure({ timeout: 60_000 });
+
+const storyId = 'ThemeVariants/ThemeVariants';
+
+legacyTest('preview shows three theme variant panels', async ({ page }) => {
+  await page.goto(`/gallery/preview.html?story=${storyId}`);
+
+  await expect(page.locator('.story-panel')).toHaveCount(3);
+
+  await Promise.all(
+    (['legacy', 'light', 'dark'] as const).map(async variant => {
+      const iframe = page.locator(`iframe[src*="rechartsTheme=${variant}"]`);
+      await expect(iframe).toHaveAttribute('src', /story=ThemeVariants%2FThemeVariants/);
+
+      const frame = page.frameLocator(`iframe[src*="rechartsTheme=${variant}"]`);
+      await expect(frame.locator('[data-recharts-theme]')).toHaveAttribute('data-recharts-theme', variant);
+    }),
+  );
+});
+
+legacyTest('index.html auto-mounts a dark story from the URL', async ({ page }) => {
+  await page.goto(`/gallery/index.html?story=${storyId}&rechartsTheme=dark`);
+
+  await expect(page.locator('[data-recharts-theme]')).toHaveAttribute('data-recharts-theme', 'dark');
+  await expect(page.locator('#root')).toHaveCSS('background-color', 'rgb(0, 0, 0)');
+});
+
+legacyTest('index.html sets a transparent background for the legacy theme', async ({ page }) => {
+  await page.goto(`/gallery/index.html?story=${storyId}&rechartsTheme=legacy`);
+
+  await expect(page.locator('#root')).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+});

--- a/test-vr/vite.config.ts
+++ b/test-vr/vite.config.ts
@@ -23,7 +23,10 @@ export default defineConfig(({ command }) => ({
     emptyOutDir: true,
     outDir: path.join(__dirname, 'dist'),
     rollupOptions: {
-      input: path.join(galleryRoot, 'preview.html'),
+      input: {
+        preview: path.join(galleryRoot, 'preview.html'),
+        index: path.join(galleryRoot, 'index.html'),
+      },
     },
   },
   cacheDir: path.join(repoRoot, 'node_modules/.vite-test-vr'),


### PR DESCRIPTION
## Description

The VR gallery at `test-vr/gallery/preview.html` used to mount the selected story once, without a
`RechartsThemeProvider`. Now selecting a story renders it in three labeled panels at the same
time, with no theme switcher:

- `legacy`: no `RechartsThemeProvider`, white canvas
- `light`: `RechartsThemeProvider` with `lightTheme`, white canvas
- `dark`: `RechartsThemeProvider` with `darkTheme`, dark canvas

Each panel is an iframe that loads the Playwright mount page (`gallery/index.html` with a `story`
and `rechartsTheme` parameter), so all three variants go through the same `window.mount` code the
screenshot tests use. Each panel also runs in its own document, so things like color-mode DOM
changes, duplicate SVG ids, `uniqueId` state and DOM mutations in one variant cannot affect
another.

Other changes:

- Moved the shared theme helpers (variant list, provider wrapper, canvas background) into
  `test-vr/gallery/theme.ts`, used by both the mount page and the preview.
- `index.html` now auto-mounts a story when the URL contains `?story=`. It stays blank for
  Playwright, which never passes that parameter.
- Added `index.html` to the Vite production input, so the GitHub Pages artifact hosts both pages
  and the iframes keep working in the deployed gallery. No CI changes needed.
- Added `PreviewGallery.spec-vr.tsx`, which checks the three panels and the URL auto-mount with
  DOM assertions only. It takes no screenshots.

Story navigation, the `?story=` URL behavior and the default story props are unchanged. Panels
grow to fit tall stories, wide stories scroll inside their panel, and each panel has an
"Open in new tab" link to its single variant.

## Related Issue

Closes #7738

Depends on the shared theme rendering from #7736, already merged via #7746.

## Motivation and Context

A theme switcher would not meet the goal here, which is seeing all three variants at once.
Rendering only the default story would also leave the gallery out of sync with the screenshot
matrix, which already renders every story in all three variants.

## How Has This Been Tested?

- `npm run check-types-test-vr`
- `npx eslint test-vr/gallery test-vr/tests/PreviewGallery.spec-vr.tsx`
- `npx vite build --config test-vr/vite.config.ts` (dist contains both `preview.html` and
  `index.html`)
- Docker: `npm run test-vr -- test-vr/tests/PreviewGallery.spec-vr.tsx
  test-vr/tests/ThemeVariants.spec-vr.tsx`. The new spec passes in the three legacy browser
  projects and is skipped in the six themed projects. The `ThemeVariants` spec still passes in
  all nine projects. No screenshots changed.
- Manual check in the dev gallery: selecting stories renders the three panels, sidebar
  navigation and `?story=` still work, wide and tall stories are usable, and "Open in new tab"
  shows a single variant.

## Screenshots (if appropriate):

<img width="515" height="952" alt="image" src="https://github.com/user-attachments/assets/760aa667-2022-4979-b7db-e45469f5003f" />


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Story previews now display legacy, light, and dark variants in separate stacked panels.
  - Each variant includes an isolated preview frame and an option to open it in a new tab.
  - Story previews can be automatically mounted using a `?story=` URL parameter.
  - Gallery pages now support theme-specific backgrounds and responsive panel sizing.

- **Documentation**
  - Updated visual-regression guidance to describe the revised preview and mount-page behavior.

- **Tests**
  - Added coverage for themed variants, automatic story mounting, and theme-specific backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->