### PR TITLE
Preview all three themes in the VR gallery

### DIFF
--- a/.agents/skills/vr-test/SKILL.md
+++ b/.agents/skills/vr-test/SKILL.md
@@ -184,7 +184,8 @@ npm run test-vr:ui
 
 This publishes the Playwright UI at http://localhost:8080 and the Vite gallery at port 3100.
 Open http://localhost:3100/gallery/preview.html for a human-facing navigation page that lets you
-click through all stories using their default props.
+click through all stories using their default props. Each selected story is rendered in three
+isolated legacy, light, and dark panels.
 
 The URL http://localhost:3100/gallery/index.html is intentionally a blank Playwright mount target.
 Playwright navigates there before calling `window.mount`; it does not contain a story list and does

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -145,7 +145,8 @@ npm run test-vr:ui
 This starts Playwright UI on http://localhost:8080 and keeps the Vite gallery server available on
 port 3100. While the command is running, use http://localhost:3100/gallery/preview.html to browse
 and click through the stories manually. The preview page mounts each selected story with its
-default props. Do not expect `/gallery/index.html` to display a navigation page.
+default props in isolated legacy, light, and dark panels. Do not expect `/gallery/index.html` to
+display a navigation page.
 
 If you want to record new snapshots or update the old ones, you can run:
 
@@ -229,6 +230,7 @@ npm run test-vr:ui
 The same command serves the human-facing story preview at
 http://localhost:3100/gallery/preview.html. The Playwright-only mount target at
 http://localhost:3100/gallery/index.html remains blank when opened directly.
+The preview page renders each selected story in isolated legacy, light, and dark panels.
 Theme projects select their variant through the Playwright project
 configuration; opening the mount target directly does not preview the project
 matrix.

--- a/test-vr/README.md
+++ b/test-vr/README.md
@@ -182,7 +182,10 @@ which Playwright starts automatically through the `webServer` option in `./playw
 
 `gallery/index.html` is the blank mount target used by Playwright. To browse stories manually,
 open `http://localhost:3100/gallery/preview.html` while the gallery server is running.
-The preview page provides navigation and mounts the selected story with its default props.
+The preview page provides navigation and mounts the selected story with its default props in
+isolated legacy, light, and dark panels. Each panel uses the same theme renderer as the Playwright
+mount page, so state, DOM mutations, document-level styles, and SVG identifiers stay scoped to
+that variant.
 
 ### `playwright-report`
 

--- a/test-vr/gallery/main.tsx
+++ b/test-vr/gallery/main.tsx
@@ -8,13 +8,8 @@
  * See https://playwright.dev/docs/test-components for the stories and
  * galleries model.
  */
-import * as React from 'react';
-import { flushSync } from 'react-dom';
 import { createRoot, type Root } from 'react-dom/client';
-import { darkTheme, lightTheme, RechartsThemeProvider } from 'recharts';
-
-type StoryComponent = React.ComponentType<Record<string, unknown>>;
-type RechartsThemeVariant = 'legacy' | 'light' | 'dark';
+import { getRechartsTheme, renderStory, setCanvasBackground, type StoryComponent } from './renderer';
 
 const rootElement = document.getElementById('root');
 if (rootElement === null) {
@@ -38,36 +33,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isComponent(value: unknown): value is StoryComponent {
   return typeof value === 'function';
-}
-
-function isRechartsThemeVariant(value: unknown): value is RechartsThemeVariant {
-  return value === 'legacy' || value === 'light' || value === 'dark';
-}
-
-function getRechartsTheme(): RechartsThemeVariant {
-  const value = new URLSearchParams(window.location.search).get('rechartsTheme');
-  return isRechartsThemeVariant(value) ? value : 'legacy';
-}
-
-function setCanvasBackground(theme: RechartsThemeVariant) {
-  if (theme === 'dark') {
-    galleryElement.style.backgroundColor = 'black';
-  } else if (theme === 'light') {
-    galleryElement.style.backgroundColor = 'white';
-  } else {
-    galleryElement.style.backgroundColor = '';
-  }
-}
-
-function renderWithRechartsTheme(theme: RechartsThemeVariant, story: React.ReactNode): React.ReactNode {
-  switch (theme) {
-    case 'light':
-      return <RechartsThemeProvider value={lightTheme}>{story}</RechartsThemeProvider>;
-    case 'dark':
-      return <RechartsThemeProvider value={darkTheme}>{story}</RechartsThemeProvider>;
-    default:
-      return story;
-  }
 }
 
 async function resolveStory(storyId: string): Promise<StoryComponent> {
@@ -99,6 +64,15 @@ async function resolveStory(storyId: string): Promise<StoryComponent> {
  * component state when a test calls component.update(props).
  */
 let root: Root | undefined;
+const urlParameters = new URLSearchParams(window.location.search);
+const isPreviewFrame = urlParameters.get('preview') === 'true';
+const previewMessageSource = 'recharts-vr-gallery';
+
+if (isPreviewFrame) {
+  document.documentElement.style.margin = '0';
+  document.body.style.margin = '0';
+  document.body.style.minWidth = '0';
+}
 
 declare global {
   interface Window {
@@ -111,20 +85,74 @@ window.mount = async ({ story, props }) => {
   const Story = await resolveStory(story);
   const storyProps: Record<string, unknown> = props ?? {};
   const theme = getRechartsTheme();
-  setCanvasBackground(theme);
   const galleryRoot = root ?? createRoot(galleryElement);
   root = galleryRoot;
-  /*
-   * flushSync makes a render error reject the promise returned by mount()
-   * instead of being swallowed by React.
-   */
-  flushSync(() => {
-    galleryRoot.render(renderWithRechartsTheme(theme, <Story {...storyProps} />));
-  });
+  renderStory(galleryRoot, galleryElement, Story, storyProps, theme);
 };
 
 window.unmount = async () => {
   root?.unmount();
   root = undefined;
-  setCanvasBackground('legacy');
+  setCanvasBackground(galleryElement, 'legacy');
 };
+
+function postPreviewMessage(message: Record<string, unknown>): void {
+  if (!isPreviewFrame || window.parent === window) {
+    return;
+  }
+
+  window.parent.postMessage({ ...message, source: previewMessageSource }, window.location.origin);
+}
+
+function reportPreviewSize(): void {
+  const height = Math.ceil(
+    Math.max(
+      galleryElement.getBoundingClientRect().height,
+      document.documentElement.scrollHeight,
+      document.body.scrollHeight,
+    ),
+  );
+  postPreviewMessage({ height, type: 'resize' });
+}
+
+function handlePreviewMessage(event: MessageEvent<unknown>): void {
+  if (
+    !isPreviewFrame ||
+    event.origin !== window.location.origin ||
+    event.source !== window.parent ||
+    !isRecord(event.data)
+  ) {
+    return;
+  }
+
+  const message = event.data;
+  if (message.source === previewMessageSource && message.type === 'request-size') {
+    reportPreviewSize();
+  }
+}
+
+if (isPreviewFrame && window.parent !== window) {
+  const resizeObserver = new ResizeObserver(reportPreviewSize);
+  resizeObserver.observe(galleryElement);
+  const mutationObserver = new MutationObserver(reportPreviewSize);
+  mutationObserver.observe(document.body, { childList: true, subtree: true });
+  window.addEventListener('message', handlePreviewMessage);
+
+  const storyId = urlParameters.get('story');
+  if (storyId !== null) {
+    window
+      .mount({ story: storyId })
+      .then(() => {
+        requestAnimationFrame(() => {
+          reportPreviewSize();
+          postPreviewMessage({ type: 'ready' });
+        });
+      })
+      .catch(error => {
+        const message = error instanceof Error ? error.message : String(error);
+        galleryElement.textContent = message;
+        reportPreviewSize();
+        postPreviewMessage({ message, type: 'error' });
+      });
+  }
+}

--- a/test-vr/gallery/main.tsx
+++ b/test-vr/gallery/main.tsx
@@ -104,54 +104,19 @@ function postPreviewMessage(message: Record<string, unknown>): void {
   window.parent.postMessage({ ...message, source: previewMessageSource }, window.location.origin);
 }
 
-function reportPreviewSize(): void {
-  const height = Math.ceil(
-    Math.max(
-      galleryElement.getBoundingClientRect().height,
-      document.documentElement.scrollHeight,
-      document.body.scrollHeight,
-    ),
-  );
-  postPreviewMessage({ height, type: 'resize' });
-}
-
-function handlePreviewMessage(event: MessageEvent<unknown>): void {
-  if (
-    !isPreviewFrame ||
-    event.origin !== window.location.origin ||
-    event.source !== window.parent ||
-    !isRecord(event.data)
-  ) {
-    return;
-  }
-
-  const message = event.data;
-  if (message.source === previewMessageSource && message.type === 'request-size') {
-    reportPreviewSize();
-  }
-}
-
 if (isPreviewFrame && window.parent !== window) {
-  const resizeObserver = new ResizeObserver(reportPreviewSize);
-  resizeObserver.observe(galleryElement);
-  const mutationObserver = new MutationObserver(reportPreviewSize);
-  mutationObserver.observe(document.body, { childList: true, subtree: true });
-  window.addEventListener('message', handlePreviewMessage);
-
   const storyId = urlParameters.get('story');
   if (storyId !== null) {
     window
       .mount({ story: storyId })
       .then(() => {
         requestAnimationFrame(() => {
-          reportPreviewSize();
           postPreviewMessage({ type: 'ready' });
         });
       })
       .catch(error => {
         const message = error instanceof Error ? error.message : String(error);
         galleryElement.textContent = message;
-        reportPreviewSize();
         postPreviewMessage({ message, type: 'error' });
       });
   }

--- a/test-vr/gallery/preview.css
+++ b/test-vr/gallery/preview.css
@@ -133,16 +133,17 @@ summary {
 }
 
 .story-variants {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 24px;
   padding: 32px;
   align-items: start;
 }
 
 .story-panel {
+  width: 1280px;
   min-width: 0;
-  overflow: hidden;
+  overflow: visible;
   border: 1px solid #d1d5db;
   border-radius: 8px;
   background: #fff;
@@ -183,8 +184,6 @@ summary {
 
 .story-panel-frame {
   display: block;
-  width: 100%;
-  min-height: 240px;
   border: 0;
   background: #fff;
 }

--- a/test-vr/gallery/preview.css
+++ b/test-vr/gallery/preview.css
@@ -115,15 +115,21 @@ summary {
   position: sticky;
   top: 0;
   z-index: 1;
+  display: block;
+  width: auto;
+  height: auto;
   padding: 20px 32px;
   border-bottom: 1px solid #e5e7eb;
   background: rgb(255 255 255 / 95%);
   backdrop-filter: blur(8px);
+  box-shadow: none;
+  line-height: normal;
 }
 
 .gallery-header h2 {
   margin: 0;
   font-size: 18px;
+  line-height: 1.2;
 }
 
 .gallery-header code {
@@ -157,9 +163,17 @@ summary {
 }
 
 .story-panel-header {
+  position: static;
+  top: auto;
+  z-index: auto;
+  display: block;
+  width: auto;
+  height: auto;
   padding: 12px 16px;
   border-bottom: 1px solid #e5e7eb;
   background: #fff;
+  box-shadow: none;
+  line-height: normal;
 }
 
 .story-panel--dark .story-panel-header {
@@ -170,12 +184,14 @@ summary {
 .story-panel-header h3 {
   margin: 0;
   font-size: 15px;
+  line-height: 1.2;
 }
 
 .story-panel-header p {
   margin: 4px 0 0;
   color: #6b7280;
   font-size: 12px;
+  line-height: 1.4;
 }
 
 .story-panel--dark .story-panel-header p {

--- a/test-vr/gallery/preview.css
+++ b/test-vr/gallery/preview.css
@@ -132,15 +132,98 @@ summary {
   font-weight: 400;
 }
 
-.story-canvas {
-  min-height: calc(100vh - 74px);
+.story-variants {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
   padding: 32px;
-  overflow: auto;
+  align-items: start;
+}
+
+.story-panel {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(17 24 39 / 8%);
+}
+
+.story-panel--dark {
+  border-color: #374151;
+  color: #f9fafb;
+  background: #000;
+}
+
+.story-panel-header {
+  padding: 12px 16px;
+  border-bottom: 1px solid #e5e7eb;
   background: #fff;
 }
 
-.story-canvas > * {
-  margin: 0 auto;
+.story-panel--dark .story-panel-header {
+  border-bottom-color: #374151;
+  background: #111827;
+}
+
+.story-panel-header h3 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.story-panel-header p {
+  margin: 4px 0 0;
+  color: #6b7280;
+  font-size: 12px;
+}
+
+.story-panel--dark .story-panel-header p {
+  color: #9ca3af;
+}
+
+.story-panel-frame {
+  display: block;
+  width: 100%;
+  min-height: 240px;
+  border: 0;
+  background: #fff;
+}
+
+.story-panel-content {
+  position: relative;
+  min-height: 240px;
+}
+
+.story-panel[data-status='waiting'] .story-panel-frame,
+.story-panel[data-status='loading'] .story-panel-frame {
+  visibility: hidden;
+}
+
+.story-panel-status {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  color: #6b7280;
+  font-size: 14px;
+  text-align: center;
+}
+
+.story-panel-status--error {
+  color: #b91c1c;
+}
+
+.story-panel--dark .story-panel-frame {
+  background: #000;
+}
+
+.story-panel--dark .story-panel-status {
+  color: #d1d5db;
+}
+
+.story-panel--dark .story-panel-status--error {
+  color: #fca5a5;
 }
 
 .gallery-empty {

--- a/test-vr/gallery/preview.tsx
+++ b/test-vr/gallery/preview.tsx
@@ -80,6 +80,9 @@ const themeVariants: readonly {
   },
 ];
 
+const STORY_FRAME_WIDTH = 1280;
+const STORY_FRAME_HEIGHT = 720;
+
 function getStoryIdFromUrl(): string | undefined {
   const storyId = new URLSearchParams(window.location.search).get('story');
   return storyId !== null && stories.some(story => story.id === storyId) ? storyId : stories[0]?.id;
@@ -95,24 +98,6 @@ function getStoryFrameUrl(storyId: string, theme: RechartsThemeVariant): string 
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
-}
-
-function getFrameHeight(value: unknown): number | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-
-  const message = value;
-  if (
-    message.source !== 'recharts-vr-gallery' ||
-    message.type !== 'resize' ||
-    typeof message.height !== 'number' ||
-    !Number.isFinite(message.height)
-  ) {
-    return undefined;
-  }
-
-  return Math.max(240, Math.ceil(message.height));
 }
 
 function getFrameStatus(value: unknown): { status: 'ready' } | { status: 'error'; message: string } | undefined {
@@ -147,7 +132,6 @@ function StoryPanel({
   onSettled: () => void;
 }) {
   const frameRef = React.useRef<HTMLIFrameElement>(null);
-  const [frameHeight, setFrameHeight] = React.useState(240);
   const [frameStatus, setFrameStatus] = React.useState<
     { status: 'waiting' } | { status: 'loading' } | { status: 'ready' } | { status: 'error'; message: string }
   >({ status: enabled ? 'loading' : 'waiting' });
@@ -157,11 +141,6 @@ function StoryPanel({
     function handleMessage(event: MessageEvent<unknown>) {
       if (event.origin !== window.location.origin || event.source !== frameRef.current?.contentWindow) {
         return;
-      }
-
-      const nextHeight = getFrameHeight(event.data);
-      if (nextHeight !== undefined) {
-        setFrameHeight(nextHeight);
       }
 
       const nextStatus = getFrameStatus(event.data);
@@ -192,13 +171,6 @@ function StoryPanel({
     }
   }, [enabled, frameStatus.status, onSettled]);
 
-  function requestFrameSize() {
-    frameRef.current?.contentWindow?.postMessage(
-      { source: 'recharts-vr-gallery', type: 'request-size' },
-      window.location.origin,
-    );
-  }
-
   return (
     <section
       className={`story-panel story-panel--${theme}`}
@@ -217,8 +189,8 @@ function StoryPanel({
             className="story-panel-frame"
             title={`${story.name} ${label} theme`}
             src={getStoryFrameUrl(story.id, theme)}
-            style={{ height: `${frameHeight}px` }}
-            onLoad={requestFrameSize}
+            width={STORY_FRAME_WIDTH}
+            height={STORY_FRAME_HEIGHT}
             onError={() => setFrameStatus({ message: 'Failed to load story frame.', status: 'error' })}
           />
         ) : null}

--- a/test-vr/gallery/preview.tsx
+++ b/test-vr/gallery/preview.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
+import type { RechartsThemeVariant } from './renderer';
 import './preview.css';
 
 type StoryComponent = React.ComponentType<Record<string, unknown>>;
@@ -57,18 +58,213 @@ const storyGroups = Array.from(
     .entries(),
 ).map(([file, groupedStories]) => ({ file, stories: groupedStories }));
 
+const themeVariants: readonly {
+  theme: RechartsThemeVariant;
+  label: string;
+  description: string;
+}[] = [
+  {
+    theme: 'legacy',
+    label: 'Legacy',
+    description: 'No RechartsThemeProvider',
+  },
+  {
+    theme: 'light',
+    label: 'Light',
+    description: 'lightTheme',
+  },
+  {
+    theme: 'dark',
+    label: 'Dark',
+    description: 'darkTheme',
+  },
+];
+
 function getStoryIdFromUrl(): string | undefined {
   const storyId = new URLSearchParams(window.location.search).get('story');
   return storyId !== null && stories.some(story => story.id === storyId) ? storyId : stories[0]?.id;
 }
 
-function StoryPreview({ story }: { story: Story }) {
-  const Story = story.component;
-  const props: Record<string, unknown> = {};
+function getStoryFrameUrl(storyId: string, theme: RechartsThemeVariant): string {
+  const url = new URL('./index.html', window.location.href);
+  url.searchParams.set('preview', 'true');
+  url.searchParams.set('rechartsTheme', theme);
+  url.searchParams.set('story', storyId);
+  return url.toString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getFrameHeight(value: unknown): number | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const message = value;
+  if (
+    message.source !== 'recharts-vr-gallery' ||
+    message.type !== 'resize' ||
+    typeof message.height !== 'number' ||
+    !Number.isFinite(message.height)
+  ) {
+    return undefined;
+  }
+
+  return Math.max(240, Math.ceil(message.height));
+}
+
+function getFrameStatus(value: unknown): { status: 'ready' } | { status: 'error'; message: string } | undefined {
+  if (!isRecord(value) || value.source !== 'recharts-vr-gallery') {
+    return undefined;
+  }
+
+  if (value.type === 'ready') {
+    return { status: 'ready' };
+  }
+
+  if (value.type === 'error' && typeof value.message === 'string') {
+    return { status: 'error', message: value.message };
+  }
+
+  return undefined;
+}
+
+function StoryPanel({
+  story,
+  theme,
+  label,
+  description,
+  enabled,
+  onSettled,
+}: {
+  story: Story;
+  theme: RechartsThemeVariant;
+  label: string;
+  description: string;
+  enabled: boolean;
+  onSettled: () => void;
+}) {
+  const frameRef = React.useRef<HTMLIFrameElement>(null);
+  const [frameHeight, setFrameHeight] = React.useState(240);
+  const [frameStatus, setFrameStatus] = React.useState<
+    { status: 'waiting' } | { status: 'loading' } | { status: 'ready' } | { status: 'error'; message: string }
+  >({ status: enabled ? 'loading' : 'waiting' });
+  const hasSettled = React.useRef(false);
+
+  React.useEffect(() => {
+    function handleMessage(event: MessageEvent<unknown>) {
+      if (event.origin !== window.location.origin || event.source !== frameRef.current?.contentWindow) {
+        return;
+      }
+
+      const nextHeight = getFrameHeight(event.data);
+      if (nextHeight !== undefined) {
+        setFrameHeight(nextHeight);
+      }
+
+      const nextStatus = getFrameStatus(event.data);
+      if (nextStatus !== undefined) {
+        setFrameStatus(nextStatus);
+      }
+    }
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      hasSettled.current = false;
+      setFrameStatus({ status: 'waiting' });
+      return;
+    }
+
+    if (frameStatus.status === 'waiting') {
+      setFrameStatus({ status: 'loading' });
+      return;
+    }
+
+    if ((frameStatus.status === 'ready' || frameStatus.status === 'error') && !hasSettled.current) {
+      hasSettled.current = true;
+      onSettled();
+    }
+  }, [enabled, frameStatus.status, onSettled]);
+
+  function requestFrameSize() {
+    frameRef.current?.contentWindow?.postMessage(
+      { source: 'recharts-vr-gallery', type: 'request-size' },
+      window.location.origin,
+    );
+  }
 
   return (
-    <div className="story-canvas">
-      <Story {...props} />
+    <section
+      className={`story-panel story-panel--${theme}`}
+      data-recharts-theme={theme}
+      data-status={frameStatus.status}
+      aria-busy={frameStatus.status === 'waiting' || frameStatus.status === 'loading'}
+    >
+      <header className="story-panel-header">
+        <h3>{label}</h3>
+        <p>{description}</p>
+      </header>
+      <div className="story-panel-content">
+        {enabled ? (
+          <iframe
+            ref={frameRef}
+            className="story-panel-frame"
+            title={`${story.name} ${label} theme`}
+            src={getStoryFrameUrl(story.id, theme)}
+            style={{ height: `${frameHeight}px` }}
+            onLoad={requestFrameSize}
+            onError={() => setFrameStatus({ message: 'Failed to load story frame.', status: 'error' })}
+          />
+        ) : null}
+        {frameStatus.status === 'waiting' ? (
+          <div className="story-panel-status" role="status">
+            Waiting for previous panel...
+          </div>
+        ) : null}
+        {frameStatus.status === 'loading' ? (
+          <div className="story-panel-status" role="status">
+            Loading story...
+          </div>
+        ) : null}
+        {frameStatus.status === 'error' ? (
+          <div className="story-panel-status story-panel-status--error" role="alert">
+            {frameStatus.message}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function StoryPreview({ story }: { story: Story }) {
+  const [enabledThemeCount, setEnabledThemeCount] = React.useState(1);
+
+  function enableNextTheme(index: number) {
+    setEnabledThemeCount(currentCount => Math.max(currentCount, index + 2));
+  }
+
+  return (
+    <div className="story-variants">
+      {themeVariants.map((variant, index) => {
+        const enabled = index < enabledThemeCount;
+        return (
+          <StoryPanel
+            key={variant.theme}
+            story={story}
+            theme={variant.theme}
+            label={variant.label}
+            description={variant.description}
+            enabled={enabled}
+            onSettled={() => enableNextTheme(index)}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/test-vr/gallery/renderer.tsx
+++ b/test-vr/gallery/renderer.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { flushSync } from 'react-dom';
+import type { Root } from 'react-dom/client';
+import { darkTheme, lightTheme, RechartsThemeProvider } from 'recharts';
+
+export type StoryComponent = React.ComponentType<Record<string, unknown>>;
+export type RechartsThemeVariant = 'legacy' | 'light' | 'dark';
+
+export function isRechartsThemeVariant(value: unknown): value is RechartsThemeVariant {
+  return value === 'legacy' || value === 'light' || value === 'dark';
+}
+
+export function getRechartsTheme(): RechartsThemeVariant {
+  const value = new URLSearchParams(window.location.search).get('rechartsTheme');
+  return isRechartsThemeVariant(value) ? value : 'legacy';
+}
+
+export function setCanvasBackground(canvas: HTMLElement, theme: RechartsThemeVariant): void {
+  const canvasStyle = canvas.style;
+  if (theme === 'dark') {
+    canvasStyle.backgroundColor = 'black';
+  } else if (theme === 'light') {
+    canvasStyle.backgroundColor = 'white';
+  } else {
+    canvasStyle.backgroundColor = '';
+  }
+}
+
+function renderWithRechartsTheme(theme: RechartsThemeVariant, story: React.ReactNode): React.ReactNode {
+  switch (theme) {
+    case 'light':
+      return <RechartsThemeProvider value={lightTheme}>{story}</RechartsThemeProvider>;
+    case 'dark':
+      return <RechartsThemeProvider value={darkTheme}>{story}</RechartsThemeProvider>;
+    default:
+      return story;
+  }
+}
+
+export function renderStory(
+  root: Root,
+  canvas: HTMLElement,
+  Story: StoryComponent,
+  props: Record<string, unknown>,
+  theme: RechartsThemeVariant,
+): void {
+  setCanvasBackground(canvas, theme);
+
+  /*
+   * flushSync makes a render error reject the promise returned by mount()
+   * instead of being swallowed by React.
+   */
+  flushSync(() => {
+    root.render(renderWithRechartsTheme(theme, <Story {...props} />));
+  });
+}

--- a/test-vr/vite.config.ts
+++ b/test-vr/vite.config.ts
@@ -23,7 +23,10 @@ export default defineConfig(({ command }) => ({
     emptyOutDir: true,
     outDir: path.join(__dirname, 'dist'),
     rollupOptions: {
-      input: path.join(galleryRoot, 'preview.html'),
+      input: {
+        index: path.join(galleryRoot, 'index.html'),
+        preview: path.join(galleryRoot, 'preview.html'),
+      },
     },
   },
   cacheDir: path.join(repoRoot, 'node_modules/.vite-test-vr'),


### PR DESCRIPTION
<img width="1763" height="1173" alt="image" src="https://github.com/user-attachments/assets/03d0d52e-583e-4869-9d88-12b81e9e5316" />

Alternative to https://github.com/recharts/recharts/pull/7753 but this one does not suffer from randomly dropped charts

Closes https://github.com/recharts/recharts/issues/7738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Story previews now display selected stories in separate legacy, light, and dark theme panels.
  * Each theme panel loads in isolation, with clearer loading and error states.
  * Preview pages can automatically open a story from a URL parameter.

* **Documentation**
  * Updated development and visual regression testing documentation to explain the themed preview panels and their isolated rendering behavior.

* **Refactor**
  * Improved consistency between the human-facing preview and automated story mounting pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->