### PR TITLE
fix: preserve repeated radar category positions

### DIFF
--- a/src/polar/PolarAngleAxis.tsx
+++ b/src/polar/PolarAngleAxis.tsx
@@ -517,7 +517,7 @@ export function PolarAngleAxis<DataPointType = any, DataValueType = any>(
       dataKey={props.dataKey}
       unit={undefined}
       name={props.name}
-      allowDuplicatedCategory={false} // Ignoring the prop on purpose because axis calculation behaves as if it was false and Tooltip requires it to be true.
+      allowDuplicatedCategory={props.allowDuplicatedCategory}
       allowDataOverflow={false}
       reversed={props.reversed}
       includeHidden={false}

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -200,6 +200,7 @@ export type AngleAxisForRadar = {
   scale: RechartsScale;
   type: 'number' | 'category';
   dataKey: DataKey<any> | undefined;
+  duplicateDomain: ReadonlyArray<unknown> | undefined;
   cx: number;
   cy: number;
   range: AxisRange;
@@ -318,7 +319,7 @@ export function computeRadarPoints({
   displayedData.forEach((entry, i) => {
     const name = getValueByDataKey(entry, angleAxis.dataKey, i);
     const value = getValueByDataKey(entry, dataKey);
-    const angle: number = (angleAxis.scale.map(name) ?? 0) + angleBandSize;
+    const angle: number = (angleAxis.scale.map(angleAxis.duplicateDomain ? i : name) ?? 0) + angleBandSize;
     const pointValue = Array.isArray(value) ? last(value) : value;
     const radius: number = isNullish(pointValue) ? 0 : (radiusAxis.scale.map(pointValue) ?? 0);
 

--- a/src/state/selectors/axisSelectors.ts
+++ b/src/state/selectors/axisSelectors.ts
@@ -1949,7 +1949,7 @@ export const combineDuplicateDomain = (
   const isCategorical = isCategoricalAxis(chartLayout, axisType);
   const allData = appliedValues.map(av => av.value);
   const validData = allData.filter(v => v != null);
-  if (dataKey && isCategorical && type === 'category' && allowDuplicatedCategory && hasDuplicate(validData)) {
+  if (dataKey != null && isCategorical && type === 'category' && allowDuplicatedCategory && hasDuplicate(validData)) {
     return allData;
   }
   return undefined;
@@ -2085,7 +2085,7 @@ export const combineAxisTicks = (
   if (isCategorical && categoricalDomain) {
     return categoricalDomain
       .map((entry: unknown, index: number): TickItem | null => {
-        const scaled = scale.map(entry);
+        const scaled = scale.map(duplicateDomain ? index : entry);
         if (!isWellBehavedNumber(scaled)) {
           return null;
         }
@@ -2205,7 +2205,7 @@ export const combineGraphicalItemTicks = (
   if (isCategorical && categoricalDomain) {
     return categoricalDomain
       .map((entry: unknown, index: number): TickItem | null => {
-        const scaled = scale.map(entry);
+        const scaled = scale.map(duplicateDomain ? index : entry);
         if (!isWellBehavedNumber(scaled)) {
           return null;
         }

--- a/src/state/selectors/combiners/combineTooltipPayload.ts
+++ b/src/state/selectors/combiners/combineTooltipPayload.ts
@@ -94,6 +94,7 @@ export const combineTooltipPayload = (
   activeLabel: ActiveLabel,
   tooltipPayloadSearcher: TooltipPayloadSearcher | undefined,
   tooltipEventType: TooltipEventType | undefined,
+  allowDuplicatedCategory?: boolean,
 ): TooltipPayload | undefined => {
   if (activeIndex == null || tooltipPayloadSearcher == null) {
     return undefined;
@@ -113,7 +114,7 @@ export const combineTooltipPayload = (
     const finalNameKey: DataKey<any> | undefined = settings?.nameKey; // ?? tooltipAxis?.nameKey;
     let tooltipPayload: unknown;
     if (
-      tooltipAxisDataKey &&
+      tooltipAxisDataKey != null &&
       Array.isArray(sliced) &&
       /*
        * findEntryInArray won't work for Scatter because Scatter provides an array of arrays
@@ -139,7 +140,15 @@ export const combineTooltipPayload = (
        */
       tooltipEventType === 'axis'
     ) {
-      tooltipPayload = findEntryInArray(sliced, tooltipAxisDataKey, activeLabel);
+      // An index distinguishes repeated labels; differently ordered item data still needs the label lookup.
+      const indexedPayload = allowDuplicatedCategory
+        ? findEntryInArray(
+            [tooltipPayloadSearcher(sliced, activeIndex, computedData, finalNameKey)],
+            tooltipAxisDataKey,
+            activeLabel,
+          )
+        : undefined;
+      tooltipPayload = indexedPayload ?? findEntryInArray(sliced, tooltipAxisDataKey, activeLabel);
       /*
        * When allowDuplicatedCategory is false and there are duplicate category values
        * in the data, findEntryInArray returns only the first matching entry.

--- a/src/state/selectors/polarScaleSelectors.ts
+++ b/src/state/selectors/polarScaleSelectors.ts
@@ -17,11 +17,34 @@ import {
 } from './polarAxisSelectors';
 import { CartesianTickItem } from '../../util/types';
 import { selectChartLayout } from '../../context/chartLayoutContext';
-import { selectPolarAppliedValues, selectPolarAxisCheckedDomain, selectPolarNiceTicks } from './polarSelectors';
+import {
+  selectPolarAppliedValues,
+  selectPolarAxisCheckedDomain,
+  selectPolarNiceTicks,
+  selectUnfilteredPolarItems,
+} from './polarSelectors';
 import { pickAxisType } from './pickAxisType';
 import { RechartsScale, rechartsScaleFactory } from '../../util/scale/RechartsScale';
 import { CustomScaleDefinition } from '../../util/scale/CustomScaleDefinition';
 import { combineConfiguredScale } from './combiners/combineConfiguredScale';
+import { selectChartName } from './rootPropsSelectors';
+
+const selectPolarDuplicateDomain = (
+  state: RechartsRootState,
+  axisType: 'angleAxis' | 'radiusAxis',
+  axisId: AxisId,
+  isPanorama: boolean,
+): ReadonlyArray<unknown> | undefined => {
+  // Radar angles use the full data range even with a Brush. A RadialBar sharing
+  // the angle axis still uses the Brush slice, so retain its existing tick domain.
+  const axisIdKey = axisType === 'angleAxis' ? 'angleAxisId' : 'radiusAxisId';
+  const hasRadialBar = selectUnfilteredPolarItems(state).some(
+    item => item.type === 'radialBar' && item[axisIdKey] === axisId,
+  );
+  const ignoreIndexes =
+    isPanorama || (axisType === 'angleAxis' && selectChartName(state) === 'RadarChart' && !hasRadialBar);
+  return selectDuplicateDomain(state, axisType, axisId, ignoreIndexes);
+};
 
 export const selectPolarAxis = (state: RechartsRootState, axisType: 'angleAxis' | 'radiusAxis', axisId: AxisId) => {
   switch (axisType) {
@@ -92,7 +115,7 @@ export const selectPolarAxisTicks: (
     selectPolarAxisScale,
     selectPolarNiceTicks,
     selectPolarAxisRangeWithReversed,
-    selectDuplicateDomain,
+    selectPolarDuplicateDomain,
     selectPolarCategoricalDomain,
     pickAxisType,
   ],
@@ -135,7 +158,7 @@ export const selectPolarGraphicalItemAxisTicks: (
     selectPolarAxis,
     selectPolarAxisScale,
     selectPolarAxisRangeWithReversed,
-    selectDuplicateDomain,
+    selectPolarDuplicateDomain,
     selectPolarCategoricalDomain,
     pickAxisType,
   ],

--- a/src/state/selectors/radarSelectors.ts
+++ b/src/state/selectors/radarSelectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import { RechartsRootState } from '../store';
 import { AngleAxisForRadar, computeRadarPoints, RadarComposedData, RadiusAxisForRadar } from '../../polar/Radar';
-import { AxisRange, BaseAxisWithScale } from './axisSelectors';
+import { AxisRange, BaseAxisWithScale, selectDuplicateDomain } from './axisSelectors';
 import { selectPolarAxisScale, selectPolarAxisTicks } from './polarScaleSelectors';
 import {
   selectAngleAxis,
@@ -100,17 +100,30 @@ const selectAngleAxisRangeForRadar = (
   angleAxisId: AxisId,
 ): AxisRange | undefined => selectAngleAxisRangeWithReversed(state, angleAxisId);
 
+const selectAngleAxisDuplicateDomain = (
+  state: RechartsRootState,
+  _radiusAxisId: AxisId,
+  angleAxisId: AxisId,
+): ReadonlyArray<unknown> | undefined => selectDuplicateDomain(state, 'angleAxis', angleAxisId, false);
+
 export const selectAngleAxisWithScaleAndViewport: (
   state: RechartsRootState,
   _radiusAxisId: AxisId,
   angleAxisId: AxisId,
 ) => AngleAxisForRadar | undefined = createSelector(
-  [selectAngleAxisForRadar, selectPolarAxisScaleForRadar, selectPolarViewBox, selectAngleAxisRangeForRadar],
+  [
+    selectAngleAxisForRadar,
+    selectPolarAxisScaleForRadar,
+    selectPolarViewBox,
+    selectAngleAxisRangeForRadar,
+    selectAngleAxisDuplicateDomain,
+  ],
   (
     axisOptions: AngleAxisSettings,
     scale: RechartsScale | undefined,
     polarViewBox: PolarViewBoxRequired | undefined,
     range: AxisRange | undefined,
+    duplicateDomain: ReadonlyArray<unknown> | undefined,
   ): AngleAxisForRadar | undefined => {
     if (polarViewBox == null || scale == null || range == null) {
       return undefined;
@@ -119,6 +132,7 @@ export const selectAngleAxisWithScaleAndViewport: (
       scale,
       type: axisOptions.type,
       dataKey: axisOptions.dataKey,
+      duplicateDomain,
       cx: polarViewBox.cx,
       cy: polarViewBox.cy,
       range,

--- a/src/state/selectors/radarSelectors.ts
+++ b/src/state/selectors/radarSelectors.ts
@@ -104,7 +104,7 @@ const selectAngleAxisDuplicateDomain = (
   state: RechartsRootState,
   _radiusAxisId: AxisId,
   angleAxisId: AxisId,
-): ReadonlyArray<unknown> | undefined => selectDuplicateDomain(state, 'angleAxis', angleAxisId, false);
+): ReadonlyArray<unknown> | undefined => selectDuplicateDomain(state, 'angleAxis', angleAxisId, true);
 
 export const selectAngleAxisWithScaleAndViewport: (
   state: RechartsRootState,

--- a/src/state/selectors/selectors.ts
+++ b/src/state/selectors/selectors.ts
@@ -25,7 +25,12 @@ import {
 } from '../../util/types';
 import { TooltipTrigger } from '../../chart/types';
 import { selectChartDataWithIndexes } from './dataSelectors';
-import { selectTooltipAxisDomain, selectTooltipAxisTicks, selectTooltipDisplayedData } from './tooltipSelectors';
+import {
+  selectTooltipAllowDuplicatedCategory,
+  selectTooltipAxisDomain,
+  selectTooltipAxisTicks,
+  selectTooltipDisplayedData,
+} from './tooltipSelectors';
 import { AxisRange, selectTooltipAxisDataKey } from './axisSelectors';
 import { selectChartName } from './rootPropsSelectors';
 import { selectChartLayout } from '../../context/chartLayoutContext';
@@ -179,6 +184,7 @@ export const selectTooltipPayload: (
     selectActiveLabel,
     selectTooltipPayloadSearcher,
     pickTooltipEventType,
+    selectTooltipAllowDuplicatedCategory,
   ],
   combineTooltipPayload,
 );

--- a/src/state/selectors/tooltipSelectors.ts
+++ b/src/state/selectors/tooltipSelectors.ts
@@ -395,7 +395,7 @@ const combineTicksOfTooltipAxis = (
   if (isCategorical && categoricalDomain) {
     return categoricalDomain
       .map((entry: unknown, index: number): TickItem | null => {
-        const scaled = scale.map(entry);
+        const scaled = scale.map(duplicateDomain ? index : entry);
         if (!isWellBehavedNumber(scaled)) {
           return null;
         }
@@ -601,6 +601,11 @@ export const selectIsTooltipActive: (state: RechartsRootState) => boolean = crea
   (tooltipInteractionState: TooltipInteractionState | undefined): boolean => tooltipInteractionState?.active ?? false,
 );
 
+export const selectTooltipAllowDuplicatedCategory = (state: RechartsRootState): boolean => {
+  const axis = selectTooltipAxis(state);
+  return axis.type === 'category' && axis.allowDuplicatedCategory;
+};
+
 export const selectActiveTooltipPayload: (state: RechartsRootState) => TooltipPayload | undefined = createSelector(
   [
     selectTooltipPayloadConfigurations,
@@ -610,6 +615,7 @@ export const selectActiveTooltipPayload: (state: RechartsRootState) => TooltipPa
     selectActiveLabel,
     selectTooltipPayloadSearcher,
     selectTooltipEventType,
+    selectTooltipAllowDuplicatedCategory,
   ],
   combineTooltipPayload,
 );

--- a/src/util/ChartUtils.ts
+++ b/src/util/ChartUtils.ts
@@ -268,7 +268,7 @@ export const getTicksOfAxis = (
   if (isCategorical && categoricalDomain) {
     return categoricalDomain
       .map((entry: unknown, index: number): TickItem | null => {
-        const scaled = scale.map(entry);
+        const scaled = scale.map(duplicateDomain ? index : entry);
         if (!isWellBehavedNumber(scaled)) {
           return null;
         }

--- a/storybook/stories/Examples/RadarChart.stories.tsx
+++ b/storybook/stories/Examples/RadarChart.stories.tsx
@@ -13,6 +13,27 @@ export default {
   },
 };
 
+export const RepeatedCategories: StoryObj = {
+  render: (args: Args) => (
+    <RadarChart {...args}>
+      <PolarGrid />
+      <PolarAngleAxis dataKey="name" />
+      <PolarRadiusAxis />
+      <Radar dataKey="value" fill="orange" fillOpacity={0.5} stroke="blue" />
+      <Tooltip defaultIndex={2} />
+    </RadarChart>
+  ),
+  args: {
+    data: [
+      { name: 'A', value: 12 },
+      { name: 'B', value: 3 },
+      { name: 'A', value: 10 },
+    ],
+    width: 360,
+    height: 360,
+  },
+};
+
 export const RangedRadarChart: StoryObj = {
   render: (args: Args) => {
     return (

--- a/test/cartesian/Line.spec.tsx
+++ b/test/cartesian/Line.spec.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { scaleBand } from 'victory-vendor/d3-scale';
 import {
   ActiveDotProps,
+  CartesianGrid,
   Customized,
   ErrorBar,
   Line,
@@ -11,9 +13,11 @@ import {
   RechartsThemeProvider,
   Tooltip,
   XAxis,
+  YAxis,
 } from '../../src';
 import { useAppSelector } from '../../src/state/hooks';
-import { selectErrorBarsSettings } from '../../src/state/selectors/axisSelectors';
+import { selectErrorBarsSettings, selectTicksOfAxis } from '../../src/state/selectors/axisSelectors';
+import { selectLinePoints } from '../../src/state/selectors/lineSelectors';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { selectTooltipPayload } from '../../src/state/selectors/selectors';
 import { expectLines } from '../helper/expectLine';
@@ -37,6 +41,42 @@ describe('<Line />', () => {
     { x: 130, y: 50, value: 100 },
     { x: 170, y: 50, value: 100 },
   ];
+
+  it.each(
+    (['band', 'point', scaleBand()] as const).flatMap(scale =>
+      ['name', 0, ''].flatMap(dataKey => [2, 'A'].map(repeatedName => ({ scale, dataKey, repeatedName }))),
+    ),
+  )(
+    'keeps repeated categories aligned with scale=$scale, dataKey=$dataKey, and repeatedName=$repeatedName',
+    ({ scale, dataKey, repeatedName }) => {
+      const names = [repeatedName, typeof repeatedName === 'number' ? 0 : 'B', repeatedName];
+      const chartData = names.map((name, index) => ({ name, 0: name, '': name, value: index + 1 }));
+      const renderTestCase = createSelectorTestCase(({ children }) => (
+        <LineChart width={500} height={500} data={chartData}>
+          <XAxis dataKey={dataKey} scale={scale} interval={0} />
+          <YAxis />
+          <CartesianGrid syncWithTicks />
+          <Line id="line-value" dataKey="value" isAnimationActive={false} />
+          {children}
+        </LineChart>
+      ));
+      const coordinates = scale === 'point' ? [65, 280, 495] : [65 + 430 / 6, 280, 495 - 430 / 6];
+      const { spy, container } = renderTestCase(state => selectTicksOfAxis(state, 'xAxis', 0, false));
+      const ticks = spy.mock.lastCall?.[0];
+      expect(ticks?.map(tick => tick.value)).toEqual(names);
+      ticks?.forEach((tick, index) => expect(tick.coordinate).toBeCloseTo(coordinates[index]));
+      const gridLines = container.querySelectorAll('.recharts-cartesian-grid-vertical line');
+      expect(gridLines).toHaveLength(names.length);
+      gridLines.forEach((line, index) => expect(Number(line.getAttribute('x1'))).toBeCloseTo(coordinates[index]));
+
+      const points = renderTestCase(state => selectLinePoints(state, 0, 0, false, 'line-value')).spy.mock.lastCall?.[0];
+      expect(points).toHaveLength(names.length);
+      points?.forEach((point, index) => {
+        expect(point.x).toBeCloseTo(coordinates[index]);
+        expect(point.payload).toBe(chartData[index]);
+      });
+    },
+  );
 
   it('Renders a path in a simple Line', () => {
     const { container } = render(

--- a/test/chart/RadarChart.spec.tsx
+++ b/test/chart/RadarChart.spec.tsx
@@ -206,7 +206,7 @@ describe('<RadarChart />', () => {
     expect(angleAxisSettingsSpy).toHaveBeenLastCalledWith({
       allowDataOverflow: false,
       allowDecimals: false,
-      allowDuplicatedCategory: false,
+      allowDuplicatedCategory: true,
       dataKey: undefined,
       domain: undefined,
       id: 0,

--- a/test/component/Tooltip/Tooltip.visibility.spec.tsx
+++ b/test/component/Tooltip/Tooltip.visibility.spec.tsx
@@ -1023,7 +1023,7 @@ describe('Tooltip visibility', () => {
       expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: false,
-        allowDuplicatedCategory: false,
+        allowDuplicatedCategory: true,
         dataKey: 'name',
         domain: undefined,
         id: 0,

--- a/test/polar/PolarAngleAxis/PolarAngleAxis.spec.tsx
+++ b/test/polar/PolarAngleAxis/PolarAngleAxis.spec.tsx
@@ -130,7 +130,7 @@ describe('<PolarAngleAxis />', () => {
         expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: false,
-          allowDuplicatedCategory: false,
+          allowDuplicatedCategory: true,
           dataKey: 'value',
           domain: undefined,
           id: 0,
@@ -379,7 +379,7 @@ describe('<PolarAngleAxis />', () => {
         expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: false,
-          allowDuplicatedCategory: false,
+          allowDuplicatedCategory: true,
           dataKey: undefined,
           domain: undefined,
           id: 0,
@@ -668,7 +668,7 @@ describe('<PolarAngleAxis />', () => {
         expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: false,
-          allowDuplicatedCategory: false,
+          allowDuplicatedCategory: true,
           dataKey: 'angle',
           domain: [0, 360],
           id: 0,
@@ -858,7 +858,7 @@ describe('<PolarAngleAxis />', () => {
       expect(angleAxisSettingsSpy).toHaveBeenLastCalledWith({
         allowDataOverflow: false,
         allowDecimals: false,
-        allowDuplicatedCategory: false,
+        allowDuplicatedCategory: true,
         dataKey: 'angle',
         domain: [0, 360],
         id: 0,
@@ -1695,7 +1695,7 @@ describe('<PolarAngleAxis />', () => {
         expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: false,
-          allowDuplicatedCategory: false,
+          allowDuplicatedCategory: true,
           dataKey: undefined,
           domain: undefined,
           id: 0,
@@ -1867,7 +1867,7 @@ describe('<PolarAngleAxis />', () => {
         expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: false,
-          allowDuplicatedCategory: false,
+          allowDuplicatedCategory: true,
           dataKey: undefined,
           domain: undefined,
           id: 0,
@@ -1900,7 +1900,7 @@ describe('<PolarAngleAxis />', () => {
       it('should select domain', () => {
         const { spy } = renderTestCase(state => selectPolarAxisDomain(state, 'angleAxis', 0));
         // this looks like a correct, categorical domain derived from the data
-        expectLastCalledWith(spy, [400, 300, 200, 278, 189]);
+        expectLastCalledWith(spy, [400, 300, 300, 200, 278, 189]);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
@@ -2081,7 +2081,7 @@ describe('<PolarAngleAxis />', () => {
         expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: false,
-          allowDuplicatedCategory: false,
+          allowDuplicatedCategory: true,
           dataKey: undefined,
           domain: undefined,
           id: 0,
@@ -2232,7 +2232,7 @@ describe('<PolarAngleAxis />', () => {
         expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: false,
-          allowDuplicatedCategory: false,
+          allowDuplicatedCategory: true,
           dataKey: undefined,
           domain: undefined,
           id: 0,
@@ -2626,7 +2626,7 @@ describe('<PolarAngleAxis />', () => {
       const expectedAxis: AngleAxisSettings = {
         allowDataOverflow: false,
         allowDecimals: false,
-        allowDuplicatedCategory: false,
+        allowDuplicatedCategory: true,
         dataKey: undefined,
         domain: undefined,
         id: 0,

--- a/test/polar/PolarGrid.spec.tsx
+++ b/test/polar/PolarGrid.spec.tsx
@@ -982,7 +982,7 @@ describe('<PolarGrid />', () => {
         expectLastCalledWith(spy, {
           allowDataOverflow: false,
           allowDecimals: false,
-          allowDuplicatedCategory: false,
+          allowDuplicatedCategory: true,
           dataKey: 'uv',
           domain: undefined,
           id: 'axis-uv',

--- a/test/polar/Radar.spec.tsx
+++ b/test/polar/Radar.spec.tsx
@@ -5,12 +5,15 @@ import { expect, it, vi } from 'vitest';
 import { scaleBand } from 'victory-vendor/d3-scale';
 import {
   DefaultZIndexes,
+  Brush,
   InternalRadarProps,
   PolarAngleAxis,
+  PolarRadiusAxis,
   Radar,
   RadarChart,
   RadarPoint,
   RadarProps,
+  RadialBar,
   Tooltip,
 } from '../../src';
 import { useAppSelector } from '../../src/state/hooks';
@@ -23,7 +26,7 @@ import { assertNotNull } from '../helper/assertNotNull';
 import { expectLastCalledWith } from '../helper/expectLastCalledWith';
 import { createSelectorTestCase } from '../helper/createSelectorTestCase';
 import { selectRadiusAxis } from '../../src/state/selectors/polarAxisSelectors';
-import { selectPolarAngleAxisTicks } from '../../src/state/selectors/polarScaleSelectors';
+import { selectPolarAngleAxisTicks, selectPolarAxisTicks } from '../../src/state/selectors/polarScaleSelectors';
 import { selectRadarPoints } from '../../src/state/selectors/radarSelectors';
 import { defaultAxisId } from '../../src/state/cartesianAxisSlice';
 import { selectActiveTooltipPayload, selectTooltipAxisTicks } from '../../src/state/selectors/tooltipSelectors';
@@ -45,6 +48,138 @@ const CustomizedLabel = () => {
 const CustomizedDot = ({ x, y }: Point) => <circle cx={x} cy={y} r={10} data-testid="customized-dot" />;
 
 describe('<Radar />', () => {
+  it.each([
+    [2, 0, 2, 1, 0],
+    [0, 1, 0, 2, 1],
+    [1, 0, 1, 2, 0],
+  ])('should retain category radius tick coordinates with Brush for %s', (...values) => {
+    const data = values.map((value, index) => ({ value, index }));
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <RadarChart data={data} width={500} height={500} layout="radial" startAngle={90} endAngle={-150}>
+        <PolarAngleAxis type="number" dataKey="index" domain={[0, 4]} />
+        <PolarRadiusAxis type="category" dataKey="value" scale="point" tick={false} />
+        <Radar id="radar" dataKey="value" isAnimationActive={false} />
+        <Brush startIndex={1} endIndex={2} />
+        {children}
+      </RadarChart>
+    ));
+    const points = renderTestCase(state => selectRadarPoints(state, 0, 0, false, 'radar'));
+    const ticks = renderTestCase(state => selectPolarAxisTicks(state, 'radiusAxis', 0, false));
+    expect(points.spy.mock.lastCall?.[0]?.points).toHaveLength(data.length);
+    for (const point of points.spy.mock.lastCall?.[0]?.points ?? []) {
+      expect(ticks.spy.mock.lastCall?.[0]).toContainEqual(
+        expect.objectContaining({ value: point.value, coordinate: point.radius }),
+      );
+    }
+  });
+
+  describe.each([false, true])('with a RadialBar hide=%s', hide => {
+    describe.each([0, 1])('using angleAxisId=%s', angleAxisId => {
+      it.each([false, true])('should preserve each axis data range with panorama=%s', isPanorama => {
+        const names = ['A', 'B', 'A', 'C', 'B'];
+        const data = names.map((name, value) => ({ name, value }));
+        const renderTestCase = createSelectorTestCase(({ children }) => (
+          <RadarChart width={500} height={500} data={data} startAngle={90} endAngle={-150}>
+            <PolarAngleAxis dataKey="name" />
+            {angleAxisId !== 0 && <PolarAngleAxis angleAxisId={angleAxisId} dataKey="name" />}
+            <Radar dataKey="value" isAnimationActive={false} />
+            <RadialBar dataKey="value" angleAxisId={angleAxisId} hide={hide} isAnimationActive={false} />
+            <Brush startIndex={1} endIndex={4} />
+            {children}
+          </RadarChart>
+        ));
+        const { spy } = renderTestCase(state => selectPolarAngleAxisTicks(state, 'angleAxis', 0, isPanorama));
+        const categories = angleAxisId === 0 && !isPanorama ? [...names.slice(1), undefined] : names;
+        expect(spy.mock.lastCall?.[0]?.map(tick => [tick.value, tick.coordinate])).toEqual(
+          categories.map((name, index) => [name, 90 - 48 * index]),
+        );
+      });
+    });
+  });
+
+  describe.each([undefined, true, false])('with Radar hide=%s', hide => {
+    it.each([false, true])('should keep full category ticks with panorama=%s', isPanorama => {
+      const names = ['A', 'B', 'A', 'C', 'B'];
+      const data = names.map((name, value) => ({ name, value }));
+      const renderTestCase = createSelectorTestCase(({ children }) => (
+        <RadarChart width={500} height={500} data={data} startAngle={90} endAngle={-150}>
+          <PolarAngleAxis dataKey="name" />
+          {hide != null && <Radar dataKey="value" hide={hide} isAnimationActive={false} />}
+          <Brush startIndex={1} endIndex={2} />
+          {children}
+        </RadarChart>
+      ));
+      const { spy } = renderTestCase(state => selectPolarAngleAxisTicks(state, 'angleAxis', 0, isPanorama));
+      expect(spy.mock.lastCall?.[0]?.map(tick => [tick.value, tick.coordinate])).toEqual(
+        names.map((name, index) => [name, 90 - 48 * index]),
+      );
+    });
+  });
+
+  describe.each(
+    [undefined, true, false].flatMap(allowDuplicatedCategory =>
+      (['auto', 'band', 'point', scaleBand()] as const).flatMap(scale =>
+        [
+          ['A', 'B', 'A', 'C', 'B'],
+          [2, 0, 2, 1, 0],
+        ].flatMap(names => [2, 4].map(endIndex => ({ allowDuplicatedCategory, scale, names, endIndex }))),
+      ),
+    ),
+  )(
+    'with Brush 1-$endIndex, names=$names, scale=$scale and allowDuplicatedCategory=$allowDuplicatedCategory',
+    ({ allowDuplicatedCategory, scale, names, endIndex }) => {
+      it('should keep the full polar domain aligned while retaining the tooltip slice', () => {
+        const data = names.map((name, index) => ({ name, value: 100 + index, extra: 200 + index }));
+        const renderTestCase = createSelectorTestCase(({ children }) => (
+          <RadarChart width={500} height={500} data={data} startAngle={90} endAngle={-150}>
+            <PolarAngleAxis dataKey="name" scale={scale} allowDuplicatedCategory={allowDuplicatedCategory} />
+            <Radar dataKey="value" id="radar-value" isAnimationActive={false} />
+            <Radar dataKey="extra" id="radar-extra" isAnimationActive={false} />
+            <Brush startIndex={1} endIndex={endIndex} />
+            <Tooltip defaultIndex={1} />
+            {children}
+          </RadarChart>
+        ));
+        const categories: (string | number)[] =
+          allowDuplicatedCategory === false ? [...new Set<string | number>(names)] : names;
+        const step = 240 / (scale === 'point' ? categories.length - 1 : categories.length);
+        const pointAngle = (name: string | number, index: number) =>
+          90 - step * (allowDuplicatedCategory === false ? categories.indexOf(name) : index);
+        for (const [id, dataKey] of [
+          ['radar-value', 'value'],
+          ['radar-extra', 'extra'],
+        ] as const) {
+          const { spy } = renderTestCase(state => selectRadarPoints(state, 0, 0, false, id));
+          expect(spy.mock.lastCall?.[0]?.points.map(point => [point.name, point.value, point.angle])).toEqual(
+            data.map((entry, index) => [entry.name, entry[dataKey], pointAngle(entry.name, index)]),
+          );
+        }
+        const axes = renderTestCase(state => selectPolarAngleAxisTicks(state, 'angleAxis', 0, false));
+        expect(axes.spy.mock.lastCall?.[0]?.map(tick => [tick.value, tick.coordinate])).toEqual(
+          categories.map((name, index) => [name, 90 - step * index]),
+        );
+        expect(
+          Array.from(
+            axes.container.querySelectorAll('.recharts-polar-angle-axis-tick-value'),
+            tick => tick.textContent,
+          ),
+        ).toEqual(categories.map(String));
+
+        const tooltip = renderTestCase(selectActiveTooltipPayload);
+        expect(tooltip.spy.mock.lastCall?.[0]?.map(entry => [entry.value, entry.payload])).toEqual([
+          [102, data[2]],
+          [202, data[2]],
+        ]);
+        expect(
+          Array.from(
+            tooltip.container.querySelectorAll('.recharts-tooltip-item-value'),
+            item => item.textContent,
+          ).sort(),
+        ).toEqual(['102', '202']);
+      });
+    },
+  );
+
   describe.each(
     [undefined, true, false].flatMap(allowDuplicatedCategory =>
       ['name', 0, ''].map(dataKey => ({ allowDuplicatedCategory, dataKey })),

--- a/test/polar/Radar.spec.tsx
+++ b/test/polar/Radar.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { expect, it, vi } from 'vitest';
+import { scaleBand } from 'victory-vendor/d3-scale';
 import {
   DefaultZIndexes,
   InternalRadarProps,
@@ -10,6 +11,7 @@ import {
   RadarChart,
   RadarPoint,
   RadarProps,
+  Tooltip,
 } from '../../src';
 import { useAppSelector } from '../../src/state/hooks';
 import { selectPolarItemsSettings } from '../../src/state/selectors/polarSelectors';
@@ -24,6 +26,7 @@ import { selectRadiusAxis } from '../../src/state/selectors/polarAxisSelectors';
 import { selectPolarAngleAxisTicks } from '../../src/state/selectors/polarScaleSelectors';
 import { selectRadarPoints } from '../../src/state/selectors/radarSelectors';
 import { defaultAxisId } from '../../src/state/cartesianAxisSlice';
+import { selectActiveTooltipPayload, selectTooltipAxisTicks } from '../../src/state/selectors/tooltipSelectors';
 
 type Point = { x?: number | string; y?: number | string };
 const CustomizedShape = ({ points }: { points: Point[] }) => {
@@ -42,6 +45,146 @@ const CustomizedLabel = () => {
 const CustomizedDot = ({ x, y }: Point) => <circle cx={x} cy={y} r={10} data-testid="customized-dot" />;
 
 describe('<Radar />', () => {
+  describe.each(
+    [undefined, true, false].flatMap(allowDuplicatedCategory =>
+      ['name', 0, ''].map(dataKey => ({ allowDuplicatedCategory, dataKey })),
+    ),
+  )(
+    'with allowDuplicatedCategory=$allowDuplicatedCategory and dataKey=$dataKey',
+    ({ allowDuplicatedCategory, dataKey }) => {
+      const data = [
+        { name: 'A', 0: 'A', '': 'A', value: 12 },
+        { name: 'B', 0: 'B', '': 'B', value: 3 },
+        { name: 'A', 0: 'A', '': 'A', value: 10 },
+      ];
+      const renderTestCase = createSelectorTestCase(({ children }) => (
+        <RadarChart width={500} height={500} data={data}>
+          <PolarAngleAxis dataKey={dataKey} allowDuplicatedCategory={allowDuplicatedCategory} />
+          <Radar dataKey="value" id="radar-value" isAnimationActive={false} />
+          {children}
+        </RadarChart>
+      ));
+
+      it('should preserve the category and value of each point at its corresponding angle', () => {
+        const { spy } = renderTestCase(state =>
+          selectRadarPoints(state, defaultAxisId, defaultAxisId, false, 'radar-value'),
+        );
+        const result = spy.mock.lastCall?.[0];
+        assertNotNull(result);
+        const angles = allowDuplicatedCategory === false ? [90, -90, 90] : [90, -30, -150];
+        expect(result.points.map(point => [point.name, point.value, point.angle])).toEqual(
+          data.map((entry, index) => [entry.name, entry.value, angles[index]]),
+        );
+      });
+    },
+  );
+
+  describe.each(
+    [undefined, true, false].flatMap(allowDuplicatedCategory =>
+      (['band', 'point', scaleBand()] as const).map(scale => ({ allowDuplicatedCategory, scale })),
+    ),
+  )('with scale=$scale and allowDuplicatedCategory=$allowDuplicatedCategory', ({ allowDuplicatedCategory, scale }) => {
+    const data = [
+      { name: 'A', value: 12 },
+      { name: 'B', value: 3 },
+      { name: 'A', value: 10 },
+    ];
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <RadarChart width={500} height={500} data={data} startAngle={90} endAngle={-150}>
+        <PolarAngleAxis dataKey="name" scale={scale} allowDuplicatedCategory={allowDuplicatedCategory} />
+        <Radar dataKey="value" id="radar-value" isAnimationActive={false} />
+        <Tooltip />
+        {children}
+      </RadarChart>
+    ));
+    const distinctAngles = scale === 'point' ? [90, -30, -150] : [90, 10, -70];
+    const mergedAngles = scale === 'point' ? [90, -150, 90] : [90, -30, 90];
+    const angles = allowDuplicatedCategory === false ? mergedAngles : distinctAngles;
+
+    it('should keep axis labels aligned with the radar points', () => {
+      const { spy, container } = renderTestCase(state => selectPolarAngleAxisTicks(state, 'angleAxis', 0, false));
+      const visibleData = allowDuplicatedCategory === false ? data.slice(0, 2) : data;
+      expect(spy.mock.lastCall?.[0]?.map(tick => [tick.value, tick.coordinate])).toEqual(
+        visibleData.map((entry, index) => [entry.name, angles[index]]),
+      );
+      expect(
+        Array.from(container.querySelectorAll('.recharts-polar-angle-axis-tick-value'), tick => tick.textContent),
+      ).toEqual(visibleData.map(entry => entry.name));
+
+      const points = renderTestCase(state => selectRadarPoints(state, 0, 0, false, 'radar-value'));
+      expect(points.spy.mock.lastCall?.[0]?.points.map(point => [point.name, point.value, point.angle])).toEqual(
+        data.map((entry, index) => [entry.name, entry.value, angles[index]]),
+      );
+    });
+
+    it('should provide a tooltip tick for each category occurrence', () => {
+      const { spy } = renderTestCase(selectTooltipAxisTicks);
+      expect(spy.mock.lastCall?.[0]?.map(tick => [tick.value, tick.coordinate, tick.index])).toEqual(
+        data.map((entry, index) => [entry.name, angles[index], index]),
+      );
+    });
+  });
+
+  it('should show the value of the selected duplicate category in the tooltip', () => {
+    const data = [
+      { name: 'A', value: 12 },
+      { name: 'B', value: 3 },
+      { name: 'A', value: 10 },
+    ];
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <RadarChart width={500} height={500} data={data}>
+        <PolarAngleAxis dataKey="name" />
+        <Radar dataKey="value" isAnimationActive={false} />
+        <Tooltip defaultIndex={2} />
+        {children}
+      </RadarChart>
+    ));
+    const { spy, container } = renderTestCase(selectActiveTooltipPayload);
+    expect(spy.mock.lastCall?.[0]?.map(entry => [entry.value, entry.payload])).toEqual([[10, data[2]]]);
+    expect(container.querySelector('.recharts-tooltip-item-value')).toHaveTextContent('10');
+  });
+
+  it('should keep numeric categories distinct from their array indexes', () => {
+    const data = [
+      { name: 2, value: 12 },
+      { name: 0, value: 3 },
+      { name: 2, value: 10 },
+    ];
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <RadarChart width={500} height={500} data={data}>
+        <PolarAngleAxis dataKey="name" />
+        <Radar dataKey="value" id="radar-value" isAnimationActive={false} />
+        {children}
+      </RadarChart>
+    ));
+    const { spy } = renderTestCase(state => selectRadarPoints(state, 0, 0, false, 'radar-value'));
+    const result = spy.mock.lastCall?.[0];
+    assertNotNull(result);
+    expect(result.points.map(point => [point.name, point.angle])).toEqual([
+      [2, 90],
+      [0, -30],
+      [2, -150],
+    ]);
+  });
+
+  it('should resolve tooltip values by category when duplicate categories are disabled', () => {
+    const data = [
+      { name: 'A', value: 12 },
+      { name: 'A', value: 3 },
+      { name: 'B', value: 10 },
+    ];
+    const renderTestCase = createSelectorTestCase(({ children }) => (
+      <RadarChart width={500} height={500} data={data}>
+        <PolarAngleAxis dataKey="name" allowDuplicatedCategory={false} />
+        <Radar dataKey="value" isAnimationActive={false} />
+        <Tooltip defaultIndex={1} />
+        {children}
+      </RadarChart>
+    ));
+    const { spy } = renderTestCase(selectActiveTooltipPayload);
+    expect(spy.mock.lastCall?.[0]?.map(entry => [entry.value, entry.payload])).toEqual([[10, data[2]]]);
+  });
+
   describe('in simple chart with implicit axes', () => {
     const renderTestCase = createSelectorTestCase(({ children }) => (
       <RadarChart width={500} height={500} data={exampleRadarData}>

--- a/test/polar/RadialBar/RadialBar.spec.tsx
+++ b/test/polar/RadialBar/RadialBar.spec.tsx
@@ -484,7 +484,7 @@ describe('<RadialBar />', () => {
       expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: false,
-        allowDuplicatedCategory: false,
+        allowDuplicatedCategory: true,
         dataKey: 'pv',
         domain: undefined,
         id: 0,
@@ -871,7 +871,7 @@ describe('<RadialBar />', () => {
       expectLastCalledWith(spy, {
         allowDataOverflow: false,
         allowDecimals: false,
-        allowDuplicatedCategory: false,
+        allowDuplicatedCategory: true,
         dataKey: undefined,
         domain: undefined,
         id: 0,

--- a/test/polar/RadialBar/RadialBar.spec.tsx
+++ b/test/polar/RadialBar/RadialBar.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, Mock, test, vi } from 'vitest';
 import {
+  Brush,
   DefaultZIndexes,
   PolarAngleAxis,
   PolarGrid,
@@ -9,6 +10,8 @@ import {
   RadialBar,
   RadialBarChart,
   RadialBarProps,
+  Radar,
+  RadarChart,
 } from '../../../src';
 import { useAppSelector } from '../../../src/state/hooks';
 import { selectPolarItemsSettings } from '../../../src/state/selectors/polarSelectors';
@@ -47,6 +50,56 @@ import { assertZIndexLayerOrder } from '../../helper/assertZIndexLayerOrder';
 import { RadialBarDataItem } from '../../../src/polar/RadialBar';
 
 describe('<RadialBar />', () => {
+  describe.each([RadarChart, RadialBarChart])('with Brush in %s', Chart => {
+    describe.each(['centric', 'radial'] as const)('with layout=%s', layout => {
+      describe.each([undefined, true, false])('with shared Radar hide=%s', hide => {
+        it.each([
+          ['A', 'B', 'A', 'C', 'B'],
+          [2, 0, 2, 1, 0],
+        ])('should retain sliced sector labels for %s', (...names) => {
+          const data = names.map((name, index) => ({ name, value: 100 + index }));
+          const settings: RadialBarSettings = {
+            id: 'bar',
+            dataKey: 'value',
+            minPointSize: 0,
+            stackId: undefined,
+            maxBarSize: undefined,
+            barSize: undefined,
+            type: 'radialBar',
+            angleAxisId: 0,
+            radiusAxisId: 0,
+            data: undefined,
+            hide: false,
+          };
+          const category = { dataKey: 'name', type: 'category' as const };
+          const numerical = { type: 'number' as const, domain: [0, 120] };
+          const renderTestCase = createSelectorTestCase(({ children }) => (
+            <Chart data={data} width={500} height={500} layout={layout} startAngle={90} endAngle={-150}>
+              <PolarAngleAxis {...(layout === 'centric' ? category : numerical)} />
+              <PolarRadiusAxis {...(layout === 'radial' ? category : numerical)} />
+              <RadialBar id="bar" dataKey="value" isAnimationActive={false} />
+              {hide != null && <Radar dataKey="value" hide={hide} isAnimationActive={false} />}
+              <Brush startIndex={1} endIndex={4} />
+              {children}
+            </Chart>
+          ));
+          const sectors = renderTestCase(state => selectRadialBarSectors(state, 0, 0, settings, undefined));
+          const geometry = sectors.spy.mock.lastCall?.[0];
+          expect(geometry?.map(sector => [sector.payload.name, sector.value])).toEqual(
+            data.slice(1).map(entry => [entry.name, entry.value]),
+          );
+          const axisType = layout === 'centric' ? 'angleAxis' : 'radiusAxis';
+          for (const selector of [selectPolarAxisTicks, selectPolarGraphicalItemAxisTicks]) {
+            const { spy } = renderTestCase(state => selector(state, axisType, 0, false));
+            expect(spy.mock.lastCall?.[0]?.slice(0, 4).map(tick => tick.value)).toEqual(
+              geometry?.map(sector => sector.payload.name),
+            );
+          }
+        });
+      });
+    });
+  });
+
   describe('with implicit axes', () => {
     const radialBarSettings: RadialBarSettings = {
       id: 'radial-bar-uv',

--- a/test/state/selectors/radarSelectors.spec.tsx
+++ b/test/state/selectors/radarSelectors.spec.tsx
@@ -531,7 +531,7 @@ describe('selectAngleAxisForBandSize', () => {
     expect(angleAxisSpy).toHaveBeenLastCalledWith({
       allowDataOverflow: false,
       allowDecimals: false,
-      allowDuplicatedCategory: false,
+      allowDuplicatedCategory: true,
       dataKey: 'value',
       domain: undefined,
       id: 0,
@@ -573,6 +573,7 @@ describe('selectAngleAxisWithScaleAndViewport', () => {
       cx: 250,
       cy: 250,
       dataKey: 'value',
+      duplicateDomain: undefined,
       range: [90, -270],
       scale: expect.toBeRechartsScale({ domain: [420, 460, 999, 500, 864, 650, 765, 365], range: [-270, 90] }),
       type: 'category',


### PR DESCRIPTION
## Description

Honor `PolarAngleAxis.allowDuplicatedCategory` and place repeated radar categories at separate axis positions. For names `A`, `B`, `A`, the default axis now renders three spokes instead of collapsing both `A` values onto one spoke. Explicit `allowDuplicatedCategory={false}` continues to deduplicate categories.

Radar uses occurrence positions while retaining each entry's name and payload. Axis, graphical-item, grid, and tooltip tick generation use those positions for custom band/point scales. Tooltip lookup retains the selected occurrence's value, with label lookup preserved when item data has a different ordering. Numeric-zero and empty-string data keys remain valid.

With a Brush, Radar already renders the full data range. Its duplicate angle metadata now uses that same range. Visible and graphical angle ticks in a RadarChart also use full-data metadata unless a RadialBar is registered on the same angle axis, including a hidden RadialBar. This preserves existing RadialBar sector/tick and categorical radius-axis behavior.

## Related Issue

Fixes #4661

## Motivation and Context

The public prop defaults to true, but the axis registered a hardcoded false. Respecting that prop creates an indexed duplicate domain, so mapping category names into it cannot identify individual occurrences. The same occurrence must remain aligned across points, ticks, grids, and tooltip values.

The Brush correction follows Radar's existing full-data contract. Shared Tooltip selectors still use the Brush slice, so some pre-existing tooltip label/value mismatches remain. A Radar and RadialBar sharing one angle axis also retain their existing different data-range requirements; this change preserves the RadialBar contract rather than redesigning that mixed-chart behavior.

## How Has This Been Tested?

- 137 added regression/compatibility cases in total. The initial 48 cover repeated categories, scales, data keys, tooltips, and Cartesian alignment; 37 fail on the original source. The additional 89 cover Brush ranges, multiple/hidden series, mixed Radar/RadialBar consumers, panorama ticks, and categorical radius identity.
- The final 197 affected tests pass; the same tests against the initially published PR source produce 25 failures and 172 passes.
- Full unit suite: 16,907 passed; 6 expected failures, 16 skipped, 1 todo, across 353 files.
- Full build, including 13 build-output tests; all five TypeScript projects; unmodified ESLint command with zero errors and 17 existing warnings.
- A separate automated reviewer independently ran 942 semantic probes and 1,264 related repository tests (9 skipped), including direct RadialBar sector/label and Radar radius/value comparisons against the published revision.
- Chromium rendering and pointer checks across original, published, and final code: 48 charts and 192 pointer moves, with no observed browser errors or previously correct in-slice tooltip check becoming incorrect. Seven existing in-slice tooltip mismatches remain, as described above.
- Added the `RepeatedCategories` Storybook example.

Validation ran on Windows with Node 24.16.0. Dependencies used the documented Windows `npm install --force` workaround. Docker visual-regression snapshots were not run or changed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

Prepared with Codex and independently reviewed by a separate automated agent. Review findings were corrected and rechecked against the final file hashes before publication. No human review is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed duplicated categorical values in Radar and polar charts so points, axis ticks, grid lines, and tooltips remain correctly aligned.
  - Improved tooltip selection for repeated categories, including numeric categories and filtered chart ranges.
  - Preserved full category domains and correct Brush behavior across Radar and RadialBar charts.

- **Examples**
  - Added a RadarChart example demonstrating repeated categories.

- **Tests**
  - Added comprehensive coverage for duplicated categories, tooltips, scales, axes, and Brush interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->