### PR TITLE
fix(z-index): drop tabIndex from z-index portal groups to stop pointer focus rings

### DIFF
--- a/src/zIndex/ZIndexPortal.tsx
+++ b/src/zIndex/ZIndexPortal.tsx
@@ -15,8 +15,8 @@ function ZIndexSvgPortal({ zIndex, isPanorama }: { zIndex: number; isPanorama: b
       dispatch(unregisterZIndexPortalElement({ zIndex, isPanorama }));
     };
   }, [dispatch, zIndex, isPanorama]);
-  // these g elements should not be tabbable
-  return <g tabIndex={-1} ref={ref} className={`recharts-zIndex-layer_${zIndex}`} />;
+  // a bare <g> is not tabbable or pointer-focusable; do not add tabIndex
+  return <g ref={ref} className={`recharts-zIndex-layer_${zIndex}`} />;
 }
 
 export function AllZIndexPortals({ children, isPanorama }: { children?: React.ReactNode; isPanorama: boolean }) {

--- a/test/zIndex/AllZIndexPortals.spec.tsx
+++ b/test/zIndex/AllZIndexPortals.spec.tsx
@@ -36,8 +36,10 @@ describe('AllZIndexPortals', () => {
     const newZIndexDefinitelyNotOneOfTheDefaults =
       Object.values(DefaultZIndexes).reduce((acc, val) => Math.max(acc, val), Number.NEGATIVE_INFINITY) + 1;
 
-    // all z-index portals should be rendered (they are <g> elements with tabIndex={-1})
-    expect(container.querySelectorAll('g[tabindex="-1"]')).toHaveLength(allZIndexes.length);
+    // all z-index portals should be rendered (they are <g> elements with a recharts-zIndex-layer_ class)
+    expect(container.querySelectorAll('g[class*="recharts-zIndex-layer_"]')).toHaveLength(allZIndexes.length);
+    // and none of them should be made focusable in any way
+    expect(container.querySelectorAll('g[tabindex]')).toHaveLength(0);
 
     act(() => {
       store.dispatch(registerZIndexPortal({ zIndex: newZIndexDefinitelyNotOneOfTheDefaults }));
@@ -45,7 +47,7 @@ describe('AllZIndexPortals', () => {
     });
 
     // After registering, should have one more z-index portal
-    const zIndexPortals = container.querySelectorAll('g[tabindex="-1"]');
+    const zIndexPortals = container.querySelectorAll('g[class*="recharts-zIndex-layer_"]');
     expect(zIndexPortals).toHaveLength(allZIndexes.length + 1);
   });
 
@@ -62,7 +64,7 @@ describe('AllZIndexPortals', () => {
 
     const state = store.getState();
 
-    const renderedElements = Array.from(container.querySelectorAll('g[tabindex="-1"]'));
+    const renderedElements = Array.from(container.querySelectorAll('g[class*="recharts-zIndex-layer_"]'));
     const storedElementIds = Object.values(state.zIndex.zIndexMap)
       .map(entry => entry.element?.id)
       .filter(isNotNil);


### PR DESCRIPTION
Fixes #7799.

`tabindex="-1"` on the z-index layer `<g>` elements makes them pointer-focusable. Clicking anywhere in a chart focuses the nearest layer group, and any app with a global `:focus-visible` rule then paints a focus ring on it. In WebKit an outline on an SVG element traces its geometry, which looks like a selected bar or ReferenceArea.

This removes the `tabIndex={-1}` prop from `ZIndexSvgPortal`. A bare SVG `<g>` is neither tabbable nor pointer-focusable, so the intent documented in PR #6687 (preventing extraneous focusable surfaces) still holds without the attribute.

Tests: the AllZIndexPortals spec now selects layer groups by their `recharts-zIndex-layer_` class instead of by tabindex, and adds an assertion that no rendered layer group carries a `tabindex` attribute. That assertion fails on main and passes with this change.

Note: the issue cites `ZIndexPortal.js`; the actual file is `src/zIndex/ZIndexPortal.tsx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SVG layer focus behavior so portal layers are not assigned a `tabindex` attribute, while remaining non-tabbable and non-pointer-focusable.
* **Tests**
  * Updated coverage to verify all portal layers render correctly without a `tabindex` attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->