### PR TITLE
Improve graphical item theme color assignment

### DIFF
--- a/scripts/snapshots/es6Files.txt
+++ b/scripts/snapshots/es6Files.txt
@@ -225,6 +225,7 @@
   "es6/theme/graphicalItemIdentity.js",
   "es6/theme/lightTheme.js",
   "es6/theme/useBackwardsCompatibleTheme.js",
+  "es6/theme/useGraphicalItemIdentity.js",
   "es6/types.js",
   "es6/util",
   "es6/util/ActiveShapeUtils.js",

--- a/scripts/snapshots/libFiles.txt
+++ b/scripts/snapshots/libFiles.txt
@@ -225,6 +225,7 @@
   "lib/theme/graphicalItemIdentity.js",
   "lib/theme/lightTheme.js",
   "lib/theme/useBackwardsCompatibleTheme.js",
+  "lib/theme/useGraphicalItemIdentity.js",
   "lib/types.js",
   "lib/util",
   "lib/util/ActiveShapeUtils.js",

--- a/scripts/snapshots/typesFiles.txt
+++ b/scripts/snapshots/typesFiles.txt
@@ -225,6 +225,7 @@
   "types/theme/graphicalItemIdentity.d.ts",
   "types/theme/lightTheme.d.ts",
   "types/theme/useBackwardsCompatibleTheme.d.ts",
+  "types/theme/useGraphicalItemIdentity.d.ts",
   "types/types.d.ts",
   "types/util",
   "types/util/ActiveShapeUtils.d.ts",

--- a/src/cartesian/Area.tsx
+++ b/src/cartesian/Area.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { MutableRefObject, PureComponent, ReactElement, ReactNode, useCallback, useMemo, useRef } from 'react';
+import { MutableRefObject, PureComponent, ReactElement, ReactNode, useMemo, useRef } from 'react';
 import { clsx } from 'clsx';
 import { BaseLineType, CurveType, Props as CurveProps } from '../shape/Curve';
 import { Layer } from '../container/Layer';
@@ -68,10 +68,10 @@ import { propsAreEqual } from '../util/propsAreEqual';
 import { AxisId } from '../state/cartesianAxisSlice';
 import { StackDataPoint } from '../util/stacks/stackTypes';
 import { AreaRevealShape, AreaRevealShapeProps } from './AreaRevealShape';
-import { graphicalItemIdentity } from '../theme/graphicalItemIdentity';
-import { GraphicalItemStyle, RechartsTheme, Styles2D } from '../theme/RechartsTheme';
+import { GraphicalItemStyle, Styles2D } from '../theme/RechartsTheme';
 import { useRechartsTheme } from '../theme/RechartsThemeContext';
 import { useBackwardsCompatibleTheme } from '../theme/useBackwardsCompatibleTheme';
+import { useGraphicalItemIdentity } from '../theme/useGraphicalItemIdentity';
 
 /**
  * @inline
@@ -1074,18 +1074,12 @@ export function computeArea({
 
 function AreaFn(outsideProps: Props<any, any>) {
   const rechartsTheme = useRechartsTheme();
-  const themeSelector = useCallback(
-    (theme: RechartsTheme): Styles2D | undefined => {
-      if (outsideProps.dataKey == null) {
-        return undefined;
-      }
-      return theme.graphicalItems[
-        graphicalItemIdentity({ dataKey: outsideProps.dataKey }, theme.graphicalItems.length)
-      ];
-    },
-    [outsideProps.dataKey],
+  const graphicalItemThemeSelector = useGraphicalItemIdentity(outsideProps.dataKey);
+  const theme = useBackwardsCompatibleTheme<GraphicalItemStyle>(
+    graphicalItemThemeSelector,
+    outsideProps,
+    defaultLegacyThemeProps,
   );
-  const theme = useBackwardsCompatibleTheme<GraphicalItemStyle>(themeSelector, outsideProps, defaultLegacyThemeProps);
   const activeDot =
     theme?.active == null ||
     outsideProps.activeDot === false ||

--- a/src/cartesian/Bar.tsx
+++ b/src/cartesian/Bar.tsx
@@ -90,9 +90,9 @@ import { AxisId } from '../state/cartesianAxisSlice';
 import { BarStackClipLayer, useStackId } from './BarStack';
 import { GraphicalItemId } from '../state/graphicalItemsSlice';
 import { ChartData } from '../state/chartDataSlice';
-import { graphicalItemIdentity } from '../theme/graphicalItemIdentity';
-import { RechartsTheme, Styles2D } from '../theme/RechartsTheme';
+import { Styles2D } from '../theme/RechartsTheme';
 import { useBackwardsCompatibleTheme } from '../theme/useBackwardsCompatibleTheme';
+import { useGraphicalItemIdentity } from '../theme/useGraphicalItemIdentity';
 
 type BarRectangleType = {
   x: number | null;
@@ -1280,14 +1280,8 @@ export function computeBarRectangles({
 }
 
 function BarFn(outsideProps: Props) {
-  const graphicalItemStyle = useBackwardsCompatibleTheme<Props>(
-    (theme: RechartsTheme) =>
-      outsideProps.dataKey == null
-        ? undefined
-        : theme.graphicalItems[graphicalItemIdentity({ dataKey: outsideProps.dataKey }, theme.graphicalItems.length)],
-    outsideProps,
-    undefined,
-  );
+  const graphicalItemThemeSelector = useGraphicalItemIdentity(outsideProps.dataKey);
+  const graphicalItemStyle = useBackwardsCompatibleTheme<Props>(graphicalItemThemeSelector, outsideProps, undefined);
   const props = resolveDefaultProps(outsideProps, defaultBarProps);
   // stackId may arrive from props or from BarStack context
   const stackId = useStackId(props.stackId);

--- a/src/cartesian/Line.tsx
+++ b/src/cartesian/Line.tsx
@@ -62,10 +62,10 @@ import { DefaultZIndexes } from '../zIndex/DefaultZIndexes';
 import { propsAreEqual } from '../util/propsAreEqual';
 import { GraphicalItemId } from '../state/graphicalItemsSlice';
 import { ChartData } from '../state/chartDataSlice';
-import { graphicalItemIdentity } from '../theme/graphicalItemIdentity';
-import { GraphicalItemStyle, RechartsTheme } from '../theme/RechartsTheme';
+import { GraphicalItemStyle } from '../theme/RechartsTheme';
 import { useRechartsTheme } from '../theme/RechartsThemeContext';
 import { useBackwardsCompatibleTheme } from '../theme/useBackwardsCompatibleTheme';
+import { useGraphicalItemIdentity } from '../theme/useGraphicalItemIdentity';
 
 export interface LinePointItem {
   readonly value: number;
@@ -924,11 +924,9 @@ export function computeLinePoints({
 
 function LineFn(outsideProps: Props) {
   const rechartsTheme = useRechartsTheme();
+  const graphicalItemThemeSelector = useGraphicalItemIdentity(outsideProps.dataKey);
   const graphicalItemTheme = useBackwardsCompatibleTheme<GraphicalItemStyle>(
-    (theme: RechartsTheme) =>
-      outsideProps.dataKey == null
-        ? undefined
-        : theme.graphicalItems[graphicalItemIdentity({ dataKey: outsideProps.dataKey }, theme.graphicalItems.length)],
+    graphicalItemThemeSelector,
     outsideProps,
     defaultLegacyThemeProps,
   );

--- a/src/cartesian/Scatter.tsx
+++ b/src/cartesian/Scatter.tsx
@@ -74,10 +74,9 @@ import { GraphicalItemId } from '../state/graphicalItemsSlice';
 import { ZIndexable, ZIndexLayer } from '../zIndex/ZIndexLayer';
 import { DefaultZIndexes } from '../zIndex/DefaultZIndexes';
 import { propsAreEqual } from '../util/propsAreEqual';
-import { graphicalItemIdentity } from '../theme/graphicalItemIdentity';
-import { RechartsTheme } from '../theme/RechartsTheme';
 import { useBackwardsCompatibleTheme } from '../theme/useBackwardsCompatibleTheme';
 import { ChartData } from '../state/chartDataSlice';
+import { useGraphicalItemIdentity } from '../theme/useGraphicalItemIdentity';
 
 export interface ScatterPointNode {
   x?: number | string;
@@ -1026,14 +1025,8 @@ function ScatterImpl(props: WithIdRequired<Props>) {
 }
 
 function ScatterFn(outsideProps: Props) {
-  const graphicalItemTheme = useBackwardsCompatibleTheme<Props>(
-    (theme: RechartsTheme) =>
-      outsideProps.dataKey == null
-        ? undefined
-        : theme.graphicalItems[graphicalItemIdentity({ dataKey: outsideProps.dataKey }, theme.graphicalItems.length)],
-    outsideProps,
-    undefined,
-  );
+  const graphicalItemThemeSelector = useGraphicalItemIdentity(outsideProps.dataKey);
+  const graphicalItemTheme = useBackwardsCompatibleTheme<Props>(graphicalItemThemeSelector, outsideProps, undefined);
   const props = resolveDefaultProps(
     {
       ...outsideProps,

--- a/src/polar/Radar.tsx
+++ b/src/polar/Radar.tsx
@@ -49,10 +49,10 @@ import { ZIndexable, ZIndexLayer } from '../zIndex/ZIndexLayer';
 import { DefaultZIndexes } from '../zIndex/DefaultZIndexes';
 import { RechartsScale } from '../util/scale/RechartsScale';
 import { usePolarChartLayout } from '../context/chartLayoutContext';
-import { graphicalItemIdentity } from '../theme/graphicalItemIdentity';
-import { GraphicalItemStyle, RechartsTheme } from '../theme/RechartsTheme';
+import { GraphicalItemStyle } from '../theme/RechartsTheme';
 import { useRechartsTheme } from '../theme/RechartsThemeContext';
 import { useBackwardsCompatibleTheme } from '../theme/useBackwardsCompatibleTheme';
+import { useGraphicalItemIdentity } from '../theme/useGraphicalItemIdentity';
 
 export interface RadarPoint {
   x: number;
@@ -657,11 +657,9 @@ function RadarImpl(props: RadarPropsWithDotFill) {
  */
 export function Radar<DataPointType = any, DataValueType = any>(outsideProps: Props<DataPointType, DataValueType>) {
   const rechartsTheme = useRechartsTheme();
+  const graphicalItemThemeSelector = useGraphicalItemIdentity(outsideProps.dataKey);
   const graphicalItemTheme = useBackwardsCompatibleTheme<GraphicalItemStyle>(
-    (theme: RechartsTheme) =>
-      outsideProps.dataKey == null
-        ? undefined
-        : theme.graphicalItems[graphicalItemIdentity({ dataKey: outsideProps.dataKey }, theme.graphicalItems.length)],
+    graphicalItemThemeSelector,
     outsideProps,
     undefined,
   );

--- a/src/polar/RadialBar.tsx
+++ b/src/polar/RadialBar.tsx
@@ -72,9 +72,9 @@ import { ZIndexable, ZIndexLayer } from '../zIndex/ZIndexLayer';
 import { DefaultZIndexes } from '../zIndex/DefaultZIndexes';
 import { getZIndexFromUnknown } from '../zIndex/getZIndexFromUnknown';
 import { usePolarChartLayout } from '../context/chartLayoutContext';
-import { graphicalItemIdentity } from '../theme/graphicalItemIdentity';
-import { RechartsTheme, Styles2D } from '../theme/RechartsTheme';
+import { Styles2D } from '../theme/RechartsTheme';
 import { useBackwardsCompatibleTheme } from '../theme/useBackwardsCompatibleTheme';
+import { useGraphicalItemIdentity } from '../theme/useGraphicalItemIdentity';
 
 const STABLE_EMPTY_ARRAY: readonly RadialBarDataItem[] = [];
 
@@ -844,13 +844,9 @@ export function computeRadialBarDataItems({
 export function RadialBar<DataPointType = any, DataValueType = any>(
   outsideProps: RadialBarProps<DataPointType, DataValueType>,
 ) {
+  const graphicalItemThemeSelector = useGraphicalItemIdentity(outsideProps.dataKey);
   const graphicalItemStyle = useBackwardsCompatibleTheme<RadialBarProps<DataPointType, DataValueType>>(
-    (theme: RechartsTheme) =>
-      outsideProps.dataKey == null
-        ? undefined
-        : theme.graphicalItems[
-            graphicalItemIdentity({ dataKey: String(outsideProps.dataKey) }, theme.graphicalItems.length)
-          ],
+    graphicalItemThemeSelector,
     outsideProps,
     undefined,
   );

--- a/src/state/selectors/graphicalItemSelectors.ts
+++ b/src/state/selectors/graphicalItemSelectors.ts
@@ -1,5 +1,13 @@
+import { createSelector } from 'reselect';
+import { isNotNil } from '../../util/DataUtils';
+import { DataKey } from '../../util/types';
 import { RechartsRootState } from '../store';
-import { GraphicalItemId } from '../graphicalItemsSlice';
+import {
+  CartesianGraphicalItemSettings,
+  GraphicalItemId,
+  GraphicalItemSettings,
+  PolarGraphicalItemSettings,
+} from '../graphicalItemsSlice';
 import { AxisId, defaultAxisId } from '../cartesianAxisSlice';
 
 export function selectXAxisIdFromGraphicalItemId(state: RechartsRootState, id: GraphicalItemId): AxisId {
@@ -9,3 +17,20 @@ export function selectXAxisIdFromGraphicalItemId(state: RechartsRootState, id: G
 export function selectYAxisIdFromGraphicalItemId(state: RechartsRootState, id: GraphicalItemId): AxisId {
   return state.graphicalItems.cartesianItems.find(item => item.id === id)?.yAxisId ?? defaultAxisId;
 }
+
+export const selectAllUnfilteredGraphicalItems: (
+  state: RechartsRootState,
+) => ReadonlyArray<CartesianGraphicalItemSettings | PolarGraphicalItemSettings> = createSelector(
+  [
+    (state: RechartsRootState) => state.graphicalItems.cartesianItems,
+    (state: RechartsRootState) => state.graphicalItems.polarItems,
+  ],
+  (cartesianItems, polarItems) => [...cartesianItems, ...polarItems],
+);
+
+export const selectAllUnfilteredGraphicalItemDataKeys: (state: RechartsRootState) => ReadonlyArray<DataKey<any>> =
+  createSelector(
+    [selectAllUnfilteredGraphicalItems],
+    (graphicalItems: ReadonlyArray<GraphicalItemSettings>): ReadonlyArray<DataKey<any>> =>
+      graphicalItems.map(item => item.dataKey).filter(isNotNil),
+  );

--- a/src/state/selectors/tooltipSelectors.ts
+++ b/src/state/selectors/tooltipSelectors.ts
@@ -49,11 +49,7 @@ import {
 } from '../../util/types';
 import { AppliedChartData, ChartData } from '../chartDataSlice';
 import { selectChartDataWithIndexes, selectChartDataSliceWithIndexes } from './dataSelectors';
-import {
-  CartesianGraphicalItemSettings,
-  GraphicalItemSettings,
-  PolarGraphicalItemSettings,
-} from '../graphicalItemsSlice';
+import { GraphicalItemSettings } from '../graphicalItemsSlice';
 import { ReferenceAreaSettings, ReferenceDotSettings, ReferenceLineSettings } from '../referenceElementsSlice';
 import { selectChartName, selectReverseStackOrder, selectStackOffsetType } from './rootPropsSelectors';
 import { isNotNil, mathSign } from '../../util/DataUtils';
@@ -97,19 +93,12 @@ import { combineRealScaleType } from './combiners/combineRealScaleType';
 import { combineConfiguredScale } from './combiners/combineConfiguredScale';
 import { CustomScaleDefinition } from '../../util/scale/CustomScaleDefinition';
 import { transformCoordinateByCameraZoom } from '../../util/zoom/transform';
+import { selectAllUnfilteredGraphicalItems } from './graphicalItemSelectors';
+
+export { selectAllUnfilteredGraphicalItems } from './graphicalItemSelectors';
 
 export const selectTooltipAxisRealScaleType: (state: RechartsRootState) => RechartsScaleType | undefined =
   createSelector([selectTooltipAxis, selectHasBar, selectChartName], combineRealScaleType);
-
-export const selectAllUnfilteredGraphicalItems: (
-  state: RechartsRootState,
-) => ReadonlyArray<CartesianGraphicalItemSettings | PolarGraphicalItemSettings> = createSelector(
-  [
-    (state: RechartsRootState) => state.graphicalItems.cartesianItems,
-    (state: RechartsRootState) => state.graphicalItems.polarItems,
-  ],
-  (cartesianItems, polarItems) => [...cartesianItems, ...polarItems],
-);
 
 const selectTooltipAxisPredicate = createSelector([selectTooltipAxisType, selectTooltipAxisId], itemAxisPredicate);
 

--- a/src/theme/RechartsTheme.ts
+++ b/src/theme/RechartsTheme.ts
@@ -54,7 +54,16 @@ export interface RechartsTheme {
   typography?: TextStyles;
   /**
    * Colors of main graphical elements (Area, Bar, Line, Treemap, etc.).
-   * If there are multiple elements in the chart, they will receive different values from this array.
+   * Line, Area, Bar, Scatter, Radar, and RadialBar select an entry by sorting the
+   * unique string representations of the `dataKey` values currently present in
+   * the chart. The first entry is assigned to the first key in that sorted
+   * list, and the palette repeats when there are more keys than entries.
+   *
+   * Graphical items with the same `dataKey` share a style. The assignment is
+   * independent of render order, but adding or removing a graphical item can
+   * change the assignment of the remaining items. The same `dataKey` can also
+   * receive different entries in charts with different sets of graphical items.
+   *
    * If this array has only one item in it then all graphical items will have the same color.
    *
    * Legend and Tooltip items inherit the same color.

--- a/src/theme/graphicalItemIdentity.ts
+++ b/src/theme/graphicalItemIdentity.ts
@@ -2,19 +2,10 @@
  * @fileOverview
  * This file provides helper methods for assigning theme identity to a
  * graphical item. Graphical items are individual drawable data representations,
- * such as Line or Bar. In previous Recharts versions these can be styled
- * individually. In next version, Recharts will allow the user to provide an
- * array of themes, and then have the graphical items pick one. There is a gap
- * however; graphical items are not sorted and not indexed. We can't use DOM
- * order because that order changes. So instead we need an identifier that:
- * - we can calculate from props, without requiring the user to provide an
- *   explicit id
- * - is stable across renders, so that the same item will always get the same
- *   theme
- * - is (within possibilities) unique across all items, so that no two items
- *   will get the same theme The uniqueness is impossible to guarantee 100% so
- * we will only provide a best-effort. This file provides a helper method to
- * calculate such an identifier.
+ * such as Line or Bar. Graphical items are not sorted and not indexed, and
+ * their Redux order is intentionally arbitrary. Instead, we collect all
+ * dataKeys in the chart, sort their string representations, and use the
+ * resulting position as the theme identity.
  */
 
 import { DataKey } from '../util/types';
@@ -24,47 +15,28 @@ export type ThemableItem = {
 };
 
 /**
- * Computes a deterministic numeric hash for the given string. Uses djb2 hash
- * algorithm with additional bit-mixing to improve distribution across small
- * moduli (e.g., themeCount = 5).
- */
-function computeHash(str: string): number {
-  let hash = 5381;
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash << 5) + hash + str.charCodeAt(i); // hash * 33 + charCode
-  }
-
-  // Bit-mixing step: multiply by a large prime, then XOR-shift to spread
-  // bit patterns. This prevents collisions that can occur with raw %
-  // themeCount when the raw hash's low bits correlate poorly across inputs.
-  hash ^= hash >>> 16;
-  hash *= 0x85ebca6b;
-  hash ^= hash >>> 16;
-
-  return hash & 0x7fffffff; // Mask to ensure non-negative 31-bit integer
-}
-
-/**
- * Calculates theme index from a given item. The identity is computed
- * deterministically from the dataKey string, ensuring stability across renders
- * and module reloads.
+ * Calculates a deterministic theme index from the sorted, unique dataKeys in
+ * the current chart.
+ *
+ * The item is included in the list in case it has not been registered in the
+ * Redux store yet. Graphical items register themselves in a layout effect, so
+ * the store can be incomplete during the first render.
  * @param item - The themable item to calculate identity for
- * @param themeCount - Optional number of available themes; if provided, clamps
- *  the hash to [0, themeCount).
+ * @param allDataKeys - DataKeys of all graphical items currently in the chart
+ * @param themeCount - Number of available themes
  */
-export function graphicalItemIdentity(item: ThemableItem, themeCount?: number): number {
-  // Negative or zero themeCount is semantically invalid (can't have negative themes,
-  // and zero themes means none available)
-  if (themeCount != null && themeCount <= 0) {
+export function graphicalItemIdentity(
+  item: ThemableItem,
+  allDataKeys: ReadonlyArray<DataKey<any>>,
+  themeCount: number,
+): number {
+  if (themeCount <= 0) {
     return 0;
   }
 
-  const keyString = String(item.dataKey);
-  const hashResult = computeHash(keyString);
+  const keyStrings = [...allDataKeys, item.dataKey].map(String);
+  const sortedUniqueKeyStrings = Array.from(new Set(keyStrings)).sort();
+  const itemIndex = sortedUniqueKeyStrings.indexOf(String(item.dataKey));
 
-  if (themeCount != null && themeCount > 0) {
-    return hashResult % themeCount;
-  }
-
-  return hashResult;
+  return itemIndex % themeCount;
 }

--- a/src/theme/useGraphicalItemIdentity.ts
+++ b/src/theme/useGraphicalItemIdentity.ts
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+import { useAppSelector } from '../state/hooks';
+import { selectAllUnfilteredGraphicalItemDataKeys } from '../state/selectors/graphicalItemSelectors';
+import { DataKey } from '../util/types';
+import { graphicalItemIdentity } from './graphicalItemIdentity';
+import { RechartsTheme } from './RechartsTheme';
+import { useRechartsTheme } from './RechartsThemeContext';
+
+type GraphicalItemThemeSelector = (theme: RechartsTheme) => RechartsTheme['graphicalItems'][number] | undefined;
+const STABLE_EMPTY_GRAPHICAL_ITEM_DATA_KEYS: ReadonlyArray<DataKey<any>> = [];
+const selectEmptyGraphicalItemDataKeys = (): ReadonlyArray<DataKey<any>> => STABLE_EMPTY_GRAPHICAL_ITEM_DATA_KEYS;
+
+/**
+ * Creates a theme selector for a graphical item using all dataKeys registered in the current chart.
+ */
+export function useGraphicalItemIdentity(dataKey: DataKey<any> | undefined): GraphicalItemThemeSelector {
+  const activeTheme = useRechartsTheme();
+  const graphicalItemDataKeys =
+    useAppSelector(activeTheme == null ? selectEmptyGraphicalItemDataKeys : selectAllUnfilteredGraphicalItemDataKeys) ??
+    STABLE_EMPTY_GRAPHICAL_ITEM_DATA_KEYS;
+
+  return useCallback(
+    (theme: RechartsTheme) => {
+      if (dataKey == null) {
+        return undefined;
+      }
+
+      return theme.graphicalItems[
+        graphicalItemIdentity({ dataKey }, graphicalItemDataKeys, theme.graphicalItems.length)
+      ];
+    },
+    [dataKey, graphicalItemDataKeys],
+  );
+}

--- a/test/cartesian/Line.spec.tsx
+++ b/test/cartesian/Line.spec.tsx
@@ -327,16 +327,16 @@ describe('<Line />', () => {
       showTooltip(container, lineChartMouseHoverTooltipSelector);
       const line1 = container.querySelector('.recharts-line-curve#line1');
       assertNotNull(line1);
-      expect(line1).toHaveAttribute('stroke', 'red');
+      expect(line1).toHaveAttribute('stroke', 'bronze');
       const line2 = container.querySelector('.recharts-line-curve#line2');
       assertNotNull(line2);
-      expect(line2).toHaveAttribute('stroke', 'bronze');
+      expect(line2).toHaveAttribute('stroke', 'red');
       const dot = container.querySelector('.recharts-dot');
       assertNotNull(dot);
-      expect(dot).toHaveAttribute('fill', 'red');
+      expect(dot).toHaveAttribute('fill', 'bronze');
       const activeDot = container.querySelector('.recharts-active-dot circle');
       assertNotNull(activeDot);
-      expect(activeDot).toHaveAttribute('fill', 'blue');
+      expect(activeDot).toHaveAttribute('fill', 'gold');
     });
   });
 

--- a/test/cartesian/Line.theme.spec.tsx
+++ b/test/cartesian/Line.theme.spec.tsx
@@ -84,8 +84,8 @@ describe('Line theme', () => {
         strokeWidth: 4,
       },
     ];
-    const themeIndex = graphicalItemIdentity({ dataKey: 'profit' }, graphicalItems.length);
-    expect(themeIndex).toBe(1);
+    const themeIndex = graphicalItemIdentity({ dataKey: 'profit' }, ['profit'], graphicalItems.length);
+    expect(themeIndex).toBe(0);
     const theme = graphicalItems[themeIndex];
     assertNotNull(theme);
 
@@ -111,6 +111,26 @@ describe('Line theme', () => {
       expect(dot).toHaveAttribute('stroke-opacity', String(theme.strokeOpacity));
       expect(dot).toHaveAttribute('stroke-dasharray', theme.strokeDasharray);
     });
+  });
+
+  it('assigns graphical-item themes by sorted dataKeys instead of render order', () => {
+    const { container } = rechartsTestRender(
+      <RechartsThemeProvider
+        value={{
+          graphicalItems: [{ stroke: 'red' }, { stroke: 'blue' }],
+        }}
+      >
+        <MyChart>
+          <Line dataKey="revenue" isAnimationActive={false} />
+          <Line dataKey="profit" isAnimationActive={false} />
+        </MyChart>
+      </RechartsThemeProvider>,
+    );
+
+    const curves = container.querySelectorAll('.recharts-line-curve');
+    expect(curves).toHaveLength(2);
+    expect(curves[0]).toHaveAttribute('stroke', 'blue');
+    expect(curves[1]).toHaveAttribute('stroke', 'red');
   });
 
   it('uses an explicit line stroke as the dot fill when it overrides the theme', () => {

--- a/test/theme/graphicalItemIdentity.spec.ts
+++ b/test/theme/graphicalItemIdentity.spec.ts
@@ -1,217 +1,53 @@
-import { describe, it, expect, vi } from 'vitest';
-import { random } from '@recharts/devtools';
+import { describe, expect, it } from 'vitest';
 import { graphicalItemIdentity, ThemableItem } from '../../src/theme/graphicalItemIdentity';
 
 describe('graphicalItemIdentity', () => {
-  const mockItem1: ThemableItem = { dataKey: 'foo' };
-  const mockItem2: ThemableItem = { dataKey: 'bar' };
-  const mockItem3: ThemableItem = { dataKey: 'bar' };
+  const allDataKeys = ['profit', 'revenue', 'expenses'];
 
-  it('should return the same number when given the same item twice', () => {
-    const index1 = graphicalItemIdentity(mockItem1, 5);
-    const index2 = graphicalItemIdentity(mockItem1, 5);
-    expect(index1).toBe(index2);
+  it('should assign indices from sorted unique dataKeys', () => {
+    expect(graphicalItemIdentity({ dataKey: 'expenses' }, allDataKeys, 3)).toBe(0);
+    expect(graphicalItemIdentity({ dataKey: 'profit' }, allDataKeys, 3)).toBe(1);
+    expect(graphicalItemIdentity({ dataKey: 'revenue' }, allDataKeys, 3)).toBe(2);
   });
 
-  it('should return different numbers for items with different dataKeys', () => {
-    const index1 = graphicalItemIdentity(mockItem1, 5); // dataKey: 'foo'
-    const index2 = graphicalItemIdentity(mockItem2, 5); // dataKey: 'bar'
-    expect(index1).not.toBe(index2);
+  it('should not depend on the order or duplicate entries in the dataKeys', () => {
+    const unsortedDataKeys = ['revenue', 'profit', 'profit', 'expenses'];
+
+    expect(graphicalItemIdentity({ dataKey: 'profit' }, unsortedDataKeys, 3)).toBe(1);
+    expect(graphicalItemIdentity({ dataKey: 'revenue' }, unsortedDataKeys, 3)).toBe(2);
   });
 
-  it('should return the same number for items with the same dataKey (structural identity)', () => {
-    const index2 = graphicalItemIdentity(mockItem2, 5); // dataKey: 'bar'
-    const index3 = graphicalItemIdentity(mockItem3, 5); // dataKey: 'bar'
-    expect(index2).toBe(index3);
+  it('should include the current item when it is not registered yet', () => {
+    expect(graphicalItemIdentity({ dataKey: 'revenue' }, ['profit'], 2)).toBe(1);
+    expect(graphicalItemIdentity({ dataKey: 'profit' }, [], 2)).toBe(0);
   });
 
-  it('should return a non-negative integer as the theme index', () => {
-    const index = graphicalItemIdentity(mockItem1, 5);
-    expect(Number.isInteger(index)).toBe(true);
-    expect(index).toBeGreaterThanOrEqual(0);
+  it('should wrap indices when there are more dataKeys than themes', () => {
+    const dataKeys = ['a', 'b', 'c'];
+
+    expect(graphicalItemIdentity({ dataKey: 'a' }, dataKeys, 2)).toBe(0);
+    expect(graphicalItemIdentity({ dataKey: 'b' }, dataKeys, 2)).toBe(1);
+    expect(graphicalItemIdentity({ dataKey: 'c' }, dataKeys, 2)).toBe(0);
   });
 
-  it('should return a different index for the default pv/uv data', () => {
-    const indexUv = graphicalItemIdentity({ dataKey: 'uv' }, 7);
-    const indexPv = graphicalItemIdentity({ dataKey: 'pv' }, 7);
-    expect(indexUv).not.toEqual(indexPv);
-  });
-
-  it('should return the same index even after page reload', async () => {
-    const newItem: ThemableItem = { dataKey: 'newIdentity' };
-
-    // Before reset - ensure item gets some valid index
-    const beforeIndex = graphicalItemIdentity(newItem, 5);
-    expect(beforeIndex).toBeGreaterThanOrEqual(0);
-
-    // now the page had reloaded - simulate with vi
-    vi.resetModules();
-
-    const { graphicalItemIdentity: freshIdentityFn } = await import('../../src/theme/graphicalItemIdentity');
-
-    // After calling with a different item, it should get different index
-    const freshItem: ThemableItem = { dataKey: 'freshStart' };
-    const afterIndex = freshIdentityFn(freshItem, 5);
-    expect(afterIndex).not.toBe(beforeIndex);
-
-    // in fact the index of the old item should be the same as before - stable!
-    const reloadedIndex = freshIdentityFn(newItem, 5);
-    expect(reloadedIndex).toBe(beforeIndex);
-  });
-
-  it('should handle numeric dataKeys by converting them to strings for hashing', () => {
-    const numericItem: ThemableItem = { dataKey: 42 };
+  it('should return the same index for items with equivalent dataKeys', () => {
     const stringItem: ThemableItem = { dataKey: '42' };
+    const numericItem: ThemableItem = { dataKey: 42 };
+    const dataKeys = ['42'];
 
-    // Numeric dataKey should be converted to its string representation.
-    // and produce the same hash as a string dataKey with equivalent content.
-    const numericIndex = graphicalItemIdentity(numericItem, 5);
-    const stringIndex = graphicalItemIdentity(stringItem, 5);
-    expect(numericIndex).toBe(stringIndex);
+    expect(graphicalItemIdentity(stringItem, dataKeys, 5)).toBe(graphicalItemIdentity(numericItem, dataKeys, 5));
   });
 
-  it('should return a bounded hash when themeCount is not provided', () => {
-    const item: ThemableItem = { dataKey: 'foo' };
-    const unboundedIndex = graphicalItemIdentity(item);
-    expect(Number.isInteger(unboundedIndex)).toBe(true);
-    expect(unboundedIndex).toBeGreaterThanOrEqual(0);
-    expect(unboundedIndex).toBeLessThanOrEqual(0x7fffffff);
+  it('should return 0 when no themes are available', () => {
+    const item: ThemableItem = { dataKey: 'anything' };
+
+    expect(graphicalItemIdentity(item, [], 0)).toBe(0);
+    expect(graphicalItemIdentity(item, [], -1)).toBe(0);
   });
 
-  it('should always return 0 when themeCount is 1', () => {
-    const itemA: ThemableItem = { dataKey: 'anything' };
-    const itemB: ThemableItem = { dataKey: 'somethingElse' };
-    expect(graphicalItemIdentity(itemA, 1)).toBe(0);
-    expect(graphicalItemIdentity(itemB, 1)).toBe(0);
-  });
+  it('should not throw when given a dataKey function', () => {
+    const dataKey = () => {};
 
-  it('should handle empty string dataKeys', () => {
-    const emptyItem: ThemableItem = { dataKey: '' };
-    const index = graphicalItemIdentity(emptyItem, 5);
-    expect(index).toBeGreaterThanOrEqual(0);
-    expect(index).toBeLessThan(5);
-  });
-
-  it('should handle numeric zero and negative numbers via String conversion', () => {
-    const zeroItem: ThemableItem = { dataKey: 0 };
-    const negativeItem: ThemableItem = { dataKey: -1 };
-    const indexZero = graphicalItemIdentity(zeroItem, 5);
-    const indexNegative = graphicalItemIdentity(negativeItem, 5);
-    // String(0) === '0', String(-1) === '-1' → different hashes
-    expect(indexZero).not.toBe(indexNegative);
-  });
-
-  it('should handle very long dataKeys without issues', () => {
-    const longDataKey = Array.from({ length: 1000 }, (_, i) => `key${i}`).join('-');
-    const longItem: ThemableItem = { dataKey: longDataKey };
-    const indexLong = graphicalItemIdentity(longItem, 5);
-    expect(indexLong).toBeGreaterThanOrEqual(0);
-    expect(indexLong).toBeLessThan(5);
-    // Same long key should always produce same hash (stability)
-    expect(graphicalItemIdentity({ dataKey: longDataKey }, 5)).toBe(indexLong);
-  });
-
-  it('should clamp the number to the themeCount parameter so that the index stays within bounds, always', () => {
-    // When there are only 3 themes (indices 0, 1, 2), no matter what
-    // the raw hash is, the returned index must be clamped within [0, themeCount).
-    const indexSmall = graphicalItemIdentity(mockItem1, 3);
-    expect(indexSmall).toBeGreaterThanOrEqual(0);
-    expect(indexSmall).toBeLessThan(3);
-
-    // Even with a large number of themes, the index must be valid.
-    const indexLarge = graphicalItemIdentity(mockItem2, 100);
-    expect(indexLarge).toBeGreaterThanOrEqual(0);
-    expect(indexLarge).toBeLessThan(100);
-  });
-
-  it('should distribute indices approximately uniformly across themes', () => {
-    // Generate deterministic strings using LCG seed=42.
-    // The LCG yields integer values in [0, 65536]. Normalize to float in [0, 1).
-    const rng = random(42);
-    const m = 65537;
-    const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
-    const strings: string[] = [];
-
-    for (let i = 0; i < 2000; i++) {
-      // Length between 1 and 10 characters
-      const len = Math.floor((rng.next().value / m) * 10) + 1;
-      const chars = new Array(len);
-      for (let j = 0; j < len; j++) {
-        const charIdx = Math.floor((rng.next().value / m) * alphabet.length);
-        chars[j] = alphabet[charIdx];
-      }
-      strings.push(chars.join(''));
-    }
-
-    // For each themeCount, check that index distribution is approximately uniform.
-    // A good hash distributes items roughly evenly across all buckets.
-    // We verify that no single bucket ever exceeds ±3 standard deviations
-    // from expected count (99.7% confidence for multinomial sampling).
-    const testThemeCounts = [3, 5, 10];
-
-    for (const themeCount of testThemeCounts) {
-      const buckets = new Array(themeCount).fill(0);
-      for (const str of strings) {
-        const idx = graphicalItemIdentity({ dataKey: str }, themeCount);
-        expect(idx).toBeGreaterThanOrEqual(0);
-        expect(idx).toBeLessThan(themeCount);
-        buckets[idx]++;
-      }
-
-      // Expected per bucket and standard deviation for uniform distribution.
-      const expected = strings.length / themeCount;
-      const stdDev = Math.sqrt(expected * (1 - 1 / themeCount));
-
-      // No bucket should be more than 5 standard deviations from expected.
-      // This is a very generous margin that catches real non-uniformity
-      // while allowing normal random variance (~99.999% confidence).
-      for (let b = 0; b < themeCount; b++) {
-        const deviation = Math.abs(buckets[b] - expected);
-        const msg = `themeCount=${themeCount}: bucket ${b} count (
-           ${buckets[b]}) deviates >5σ from expected (${expected.toFixed(0)}, σ=${stdDev.toFixed(1)})`;
-        expect(deviation, msg).toBeLessThanOrEqual(5 * stdDev);
-      }
-    }
-  });
-
-  it('should handle numeric dataKey values and convert them to strings for hashing', () => {
-    const numericItem: ThemableItem = { dataKey: 123 };
-    const stringEquivalentItem: ThemableItem = { dataKey: '123' };
-
-    // Numeric dataKey should be converted to the same string as String(123)
-    // which is '123', and produce identical hash results as a string dataKey.
-    const numericIndex = graphicalItemIdentity(numericItem, 7);
-    const stringIndex = graphicalItemIdentity(stringEquivalentItem, 7);
-    expect(numericIndex).toBe(stringIndex);
-  });
-
-  it('should handle floating point dataKeys without producing NaN or Infinity', () => {
-    const floatItem: ThemableItem = { dataKey: 3.14 };
-    const index = graphicalItemIdentity(floatItem, 5);
-    expect(Number.isInteger(index)).toBe(true);
-    expect(index).toBeGreaterThanOrEqual(0);
-    expect(index).toBeLessThan(5);
-  });
-
-  it('should return 0 for negative themeCount since it is semantically invalid', () => {
-    // Negative themeCount is semantically impossible (you can't have "negative themes").
-    // The function should treat this as a special case and return 0, not a random large hash.
-    const itemA: ThemableItem = { dataKey: 'anything' };
-    const itemB: ThemableItem = { dataKey: 'somethingElse' };
-    expect(graphicalItemIdentity(itemA, -1)).toBe(0);
-    expect(graphicalItemIdentity(itemA, -5)).toBe(0);
-    expect(graphicalItemIdentity(itemB, -99)).toBe(0);
-  });
-
-  it('should return 0 when themeCount is 0 since no themes are available', () => {
-    const itemA: ThemableItem = { dataKey: 'anything' };
-    const itemB: ThemableItem = { dataKey: 'somethingElse' };
-    expect(graphicalItemIdentity(itemA, 0)).toBe(0);
-    expect(graphicalItemIdentity(itemB, 0)).toBe(0);
-  });
-
-  it('should not throw when given dataKey function', () => {
-    const itemA: ThemableItem = { dataKey: () => {} };
-    expect(graphicalItemIdentity(itemA, 10)).toBeGreaterThanOrEqual(0);
+    expect(graphicalItemIdentity({ dataKey }, [], 10)).toBe(0);
   });
 });

--- a/test/theme/useGraphicalItemIdentity.spec.tsx
+++ b/test/theme/useGraphicalItemIdentity.spec.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { RechartsTheme, RechartsThemeProvider } from '../../src';
+import { RechartsStoreProvider } from '../../src/state/RechartsStoreProvider';
+import { LineSettings } from '../../src/state/types/LineSettings';
+import { useGraphicalItemIdentity } from '../../src/theme/useGraphicalItemIdentity';
+
+const theme: RechartsTheme = {
+  graphicalItems: [{ stroke: 'red' }, { stroke: 'blue' }],
+};
+
+function createLineSettings(id: string, dataKey: string): LineSettings {
+  return {
+    id,
+    type: 'line',
+    data: undefined,
+    dataKey,
+    hide: false,
+    xAxisId: 0,
+    yAxisId: 0,
+    zAxisId: 0,
+    isPanorama: false,
+  };
+}
+
+function createWrapper(dataKeys: ReadonlyArray<string>) {
+  const preloadedState = {
+    graphicalItems: {
+      cartesianItems: dataKeys.map((dataKey, index) => createLineSettings(`line-${index}`, dataKey)),
+      polarItems: [],
+    },
+  };
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <RechartsThemeProvider value={theme}>
+        <RechartsStoreProvider preloadedState={preloadedState}>{children}</RechartsStoreProvider>
+      </RechartsThemeProvider>
+    );
+  };
+}
+
+describe('useGraphicalItemIdentity', () => {
+  it('selects the theme entry using all graphical item dataKeys from Redux', () => {
+    const { result } = renderHook(() => useGraphicalItemIdentity('revenue'), {
+      wrapper: createWrapper(['revenue', 'profit']),
+    });
+
+    expect(result.current(theme)).toBe(theme.graphicalItems[1]);
+  });
+
+  it('includes the current dataKey when it is not registered in Redux yet', () => {
+    const { result } = renderHook(() => useGraphicalItemIdentity('revenue'), {
+      wrapper: createWrapper(['profit']),
+    });
+
+    expect(result.current(theme)).toBe(theme.graphicalItems[1]);
+  });
+
+  it('returns undefined when the graphical item has no dataKey', () => {
+    const { result } = renderHook(() => useGraphicalItemIdentity(undefined), {
+      wrapper: createWrapper(['profit']),
+    });
+
+    expect(result.current(theme)).toBeUndefined();
+  });
+
+  it('uses an empty dataKey list outside a theme provider', () => {
+    const { result } = renderHook(() => useGraphicalItemIdentity('profit'));
+
+    expect(result.current(theme)).toBe(theme.graphicalItems[0]);
+  });
+
+  it('updates the selector when the dataKey changes', () => {
+    const { result, rerender } = renderHook(({ dataKey }) => useGraphicalItemIdentity(dataKey), {
+      initialProps: { dataKey: 'profit' },
+      wrapper: createWrapper(['profit', 'revenue']),
+    });
+
+    expect(result.current(theme)).toBe(theme.graphicalItems[0]);
+
+    rerender({ dataKey: 'revenue' });
+
+    expect(result.current(theme)).toBe(theme.graphicalItems[1]);
+  });
+});

--- a/www/src/components/GuideView/Theming/CustomThemeExample.tsx
+++ b/www/src/components/GuideView/Theming/CustomThemeExample.tsx
@@ -31,10 +31,6 @@ const brandTheme: RechartsTheme = {
     fontFamily: 'Georgia, serif',
     fontSize: 13,
   },
-  /*
-   * `revenue` picks index 0 and `profit` picks index 1 of this array.
-   * The index comes from a hash of the dataKey, not from the render order.
-   */
   graphicalItems: [
     {
       stroke: '#4338ca',

--- a/www/src/components/GuideView/Theming/index.tsx
+++ b/www/src/components/GuideView/Theming/index.tsx
@@ -476,39 +476,12 @@ export function ThemingGuide() {
 
       <h2>Colors for multiple series</h2>
       <p>
-        <code>graphicalItems</code> is an array, and each graphical item in a chart picks one entry from it. The
-        interesting question is <em>which</em> entry.
+        The theme uses each graphical item&apos;s <code>dataKey</code> to decide which entry from{' '}
+        <code>graphicalItems</code> to use for its color.
       </p>
       <p>
-        Recharts does not use render order. Render order is not stable: series get toggled, conditionally rendered, or
-        reordered, and React does not guarantee the traversal order you might expect. Coloring by position means colors
-        jump around when any of that happens.
-      </p>
-      <p>
-        Instead, most graphical items derive their index from a{' '}
-        <strong>
-          hash of their <code>dataKey</code>
-        </strong>
-        . The same <code>dataKey</code> therefore always gets the same color, in every chart, across renders and
-        reloads.
-      </p>
-      <ul>
-        <li>
-          <LinkToApi>Line</LinkToApi>, <LinkToApi>Area</LinkToApi>, <LinkToApi>Bar</LinkToApi>,{' '}
-          <LinkToApi>Scatter</LinkToApi>, <LinkToApi>Radar</LinkToApi> and <LinkToApi>RadialBar</LinkToApi> hash their{' '}
-          <code>dataKey</code> into the array. An item with no <code>dataKey</code> gets no themed color.
-        </li>
-        <li>
-          <LinkToApi>Pie</LinkToApi>, <LinkToApi>Funnel</LinkToApi> and <LinkToApi>Treemap</LinkToApi> draw many shapes
-          from a single series, so they walk the array by position instead: sector <code>i</code> gets entry{' '}
-          <code>i % graphicalItems.length</code>.
-        </li>
-      </ul>
-      <p>
-        Hashing is best-effort, not a guarantee. Two dataKeys can land on the same entry, especially with a short array
-        - <code>&quot;x&quot;</code> and <code>&quot;y&quot;</code> collide in a two-color theme, for instance. A longer
-        palette makes collisions less likely; an explicit <code>fill</code> or <code>stroke</code> prop removes the
-        question entirely.
+        This is a convenient default. If you need different colors or want to control the assignment yourself, provide
+        an explicit <code>fill</code> or <code>stroke</code> prop on the graphical item.
       </p>
       <p>
         Each entry can also carry an <code>active</code> block, which styles the highlighted representation of that
@@ -609,10 +582,6 @@ export function ThemingGuide() {
         <li>
           Themes are not deep-merged. Nested providers replace, and there is no <code>createTheme</code> helper to merge
           for you.
-        </li>
-        <li>
-          Series colors are assigned by a hash, which is stable but not collision-free. Use explicit props when a
-          specific color matters.
         </li>
       </ul>
     </article>


### PR DESCRIPTION
## Description

Improve chart-local graphical-item theme color assignment by using the chart's `dataKey` values instead of a hash-based identity. Add the reusable `useGraphicalItemIdentity` hook for Line, Area, Bar, Scatter, Radar, and RadialBar, and update the related tests and documentation.

## Related Issue

N/A

## Motivation and Context

Hash-based assignment produced too many color conflicts in simple charts with short palettes. The new approach gives the theme enough information to assign colors consistently by `dataKey` while allowing users to override any choice with explicit `fill` or `stroke` props.

## How Has This Been Tested?

- `npm run test -- --reporter=minimal` (353 test files pass; the repository's six existing `.fails` tests remain explicitly marked)
- `npm run check-types-lib`
- `npm run check-types-test`
- Targeted ESLint checks for changed files

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chart series now receive theme colors deterministically based on their data keys rather than render order.
  * Consistent theme color assignment is applied across cartesian and polar chart types.
  * Series with the same data key share a theme style.

* **Documentation**
  * Updated theming guidance to explain data-key-based color selection and prop overrides.
  * Clarified graphical-item palette assignment behavior.

* **Tests**
  * Added coverage for deterministic assignments, duplicate data keys, unregistered series, and palette wrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->