### PR TITLE
Configure Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,16 @@ updates:
         patterns:
           - 'vitest'
           - '@vitest/*'
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    # Look for workflow files in the `.github/workflows` directory
+    directory: '/'
+    # Check for GitHub Actions updates every day
+    schedule:
+      interval: 'daily'
+    # add the 'dependencies' label to PRs
+    labels:
+      - 'dependencies'
+    # max of 10 PRs at a time from dependabot
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Description

Configure Dependabot to monitor GitHub Actions used by the repository's workflows and propose version updates.

## Related Issue

N/A

## Motivation and Context

The existing Dependabot configuration only checks npm dependencies, so action references such as `actions/checkout` and `actions/setup-node` could become outdated without automated update pull requests. This adds daily GitHub Actions checks while keeping the existing dependency label and 10-open-PR limit.

## How Has This Been Tested?

Validated the Dependabot configuration diff with `git diff --check`.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or VR test, or extended an existing story or VR test to show my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated daily checks for GitHub Actions dependency updates.
  - Configured update pull requests with a standard label and a limit of 10 open requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->